### PR TITLE
Added support for xf:rebuild

### DIFF
--- a/demos/css/style.css
+++ b/demos/css/style.css
@@ -14,6 +14,10 @@
     display:block;
 }
 
+.repeat {
+    margin-left: 1em;
+}
+
 /* 
 Text blue: #3D5B96
 Dark blue: #c1cede

--- a/demos/demo-repeat.html
+++ b/demos/demo-repeat.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+       <title>Repeat | XForms demo</title>
+      <link rel="stylesheet" href="css/style.css" type="text/css" />
+      <script src="../Saxon-JS-1.1.0/SaxonJS.js"></script>
+
+      <script>
+      window.onload = function() {
+        SaxonJS.transform({
+           "stylesheetLocation":"../sef/saxon-xforms.sef.xml",
+           "sourceLocation":"xml/demo-repeat-xform.xml",
+           "stylesheetParams": {
+              "xforms-file": "../demos/xml/demo-repeat-xform.xml",
+           }
+        })
+      }     
+      </script>
+   </head>
+
+   <body>
+       <h1 id="title">XForms demo: repeat</h1>
+       
+       <div class="demo-description">
+           <p>This page demonstrates:</p>
+           <ul>
+               <li>Display of a data set as a list (Xforms <a href="https://www.w3.org/TR/xforms11/#ui-repeat" class="xforms-spec-link">&lt;repeat&gt;</a>)</li>
+           </ul>
+       </div>
+      
+      <div id="xForm"></div>
+    
+
+   </body>
+</html>

--- a/demos/xml/demo-repeat-xform.xml
+++ b/demos/xml/demo-repeat-xform.xml
@@ -1,0 +1,140 @@
+<xf:xform xmlns:rest="http://exquery.org/ns/restxq" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:demo="urn:saxon-xforms:demo">
+    <!-- 
+    
+    Have to use *: in XPaths. For some reason namespace declaration is not retained by betterForms
+    
+    Have to use namespace. For some reason betterForms treats no namespace as XHTML namespace.
+    
+    -->
+    <xf:model id="m-recipes">
+        <xf:instance id="all">
+            <demo:recipes>
+                <demo:recipe>
+                    <demo:id>1</demo:id>
+                    <demo:title>Orange and ginger chicken</demo:title>
+                    <demo:ingredients>
+                        <demo:ingredient>chicken</demo:ingredient>
+                        <demo:ingredient>ginger</demo:ingredient>
+                        <demo:ingredient>orange</demo:ingredient>
+                    </demo:ingredients>
+                </demo:recipe>
+                <demo:recipe>
+                    <demo:id>2</demo:id>
+                    <demo:title>Sausage and mash</demo:title>
+                    <demo:ingredients>
+                        <demo:ingredient>sausages</demo:ingredient>
+                        <demo:ingredient>potatoes</demo:ingredient>
+                        <demo:ingredient>gravy</demo:ingredient>
+                    </demo:ingredients>
+                </demo:recipe>
+                <demo:recipe>
+                    <demo:id>3</demo:id>
+                    <demo:title>Broccoli pasta</demo:title>
+                    <demo:ingredients>
+                        <demo:ingredient>broccoli</demo:ingredient>
+                        <demo:ingredient>pasta</demo:ingredient>
+                        <demo:ingredient>pesto</demo:ingredient>
+                        <demo:ingredient>lemon</demo:ingredient>
+                    </demo:ingredients>
+                </demo:recipe>
+            </demo:recipes>
+        </xf:instance>
+               
+        <!-- empty <ingredient> to insert -->
+        <xf:instance id="i-new-ingredient">
+            <demo:ingredient/>
+        </xf:instance>
+        
+    </xf:model>
+    
+    
+    <div id="content">
+        <h2>Recipe list</h2>
+        
+        <xf:repeat id="recipe-repeat" nodeset="instance('all')/demo:recipe" class="repeat">
+            <xf:output ref="demo:title"/>
+            <xf:repeat id="ingredient-repeat" nodeset="demo:ingredients/demo:ingredient" class="repeat">
+                <xf:output ref="text()"/>
+            </xf:repeat>
+        </xf:repeat>  
+        
+        <xf:trigger>
+            <xf:label>Rebuild</xf:label>
+            <xf:action ev:event="DOMActivate">
+                <xf:rebuild model="m-recipes"/>
+            </xf:action>
+        </xf:trigger>
+        
+        <!-- 
+                            
+                            EDIT RECIPE 
+                        
+                        -->
+        
+        <h2>Edit recipe</h2>
+        
+        <xf:group ref="instance('all')/demo:recipe[index('recipe-repeat')]" appearance="full" class="edit">
+            <xf:input ref="demo:title">
+                <xf:label>Recipe Name:</xf:label>
+            </xf:input>
+            <xf:repeat id="ingredients-repeat" nodeset="demo:ingredients/demo:ingredient">
+                <xf:input ref=".">
+                    <xf:label>Ingredient:</xf:label>
+                </xf:input>
+            </xf:repeat>
+            
+            
+            <!-- http://wiki.orbeon.com/forms/how-to/logic/repeat-insert-position -->
+            <xf:trigger>
+                <xf:label>Add ingredient after selected item</xf:label>
+                <xf:action ev:event="DOMActivate">
+                    <xf:insert context="." nodeset="demo:ingredients/demo:ingredient" at="index('ingredients-repeat')" position="after" origin="instance('i-new-ingredient')"/>
+                </xf:action>
+            </xf:trigger>
+
+            <xf:trigger>
+                <xf:label>Delete selected ingredient</xf:label>
+                <xf:action ev:event="DOMActivate">
+                    <xf:delete context="." nodeset="demo:ingredients/demo:ingredient" at="index('ingredients-repeat')"/>
+                </xf:action>
+            </xf:trigger>
+            
+            <xf:trigger>
+                <xf:label>Move selected ingredient Up</xf:label>
+                <!-- xf:action groups a sequence of actions -->
+                <xf:action ev:event="DOMActivate" if="index('ingredients-repeat') != 1">
+                    <!-- insert changes "focus" index to the newly inserted node -->
+                    <xf:insert context="." nodeset="demo:ingredients/demo:ingredient" at="index('ingredients-repeat') - 1" position="before" origin="demo:ingredients/demo:ingredient[index('ingredients-repeat')]"/>
+                    <!-- push focus back to original node -->
+                    <xf:setindex repeat="ingredients-repeat" index="index('ingredients-repeat') + 2"/>
+                    <xf:setfocus control="ingredients-repeat"/>
+                    <xf:delete context="." nodeset="demo:ingredients/demo:ingredient" at="index('ingredients-repeat')"/>
+                    <xf:rebuild model="m-recipes"/>
+                </xf:action>
+            </xf:trigger>
+            
+            <xf:trigger>
+                <xf:label>Move selected ingredient Down</xf:label>
+                <!-- xf:action groups a sequence of actions 
+                     
+                     tried position() instead of index('ingredients-repeat') but didn't work
+                     possibly because focus was on a different row from where 'Down' was clicked
+                     -->
+                <xf:action ev:event="DOMActivate" if="index('ingredients-repeat') != count(ingredients/ingredient)">
+                    <!-- insert changes "focus" index to the newly inserted node 
+                     
+                     weirdly, this doesn't work properly using the REST URL
+                     -->
+                    <xf:insert context="." nodeset="demo:ingredients/demo:ingredient" at="index('ingredients-repeat') + 1" position="after" origin="demo:ingredients/demo:ingredient[index('ingredients-repeat')]"/>
+                    <!-- push focus back to original node -->
+                    <xf:setindex repeat="ingredients-repeat" index="index('ingredients-repeat') - 2"/>
+                    <xf:setfocus control="ingredients-repeat"/>
+                    <xf:delete context="." nodeset="demo:ingredients/demo:ingredient" at="index('ingredients-repeat')"/>
+                </xf:action>
+            </xf:trigger>
+        </xf:group>
+        
+        
+   </div>
+    
+</xf:xform>

--- a/src/saxon-xforms.xsl
+++ b/src/saxon-xforms.xsl
@@ -60,7 +60,7 @@
     <xsl:param name="xforms-file" as="xs:string?"/>
 
     <xsl:variable static="yes" name="debugMode" select="true()"/>
-    <xsl:variable static="yes" name="debugTiming" select="true()"/>
+    <xsl:variable static="yes" name="debugTiming" select="false()"/>
     <xsl:variable static="yes" name="default-instance-id" select="'saxon-forms-default'" as="xs:string"/>
     <xsl:variable static="yes" name="default-submission-id" select="'saxon-forms-default-submission'" as="xs:string"/>
     
@@ -950,8 +950,7 @@
     <xsl:template match="xforms:output">
         <xsl:param name="position" as="xs:integer" required="no" select="0"/>
 
-        <xsl:variable name="myid" as="xs:string"
-            select=" if (exists(@id)) then @id else concat(generate-id(), '-', $position )"/>
+        <xsl:variable name="myid" as="xs:string" select="if (exists(@id)) then @id else concat( generate-id(), '-', $position )"/>
         
          
         <!-- get xforms:bind element relevant to this -->
@@ -1052,8 +1051,7 @@
     <xsl:template match="xforms:input">
         <xsl:param name="position" as="xs:integer" required="no" select="0"/>
         
-        <xsl:variable name="myid" as="xs:string"
-            select=" if (exists(@id)) then @id else concat(generate-id(), '-', $position )"/>
+        <xsl:variable name="myid" as="xs:string" select="if (exists(@id)) then @id else concat( generate-id(), '-', $position )"/>
         
         <xsl:variable name="time-id" as="xs:string" select="generate-id()"/>
         <xsl:sequence use-when="$debugTiming" select="js:startTime(concat('XForms-input-', $time-id))" />
@@ -1241,9 +1239,8 @@
     <xsl:template match="xforms:textarea" priority="2">
         <xsl:param name="position" as="xs:integer" required="no" select="0"/>
         
-        <xsl:variable name="myid" as="xs:string"
-            select=" if (exists(@id)) then @id else concat(generate-id(), '-', $position )"/>
-                
+        <xsl:variable name="myid" as="xs:string" select="if (exists(@id)) then @id else concat( generate-id(), '-', $position )"/>
+        
         <!-- get xforms:bind element relevant to this -->
         <xsl:variable name="bindingi" as="node()?">
             <xsl:call-template name="getBinding">
@@ -1318,9 +1315,8 @@
     </xd:doc>
     <xsl:template match="xforms:select1 | xforms:select">
         <xsl:param name="position" as="xs:integer" required="no" select="0"/>
-
-        <xsl:variable name="myid" as="xs:string"
-            select=" if (exists(@id)) then @id else concat(generate-id(), '-', $position )"/>
+        
+        <xsl:variable name="myid" as="xs:string" select="if (exists(@id)) then @id else concat( generate-id(), '-', $position )"/>
         
         <xsl:variable name="time-id" select="generate-id()"/>
         <xsl:sequence use-when="$debugTiming" select="js:startTime(concat('XForms-select', $time-id))" />
@@ -1506,8 +1502,7 @@
     <xsl:template match="xforms:repeat">
         <xsl:param name="position" as="xs:integer" required="no" select="0"/>
         
-        <xsl:variable name="myid" as="xs:string"
-            select=" if (exists(@id)) then @id else concat(generate-id(), '-', $position )"/>
+        <xsl:variable name="myid" as="xs:string" select="if (exists(@id)) then @id else concat( generate-id(), '-', $position )"/>
         
         <xsl:variable name="time-id" select="generate-id()"/>
         <xsl:sequence use-when="$debugTiming" select="js:startTime(concat('XForms-repeat', $time-id))" />
@@ -1549,6 +1544,8 @@
            
         <xsl:if test="exists($selectedRepeatVar)">
             <div>
+                <xsl:sequence select="xforms:getClass(.)"/>
+                
                 <xsl:attribute name="data-repeatable-context" select="$refi" />
                 <xsl:attribute name="data-count" select="count($selectedRepeatVar)" />
                 <xsl:attribute name="id" select="$myid"/>
@@ -1694,7 +1691,7 @@
     
     <xsl:template match="*" mode="update-ref" >
         <xsl:param name="path" as="xs:string" select="''" />
-        <xsl:param name="position" select="0" />
+        <xsl:param name="position" select="'0'" />
         
         <xsl:copy>
             <xsl:apply-templates select="@*|node()" mode="update-ref" >
@@ -1729,8 +1726,7 @@
     <xsl:template match="xforms:trigger">
         <xsl:param name="position" as="xs:integer" required="no" select="0"/>
         
-        <xsl:variable name="myid" as="xs:string"
-            select=" if (exists(@id)) then @id else concat(generate-id(), '-', $position )"/>
+        <xsl:variable name="myid" as="xs:string" select="if (exists(@id)) then @id else concat( generate-id(), '-', $position )"/>
         
         <!-- get xforms:bind element relevant to this -->
         <xsl:variable name="bindingi" as="node()?">
@@ -1801,11 +1797,7 @@
         </xd:desc>
     </xd:doc>
     <xsl:template match="xforms:action | xforms:*[local-name() = $xforms-actions] | xforms:show | xforms:hide | xforms:script | xforms:unload">
-        <xsl:variable name="myid"
-            select="
-            if (exists(@id)) 
-            then @id
-            else generate-id()"/>
+        <xsl:variable name="myid" select="if (exists(@id)) then @id else generate-id()"/>
         
         <xsl:variable name="time-id" select="generate-id()"/>
         <xsl:sequence use-when="$debugTiming" select="js:startTime(concat('XForms-action', $time-id))" />        
@@ -2079,6 +2071,7 @@
            </xsl:variable>
            <xsl:sequence select="array{$array}" />
        </xsl:map-entry>
+        
         
     </xsl:template>
     
@@ -2908,8 +2901,10 @@
                             <xsl:with-param name="instance-id" select="map:get($instance-map,'instance-id')"/>
                         </xsl:call-template>
                     </xsl:variable>
-                                        
-                    <xsl:evaluate xpath="map:get($instance-map,'xpath')" context-item="$this-instance" namespace-context="$this-instance"/>
+                    
+                    <xsl:variable name="xpath-mod" as="xs:string" select="xforms:impose(map:get($instance-map,'xpath'))"/>
+                    
+                    <xsl:evaluate xpath="$xpath-mod" context-item="$this-instance" namespace-context="$this-instance"/>
                     
                 </xsl:when>
                 <xsl:otherwise>
@@ -3048,7 +3043,7 @@
         
         <xsl:variable name="instance-id" as="xs:string" select="xforms:getInstanceId($ref)"/>
         <!-- override tunnel variable $instanceXML if $refz refers to a different instance -->
-        <xsl:variable name="instanceXML2" as="element()">
+        <xsl:variable name="instanceXML2" as="element()?">
             <xsl:choose>
                 <xsl:when test="$instance-id = $default-instance-id and exists($instanceXML)">
                     <xsl:sequence select="$instanceXML"/>
@@ -3090,6 +3085,9 @@
             <xsl:variable name="action-name" as="xs:string" select="map:get($action-map,'name')"/>
             
             <xsl:choose>
+                <xsl:when test="$action-name = 'action'">
+                    <!-- xforms:action is just a wrapper -->
+                </xsl:when>
                 <xsl:when test="$action-name = 'setvalue'">
                     <xsl:call-template name="action-setvalue">
                         <xsl:with-param name="nodeset" select="$ref" as="xs:string" tunnel="yes"/>
@@ -3110,6 +3108,9 @@
                 </xsl:when>
                 <xsl:when test="$action-name = 'message'">
                     <xsl:call-template name="action-message"/>
+                </xsl:when>
+                <xsl:when test="$action-name = 'rebuild'">
+                    <xsl:call-template name="xforms-rebuild"/>
                 </xsl:when>
                 <xsl:otherwise>
                     <xsl:message use-when="$debugMode">[applyActions] action '<xsl:value-of select="$action-name"/>' not yet handled!</xsl:message>
@@ -3139,12 +3140,14 @@
         <xsl:param name="action-name" required="yes" as="xs:string"/>
         
         <xsl:if test="map:contains($action-map,$action-name)">
-            <xsl:variable name="actionsArray" select="map:find($action-map, $action-name)" as="array(map(*))"/>
+            <xsl:variable name="actionsArray" select="map:get($action-map, $action-name)" as="array(map(*))"/>
             <xsl:variable name="actions" as="item()*">
                 <xsl:sequence select="array:flatten($actionsArray)"/>
             </xsl:variable>
             <xsl:for-each select="$actions">
-                <xsl:call-template name="applyActions"/>
+                <xsl:call-template name="applyActions">
+                    <xsl:with-param name="action-map" select="." tunnel="yes"/>
+                </xsl:call-template>
             </xsl:for-each>
         </xsl:if>
     </xsl:template>
@@ -3213,6 +3216,10 @@
                 <xsl:map-entry key="'@submission'" select="string(@submission)" />
             </xsl:if>
             
+            <xsl:if test="exists(@model)">
+                <xsl:map-entry key="'@model'" select="string(@model)" />
+            </xsl:if>
+
             <xsl:for-each-group select="$this/child::*" group-by="local-name()">
                 <xsl:apply-templates select="." mode="xforms-action-map"/>
             </xsl:for-each-group>          


### PR DESCRIPTION
The @model attribute is not yet supported. Any supplied value is ignored and the entire XForm is rebuilt.

New demo added to illustrate xf:repeat (still WIP).

A couple of fixes made:
- nested action elements (e.g. xf:action/xf:rebuild) are now handled
- ensure namespace-context-item is an element
