### PR TITLE
Improvements to insert and repeat

### DIFF
--- a/builds/saxon-xforms.sef.xml
+++ b/builds/saxon-xforms.sef.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://ns.saxonica.com/xslt/export" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:vv="http://saxon.sf.net/generated-variable" xmlns:java-type="http://saxon.sf.net/java-type" version="30" packageVersion="1" saxonVersion="9.8.0.12" target="JS" targetVersion="1" relocatable="true">
  <co id="0" binds="1 2 3 4 5 6 7">
-  <template name="Q{}action-insert" flags="os" line="3519" module="saxon-xforms.xsl" slots="8">
-   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="3520">
+  <template name="Q{}action-insert" flags="os" line="4137" module="saxon-xforms.xsl" slots="9">
+   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="4138">
     <param name="Q{}action-map" slot="0" flags="tr" as="map(*)">
      <treat role="conversion" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="8|0|XTTE0590|action-map">
       <check card="1" diag="8|0|XTTE0590|action-map">
@@ -10,7 +10,7 @@
       </check>
      </treat>
     </param>
-    <param line="3521" name="Q{}instanceXML" slot="1" flags="t" as="element()?">
+    <param line="4139" name="Q{}instanceXML" slot="1" flags="t" as="element()?">
      <empty role="select"/>
      <treat role="conversion" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="8|0|XTTE0590|instanceXML">
       <check card="?" diag="8|0|XTTE0590|instanceXML">
@@ -18,7 +18,7 @@
       </check>
      </treat>
     </param>
-    <param line="3522" name="Q{}nodeset" slot="2" flags="t" as="xs:string">
+    <param line="4140" name="Q{}nodeset" slot="2" flags="t" as="xs:string">
      <str role="select" val=""/>
      <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|nodeset">
       <check card="1" diag="8|0|XTTE0590|nodeset">
@@ -30,7 +30,7 @@
       </check>
      </treat>
     </param>
-    <let line="3524" var="ref" as="xs:string" slot="3" eval="7">
+    <let line="4142" var="ref" as="xs:string" slot="3" eval="7">
      <ufCall name="Q{http://www.w3.org/2002/xforms}resolveXPathStrings" tailCall="false" bSlot="0" eval="6 7">
       <varRef name="nodeset" slot="2"/>
       <treat as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="0|1||xforms:resolveXPathStrings">
@@ -46,7 +46,7 @@
        </check>
       </treat>
      </ufCall>
-     <let line="3525" var="at" as="xs:string?" slot="4" eval="7">
+     <let line="4143" var="at" as="xs:string?" slot="4" eval="7">
       <treat as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|at">
        <check card="?" diag="3|0|XTTE0570|at">
         <cvUntyped to="xs:string">
@@ -59,93 +59,124 @@
         </cvUntyped>
        </check>
       </treat>
-      <let line="3541" var="instanceXML2" as="element()" slot="5" eval="7">
-       <choose line="3543">
-        <and op="and">
-         <vc op="eq" onEmpty="0" comp="CCC">
-          <ufCall line="3539" name="Q{http://www.w3.org/2002/xforms}getInstanceId" tailCall="false" bSlot="1" eval="6">
+      <let line="4145" var="origin" as="node()?" slot="5" eval="7">
+       <treat as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|origin">
+        <check card="?" diag="3|0|XTTE0570|origin">
+         <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+          <varRef name="action-map" slot="0"/>
+          <str val="@origin"/>
+         </ifCall>
+        </check>
+       </treat>
+       <let line="4160" var="instanceXML2" as="element()" slot="6" eval="7">
+        <choose line="4162">
+         <and op="and">
+          <vc op="eq" onEmpty="0" comp="CCC">
+           <ufCall line="4158" name="Q{http://www.w3.org/2002/xforms}getInstanceId" tailCall="false" bSlot="1" eval="6">
+            <varRef name="ref" slot="3"/>
+           </ufCall>
+           <str val="saxon-forms-default"/>
+          </vc>
+          <fn name="exists">
+           <varRef name="instanceXML" slot="1"/>
+          </fn>
+         </and>
+         <check line="4163" card="1" diag="3|0|XTTE0570|instanceXML2">
+          <varRef name="instanceXML" slot="1"/>
+         </check>
+         <true/>
+         <check line="4166" card="1" diag="3|0|XTTE0570|instanceXML2">
+          <ufCall name="Q{http://www.w3.org/2002/xforms}getInstance-JS" tailCall="false" bSlot="2" eval="6">
            <varRef name="ref" slot="3"/>
           </ufCall>
-          <str val="saxon-forms-default"/>
-         </vc>
-         <fn name="exists">
-          <varRef name="instanceXML" slot="1"/>
-         </fn>
-        </and>
-        <check line="3544" card="1" diag="3|0|XTTE0570|instanceXML2">
-         <varRef name="instanceXML" slot="1"/>
-        </check>
-        <true/>
-        <check line="3547" card="1" diag="3|0|XTTE0570|instanceXML2">
-         <ufCall name="Q{http://www.w3.org/2002/xforms}getInstance-JS" tailCall="false" bSlot="2" eval="6">
-          <varRef name="ref" slot="3"/>
-         </ufCall>
-        </check>
-       </choose>
-       <let line="3552" var="insert-node" as="node()" slot="6" eval="7">
-        <treat line="3553" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|insert-node">
-         <check card="1" diag="3|0|XTTE0570|insert-node">
-          <evaluate dxns="">
-           <ufCall role="xpath" name="Q{http://www.w3.org/2002/xforms}impose" tailCall="false" bSlot="3" eval="4">
-            <check card="1" diag="0|0||xforms:impose">
-             <choose line="3537">
-              <fn name="exists">
-               <varRef name="ref" slot="3"/>
-              </fn>
-              <choose>
-               <fn name="exists">
-                <varRef name="at" slot="4"/>
-               </fn>
-               <fn name="concat">
-                <varRef name="ref" slot="3"/>
-                <str val="["/>
-                <varRef name="at" slot="4"/>
-                <str val="]"/>
-               </fn>
-               <true/>
-               <varRef name="ref" slot="3"/>
-              </choose>
-             </choose>
-            </check>
-           </ufCall>
-           <varRef role="cxt" name="instanceXML2" slot="5"/>
-           <str role="sa" val="no"/>
-           <map role="wp" size="0"/>
-          </evaluate>
          </check>
-        </treat>
-        <let line="3556" var="instance-with-insert" as="element()" slot="7" eval="7">
-         <treat line="3557" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="3|0|XTTE0570|instance-with-insert">
-          <check card="1" diag="3|0|XTTE0570|instance-with-insert">
-           <applyT mode="Q{}insert-node" bSlot="4">
-            <varRef role="select" name="instanceXML2" slot="5"/>
-            <withParam name="Q{}insert-node" flags="t" as="node()">
-             <varRef line="3558" name="insert-node" slot="6"/>
-            </withParam>
-            <withParam name="Q{}position-relative" flags="t" as="xs:string?">
-             <treat line="3526" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|position">
-              <check card="?" diag="3|0|XTTE0570|position">
-               <cvUntyped to="xs:string">
-                <data>
-                 <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
-                  <varRef name="action-map" slot="0"/>
-                  <str val="@position"/>
-                 </ifCall>
-                </data>
-               </cvUntyped>
-              </check>
-             </treat>
-            </withParam>
-           </applyT>
+        </choose>
+        <let line="4174" var="insert-node-location" as="node()" slot="7" eval="7">
+         <treat line="4175" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|insert-node-location">
+          <check card="1" diag="3|0|XTTE0570|insert-node-location">
+           <evaluate dxns="">
+            <ufCall role="xpath" name="Q{http://www.w3.org/2002/xforms}impose" tailCall="false" bSlot="3" eval="4">
+             <check card="1" diag="0|0||xforms:impose">
+              <choose line="4156">
+               <and op="and">
+                <fn name="exists">
+                 <varRef name="ref" slot="3"/>
+                </fn>
+                <vc op="ne" onEmpty="0" comp="GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint">
+                 <varRef name="ref" slot="3"/>
+                 <str val=""/>
+                </vc>
+               </and>
+               <choose>
+                <fn name="exists">
+                 <varRef name="at" slot="4"/>
+                </fn>
+                <fn name="concat">
+                 <varRef name="ref" slot="3"/>
+                 <str val="["/>
+                 <varRef name="at" slot="4"/>
+                 <str val="]"/>
+                </fn>
+                <true/>
+                <varRef name="ref" slot="3"/>
+               </choose>
+              </choose>
+             </check>
+            </ufCall>
+            <varRef role="cxt" name="instanceXML2" slot="6"/>
+            <varRef role="nsCxt" name="instanceXML2" slot="6"/>
+            <str role="sa" val="no"/>
+            <map role="wp" size="0"/>
+           </evaluate>
           </check>
          </treat>
-         <sequence line="3563">
-          <ufCall name="Q{http://www.w3.org/2002/xforms}setInstance-JS" tailCall="false" bSlot="5" eval="6 6">
-           <varRef name="ref" slot="3"/>
-           <varRef name="instance-with-insert" slot="7"/>
-          </ufCall>
-          <callT line="3564" name="xforms-rebuild" bSlot="6" flags="t"/>
-         </sequence>
+         <let line="4191" var="instance-with-insert" as="element()" slot="8" eval="7">
+          <treat line="4192" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="3|0|XTTE0570|instance-with-insert">
+           <check card="1" diag="3|0|XTTE0570|instance-with-insert">
+            <applyT mode="Q{}insert-node" bSlot="4">
+             <varRef role="select" name="instanceXML2" slot="6"/>
+             <withParam name="Q{}insert-node-location" flags="t" as="node()">
+              <varRef line="4193" name="insert-node-location" slot="7"/>
+             </withParam>
+             <withParam name="Q{}node-to-insert" flags="t" as="node()?">
+              <choose line="4180">
+               <fn name="exists">
+                <varRef name="origin" slot="5"/>
+               </fn>
+               <copyOf line="4181" flags="vc">
+                <varRef name="origin" slot="5"/>
+               </copyOf>
+               <true/>
+               <copyOf line="4184" flags="vc">
+                <varRef name="insert-node-location" slot="7"/>
+               </copyOf>
+              </choose>
+             </withParam>
+             <withParam name="Q{}position-relative" flags="t" as="xs:string?">
+              <treat line="4144" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|position">
+               <check card="?" diag="3|0|XTTE0570|position">
+                <cvUntyped to="xs:string">
+                 <data>
+                  <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+                   <varRef name="action-map" slot="0"/>
+                   <str val="@position"/>
+                  </ifCall>
+                 </data>
+                </cvUntyped>
+               </check>
+              </treat>
+             </withParam>
+            </applyT>
+           </check>
+          </treat>
+          <sequence line="4199">
+           <ufCall name="Q{http://www.w3.org/2002/xforms}setInstance-JS" tailCall="false" bSlot="5" eval="6 6">
+            <varRef name="ref" slot="3"/>
+            <varRef name="instance-with-insert" slot="8"/>
+           </ufCall>
+           <callT line="4200" name="xforms-rebuild" bSlot="6" flags="t"/>
+          </sequence>
+         </let>
         </let>
        </let>
       </let>
@@ -154,9 +185,9 @@
    </sequence>
   </template>
  </co>
- <co id="8" binds="1 2 3 4 9 6 7">
-  <template name="Q{}action-delete" flags="os" line="3577" module="saxon-xforms.xsl" slots="11">
-   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="3578">
+ <co id="8" binds="1 2 3 4 4 9 6 7">
+  <template name="Q{}action-delete" flags="os" line="4213" module="saxon-xforms.xsl" slots="11">
+   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="4214">
     <param name="Q{}action-map" slot="0" flags="tr" as="map(*)">
      <treat role="conversion" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="8|0|XTTE0590|action-map">
       <check card="1" diag="8|0|XTTE0590|action-map">
@@ -164,14 +195,14 @@
       </check>
      </treat>
     </param>
-    <param line="3579" name="Q{}instanceXML" slot="1" flags="ti" as="element()">
+    <param line="4215" name="Q{}instanceXML" slot="1" flags="ti" as="element()">
      <treat role="conversion" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="8|0|XTTE0590|instanceXML">
       <check card="1" diag="8|0|XTTE0590|instanceXML">
        <supplied slot="1"/>
       </check>
      </treat>
     </param>
-    <param line="3580" name="Q{}nodeset" slot="2" flags="t" as="xs:string">
+    <param line="4216" name="Q{}nodeset" slot="2" flags="t" as="xs:string">
      <str role="select" val=""/>
      <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|nodeset">
       <check card="1" diag="8|0|XTTE0590|nodeset">
@@ -183,7 +214,7 @@
       </check>
      </treat>
     </param>
-    <let line="3582" var="ref" as="xs:string" slot="3" eval="7">
+    <let line="4218" var="ref" as="xs:string" slot="3" eval="7">
      <ufCall name="Q{http://www.w3.org/2002/xforms}resolveXPathStrings" tailCall="false" bSlot="0" eval="6 7">
       <varRef name="nodeset" slot="2"/>
       <treat as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="0|1||xforms:resolveXPathStrings">
@@ -199,7 +230,7 @@
        </check>
       </treat>
      </ufCall>
-     <let line="3583" var="at" as="xs:string?" slot="4" eval="7">
+     <let line="4219" var="at" as="xs:string?" slot="4" eval="7">
       <treat as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|at">
        <check card="?" diag="3|0|XTTE0570|at">
         <cvUntyped to="xs:string">
@@ -212,7 +243,7 @@
         </cvUntyped>
        </check>
       </treat>
-      <let line="3593" var="ref-qualified" as="xs:string?" slot="5" eval="7">
+      <let line="4229" var="ref-qualified" as="xs:string?" slot="5" eval="7">
        <choose>
         <fn name="exists">
          <varRef name="ref" slot="3"/>
@@ -231,11 +262,11 @@
          <varRef name="ref" slot="3"/>
         </choose>
        </choose>
-       <let line="3597" var="instanceXML2" as="element()" slot="6" eval="7">
-        <choose line="3599">
+       <let line="4233" var="instanceXML2" as="element()" slot="6" eval="7">
+        <choose line="4235">
          <and op="and">
           <vc op="eq" onEmpty="0" comp="CCC">
-           <ufCall line="3595" name="Q{http://www.w3.org/2002/xforms}getInstanceId" tailCall="false" bSlot="1" eval="6">
+           <ufCall line="4231" name="Q{http://www.w3.org/2002/xforms}getInstanceId" tailCall="false" bSlot="1" eval="6">
             <varRef name="ref" slot="3"/>
            </ufCall>
            <str val="saxon-forms-default"/>
@@ -244,26 +275,26 @@
            <varRef name="instanceXML" slot="1"/>
           </fn>
          </and>
-         <varRef line="3600" name="instanceXML" slot="1"/>
+         <varRef line="4236" name="instanceXML" slot="1"/>
          <true/>
-         <check line="3603" card="1" diag="3|0|XTTE0570|instanceXML2">
+         <check line="4239" card="1" diag="3|0|XTTE0570|instanceXML2">
           <ufCall name="Q{http://www.w3.org/2002/xforms}getInstance-JS" tailCall="false" bSlot="2" eval="6">
            <varRef name="ref" slot="3"/>
           </ufCall>
          </check>
         </choose>
-        <let line="3608" var="ifVar" as="xs:string?" slot="7" eval="7">
-         <choose line="563">
+        <let line="4244" var="ifVar" as="xs:string?" slot="7" eval="7">
+         <choose line="715">
           <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}contains" type="xs:boolean">
-           <varRef line="3608" name="action-map" slot="0"/>
+           <varRef line="4244" name="action-map" slot="0"/>
            <str val="@if"/>
           </ifCall>
-          <treat line="564" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="5|0|XTTE0780|xforms:getIfStatement">
+          <treat line="716" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="5|0|XTTE0780|xforms:getIfStatement">
            <check card="?" diag="5|0|XTTE0780|xforms:getIfStatement">
             <cvUntyped to="xs:string">
              <data>
               <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
-               <varRef line="3608" name="action-map" slot="0"/>
+               <varRef line="4244" name="action-map" slot="0"/>
                <str val="@if"/>
               </ifCall>
              </data>
@@ -271,8 +302,8 @@
            </check>
           </treat>
          </choose>
-         <let line="3611" var="delete-node" as="node()?" slot="8" eval="7">
-          <choose line="3613">
+         <let line="4247" var="delete-node" as="node()?" slot="8" eval="7">
+          <choose line="4249">
            <and op="and">
             <fn name="exists">
              <varRef name="ref-qualified" slot="5"/>
@@ -284,7 +315,7 @@
              </gc>
             </fn>
            </and>
-           <treat line="3614" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|delete-node">
+           <treat line="4250" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|delete-node">
             <check card="?" diag="3|0|XTTE0570|delete-node">
              <evaluate dxns="">
               <ufCall role="xpath" name="Q{http://www.w3.org/2002/xforms}impose" tailCall="false" bSlot="3" eval="7">
@@ -293,26 +324,32 @@
                </check>
               </ufCall>
               <varRef role="cxt" name="instanceXML2" slot="6"/>
+              <varRef role="nsCxt" name="instanceXML2" slot="6"/>
               <str role="sa" val="no"/>
               <map role="wp" size="0"/>
              </evaluate>
             </check>
            </treat>
           </choose>
-          <let line="3619" var="ifExecuted" as="xs:boolean" slot="9" eval="7">
-           <choose line="3621">
+          <let line="4255" var="ifExecuted" as="xs:boolean" slot="9" eval="7">
+           <choose line="4257">
             <fn name="exists">
              <varRef name="ifVar" slot="7"/>
             </fn>
-            <treat line="3622" as="xs:boolean" jsTest="return SaxonJS.U.Atomic.boolean.matches(item);" diag="3|0|XTTE0570|ifExecuted">
+            <treat line="4258" as="xs:boolean" jsTest="return SaxonJS.U.Atomic.boolean.matches(item);" diag="3|0|XTTE0570|ifExecuted">
              <check card="1" diag="3|0|XTTE0570|ifExecuted">
               <cvUntyped to="xs:boolean">
                <data>
                 <evaluate dxns="">
-                 <check role="xpath" card="1" diag="4|0||xsl:evaluate/xpath">
-                  <varRef name="ifVar" slot="7"/>
-                 </check>
+                 <ufCall role="xpath" name="Q{http://www.w3.org/2002/xforms}impose" tailCall="false" bSlot="4" eval="7">
+                  <check card="1" diag="0|0||xforms:impose">
+                   <varRef name="ifVar" slot="7"/>
+                  </check>
+                 </ufCall>
                  <varRef role="cxt" name="delete-node" slot="8"/>
+                 <check role="nsCxt" card="1" diag="4|0|XTTE3170|xsl:evaluate/namespace-context">
+                  <varRef name="delete-node" slot="8"/>
+                 </check>
                  <str role="sa" val="no"/>
                  <map role="wp" size="0"/>
                 </evaluate>
@@ -323,25 +360,25 @@
             <true/>
             <true/>
            </choose>
-           <choose line="3630">
+           <choose line="4266">
             <varRef name="ifExecuted" slot="9"/>
-            <let line="3631" var="instance-with-delete" as="element()" slot="10" eval="7">
-             <treat line="3632" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="3|0|XTTE0570|instance-with-delete">
+            <let line="4267" var="instance-with-delete" as="element()" slot="10" eval="7">
+             <treat line="4268" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="3|0|XTTE0570|instance-with-delete">
               <check card="1" diag="3|0|XTTE0570|instance-with-delete">
-               <applyT mode="Q{}delete-node" bSlot="4">
+               <applyT mode="Q{}delete-node" bSlot="5">
                 <varRef role="select" name="instanceXML2" slot="6"/>
                 <withParam name="Q{}delete-node" flags="t" as="node()?">
-                 <varRef line="3633" name="delete-node" slot="8"/>
+                 <varRef line="4269" name="delete-node" slot="8"/>
                 </withParam>
                </applyT>
               </check>
              </treat>
-             <sequence line="3637">
-              <ufCall name="Q{http://www.w3.org/2002/xforms}setInstance-JS" tailCall="false" bSlot="5" eval="6 6">
+             <sequence line="4273">
+              <ufCall name="Q{http://www.w3.org/2002/xforms}setInstance-JS" tailCall="false" bSlot="6" eval="6 6">
                <varRef name="ref" slot="3"/>
                <varRef name="instance-with-delete" slot="10"/>
               </ufCall>
-              <callT line="3638" name="xforms-rebuild" bSlot="6" flags="t"/>
+              <callT line="4274" name="xforms-rebuild" bSlot="7" flags="t"/>
              </sequence>
             </let>
            </choose>
@@ -355,75 +392,75 @@
    </sequence>
   </template>
  </co>
- <co id="10" binds="11">
-  <mode name="Q{}xforms-action-map" onNo="TC" flags="W" patternSlots="0">
-   <templateRule prec="0" prio="0.5" seq="0" rank="0" minImp="0" slots="2" flags="s" line="2017" module="saxon-xforms.xsl">
-    <p.withPredicate role="match">
-     <p.nodeTest test="Q{http://www.w3.org/2002/xforms}*" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.uri==='http://www.w3.org/2002/xforms'"/>
-     <gc ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2017" op="=" card="N:1" comp="GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint">
-      <literal count="15">
-       <str val="setvalue"/>
-       <str val="insert"/>
-       <str val="delete"/>
-       <str val="setindex"/>
-       <str val="toggle"/>
-       <str val="setfocus"/>
-       <str val="dispatch"/>
-       <str val="rebuild"/>
-       <str val="recalculate"/>
-       <str val="revalidate"/>
-       <str val="refresh"/>
-       <str val="reset"/>
-       <str val="load"/>
-       <str val="send"/>
-       <str val="message"/>
-      </literal>
-      <fn name="local-name">
-       <dot type="Q{http://www.w3.org/2002/xforms}*"/>
-      </fn>
-     </gc>
-    </p.withPredicate>
-    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2019">
-     <param name="Q{}nodeset" slot="0" flags="t">
-      <str role="select" val=""/>
-      <supplied role="conversion" slot="0"/>
-     </param>
-     <ifCall line="2021" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
-      <fn name="local-name">
-       <dot type="Q{http://www.w3.org/2002/xforms}*"/>
-      </fn>
-      <let line="2022" var="array" as="map(*)*" slot="1" eval="8">
-       <treat line="2023" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|array">
-        <forEach>
-         <currentGroup/>
-         <applyT line="2024" bSlot="0">
-          <dot role="select"/>
-         </applyT>
-        </forEach>
-       </treat>
-       <ifCall line="2027" name="Q{http://www.w3.org/2005/xpath-functions/array}_from-sequence" type="array(*)">
-        <varRef name="array" slot="1"/>
-       </ifCall>
-      </let>
-     </ifCall>
+ <co id="10" binds="">
+  <function name="Q{http://www.w3.org/2002/xforms}usesIndexFunction" line="2816" module="saxon-xforms.xsl" eval="8" flags="pU" as="xs:boolean" slots="1">
+   <arg name="this" as="element()"/>
+   <fn role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2852" name="exists">
+    <sequence line="2827">
+     <analyzeString>
+      <cvUntyped role="select" to="xs:string">
+       <data>
+        <slash simple="1">
+         <varRef name="this" slot="0"/>
+         <axis name="attribute" nodeTest="attribute(Q{}ref)" jsTest="return item.name==='ref'"/>
+        </slash>
+       </data>
+      </cvUntyped>
+      <str role="regex" val="\i\c*\("/>
+      <str role="flags" val=""/>
+      <choose role="matching" line="2830">
+       <vc op="eq" onEmpty="0" comp="CCC">
+        <fn name="substring-before">
+         <dot type="xs:string"/>
+         <str val="("/>
+        </fn>
+        <str val="index"/>
+       </vc>
+       <str val="i"/>
+      </choose>
+      <empty role="nonMatching"/>
+     </analyzeString>
+     <analyzeString line="2839">
+      <cvUntyped role="select" to="xs:string">
+       <data>
+        <slash simple="1">
+         <varRef name="this" slot="0"/>
+         <axis name="attribute" nodeTest="attribute(Q{}nodeset)" jsTest="return item.name==='nodeset'"/>
+        </slash>
+       </data>
+      </cvUntyped>
+      <str role="regex" val="\i\c*\("/>
+      <str role="flags" val=""/>
+      <choose role="matching" line="2842">
+       <vc op="eq" onEmpty="0" comp="CCC">
+        <fn name="substring-before">
+         <dot type="xs:string"/>
+         <str val="("/>
+        </fn>
+        <str val="index"/>
+       </vc>
+       <str val="i"/>
+      </choose>
+      <empty role="nonMatching"/>
+     </analyzeString>
     </sequence>
-   </templateRule>
-  </mode>
+   </fn>
+  </function>
  </co>
- <co id="12" binds="12 13 12 12 13">
+ <co id="11" binds="11 12 11 11 12">
   <mode name="Q{}form-check" onNo="TC" flags="W" patternSlots="0">
-   <templateRule prec="0" prio="-0.5" seq="0" rank="0" minImp="0" slots="10" flags="s" line="2220" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="-0.5" seq="0" rank="0" minImp="0" slots="10" flags="s" line="2468" module="saxon-xforms.xsl">
     <p.nodeTest role="match" test="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;"/>
-    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2221">
+    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2469">
      <param name="Q{}curPath" slot="0">
       <str role="select" val=""/>
       <supplied role="conversion" slot="0"/>
      </param>
-     <param line="2222" name="Q{}position" slot="1">
+     <param line="2470" name="Q{}position" slot="1">
       <int role="select" val="0"/>
       <supplied role="conversion" slot="1"/>
      </param>
-     <param line="2223" name="Q{}pendingUpdates" slot="2" flags="t" as="map(xs:string, xs:string)?">
+     <param line="2471" name="Q{}pendingUpdates" slot="2" flags="t" as="map(xs:string, xs:string)?">
       <empty role="select"/>
       <treat role="conversion" as="map(xs:string, xs:string)" jsTest="function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="8|0|XTTE0590|pendingUpdates">
        <check card="?" diag="8|0|XTTE0590|pendingUpdates">
@@ -431,7 +468,7 @@
        </check>
       </treat>
      </param>
-     <let line="2230" var="updatedPath" as="xs:string" slot="3" eval="7">
+     <let line="2477" var="updatedPath" as="xs:string" slot="3" eval="7">
       <choose>
        <gc op="&gt;" card="N:1" comp="GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint">
         <data>
@@ -443,7 +480,7 @@
         <atomSing card="?" diag="0|0||fn:concat">
          <varRef name="curPath" slot="0"/>
         </atomSing>
-        <fn name="local-name">
+        <fn name="name">
          <dot type="element()"/>
         </fn>
         <str val="["/>
@@ -457,43 +494,84 @@
         <atomSing card="?" diag="0|0||fn:concat">
          <varRef name="curPath" slot="0"/>
         </atomSing>
-        <fn name="local-name">
+        <fn name="name">
          <dot type="element()"/>
         </fn>
        </fn>
       </choose>
-      <copy line="2238" flags="cin">
+      <copy line="2485" flags="cin">
        <sequence role="content">
         <applyT mode="Q{}form-check" bSlot="0">
          <axis role="select" name="attribute" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
          <withParam name="Q{}curPath" as="xs:string">
-          <fn line="2239" name="concat">
+          <fn line="2486" name="concat">
            <varRef name="updatedPath" slot="3"/>
            <str val="/"/>
           </fn>
          </withParam>
         </applyT>
-        <let line="2245" var="associated-form-control" as="node()*" slot="4" eval="8">
-         <slash>
-          <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}page" type="document-node()?"/>
-          <fn name="key">
-           <str val="Q{http://saxon.sf.net/}kk102"/>
+        <let line="2492" var="associated-form-control" as="element()*" slot="4" eval="8">
+         <filter flags="b">
+          <filter flags="b">
+           <slash simple="1">
+            <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}page" type="document-node()?"/>
+            <axis name="descendant" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+           </slash>
+           <or op="or">
+            <or op="or">
+             <fn name="exists">
+              <axis name="self" nodeTest="element(Q{}input)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='input';"/>
+             </fn>
+             <fn name="exists">
+              <axis name="self" nodeTest="element(Q{}select)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='select';"/>
+             </fn>
+            </or>
+            <fn name="exists">
+             <axis name="self" nodeTest="element(Q{}textarea)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='textarea';"/>
+            </fn>
+           </or>
+          </filter>
+          <gc op="=" card="1:1" comp="CCC">
+           <attVal name="Q{}data-ref" chk="0"/>
            <varRef name="updatedPath" slot="3"/>
-           <dot type="document-node()"/>
-          </fn>
-         </slash>
-         <sequence line="2248">
+          </gc>
+         </filter>
+         <sequence line="2494">
           <choose>
+           <fn name="exists">
+            <tail start="2">
+             <varRef name="associated-form-control" slot="4"/>
+            </tail>
+           </fn>
+           <message line="2495">
+            <sequence role="select">
+             <valueOf>
+              <str val="[form-check] More than one form element controls the value of XForm node at "/>
+             </valueOf>
+             <valueOf>
+              <varRef name="updatedPath" slot="3"/>
+             </valueOf>
+             <valueOf>
+              <str val="; Saxon-Forms will apply the value of the first"/>
+             </valueOf>
+            </sequence>
+            <str role="terminate" val="no"/>
+            <str role="error" val="Q{http://www.w3.org/2005/xqt-errors}XTMM9000"/>
+           </message>
+          </choose>
+          <choose line="2499">
            <fn name="exists">
             <varRef name="associated-form-control" slot="4"/>
            </fn>
-           <valueOf line="2252" flags="l">
+           <valueOf line="2503" flags="l">
             <fn name="string-join">
              <convert from="xs:anyAtomicType" to="xs:string">
               <data>
                <mergeAdj>
                 <applyT mode="Q{}get-field" bSlot="1">
-                 <varRef role="select" name="associated-form-control" slot="4"/>
+                 <first role="select">
+                  <varRef name="associated-form-control" slot="4"/>
+                 </first>
                 </applyT>
                </mergeAdj>
               </data>
@@ -501,7 +579,7 @@
              <str val=""/>
             </fn>
            </valueOf>
-           <and line="2255" op="and">
+           <and line="2506" op="and">
             <fn name="exists">
              <varRef name="pendingUpdates" slot="2"/>
             </fn>
@@ -512,7 +590,7 @@
              <varRef name="updatedPath" slot="3"/>
             </ifCall>
            </and>
-           <valueOf line="2263" flags="l">
+           <valueOf line="2514" flags="l">
             <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
              <check card="1" diag="0|0||map:get">
               <varRef name="pendingUpdates" slot="2"/>
@@ -521,7 +599,7 @@
             </ifCall>
            </valueOf>
            <true/>
-           <valueOf line="2272" flags="l">
+           <valueOf line="2523" flags="l">
             <fn name="normalize-space">
              <fn name="string-join">
               <data>
@@ -532,13 +610,13 @@
             </fn>
            </valueOf>
           </choose>
-          <forEachGroup line="2277" algorithm="by">
+          <forEachGroup line="2528" algorithm="by">
            <axis role="select" name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
            <fn role="key" name="local-name">
             <dot type="element()"/>
            </fn>
            <str role="collation" val="http://www.w3.org/2005/xpath-functions/collation/codepoint"/>
-           <let role="content" line="2279" var="updatedChildPath" as="xs:string" slot="5" eval="8">
+           <let role="content" line="2530" var="updatedChildPath" as="xs:string" slot="5" eval="8">
             <fn name="concat">
              <varRef name="updatedPath" slot="3"/>
              <str val="/"/>
@@ -546,7 +624,7 @@
               <currentGroupingKey/>
              </check>
             </fn>
-            <let line="2284" var="vv:v0" as="xs:string" slot="6" eval="13">
+            <let line="2535" var="vv:v0" as="xs:string" slot="6" eval="13">
              <fn name="concat">
               <varRef name="updatedChildPath" slot="5"/>
               <str val="["/>
@@ -564,7 +642,7 @@
                 <varRef name="vv:v0" slot="6"/>
                </fn>
               </filter>
-              <choose line="2287">
+              <choose line="2538">
                <or op="or">
                 <fn name="exists">
                  <tail start="2">
@@ -575,36 +653,36 @@
                  <varRef name="dataRefWithFilter" slot="7"/>
                 </fn>
                </or>
-               <let line="2290" var="vv:v1" as="xs:string" slot="8" eval="13">
+               <let line="2541" var="vv:v1" as="xs:string" slot="8" eval="13">
                 <fn name="concat">
                  <varRef name="updatedPath" slot="3"/>
                  <str val="/"/>
                 </fn>
-                <forEach line="2288">
+                <forEach line="2539">
                  <currentGroup/>
-                 <applyT line="2289" mode="Q{}form-check" bSlot="2">
+                 <applyT line="2540" mode="Q{}form-check" bSlot="2">
                   <dot role="select"/>
                   <withParam name="Q{}curPath" as="xs:string">
-                   <varRef line="2290" name="vv:v1" slot="8"/>
+                   <varRef line="2541" name="vv:v1" slot="8"/>
                   </withParam>
                   <withParam name="Q{}position" as="xs:integer">
-                   <fn line="2291" name="position"/>
+                   <fn line="2542" name="position"/>
                   </withParam>
                  </applyT>
                 </forEach>
                </let>
                <true/>
-               <let line="2299" var="vv:v2" as="xs:string" slot="9" eval="13">
+               <let line="2550" var="vv:v2" as="xs:string" slot="9" eval="13">
                 <fn name="concat">
                  <varRef name="updatedPath" slot="3"/>
                  <str val="/"/>
                 </fn>
-                <forEach line="2297">
+                <forEach line="2548">
                  <currentGroup/>
-                 <applyT line="2298" mode="Q{}form-check" bSlot="3">
+                 <applyT line="2549" mode="Q{}form-check" bSlot="3">
                   <dot role="select"/>
                   <withParam name="Q{}curPath" as="xs:string">
-                   <varRef line="2299" name="vv:v2" slot="9"/>
+                   <varRef line="2550" name="vv:v2" slot="9"/>
                   </withParam>
                  </applyT>
                 </forEach>
@@ -621,14 +699,14 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec="0" prio="-0.5" seq="1" rank="0" minImp="0" slots="4" flags="s" line="2320" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="-0.5" seq="1" rank="0" minImp="0" slots="4" flags="s" line="2688" module="saxon-xforms.xsl">
     <p.nodeTest role="match" test="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
-    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2321">
+    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2689">
      <param name="Q{}curPath" slot="0">
       <str role="select" val=""/>
       <supplied role="conversion" slot="0"/>
      </param>
-     <param line="2322" name="Q{}pendingUpdates" slot="1" flags="t" as="map(xs:string, xs:string)?">
+     <param line="2690" name="Q{}pendingUpdates" slot="1" flags="t" as="map(xs:string, xs:string)?">
       <empty role="select"/>
       <treat role="conversion" as="map(xs:string, xs:string)" jsTest="function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="8|0|XTTE0590|pendingUpdates">
        <check card="?" diag="8|0|XTTE0590|pendingUpdates">
@@ -636,7 +714,7 @@
        </check>
       </treat>
      </param>
-     <let line="2323" var="updatedPath" as="xs:string" slot="2" eval="8">
+     <let line="2691" var="updatedPath" as="xs:string" slot="2" eval="8">
       <fn name="concat">
        <atomSing card="?" diag="0|0||fn:concat">
         <varRef name="curPath" slot="0"/>
@@ -646,24 +724,24 @@
         <dot type="attribute()"/>
        </fn>
       </fn>
-      <let line="2332" var="associated-form-control" as="node()*" slot="3" eval="8">
+      <let line="2700" var="associated-form-control" as="node()*" slot="3" eval="8">
        <slash>
         <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}page" type="document-node()?"/>
         <fn name="key">
-         <str val="Q{http://saxon.sf.net/}kk102"/>
+         <str val="Q{http://saxon.sf.net/}kk101"/>
          <varRef name="updatedPath" slot="2"/>
          <dot type="document-node()"/>
         </fn>
        </slash>
-       <choose line="2335">
+       <choose line="2703">
         <fn name="exists">
          <varRef name="associated-form-control" slot="3"/>
         </fn>
-        <compAtt line="2338">
+        <compAtt line="2706">
          <fn role="name" name="local-name">
           <dot type="attribute()"/>
          </fn>
-         <fn role="select" line="2340" name="string-join">
+         <fn role="select" line="2707" name="string-join">
           <convert from="xs:anyAtomicType" to="xs:string">
            <data>
             <mergeAdj>
@@ -676,7 +754,7 @@
           <str val=""/>
          </fn>
         </compAtt>
-        <and line="2343" op="and">
+        <and line="2710" op="and">
          <fn name="exists">
           <varRef name="pendingUpdates" slot="1"/>
          </fn>
@@ -687,11 +765,11 @@
           <varRef name="updatedPath" slot="2"/>
          </ifCall>
         </and>
-        <compAtt line="2344">
+        <compAtt line="2711">
          <fn role="name" name="local-name">
           <dot type="attribute()"/>
          </fn>
-         <ifCall role="select" line="2345" name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+         <ifCall role="select" line="2712" name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
           <check card="1" diag="0|0||map:get">
            <varRef name="pendingUpdates" slot="1"/>
           </check>
@@ -699,7 +777,7 @@
          </ifCall>
         </compAtt>
         <true/>
-        <forEach line="2349">
+        <forEach line="2716">
          <dot type="attribute()"/>
          <copy flags="cin">
           <empty role="content"/>
@@ -712,11 +790,11 @@
    </templateRule>
   </mode>
  </co>
- <co id="14" binds="12">
+ <co id="13" binds="11 11">
   <mode name="Q{}form-check-initial" onNo="TC" flags="W" patternSlots="0">
-   <templateRule prec="0" prio="-0.5" seq="0" rank="0" minImp="0" slots="2" flags="s" line="2186" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="-0.5" seq="0" rank="0" minImp="0" slots="6" flags="s" line="2406" module="saxon-xforms.xsl">
     <p.nodeTest role="match" test="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;"/>
-    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2187">
+    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2407">
      <param name="Q{}instance-id" slot="0" as="xs:string">
       <str role="select" val="saxon-forms-default"/>
       <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|instance-id">
@@ -729,7 +807,7 @@
        </check>
       </treat>
      </param>
-     <param line="2188" name="Q{}pendingUpdates" slot="1" flags="t" as="map(xs:string, xs:string)?">
+     <param line="2408" name="Q{}pendingUpdates" slot="1" flags="t" as="map(xs:string, xs:string)?">
       <empty role="select"/>
       <treat role="conversion" as="map(xs:string, xs:string)" jsTest="function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="8|0|XTTE0590|pendingUpdates">
        <check card="?" diag="8|0|XTTE0590|pendingUpdates">
@@ -737,37 +815,103 @@
        </check>
       </treat>
      </param>
-     <copy line="2206" flags="cin">
-      <applyT role="content" mode="Q{}form-check" bSlot="0">
-       <axis role="select" name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
-       <withParam name="Q{}curPath" as="xs:string">
-        <choose line="2196">
-         <vc op="eq" onEmpty="0" comp="CCC">
+     <let line="2414" var="curPath" as="xs:string" slot="2" eval="7">
+      <choose line="2416">
+       <vc op="eq" onEmpty="0" comp="CCC">
+        <varRef name="instance-id" slot="0"/>
+        <str val="saxon-forms-default"/>
+       </vc>
+       <str val=""/>
+       <true/>
+       <cvUntyped line="2420" to="xs:string">
+        <cast as="xs:untypedAtomic" emptiable="0">
+         <fn name="concat">
+          <str val="instance('"/>
           <varRef name="instance-id" slot="0"/>
-          <str val="saxon-forms-default"/>
-         </vc>
-         <str val=""/>
-         <true/>
-         <cvUntyped line="2200" to="xs:string">
-          <cast as="xs:untypedAtomic" emptiable="0">
-           <fn name="concat">
-            <str val="instance('"/>
-            <varRef name="instance-id" slot="0"/>
-            <str val="')/"/>
-           </fn>
-          </cast>
-         </cvUntyped>
-        </choose>
-       </withParam>
-      </applyT>
-     </copy>
+          <str val="')/"/>
+         </fn>
+        </cast>
+       </cvUntyped>
+      </choose>
+      <copy line="2427" flags="cin">
+       <forEachGroup role="content" algorithm="by">
+        <axis role="select" name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+        <fn role="key" name="local-name">
+         <dot type="element()"/>
+        </fn>
+        <str role="collation" val="http://www.w3.org/2005/xpath-functions/collation/codepoint"/>
+        <let role="content" line="2429" var="updatedChildPath" as="xs:string" slot="3" eval="8">
+         <fn name="concat">
+          <varRef name="curPath" slot="2"/>
+          <check card="?" diag="0|1||fn:concat">
+           <currentGroupingKey/>
+          </check>
+         </fn>
+         <let line="2434" var="vv:v0" as="xs:string" slot="4" eval="13">
+          <fn name="concat">
+           <varRef name="updatedChildPath" slot="3"/>
+           <str val="["/>
+          </fn>
+          <let var="dataRefWithFilter" as="element()*" slot="5" eval="8">
+           <filter flags="b">
+            <slash simple="1">
+             <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}page" type="document-node()?"/>
+             <axis name="descendant" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+            </slash>
+            <fn name="starts-with">
+             <cvUntyped to="xs:string">
+              <attVal name="Q{}data-ref" chk="0"/>
+             </cvUntyped>
+             <varRef name="vv:v0" slot="4"/>
+            </fn>
+           </filter>
+           <choose line="2436">
+            <or op="or">
+             <fn name="exists">
+              <tail start="2">
+               <currentGroup/>
+              </tail>
+             </fn>
+             <fn name="exists">
+              <varRef name="dataRefWithFilter" slot="5"/>
+             </fn>
+            </or>
+            <forEach line="2437">
+             <currentGroup/>
+             <applyT line="2438" mode="Q{}form-check" bSlot="0">
+              <dot role="select"/>
+              <withParam name="Q{}curPath" as="xs:string">
+               <varRef line="2439" name="curPath" slot="2"/>
+              </withParam>
+              <withParam name="Q{}position" as="xs:integer">
+               <fn line="2440" name="position"/>
+              </withParam>
+             </applyT>
+            </forEach>
+            <true/>
+            <forEach line="2446">
+             <currentGroup/>
+             <applyT line="2447" mode="Q{}form-check" bSlot="1">
+              <dot role="select"/>
+              <withParam name="Q{}curPath" as="xs:string">
+               <varRef line="2448" name="curPath" slot="2"/>
+              </withParam>
+             </applyT>
+            </forEach>
+           </choose>
+          </let>
+         </let>
+        </let>
+       </forEachGroup>
+      </copy>
+     </let>
     </sequence>
    </templateRule>
   </mode>
  </co>
- <co id="15" binds="">
-  <template name="Q{}action-reset" flags="os" line="3666" module="saxon-xforms.xsl" slots="1">
-   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="3667">
+ <co id="14" binds="">
+  <template name="Q{}action-reset" flags="os" line="4340" module="saxon-xforms.xsl" slots="1">
+   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="4341">
     <param name="Q{}action-map" slot="0" flags="tr" as="map(*)">
      <treat role="conversion" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="8|0|XTTE0590|action-map">
       <check card="1" diag="8|0|XTTE0590|action-map">
@@ -775,7 +919,7 @@
       </check>
      </treat>
     </param>
-    <message line="3669">
+    <message line="4343">
      <valueOf role="select">
       <str val="[action-reset] Reset triggered!"/>
      </valueOf>
@@ -785,202 +929,9 @@
    </sequence>
   </template>
  </co>
- <co id="16" binds="16">
-  <mode name="Q{}update-ref" onNo="TC" flags="W" patternSlots="0">
-   <templateRule prec="0" prio="-0.5" seq="2" rank="0" minImp="0" slots="2" flags="s" line="1642" module="saxon-xforms.xsl">
-    <p.nodeTest role="match" test="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;"/>
-    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1643">
-     <param name="Q{}path" slot="0" as="xs:string">
-      <str role="select" val=""/>
-      <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|path">
-       <check card="1" diag="8|0|XTTE0590|path">
-        <cvUntyped to="xs:string">
-         <data>
-          <supplied slot="0"/>
-         </data>
-        </cvUntyped>
-       </check>
-      </treat>
-     </param>
-     <param line="1644" name="Q{}position" slot="1">
-      <int role="select" val="0"/>
-      <supplied role="conversion" slot="1"/>
-     </param>
-     <copy line="1647" flags="cin">
-      <applyT role="content" mode="Q{}update-ref" bSlot="0">
-       <sequence role="select">
-        <axis name="attribute" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
-        <axis name="child" nodeTest="( element() | text() | comment() | processing-instruction() )" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);"/>
-       </sequence>
-       <withParam name="Q{}path" as="xs:string">
-        <varRef line="1648" name="path" slot="0"/>
-       </withParam>
-       <withParam name="Q{}position">
-        <varRef line="1649" name="position" slot="1"/>
-       </withParam>
-      </applyT>
-     </copy>
-    </sequence>
-   </templateRule>
-   <templateRule prec="0" prio="-0.5" seq="1" rank="0" minImp="0" slots="3" flags="s" line="1623" module="saxon-xforms.xsl">
-    <p.nodeTest role="match" test="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
-    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1624">
-     <param name="Q{}path" slot="0" as="xs:string">
-      <str role="select" val=""/>
-      <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|path">
-       <check card="1" diag="8|0|XTTE0590|path">
-        <cvUntyped to="xs:string">
-         <data>
-          <supplied slot="0"/>
-         </data>
-        </cvUntyped>
-       </check>
-      </treat>
-     </param>
-     <param line="1625" name="Q{}position" slot="1">
-      <int role="select" val="0"/>
-      <supplied role="conversion" slot="1"/>
-     </param>
-     <let line="1627" var="path-updated" as="xs:string" slot="2" eval="7">
-      <choose>
-       <gc op="&gt;" card="N:1" comp="GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint">
-        <data>
-         <varRef name="position" slot="1"/>
-        </data>
-        <int val="0"/>
-       </gc>
-       <fn name="concat">
-        <varRef name="path" slot="0"/>
-        <str val="["/>
-        <atomSing card="?" diag="0|2||fn:concat">
-         <varRef name="position" slot="1"/>
-        </atomSing>
-        <str val="]"/>
-       </fn>
-       <true/>
-       <varRef name="path" slot="0"/>
-      </choose>
-      <choose line="1631">
-       <vc op="eq" onEmpty="0" comp="CCC">
-        <fn name="substring">
-         <cvUntyped to="xs:string">
-          <data>
-           <dot type="attribute()"/>
-          </data>
-         </cvUntyped>
-         <int val="1"/>
-         <fn line="1628" name="string-length">
-          <varRef name="path" slot="0"/>
-         </fn>
-        </fn>
-        <varRef name="path" slot="0"/>
-       </vc>
-       <compAtt line="1632">
-        <fn role="name" line="1626" name="name">
-         <dot type="attribute()"/>
-        </fn>
-        <convert role="select" line="1633" from="xs:untypedAtomic" to="xs:string">
-         <cast as="xs:untypedAtomic" emptiable="0">
-          <fn name="concat">
-           <varRef name="path-updated" slot="2"/>
-           <fn name="substring">
-            <cvUntyped to="xs:string">
-             <data>
-              <dot type="attribute()"/>
-             </data>
-            </cvUntyped>
-            <arith op="+" calc="i+i">
-             <fn name="string-length">
-              <varRef name="path-updated" slot="2"/>
-             </fn>
-             <int val="1"/>
-            </arith>
-           </fn>
-          </fn>
-         </cast>
-        </convert>
-       </compAtt>
-       <true/>
-       <copyOf line="1637" flags="vc">
-        <dot type="attribute()"/>
-       </copyOf>
-      </choose>
-     </let>
-    </sequence>
-   </templateRule>
-   <templateRule prec="0" prio="2.0" seq="0" rank="1" minImp="0" slots="3" flags="s" line="1609" module="saxon-xforms.xsl">
-    <p.nodeTest role="match" test="attribute(Q{}data-action)" jsTest="return SaxonJS.U.isAttr(item) &amp;&amp; item.name==='data-action'"/>
-    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1610">
-     <param name="Q{}path" slot="0" as="xs:string">
-      <str role="select" val=""/>
-      <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|path">
-       <check card="1" diag="8|0|XTTE0590|path">
-        <cvUntyped to="xs:string">
-         <data>
-          <supplied slot="0"/>
-         </data>
-        </cvUntyped>
-       </check>
-      </treat>
-     </param>
-     <param line="1611" name="Q{}position" slot="1">
-      <int role="select" val="0"/>
-      <supplied role="conversion" slot="1"/>
-     </param>
-     <let line="1613" var="myid" as="xs:string" slot="2" eval="8">
-      <fn name="concat">
-       <fn name="generate-id">
-        <dot type="attribute(Q{}data-action)"/>
-       </fn>
-       <atomSing card="?" diag="0|1||fn:concat">
-        <varRef name="position" slot="1"/>
-       </atomSing>
-      </fn>
-      <sequence line="1615">
-       <att name="data-old-action">
-        <convert from="xs:untypedAtomic" to="xs:string">
-         <data>
-          <dot type="attribute(Q{}data-action)"/>
-         </data>
-        </convert>
-       </att>
-       <att line="1618" name="data-action">
-        <convert from="xs:untypedAtomic" to="xs:string">
-         <cast as="xs:untypedAtomic" emptiable="0">
-          <choose>
-           <fn name="exists">
-            <slash>
-             <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}page" type="document-node()?"/>
-             <fn name="key">
-              <str val="Q{http://saxon.sf.net/}kk101"/>
-              <varRef name="myid" slot="2"/>
-              <dot type="document-node()"/>
-             </fn>
-            </slash>
-           </fn>
-           <fn name="concat">
-            <fn name="generate-id">
-             <dot type="attribute(Q{}data-action)"/>
-            </fn>
-            <fn name="generate-id">
-             <dot type="attribute(Q{}data-action)"/>
-            </fn>
-           </fn>
-           <true/>
-           <varRef name="myid" slot="2"/>
-          </choose>
-         </cast>
-        </convert>
-       </att>
-      </sequence>
-     </let>
-    </sequence>
-   </templateRule>
-  </mode>
- </co>
- <co id="17" binds="14 3 2 6 18 19 20">
-  <template name="Q{}xforms-value-changed" flags="os" line="3187" module="saxon-xforms.xsl" slots="5">
-   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="3188">
+ <co id="15" binds="13 3 2 6 16 17 18">
+  <template name="Q{}xforms-value-changed" flags="os" line="3801" module="saxon-xforms.xsl" slots="5">
+   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="3802">
     <param name="Q{}form-control" slot="0" flags="i" as="node()">
      <treat role="conversion" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="8|0|XTTE0590|form-control">
       <check card="1" diag="8|0|XTTE0590|form-control">
@@ -988,12 +939,12 @@
       </check>
      </treat>
     </param>
-    <let line="3190" var="refi" as="attribute(Q{}data-ref)?" slot="1" eval="8">
+    <let line="3804" var="refi" as="attribute(Q{}data-ref)?" slot="1" eval="8">
      <slash simple="1">
       <varRef name="form-control" slot="0"/>
       <axis name="attribute" nodeTest="attribute(Q{}data-ref)" jsTest="return item.name==='data-ref'"/>
      </slash>
-     <let line="3194" var="actions" as="item()?" slot="2" eval="8">
+     <let line="3808" var="actions" as="item()?" slot="2" eval="8">
       <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
        <check card="1" diag="0|0||ixsl:call">
         <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
@@ -1008,11 +959,11 @@
         </fn>
        </arrayBlock>
       </ifCall>
-      <let line="3198" var="updatedInstanceXML" as="element()" slot="3" eval="7">
-       <treat line="3199" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="3|0|XTTE0570|updatedInstanceXML">
+      <let line="3812" var="updatedInstanceXML" as="element()" slot="3" eval="7">
+       <treat line="3813" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="3|0|XTTE0570|updatedInstanceXML">
         <check card="1" diag="3|0|XTTE0570|updatedInstanceXML">
          <applyT mode="Q{}form-check-initial" bSlot="0">
-          <check role="select" line="3197" card="1" diag="3|0|XTTE0570|instanceXML">
+          <check role="select" line="3811" card="1" diag="3|0|XTTE0570|instanceXML">
            <ufCall name="Q{http://www.w3.org/2002/xforms}getInstance-JS" tailCall="false" bSlot="1" eval="7">
             <check card="1" diag="0|0||xforms:getInstance-JS">
              <cvUntyped to="xs:string">
@@ -1024,7 +975,7 @@
            </ufCall>
           </check>
           <withParam name="Q{}instance-id" as="xs:string">
-           <ufCall line="3193" name="Q{http://www.w3.org/2002/xforms}getInstanceId" tailCall="false" bSlot="2" eval="7">
+           <ufCall line="3807" name="Q{http://www.w3.org/2002/xforms}getInstanceId" tailCall="false" bSlot="2" eval="7">
             <check card="1" diag="0|0||xforms:getInstanceId">
              <cvUntyped to="xs:string">
               <data>
@@ -1037,7 +988,7 @@
          </applyT>
         </check>
        </treat>
-       <sequence line="3204">
+       <sequence line="3819">
         <ufCall name="Q{http://www.w3.org/2002/xforms}setInstance-JS" tailCall="false" bSlot="3" eval="7 6">
          <check card="1" diag="0|0||xforms:setInstance-JS">
           <cvUntyped to="xs:string">
@@ -1048,41 +999,40 @@
          </check>
          <varRef name="updatedInstanceXML" slot="3"/>
         </ufCall>
-        <callT line="3205" name="refreshOutputs-JS" bSlot="4"/>
-        <ifCall line="3211" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+        <ifCall line="3826" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
          <check card="1" diag="0|0||ixsl:call">
           <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
          </check>
          <str val="setPendingUpdates"/>
          <arrayBlock>
-          <treat line="3208" as="map(°)" jsTest="function k(item) {return SaxonJS.U.Atomic.anyAtomicType.matches(item);};function v(item) {return true;};function c() {return true;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="3|0||pendingInstanceUpdates">
+          <treat line="3823" as="map(°)" jsTest="function k(item) {return SaxonJS.U.Atomic.anyAtomicType.matches(item);};function v(item) {return true;};function c() {return true;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="3|0||pendingInstanceUpdates">
            <map size="0"/>
           </treat>
          </arrayBlock>
         </ifCall>
-        <ifCall line="3212" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+        <ifCall line="3827" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
          <check card="1" diag="0|0||ixsl:call">
           <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
          </check>
          <str val="setUpdates"/>
          <arrayBlock>
-          <treat line="3209" as="map(°)" jsTest="function k(item) {return SaxonJS.U.Atomic.anyAtomicType.matches(item);};function v(item) {return true;};function c() {return true;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="3|0||instanceUpdates">
+          <treat line="3824" as="map(°)" jsTest="function k(item) {return SaxonJS.U.Atomic.anyAtomicType.matches(item);};function v(item) {return true;};function c() {return true;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="3|0||instanceUpdates">
            <map size="0"/>
           </treat>
          </arrayBlock>
         </ifCall>
-        <forEach line="3214">
+        <forEach line="3829">
          <varRef name="actions" slot="2"/>
-         <let line="3215" var="action-map" as="item()" slot="4" eval="7">
+         <let line="3830" var="action-map" as="item()" slot="4" eval="7">
           <dot/>
-          <choose line="3217">
+          <choose line="3832">
            <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}contains" type="xs:boolean">
             <treat as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="0|0||map:contains">
              <varRef name="action-map" slot="4"/>
             </treat>
             <str val="@event"/>
            </ifCall>
-           <choose line="3218">
+           <choose line="3833">
             <gc op="=" card="N:1" comp="GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint">
              <data>
               <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
@@ -1094,12 +1044,12 @@
              </data>
              <str val="xforms-value-changed"/>
             </gc>
-            <callT line="3220" name="applyActions" bSlot="5">
+            <callT line="3835" name="applyActions" bSlot="4">
              <withParam name="Q{}action-map" flags="t" as="item()">
-              <varRef line="3221" name="action-map" slot="4"/>
+              <varRef line="3836" name="action-map" slot="4"/>
              </withParam>
              <withParam name="Q{}nodeset" flags="t" as="xs:string">
-              <check line="3222" card="1" diag="8|0|XTTE0590|nodeset">
+              <check line="3837" card="1" diag="8|0|XTTE0590|nodeset">
                <cvUntyped to="xs:string">
                 <data>
                  <varRef name="refi" slot="1"/>
@@ -1108,18 +1058,19 @@
               </check>
              </withParam>
              <withParam name="Q{}instanceXML" flags="t" as="element()">
-              <varRef line="3223" name="updatedInstanceXML" slot="3"/>
+              <varRef line="3838" name="updatedInstanceXML" slot="3"/>
              </withParam>
             </callT>
            </choose>
           </choose>
          </let>
         </forEach>
-        <ufCall line="3229" name="Q{http://www.w3.org/2002/xforms}checkRelevantFields" tailCall="false" bSlot="6" eval="4">
+        <callT line="3844" name="xforms-recalculate" bSlot="5"/>
+        <ufCall line="3846" name="Q{http://www.w3.org/2002/xforms}checkRelevantFields" tailCall="false" bSlot="6" eval="4">
          <check card="1" diag="0|0||xforms:checkRelevantFields">
           <cvUntyped to="xs:string">
            <data>
-            <slash line="3191" simple="1">
+            <slash line="3805" simple="1">
              <varRef name="form-control" slot="0"/>
              <axis name="attribute" nodeTest="attribute(Q{}data-element)" jsTest="return item.name==='data-element'"/>
             </slash>
@@ -1134,9 +1085,9 @@
    </sequence>
   </template>
  </co>
- <co id="21" binds="22 23 23">
-  <template name="Q{}getReferencedInstanceField" flags="os" line="2685" module="saxon-xforms.xsl" slots="5">
-   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2686">
+ <co id="19" binds="20 21 4 21">
+  <template name="Q{}getReferencedInstanceField" flags="os" line="3160" module="saxon-xforms.xsl" slots="5">
+   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="3161">
     <param name="Q{}refi" slot="0" as="xs:string">
      <str role="select" val=""/>
      <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|refi">
@@ -1149,17 +1100,17 @@
       </check>
      </treat>
     </param>
-    <let line="2688" var="field" as="node()*" slot="1" eval="8">
-     <choose line="2690">
+    <let line="3165" var="field" as="node()*" slot="1" eval="8">
+     <choose line="3167">
       <varRef name="refi" slot="0"/>
-      <let line="2691" var="instance-map" as="map(xs:string, xs:string)" slot="2" eval="7">
+      <let line="3168" var="instance-map" as="map(xs:string, xs:string)" slot="2" eval="7">
        <ufCall name="Q{http://www.w3.org/2002/xforms}getInstanceMap" tailCall="false" bSlot="0" eval="6">
         <varRef name="refi" slot="0"/>
        </ufCall>
-       <let line="2698" var="this-instance" as="element()?" slot="3" eval="9">
-        <callT line="2699" name="getInstance" bSlot="1">
+       <let line="3175" var="this-instance" as="element()?" slot="3" eval="9">
+        <callT line="3176" name="getInstance" bSlot="1">
          <withParam name="Q{}instance-id" flags="c" as="xs:string">
-          <check line="2700" card="1" diag="8|0|XTTE0590|instance-id">
+          <check line="3177" card="1" diag="8|0|XTTE0590|instance-id">
            <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
             <varRef name="instance-map" slot="2"/>
             <str val="instance-id"/>
@@ -1167,14 +1118,16 @@
           </check>
          </withParam>
         </callT>
-        <treat line="2706" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|field">
+        <treat line="3184" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|field">
          <evaluate dxns="">
-          <check role="xpath" card="1" diag="4|0||xsl:evaluate/xpath">
-           <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
-            <varRef name="instance-map" slot="2"/>
-            <str val="xpath"/>
-           </ifCall>
-          </check>
+          <ufCall role="xpath" line="3181" name="Q{http://www.w3.org/2002/xforms}impose" tailCall="false" bSlot="2" eval="7">
+           <check card="1" diag="0|0||xforms:impose">
+            <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+             <varRef name="instance-map" slot="2"/>
+             <str val="xpath"/>
+            </ifCall>
+           </check>
+          </ufCall>
           <varRef role="cxt" name="this-instance" slot="3"/>
           <check role="nsCxt" card="1" diag="4|0|XTTE3170|xsl:evaluate/namespace-context">
            <varRef name="this-instance" slot="3"/>
@@ -1186,23 +1139,23 @@
        </let>
       </let>
       <true/>
-      <let line="2711" var="default-instance" as="element()?" slot="4" eval="9">
-       <callT line="2712" name="getInstance" bSlot="2">
+      <let line="3189" var="default-instance" as="element()?" slot="4" eval="9">
+       <callT line="3190" name="getInstance" bSlot="3">
         <withParam name="Q{}instance-id" flags="c" as="xs:string">
          <str val="saxon-forms-default"/>
         </withParam>
        </callT>
-       <varRef line="2716" name="default-instance" slot="4"/>
+       <varRef line="3194" name="default-instance" slot="4"/>
       </let>
      </choose>
-     <varRef line="2721" name="field" slot="1"/>
+     <varRef line="3199" name="field" slot="1"/>
     </let>
    </sequence>
   </template>
  </co>
- <co id="24" binds="">
-  <template name="Q{}action-message" flags="os" line="3650" module="saxon-xforms.xsl" slots="1">
-   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="3651">
+ <co id="22" binds="">
+  <template name="Q{}action-message" flags="os" line="4286" module="saxon-xforms.xsl" slots="1">
+   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="4287">
     <param name="Q{}action-map" slot="0" flags="tr" as="map(*)">
      <treat role="conversion" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="8|0|XTTE0590|action-map">
       <check card="1" diag="8|0|XTTE0590|action-map">
@@ -1210,13 +1163,13 @@
       </check>
      </treat>
     </param>
-    <message line="3655">
+    <message line="4291">
      <sequence role="select">
       <valueOf>
        <str val="[action-message] Message reads &#34;"/>
       </valueOf>
       <valueOf>
-       <treat line="3653" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|message-value">
+       <treat line="4289" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|message-value">
         <check card="1" diag="3|0|XTTE0570|message-value">
          <cvUntyped to="xs:string">
           <data>
@@ -1240,136 +1193,184 @@
   </template>
  </co>
  <co id="1" binds="">
-  <function name="Q{http://www.w3.org/2002/xforms}resolveXPathStrings" line="601" module="saxon-xforms.xsl" eval="7" flags="pU" as="xs:string" slots="5">
+  <function name="Q{http://www.w3.org/2002/xforms}resolveXPathStrings" line="753" module="saxon-xforms.xsl" eval="8" flags="pU" as="xs:string" slots="7">
    <arg name="base" as="xs:string"/>
    <arg name="relative" as="xs:string"/>
-   <choose role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="606">
-    <fn name="starts-with">
-     <varRef name="relative" slot="1"/>
-     <str val="/"/>
-    </fn>
-    <varRef line="607" name="relative" slot="1"/>
-    <fn line="609" name="starts-with">
-     <varRef name="relative" slot="1"/>
-     <str val="instance("/>
-    </fn>
-    <varRef line="610" name="relative" slot="1"/>
-    <fn line="612" name="not">
-     <varRef name="base" slot="0"/>
-    </fn>
-    <varRef line="613" name="relative" slot="1"/>
-    <fn line="615" name="not">
-     <varRef name="relative" slot="1"/>
-    </fn>
-    <varRef line="616" name="base" slot="0"/>
-    <true/>
-    <let line="620" var="parentCallCount" as="xs:integer" slot="2" eval="7">
-     <choose>
-      <fn name="contains">
-       <varRef name="relative" slot="1"/>
-       <str val="/"/>
-      </fn>
-      <fn name="count">
-       <filter flags="b">
-        <fn name="tokenize">
-         <varRef name="relative" slot="1"/>
-         <str val="/"/>
-         <str val=""/>
-        </fn>
-        <vc op="eq" comp="CCC">
-         <dot type="xs:string"/>
-         <str val=".."/>
-        </vc>
-       </filter>
-      </fn>
-      <fn name="contains">
-       <varRef name="relative" slot="1"/>
-       <str val=".."/>
-      </fn>
-      <int val="1"/>
-      <true/>
-      <int val="0"/>
-     </choose>
-     <let line="623" var="slashes" as="xs:integer*" slot="3" eval="3">
-      <choose>
-       <fn name="contains">
-        <varRef name="base" slot="0"/>
-        <str val="/"/>
-       </fn>
-       <fn name="index-of">
-        <fn name="string-to-codepoints">
-         <varRef name="base" slot="0"/>
-        </fn>
-        <int val="47"/>
-       </fn>
-       <true/>
-       <int val="0"/>
-      </choose>
-      <choose line="655">
-       <compareToInt op="gt" val="0">
-        <varRef name="parentCallCount" slot="2"/>
-       </compareToInt>
-       <fn line="659" name="concat">
-        <fn name="substring">
-         <varRef name="base" slot="0"/>
-         <int val="1"/>
-         <choose line="634">
-          <and op="and">
-           <vc op="ge" onEmpty="0" comp="CAVC">
-            <fn name="count">
-             <varRef name="slashes" slot="3"/>
-            </fn>
-            <varRef name="parentCallCount" slot="2"/>
-           </vc>
-           <compareToInt op="gt" val="0">
-            <varRef name="parentCallCount" slot="2"/>
-           </compareToInt>
-          </and>
-          <let line="635" var="vv:v0" as="xs:integer" slot="4" eval="13">
-           <arith op="-" calc="i-i">
-            <varRef name="parentCallCount" slot="2"/>
-            <int val="1"/>
-           </arith>
-           <check card="1" diag="3|0|XTTE0570|parentSlash">
-            <filter flags="p">
-             <varRef name="slashes" slot="3"/>
-             <arith op="-" calc="i-i">
-              <fn name="last"/>
-              <varRef name="vv:v0" slot="4"/>
-             </arith>
-            </filter>
-           </check>
-          </let>
-          <true/>
-          <check line="638" card="1" diag="3|0|XTTE0570|parentSlash">
-           <lastOf>
-            <varRef name="slashes" slot="3"/>
-           </lastOf>
-          </check>
-         </choose>
-        </fn>
-        <fn name="replace">
-         <varRef name="relative" slot="1"/>
-         <str val="\.\./"/>
-         <str val=""/>
-         <str val=""/>
-        </fn>
-       </fn>
-       <true/>
-       <fn line="662" name="concat">
-        <varRef name="base" slot="0"/>
-        <str val="/"/>
+   <let role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="825" var="full-path-parsed-components" as="xs:string+" slot="2" eval="8">
+    <check line="826" card="+" diag="3|0|XTTE0570|full-path-parsed-components">
+     <analyzeString>
+      <choose role="select" line="760">
+       <fn name="starts-with">
         <varRef name="relative" slot="1"/>
+        <str val="/"/>
        </fn>
+       <varRef line="761" name="relative" slot="1"/>
+       <fn line="763" name="starts-with">
+        <varRef name="relative" slot="1"/>
+        <str val="instance("/>
+       </fn>
+       <varRef line="764" name="relative" slot="1"/>
+       <fn line="766" name="not">
+        <varRef name="base" slot="0"/>
+       </fn>
+       <varRef line="767" name="relative" slot="1"/>
+       <or line="769" op="or">
+        <fn name="not">
+         <varRef name="relative" slot="1"/>
+        </fn>
+        <vc op="eq" onEmpty="0" comp="CCC">
+         <varRef name="relative" slot="1"/>
+         <str val="."/>
+        </vc>
+       </or>
+       <varRef line="770" name="base" slot="0"/>
+       <true/>
+       <let line="774" var="parentCallCount" as="xs:integer" slot="3" eval="7">
+        <choose>
+         <fn name="contains">
+          <varRef name="relative" slot="1"/>
+          <str val="/"/>
+         </fn>
+         <fn name="count">
+          <filter flags="b">
+           <fn name="tokenize">
+            <varRef name="relative" slot="1"/>
+            <str val="/"/>
+            <str val=""/>
+           </fn>
+           <vc op="eq" comp="CCC">
+            <dot type="xs:string"/>
+            <str val=".."/>
+           </vc>
+          </filter>
+         </fn>
+         <fn name="contains">
+          <varRef name="relative" slot="1"/>
+          <str val=".."/>
+         </fn>
+         <int val="1"/>
+         <true/>
+         <int val="0"/>
+        </choose>
+        <let line="777" var="slashes" as="xs:integer*" slot="4" eval="3">
+         <choose>
+          <fn name="contains">
+           <varRef name="base" slot="0"/>
+           <str val="/"/>
+          </fn>
+          <fn name="index-of">
+           <fn name="string-to-codepoints">
+            <varRef name="base" slot="0"/>
+           </fn>
+           <int val="47"/>
+          </fn>
+          <true/>
+          <int val="0"/>
+         </choose>
+         <choose line="809">
+          <compareToInt op="gt" val="0">
+           <varRef name="parentCallCount" slot="3"/>
+          </compareToInt>
+          <fn line="813" name="concat">
+           <fn name="substring">
+            <varRef name="base" slot="0"/>
+            <int val="1"/>
+            <choose line="788">
+             <and op="and">
+              <vc op="ge" onEmpty="0" comp="CAVC">
+               <fn name="count">
+                <varRef name="slashes" slot="4"/>
+               </fn>
+               <varRef name="parentCallCount" slot="3"/>
+              </vc>
+              <compareToInt op="gt" val="0">
+               <varRef name="parentCallCount" slot="3"/>
+              </compareToInt>
+             </and>
+             <let line="789" var="vv:v0" as="xs:integer" slot="5" eval="13">
+              <arith op="-" calc="i-i">
+               <varRef name="parentCallCount" slot="3"/>
+               <int val="1"/>
+              </arith>
+              <check card="1" diag="3|0|XTTE0570|parentSlash">
+               <filter flags="p">
+                <varRef name="slashes" slot="4"/>
+                <arith op="-" calc="i-i">
+                 <fn name="last"/>
+                 <varRef name="vv:v0" slot="5"/>
+                </arith>
+               </filter>
+              </check>
+             </let>
+             <true/>
+             <check line="792" card="1" diag="3|0|XTTE0570|parentSlash">
+              <lastOf>
+               <varRef name="slashes" slot="4"/>
+              </lastOf>
+             </check>
+            </choose>
+           </fn>
+           <fn name="replace">
+            <varRef name="relative" slot="1"/>
+            <str val="\.\./"/>
+            <str val=""/>
+            <str val=""/>
+           </fn>
+          </fn>
+          <true/>
+          <fn line="816" name="concat">
+           <varRef name="base" slot="0"/>
+           <str val="/"/>
+           <varRef name="relative" slot="1"/>
+          </fn>
+         </choose>
+        </let>
+       </let>
       </choose>
-     </let>
-    </let>
-   </choose>
+      <str role="regex" val="(index\('([^']+)'\)|/\.$)"/>
+      <str role="flags" val=""/>
+      <let role="matching" line="828" var="match" as="xs:string" slot="6" eval="8">
+       <fn name="regex-group">
+        <int val="1"/>
+       </fn>
+       <choose line="830">
+        <vc op="eq" onEmpty="0" comp="CCC">
+         <varRef name="match" slot="6"/>
+         <str val="/."/>
+        </vc>
+        <empty/>
+        <true/>
+        <cast line="832" as="xs:string" emptiable="1">
+         <atomSing card="?" diag="2|0||cast as">
+          <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+           <check card="1" diag="0|0||ixsl:call">
+            <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+           </check>
+           <str val="getRepeatIndex"/>
+           <arrayBlock>
+            <fn name="regex-group">
+             <int val="2"/>
+            </fn>
+           </arrayBlock>
+          </ifCall>
+         </atomSing>
+        </cast>
+       </choose>
+      </let>
+      <fn role="nonMatching" line="837" name="normalize-space">
+       <dot type="xs:string"/>
+      </fn>
+     </analyzeString>
+    </check>
+    <fn line="842" name="string-join">
+     <varRef name="full-path-parsed-components" slot="2"/>
+    </fn>
+   </let>
   </function>
  </co>
- <co id="25" binds="">
-  <function name="Q{http://saxonica.com/ns/forms-local}current-date" line="103" module="xforms-function-library.xsl" eval="7" flags="pU" as="xs:string" slots="0">
-   <treat role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="104" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|today">
+ <co id="23" binds="">
+  <function name="Q{http://saxonica.com/ns/forms-local}current-date" line="96" module="xforms-function-library.xsl" eval="7" flags="pU" as="xs:string" slots="0">
+   <treat role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="97" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|today">
     <check card="1" diag="3|0|XTTE0570|today">
      <cvUntyped to="xs:string">
       <data>
@@ -1386,9 +1387,9 @@
    </treat>
   </function>
  </co>
- <co id="26" binds="1 2 4 4 27 14 3 6 18">
-  <template name="Q{}action-setvalue" flags="os" line="3431" module="saxon-xforms.xsl" slots="10">
-   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="3432">
+ <co id="24" binds="">
+  <template name="Q{}action-setindex" flags="os" line="4317" module="saxon-xforms.xsl" slots="1">
+   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="4318">
     <param name="Q{}action-map" slot="0" flags="tr" as="map(*)">
      <treat role="conversion" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="8|0|XTTE0590|action-map">
       <check card="1" diag="8|0|XTTE0590|action-map">
@@ -1396,7 +1397,63 @@
       </check>
      </treat>
     </param>
-    <param line="3433" name="Q{}instanceXML" slot="1" flags="t" as="element()?">
+    <ifCall line="4326" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+     <check card="1" diag="0|0||ixsl:call">
+      <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+     </check>
+     <str val="setRepeatIndex"/>
+     <arrayBlock>
+      <treat line="4320" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|repeatID">
+       <check card="1" diag="3|0|XTTE0570|repeatID">
+        <cvUntyped to="xs:string">
+         <data>
+          <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+           <varRef name="action-map" slot="0"/>
+           <str val="@repeat"/>
+          </ifCall>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+      <treat line="4321" as="xs:integer" jsTest="return SaxonJS.U.Atomic.integer.matches(item);" diag="3|0|XTTE0570|new-index">
+       <check card="1" diag="3|0|XTTE0570|new-index">
+        <cvUntyped to="xs:integer">
+         <data>
+          <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+           <varRef name="action-map" slot="0"/>
+           <str val="@index"/>
+          </ifCall>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </arrayBlock>
+    </ifCall>
+   </sequence>
+  </template>
+ </co>
+ <co id="25" binds="">
+  <template name="Q{}action-setfocus" flags="os" line="4301" module="saxon-xforms.xsl" slots="1">
+   <param role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="4302" name="Q{}action-map" slot="0" flags="tr" as="map(*)">
+    <treat role="conversion" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="8|0|XTTE0590|action-map">
+     <check card="1" diag="8|0|XTTE0590|action-map">
+      <supplied slot="0"/>
+     </check>
+    </treat>
+   </param>
+  </template>
+ </co>
+ <co id="26" binds="1 2 4 4 27 13 3 6 28">
+  <template name="Q{}action-setvalue" flags="os" line="4049" module="saxon-xforms.xsl" slots="10">
+   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="4050">
+    <param name="Q{}action-map" slot="0" flags="tr" as="map(*)">
+     <treat role="conversion" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="8|0|XTTE0590|action-map">
+      <check card="1" diag="8|0|XTTE0590|action-map">
+       <supplied slot="0"/>
+      </check>
+     </treat>
+    </param>
+    <param line="4051" name="Q{}instanceXML" slot="1" flags="t" as="element()?">
      <empty role="select"/>
      <treat role="conversion" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="8|0|XTTE0590|instanceXML">
       <check card="?" diag="8|0|XTTE0590|instanceXML">
@@ -1404,7 +1461,7 @@
       </check>
      </treat>
     </param>
-    <param line="3434" name="Q{}nodeset" slot="2" flags="t" as="xs:string">
+    <param line="4052" name="Q{}nodeset" slot="2" flags="t" as="xs:string">
      <str role="select" val=""/>
      <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|nodeset">
       <check card="1" diag="8|0|XTTE0590|nodeset">
@@ -1416,7 +1473,7 @@
       </check>
      </treat>
     </param>
-    <let line="3438" var="refz" as="xs:string" slot="3" eval="7">
+    <let line="4056" var="refz" as="xs:string" slot="3" eval="7">
      <ufCall name="Q{http://www.w3.org/2002/xforms}resolveXPathStrings" tailCall="false" bSlot="0" eval="6 7">
       <varRef name="nodeset" slot="2"/>
       <treat as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="0|1||xforms:resolveXPathStrings">
@@ -1432,27 +1489,30 @@
        </check>
       </treat>
      </ufCall>
-     <let line="3440" var="instance-id" as="xs:string" slot="4" eval="7">
+     <let line="4058" var="instance-id" as="xs:string" slot="4" eval="7">
       <ufCall name="Q{http://www.w3.org/2002/xforms}getInstanceId" tailCall="false" bSlot="1" eval="6">
        <varRef name="refz" slot="3"/>
       </ufCall>
-      <let line="3453" var="valuez" as="document-node()" slot="5" eval="7">
-       <doc line="3455" validation="preserve">
+      <let line="4071" var="valuez" as="document-node()" slot="5" eval="7">
+       <doc line="4073" validation="preserve">
         <choose>
          <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}contains" type="xs:boolean">
           <varRef name="action-map" slot="0"/>
           <str val="@value"/>
          </ifCall>
-         <let line="3456" var="contexti" as="node()" slot="6" eval="8">
-          <evaluate line="3457" as="node()" dxns="">
+         <let line="4074" var="contexti" as="node()" slot="6" eval="8">
+          <evaluate line="4075" as="node()" dxns="">
            <ufCall role="xpath" name="Q{http://www.w3.org/2002/xforms}impose" tailCall="false" bSlot="2" eval="6">
             <varRef name="nodeset" slot="2"/>
            </ufCall>
            <varRef role="cxt" name="instanceXML" slot="1"/>
+           <check role="nsCxt" card="1" diag="4|0|XTTE3170|xsl:evaluate/namespace-context">
+            <varRef name="instanceXML" slot="1"/>
+           </check>
            <str role="sa" val="no"/>
            <map role="wp" size="0"/>
           </evaluate>
-          <evaluate line="3460" dxns="">
+          <evaluate line="4078" dxns="">
            <ufCall role="xpath" name="Q{http://www.w3.org/2002/xforms}impose" tailCall="false" bSlot="3" eval="7">
             <treat as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="0|0||xforms:impose">
              <check card="1" diag="0|0||xforms:impose">
@@ -1468,17 +1528,18 @@
             </treat>
            </ufCall>
            <varRef role="cxt" name="contexti" slot="6"/>
+           <varRef role="nsCxt" name="contexti" slot="6"/>
            <str role="sa" val="no"/>
            <map role="wp" size="0"/>
           </evaluate>
          </let>
-         <ifCall line="3463" name="Q{http://www.w3.org/2005/xpath-functions/map}contains" type="xs:boolean">
+         <ifCall line="4081" name="Q{http://www.w3.org/2005/xpath-functions/map}contains" type="xs:boolean">
           <treat as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="0|0||map:contains">
            <dot flags="a"/>
           </treat>
           <str val="value"/>
          </ifCall>
-         <ifCall line="3464" name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+         <ifCall line="4082" name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
           <varRef name="action-map" slot="0"/>
           <str val="value"/>
          </ifCall>
@@ -1486,38 +1547,38 @@
          <str val=""/>
         </choose>
        </doc>
-       <sequence line="3474">
+       <sequence line="4092">
         <choose>
          <fn name="exists">
           <varRef name="refz" slot="3"/>
          </fn>
-         <let line="3476" var="associated-form-control" as="node()?" slot="7" eval="7">
+         <let line="4094" var="associated-form-control" as="node()?" slot="7" eval="7">
           <check card="?" diag="3|0|XTTE0570|associated-form-control">
            <slash>
             <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}page" type="document-node()?"/>
             <fn name="key">
-             <str val="Q{http://saxon.sf.net/}kk102"/>
+             <str val="Q{http://saxon.sf.net/}kk101"/>
              <varRef name="refz" slot="3"/>
              <dot type="document-node()"/>
             </fn>
            </slash>
           </check>
-          <choose line="3478">
+          <choose line="4096">
            <fn name="exists">
             <varRef name="associated-form-control" slot="7"/>
            </fn>
-           <sequence line="3479">
+           <sequence line="4097">
             <applyT mode="Q{}set-field" bSlot="4">
              <varRef role="select" name="associated-form-control" slot="7"/>
              <withParam name="Q{}value" flags="t" as="xs:string">
-              <cast line="3480" as="xs:string" emptiable="0">
+              <cast line="4098" as="xs:string" emptiable="0">
                <data>
                 <varRef name="valuez" slot="5"/>
                </data>
               </cast>
              </withParam>
             </applyT>
-            <ifCall line="3482" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+            <ifCall line="4100" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
              <check card="1" diag="0|0||ixsl:call">
               <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
              </check>
@@ -1546,7 +1607,7 @@
             </ifCall>
            </sequence>
            <true/>
-           <ifCall line="3485" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+           <ifCall line="4103" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
             <check card="1" diag="0|0||ixsl:call">
              <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
             </check>
@@ -1576,7 +1637,7 @@
           </choose>
          </let>
         </choose>
-        <choose line="3491">
+        <choose line="4109">
          <and op="and">
           <fn name="exists">
            <varRef name="refz" slot="3"/>
@@ -1586,7 +1647,7 @@
            <str val=""/>
           </vc>
          </and>
-         <let line="3493" var="pendingUpdates" as="map(xs:string, xs:string)?" slot="8" eval="7">
+         <let line="4111" var="pendingUpdates" as="map(xs:string, xs:string)?" slot="8" eval="7">
           <treat as="map(xs:string, xs:string)" jsTest="function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="3|0|XTTE0570|pendingUpdates">
            <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
             <check card="1" diag="0|0||ixsl:call">
@@ -1596,11 +1657,11 @@
             <arrayBlock/>
            </ifCall>
           </treat>
-          <let line="3495" var="updatedInstanceXML" as="element()" slot="9" eval="7">
-           <treat line="3496" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="3|0|XTTE0570|updatedInstanceXML">
+          <let line="4113" var="updatedInstanceXML" as="element()" slot="9" eval="7">
+           <treat line="4114" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="3|0|XTTE0570|updatedInstanceXML">
             <check card="1" diag="3|0|XTTE0570|updatedInstanceXML">
              <applyT mode="Q{}form-check-initial" bSlot="5">
-              <choose role="select" line="3444">
+              <choose role="select" line="4062">
                <and op="and">
                 <vc op="eq" onEmpty="0" comp="CCC">
                  <varRef name="instance-id" slot="4"/>
@@ -1610,31 +1671,31 @@
                  <varRef name="instanceXML" slot="1"/>
                 </fn>
                </and>
-               <check line="3445" card="1" diag="3|0|XTTE0570|instanceXML2">
+               <check line="4063" card="1" diag="3|0|XTTE0570|instanceXML2">
                 <varRef name="instanceXML" slot="1"/>
                </check>
                <true/>
-               <check line="3448" card="1" diag="3|0|XTTE0570|instanceXML2">
+               <check line="4066" card="1" diag="3|0|XTTE0570|instanceXML2">
                 <ufCall name="Q{http://www.w3.org/2002/xforms}getInstance-JS" tailCall="false" bSlot="6" eval="6">
                  <varRef name="refz" slot="3"/>
                 </ufCall>
                </check>
               </choose>
               <withParam name="Q{}instance-id" as="xs:string">
-               <varRef line="3497" name="instance-id" slot="4"/>
+               <varRef line="4115" name="instance-id" slot="4"/>
               </withParam>
               <withParam name="Q{}pendingUpdates" flags="t" as="map(xs:string, xs:string)?">
-               <varRef line="3498" name="pendingUpdates" slot="8"/>
+               <varRef line="4116" name="pendingUpdates" slot="8"/>
               </withParam>
              </applyT>
             </check>
            </treat>
-           <sequence line="3503">
+           <sequence line="4121">
             <ufCall name="Q{http://www.w3.org/2002/xforms}setInstance-JS" tailCall="false" bSlot="7" eval="6 6">
              <varRef name="refz" slot="3"/>
              <varRef name="updatedInstanceXML" slot="9"/>
             </ufCall>
-            <callT line="3504" name="refreshOutputs-JS" bSlot="8" flags="t"/>
+            <callT line="4122" name="refreshOutputs-JS" bSlot="8" flags="t"/>
            </sequence>
           </let>
          </let>
@@ -1646,14 +1707,14 @@
    </sequence>
   </template>
  </co>
- <co id="28" binds="">
-  <globalVariable name="Q{}default-submission-id" type="xs:string" line="45" module="saxon-xforms.xsl" visibility="PRIVATE" jsAcceptor="return SaxonJS.U.Atomic.string.cast(val);" jsCardCheck="function c(n) {return n==1;};">
+ <co id="29" binds="">
+  <globalVariable name="Q{}default-submission-id" type="xs:string" line="65" module="saxon-xforms.xsl" visibility="PRIVATE" jsAcceptor="return SaxonJS.U.Atomic.string.cast(val);" jsCardCheck="function c(n) {return n==1;};">
    <str val="saxon-forms-default-submission"/>
   </globalVariable>
  </co>
- <co id="19" binds="2 3 4 26 0 8 24 29">
-  <template name="Q{}applyActions" flags="os" line="2815" module="saxon-xforms.xsl" slots="11">
-   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2816">
+ <co id="16" binds="2 3 4 4 26 0 8 22 24 7 16">
+  <template name="Q{}applyActions" flags="os" line="3338" module="saxon-xforms.xsl" slots="11">
+   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="3339">
     <param name="Q{}action-map" slot="0" flags="tr" as="map(*)">
      <treat role="conversion" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="8|0|XTTE0590|action-map">
       <check card="1" diag="8|0|XTTE0590|action-map">
@@ -1661,7 +1722,7 @@
       </check>
      </treat>
     </param>
-    <param line="2817" name="Q{}instanceXML" slot="1" flags="t" as="element()?">
+    <param line="3340" name="Q{}instanceXML" slot="1" flags="t" as="element()?">
      <empty role="select"/>
      <treat role="conversion" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="8|0|XTTE0590|instanceXML">
       <check card="?" diag="8|0|XTTE0590|instanceXML">
@@ -1669,7 +1730,7 @@
       </check>
      </treat>
     </param>
-    <param line="2818" name="Q{}nodeset" slot="2" flags="t" as="xs:string">
+    <param line="3341" name="Q{}nodeset" slot="2" flags="t" as="xs:string">
      <str role="select" val=""/>
      <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|nodeset">
       <check card="1" diag="8|0|XTTE0590|nodeset">
@@ -1681,7 +1742,7 @@
       </check>
      </treat>
     </param>
-    <let line="2820" var="ref" as="xs:string?" slot="3" eval="7">
+    <let line="3343" var="ref" as="xs:string?" slot="3" eval="7">
      <treat as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|ref">
       <check card="?" diag="3|0|XTTE0570|ref">
        <cvUntyped to="xs:string">
@@ -1694,7 +1755,7 @@
        </cvUntyped>
       </check>
      </treat>
-     <let line="2821" var="at" as="xs:string?" slot="4" eval="7">
+     <let line="3344" var="at" as="xs:string?" slot="4" eval="7">
       <treat as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|at">
        <check card="?" diag="3|0|XTTE0570|at">
         <cvUntyped to="xs:string">
@@ -1707,11 +1768,17 @@
         </cvUntyped>
        </check>
       </treat>
-      <let line="2834" var="ref-qualified" as="xs:string?" slot="5" eval="7">
+      <let line="3357" var="ref-qualified" as="xs:string?" slot="5" eval="7">
        <choose>
-        <fn name="exists">
-         <varRef name="ref" slot="3"/>
-        </fn>
+        <and op="and">
+         <fn name="exists">
+          <varRef name="ref" slot="3"/>
+         </fn>
+         <gc op="!=" card="1:1" comp="CCC">
+          <varRef name="ref" slot="3"/>
+          <str val=""/>
+         </gc>
+        </and>
         <choose>
          <fn name="exists">
           <varRef name="at" slot="4"/>
@@ -1726,11 +1793,11 @@
          <varRef name="ref" slot="3"/>
         </choose>
        </choose>
-       <let line="2838" var="instanceXML2" as="element()" slot="6" eval="7">
-        <choose line="2840">
+       <let line="3361" var="instanceXML2" as="element()?" slot="6" eval="7">
+        <choose line="3363">
          <and op="and">
           <vc op="eq" onEmpty="0" comp="CCC">
-           <ufCall line="2836" name="Q{http://www.w3.org/2002/xforms}getInstanceId" tailCall="false" bSlot="0" eval="7">
+           <ufCall line="3359" name="Q{http://www.w3.org/2002/xforms}getInstanceId" tailCall="false" bSlot="0" eval="7">
             <check card="1" diag="0|0||xforms:getInstanceId">
              <varRef name="ref" slot="3"/>
             </check>
@@ -1741,20 +1808,18 @@
            <varRef name="instanceXML" slot="1"/>
           </fn>
          </and>
-         <check line="2841" card="1" diag="3|0|XTTE0570|instanceXML2">
-          <varRef name="instanceXML" slot="1"/>
-         </check>
-         <true/>
-         <check line="2844" card="1" diag="3|0|XTTE0570|instanceXML2">
-          <ufCall name="Q{http://www.w3.org/2002/xforms}getInstance-JS" tailCall="false" bSlot="1" eval="7">
-           <check card="1" diag="0|0||xforms:getInstance-JS">
-            <varRef name="ref-qualified" slot="5"/>
-           </check>
-          </ufCall>
-         </check>
+         <varRef line="3364" name="instanceXML" slot="1"/>
+         <fn line="3366" name="exists">
+          <varRef name="ref-qualified" slot="5"/>
+         </fn>
+         <ufCall line="3367" name="Q{http://www.w3.org/2002/xforms}getInstance-JS" tailCall="false" bSlot="1" eval="7">
+          <check card="1" diag="0|0||xforms:getInstance-JS">
+           <varRef name="ref-qualified" slot="5"/>
+          </check>
+         </ufCall>
         </choose>
-        <let line="2851" var="context" as="node()?" slot="7" eval="7">
-         <choose line="2853">
+        <let line="3375" var="context" as="node()?" slot="7" eval="7">
+         <choose line="3377">
           <and op="and">
            <and op="and">
             <fn name="exists">
@@ -1771,7 +1836,7 @@
             <varRef name="instanceXML2" slot="6"/>
            </fn>
           </and>
-          <treat line="2854" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|context">
+          <treat line="3378" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|context">
            <check card="?" diag="3|0|XTTE0570|context">
             <evaluate dxns="">
              <ufCall role="xpath" name="Q{http://www.w3.org/2002/xforms}impose" tailCall="false" bSlot="2" eval="7">
@@ -1780,24 +1845,27 @@
               </check>
              </ufCall>
              <varRef role="cxt" name="instanceXML2" slot="6"/>
+             <check role="nsCxt" card="1" diag="4|0|XTTE3170|xsl:evaluate/namespace-context">
+              <varRef name="instanceXML2" slot="6"/>
+             </check>
              <str role="sa" val="no"/>
              <map role="wp" size="0"/>
             </evaluate>
            </check>
           </treat>
          </choose>
-         <let line="2861" var="ifVar" as="xs:string?" slot="8" eval="7">
-          <choose line="563">
+         <let line="3385" var="ifVar" as="xs:string?" slot="8" eval="7">
+          <choose line="715">
            <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}contains" type="xs:boolean">
-            <varRef line="2861" name="action-map" slot="0"/>
+            <varRef line="3385" name="action-map" slot="0"/>
             <str val="@if"/>
            </ifCall>
-           <treat line="564" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="5|0|XTTE0780|xforms:getIfStatement">
+           <treat line="716" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="5|0|XTTE0780|xforms:getIfStatement">
             <check card="?" diag="5|0|XTTE0780|xforms:getIfStatement">
              <cvUntyped to="xs:string">
               <data>
                <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
-                <varRef line="2861" name="action-map" slot="0"/>
+                <varRef line="3385" name="action-map" slot="0"/>
                 <str val="@if"/>
                </ifCall>
               </data>
@@ -1805,8 +1873,8 @@
             </check>
            </treat>
           </choose>
-          <let line="2865" var="ifExecuted" as="xs:boolean" slot="9" eval="7">
-           <choose line="2867">
+          <let line="3389" var="ifExecuted" as="xs:boolean" slot="9" eval="7">
+           <choose line="3391">
             <and op="and">
              <fn name="exists">
               <varRef name="ifVar" slot="8"/>
@@ -1815,15 +1883,20 @@
               <varRef name="context" slot="7"/>
              </fn>
             </and>
-            <treat line="2868" as="xs:boolean" jsTest="return SaxonJS.U.Atomic.boolean.matches(item);" diag="3|0|XTTE0570|ifExecuted">
+            <treat line="3392" as="xs:boolean" jsTest="return SaxonJS.U.Atomic.boolean.matches(item);" diag="3|0|XTTE0570|ifExecuted">
              <check card="1" diag="3|0|XTTE0570|ifExecuted">
               <cvUntyped to="xs:boolean">
                <data>
                 <evaluate dxns="">
-                 <check role="xpath" card="1" diag="4|0||xsl:evaluate/xpath">
-                  <varRef name="ifVar" slot="8"/>
-                 </check>
+                 <ufCall role="xpath" name="Q{http://www.w3.org/2002/xforms}impose" tailCall="false" bSlot="3" eval="7">
+                  <check card="1" diag="0|0||xforms:impose">
+                   <varRef name="ifVar" slot="8"/>
+                  </check>
+                 </ufCall>
                  <varRef role="cxt" name="context" slot="7"/>
+                 <check role="nsCxt" card="1" diag="4|0|XTTE3170|xsl:evaluate/namespace-context">
+                  <varRef name="context" slot="7"/>
+                 </check>
                  <str role="sa" val="no"/>
                  <map role="wp" size="0"/>
                 </evaluate>
@@ -1834,9 +1907,9 @@
             <true/>
             <true/>
            </choose>
-           <choose line="2876">
+           <choose line="3400">
             <varRef name="ifExecuted" slot="9"/>
-            <let line="2877" var="action-name" as="xs:string" slot="10" eval="7">
+            <let line="3401" var="action-name" as="xs:string" slot="10" eval="7">
              <treat as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|action-name">
               <check card="1" diag="3|0|XTTE0570|action-name">
                <cvUntyped to="xs:string">
@@ -1849,85 +1922,109 @@
                </cvUntyped>
               </check>
              </treat>
-             <sequence line="2880">
+             <sequence line="3404">
               <choose>
                <vc op="eq" onEmpty="0" comp="CCC">
                 <varRef name="action-name" slot="10"/>
+                <str val="action"/>
+               </vc>
+               <empty/>
+               <vc line="3407" op="eq" onEmpty="0" comp="CCC">
+                <varRef name="action-name" slot="10"/>
                 <str val="setvalue"/>
                </vc>
-               <callT line="2881" name="action-setvalue" bSlot="3">
+               <callT line="3408" name="action-setvalue" bSlot="4">
                 <withParam name="Q{}nodeset" flags="t" as="xs:string">
-                 <check line="2882" card="1" diag="8|0|XTTE0590|nodeset">
+                 <check line="3409" card="1" diag="8|0|XTTE0590|nodeset">
                   <varRef name="ref" slot="3"/>
                  </check>
                 </withParam>
                 <withParam name="Q{}instanceXML" flags="t" as="element()">
-                 <varRef line="2883" name="instanceXML2" slot="6"/>
+                 <check line="3410" card="1" diag="8|0|XTTE0590|instanceXML">
+                  <varRef name="instanceXML2" slot="6"/>
+                 </check>
                 </withParam>
                </callT>
-               <vc line="2886" op="eq" onEmpty="0" comp="CCC">
+               <vc line="3413" op="eq" onEmpty="0" comp="CCC">
                 <varRef name="action-name" slot="10"/>
                 <str val="insert"/>
                </vc>
-               <callT line="2887" name="action-insert" bSlot="4">
+               <callT line="3414" name="action-insert" bSlot="5">
                 <withParam name="Q{}nodeset" flags="t" as="xs:string">
-                 <check line="2888" card="1" diag="8|0|XTTE0590|nodeset">
+                 <check line="3415" card="1" diag="8|0|XTTE0590|nodeset">
                   <varRef name="ref-qualified" slot="5"/>
                  </check>
                 </withParam>
                 <withParam name="Q{}instanceXML" flags="t" as="element()">
-                 <varRef line="2889" name="instanceXML2" slot="6"/>
+                 <check line="3416" card="1" diag="8|0|XTTE0590|instanceXML">
+                  <varRef name="instanceXML2" slot="6"/>
+                 </check>
                 </withParam>
                </callT>
-               <vc line="2892" op="eq" onEmpty="0" comp="CCC">
+               <vc line="3419" op="eq" onEmpty="0" comp="CCC">
                 <varRef name="action-name" slot="10"/>
                 <str val="delete"/>
                </vc>
-               <callT line="2893" name="action-delete" bSlot="5">
+               <callT line="3420" name="action-delete" bSlot="6">
                 <withParam name="Q{}nodeset" flags="t" as="xs:string">
-                 <check line="2894" card="1" diag="8|0|XTTE0590|nodeset">
+                 <check line="3421" card="1" diag="8|0|XTTE0590|nodeset">
                   <varRef name="ref-qualified" slot="5"/>
                  </check>
                 </withParam>
                 <withParam name="Q{}instanceXML" flags="t" as="element()">
-                 <varRef line="2895" name="instanceXML2" slot="6"/>
+                 <check line="3422" card="1" diag="8|0|XTTE0590|instanceXML">
+                  <varRef name="instanceXML2" slot="6"/>
+                 </check>
                 </withParam>
                </callT>
-               <vc line="2898" op="eq" onEmpty="0" comp="CCC">
+               <vc line="3425" op="eq" onEmpty="0" comp="CCC">
                 <varRef name="action-name" slot="10"/>
                 <str val="message"/>
                </vc>
-               <callT line="2899" name="action-message" bSlot="6"/>
-              </choose>
-              <forEach line="2906">
-               <literal count="15">
-                <str val="setvalue"/>
-                <str val="insert"/>
-                <str val="delete"/>
+               <callT line="3426" name="action-message" bSlot="7"/>
+               <vc line="3428" op="eq" onEmpty="0" comp="CCC">
+                <varRef name="action-name" slot="10"/>
                 <str val="setindex"/>
-                <str val="toggle"/>
-                <str val="setfocus"/>
-                <str val="dispatch"/>
+               </vc>
+               <callT line="3429" name="action-setindex" bSlot="8"/>
+               <vc line="3431" op="eq" onEmpty="0" comp="CCC">
+                <varRef name="action-name" slot="10"/>
                 <str val="rebuild"/>
-                <str val="recalculate"/>
-                <str val="revalidate"/>
-                <str val="refresh"/>
-                <str val="reset"/>
-                <str val="load"/>
-                <str val="send"/>
-                <str val="message"/>
-               </literal>
-               <choose line="2907">
-                <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}contains" type="xs:boolean">
-                 <varRef name="action-map" slot="0"/>
-                 <dot type="xs:string"/>
-                </ifCall>
-                <callT line="2908" name="applyNestedActions" bSlot="7">
-                 <withParam name="Q{}action-name" flags="c" as="xs:string">
-                  <dot line="2909" type="xs:string"/>
-                 </withParam>
-                </callT>
-               </choose>
+               </vc>
+               <callT line="3432" name="xforms-rebuild" bSlot="9"/>
+               <true/>
+               <message line="3435">
+                <sequence role="select">
+                 <valueOf>
+                  <str val="[applyActions] action '"/>
+                 </valueOf>
+                 <valueOf>
+                  <varRef name="action-name" slot="10"/>
+                 </valueOf>
+                 <valueOf>
+                  <str val="' not yet handled!"/>
+                 </valueOf>
+                </sequence>
+                <str role="terminate" val="no"/>
+                <str role="error" val="Q{http://www.w3.org/2005/xqt-errors}XTMM9000"/>
+               </message>
+              </choose>
+              <forEach line="3444">
+               <ifCall line="3440" name="Q{http://www.w3.org/2005/xpath-functions/array}flatten" type="item()*">
+                <treat as="array(map(*))" jsTest="function v(item) {return SaxonJS.U.isMap(item)};function c(n) {return n==1;};return SaxonJS.U.isArray(item) &amp;&amp; SaxonJS.U.ForArray(item.value).every(function(seq){return c(seq.length) &amp;&amp; SaxonJS.U.ForArray(seq).every(v)});" diag="3|0|XTTE0570|nested-actions-array">
+                 <check card="?" diag="3|0|XTTE0570|nested-actions-array">
+                  <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+                   <varRef name="action-map" slot="0"/>
+                   <str val="nested-actions"/>
+                  </ifCall>
+                 </check>
+                </treat>
+               </ifCall>
+               <callT line="3445" name="applyActions" bSlot="10">
+                <withParam name="Q{}action-map" flags="t" as="item()">
+                 <dot line="3446"/>
+                </withParam>
+               </callT>
               </forEach>
              </sequence>
             </let>
@@ -1944,135 +2041,112 @@
  </co>
  <co id="5" binds="5">
   <mode name="Q{}insert-node" onNo="TC" flags="W" patternSlots="0">
-   <templateRule prec="0" prio="-0.5" seq="0" rank="0" minImp="0" slots="2" flags="s" line="1558" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="-0.5" seq="0" rank="0" minImp="0" slots="3" flags="s" line="1771" module="saxon-xforms.xsl">
     <p.nodeTest role="match" test="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;"/>
-    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1559">
-     <param name="Q{}insert-node" slot="0" flags="ti" as="node()">
-      <treat role="conversion" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="8|0|XTTE0590|insert-node">
-       <check card="1" diag="8|0|XTTE0590|insert-node">
+    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1772">
+     <param name="Q{}insert-node-location" slot="0" flags="ti" as="node()">
+      <treat role="conversion" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="8|0|XTTE0590|insert-node-location">
+       <check card="1" diag="8|0|XTTE0590|insert-node-location">
         <supplied slot="0"/>
        </check>
       </treat>
      </param>
-     <param line="1560" name="Q{}position-relative" slot="1" flags="t" as="xs:string?">
+     <param line="1773" name="Q{}node-to-insert" slot="1" flags="ti" as="node()">
+      <treat role="conversion" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="8|0|XTTE0590|node-to-insert">
+       <check card="1" diag="8|0|XTTE0590|node-to-insert">
+        <supplied slot="1"/>
+       </check>
+      </treat>
+     </param>
+     <param line="1774" name="Q{}position-relative" slot="2" flags="t" as="xs:string?">
       <str role="select" val="after"/>
       <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|position-relative">
        <check card="?" diag="8|0|XTTE0590|position-relative">
         <cvUntyped to="xs:string">
          <data>
-          <supplied slot="1"/>
+          <supplied slot="2"/>
          </data>
         </cvUntyped>
        </check>
       </treat>
      </param>
-     <choose line="1563">
+     <choose line="1777">
       <and op="and">
        <is op="is">
         <dot type="element()"/>
-        <varRef name="insert-node" slot="0"/>
+        <varRef name="insert-node-location" slot="0"/>
        </is>
        <gc op="=" card="1:1" comp="CCC">
-        <varRef name="position-relative" slot="1"/>
+        <varRef name="position-relative" slot="2"/>
         <str val="before"/>
        </gc>
       </and>
-      <sequence line="1564">
-       <message>
-        <sequence role="select">
-         <valueOf>
-          <str val="[insert-node mode] Found! "/>
-         </valueOf>
-         <valueOf>
-          <fn name="serialize">
-           <varRef name="insert-node" slot="0"/>
-          </fn>
-         </valueOf>
-        </sequence>
-        <str role="terminate" val="no"/>
-        <str role="error" val="Q{http://www.w3.org/2005/xqt-errors}XTMM9000"/>
-       </message>
-       <copyOf line="1565" flags="vc">
-        <varRef name="insert-node" slot="0"/>
-       </copyOf>
-      </sequence>
+      <copyOf line="1779" flags="vc">
+       <varRef name="node-to-insert" slot="1"/>
+      </copyOf>
      </choose>
-     <copy line="1568" flags="cin">
+     <copy line="1782" flags="cin">
       <sequence role="content">
        <copyOf flags="vc">
         <axis name="attribute" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
        </copyOf>
-       <applyT line="1569" mode="Q{}insert-node" bSlot="0">
+       <applyT line="1783" mode="Q{}insert-node" bSlot="0">
         <axis role="select" name="child" nodeTest="( element() | text() | comment() | processing-instruction() )" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);"/>
        </applyT>
       </sequence>
      </copy>
-     <choose line="1571">
+     <choose line="1785">
       <and op="and">
        <is op="is">
         <dot type="element()"/>
-        <varRef name="insert-node" slot="0"/>
+        <varRef name="insert-node-location" slot="0"/>
        </is>
        <gc op="=" card="1:1" comp="CCC">
-        <varRef name="position-relative" slot="1"/>
+        <varRef name="position-relative" slot="2"/>
         <str val="after"/>
        </gc>
       </and>
-      <copyOf line="1572" flags="vc">
-       <varRef name="insert-node" slot="0"/>
+      <copyOf line="1786" flags="vc">
+       <varRef name="node-to-insert" slot="1"/>
       </copyOf>
      </choose>
     </sequence>
    </templateRule>
   </mode>
  </co>
- <co id="30" binds="31">
-  <function name="Q{http://www.w3.org/2002/xforms}convert-json-to-xml" line="2111" module="saxon-xforms.xsl" eval="7" flags="pU" as="node()" slots="2">
-   <arg name="jinstance" as="xs:string"/>
-   <let role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2117" var="result" as="document-node()" slot="1" eval="7">
-    <doc line="2119" validation="preserve">
-     <applyT mode="Q{}jxml-xml" bSlot="0">
-      <doc role="select" line="2114" validation="preserve">
-       <fn name="json-to-xml">
-        <varRef name="jinstance" slot="0"/>
-       </fn>
-      </doc>
-     </applyT>
-    </doc>
-    <varRef line="2122" name="result" slot="1"/>
-   </let>
-  </function>
- </co>
- <co id="32" binds="">
-  <function name="Q{http://www.w3.org/2002/xforms}hasClass" line="2433" module="saxon-xforms.xsl" eval="7" flags="pU" as="xs:boolean" slots="2">
-   <arg name="class" as="attribute(Q{}class)"/>
+ <co id="30" binds="">
+  <function name="Q{http://www.w3.org/2002/xforms}hasClass" line="2880" module="saxon-xforms.xsl" eval="7" flags="pU" as="xs:boolean" slots="2">
+   <arg name="element" as="element()"/>
    <arg name="string" as="xs:string"/>
-   <gc role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2436" op="=" card="N:1" comp="CCC">
+   <gc role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2884" op="=" card="N:1" comp="CCC">
     <fn name="tokenize">
      <cvUntyped to="xs:string">
       <data>
-       <varRef name="class" slot="0"/>
+       <slash simple="1">
+        <varRef name="element" slot="0"/>
+        <axis name="attribute" nodeTest="attribute(Q{}class)" jsTest="return item.name==='class'"/>
+       </slash>
       </data>
      </cvUntyped>
     </fn>
-    <varRef line="2438" name="string" slot="1"/>
+    <varRef line="2887" name="string" slot="1"/>
    </gc>
   </function>
  </co>
- <co id="33" vis="PUBLIC" binds="">
-  <globalParam name="Q{}xforms-instance-id" type="item()*" line="34" module="saxon-xforms.xsl" visibility="PUBLIC" jsAcceptor="return val;" jsCardCheck="function c() {return true;};">
+ <co id="31" vis="PUBLIC" binds="">
+  <globalParam name="Q{}xforms-instance-id" type="item()*" line="54" module="saxon-xforms.xsl" visibility="PUBLIC" jsAcceptor="return val;" jsCardCheck="function c() {return true;};">
    <str val="xforms-jinstance"/>
   </globalParam>
  </co>
- <co id="34" binds="">
-  <function name="Q{http://www.w3.org/2002/xforms}getIfStatement" line="560" module="saxon-xforms.xsl" eval="7" flags="pU" as="xs:string?" slots="1">
+ <co id="32" binds="">
+  <function name="Q{http://www.w3.org/2002/xforms}getIfStatement" line="712" module="saxon-xforms.xsl" eval="7" flags="pU" as="xs:string?" slots="1">
    <arg name="map" as="map(*)"/>
-   <choose role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="563">
+   <choose role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="715">
     <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}contains" type="xs:boolean">
      <varRef name="map" slot="0"/>
      <str val="@if"/>
     </ifCall>
-    <treat line="564" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="5|0|XTTE0780|xforms:getIfStatement">
+    <treat line="716" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="5|0|XTTE0780|xforms:getIfStatement">
      <check card="?" diag="5|0|XTTE0780|xforms:getIfStatement">
       <cvUntyped to="xs:string">
        <data>
@@ -2087,9 +2161,71 @@
    </choose>
   </function>
  </co>
- <co id="18" binds="4 35 22 22">
-  <template name="Q{}refreshOutputs-JS" flags="os" line="2729" module="saxon-xforms.xsl" slots="5">
-   <let role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2736" var="output-keys" as="item()?" slot="0" eval="8">
+ <co id="33" binds="">
+  <function name="Q{http://www.w3.org/2002/xforms}getClass" line="2901" module="saxon-xforms.xsl" eval="7" flags="pU" as="attribute(Q{}class)?" slots="3">
+   <arg name="element" as="element()"/>
+   <let role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2904" var="class" as="xs:string?" slot="1" eval="7">
+    <choose line="2905">
+     <fn name="exists">
+      <slash simple="1">
+       <varRef name="element" slot="0"/>
+       <axis name="attribute" nodeTest="attribute(Q{}class)" jsTest="return item.name==='class'"/>
+      </slash>
+     </fn>
+     <cvUntyped line="2906" to="xs:string">
+      <cast as="xs:untypedAtomic" emptiable="0">
+       <fn name="string">
+        <convert from="xs:untypedAtomic" to="xs:string">
+         <data>
+          <slash simple="1">
+           <varRef name="element" slot="0"/>
+           <axis name="attribute" nodeTest="attribute(Q{}class)" jsTest="return item.name==='class'"/>
+          </slash>
+         </data>
+        </convert>
+       </fn>
+      </cast>
+     </cvUntyped>
+    </choose>
+    <let line="2909" var="class-mod" as="xs:string?" slot="2" eval="7">
+     <choose line="2911">
+      <fn name="exists">
+       <slash simple="1">
+        <varRef name="element" slot="0"/>
+        <axis name="attribute" nodeTest="attribute(Q{}incremental)" jsTest="return item.name==='incremental'"/>
+       </slash>
+      </fn>
+      <cvUntyped line="2912" to="xs:string">
+       <cast as="xs:untypedAtomic" emptiable="0">
+        <fn name="string-join">
+         <sequence>
+          <varRef name="class" slot="1"/>
+          <str val="incremental"/>
+         </sequence>
+         <str val=" "/>
+        </fn>
+       </cast>
+      </cvUntyped>
+      <true/>
+      <varRef line="2915" name="class" slot="1"/>
+     </choose>
+     <choose line="2919">
+      <fn name="exists">
+       <varRef name="class-mod" slot="2"/>
+      </fn>
+      <treat line="2920" as="attribute(Q{}class)" jsTest="return item.name==='class'" diag="5|0|XTTE0780|xforms:getClass">
+       <att name="class">
+        <varRef name="class-mod" slot="2"/>
+       </att>
+      </treat>
+     </choose>
+    </let>
+   </let>
+  </function>
+ </co>
+ <co id="28" binds="34 20 20 4">
+  <template name="Q{}refreshOutputs-JS" flags="os" line="3208" module="saxon-xforms.xsl" slots="7">
+   <let role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="3215" var="output-keys" as="item()?" slot="0" eval="8">
     <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
      <check card="1" diag="0|0||ixsl:call">
       <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
@@ -2097,9 +2233,9 @@
      <str val="getOutputKeys"/>
      <arrayBlock/>
     </ifCall>
-    <forEach line="2738">
+    <forEach line="3217">
      <varRef name="output-keys" slot="0"/>
-     <let line="2739" var="this-key" as="xs:string" slot="1" eval="7">
+     <let line="3218" var="this-key" as="xs:string" slot="1" eval="7">
       <treat as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|this-key">
        <check card="1" diag="3|0|XTTE0570|this-key">
         <cvUntyped to="xs:string">
@@ -2109,7 +2245,7 @@
         </cvUntyped>
        </check>
       </treat>
-      <let line="2740" var="this-output" as="map(*)" slot="2" eval="7">
+      <let line="3219" var="this-output" as="map(*)" slot="2" eval="7">
        <treat as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|this-output">
         <check card="1" diag="3|0|XTTE0570|this-output">
          <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
@@ -2123,113 +2259,139 @@
          </ifCall>
         </check>
        </treat>
-       <let line="2775" var="value" as="xs:string" slot="3" eval="7">
-        <treat line="2776" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|value">
-         <check card="1" diag="3|0|XTTE0570|value">
-          <cvUntyped to="xs:string">
-           <data>
-            <evaluate dxns="">
-             <ufCall role="xpath" line="2743" name="Q{http://www.w3.org/2002/xforms}impose" tailCall="false" bSlot="0" eval="4">
-              <choose>
-               <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
-                <varRef name="this-output" slot="2"/>
-                <str val="@value"/>
-               </ifCall>
-               <treat line="2744" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|xpath">
-                <check card="1" diag="3|0|XTTE0570|xpath">
-                 <cvUntyped to="xs:string">
-                  <data>
-                   <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
-                    <varRef name="this-output" slot="2"/>
-                    <str val="@value"/>
-                   </ifCall>
-                  </data>
-                 </cvUntyped>
-                </check>
-               </treat>
-               <ifCall line="2746" name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
-                <varRef name="this-output" slot="2"/>
-                <str val="@ref"/>
-               </ifCall>
-               <treat line="2747" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|xpath">
-                <check card="1" diag="3|0|XTTE0570|xpath">
-                 <cvUntyped to="xs:string">
-                  <data>
-                   <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
-                    <varRef name="this-output" slot="2"/>
-                    <str val="@ref"/>
-                   </ifCall>
-                  </data>
-                 </cvUntyped>
-                </check>
-               </treat>
-               <true/>
-               <str val=""/>
-              </choose>
-             </ufCall>
-             <ufCall role="cxt" line="2759" name="Q{http://www.w3.org/2002/xforms}instance" tailCall="false" bSlot="1" eval="7">
-              <check card="1" diag="3|0|XTTE0570|this-instance-id">
-               <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
-                <choose>
-                 <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}contains" type="xs:boolean">
+       <let line="3250" var="contexti" as="element()?" slot="3" eval="7">
+        <ufCall line="3251" name="Q{http://www.w3.org/2002/xforms}instance" tailCall="false" bSlot="0" eval="7">
+         <check line="3238" card="1" diag="3|0|XTTE0570|this-instance-id">
+          <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+           <choose>
+            <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}contains" type="xs:boolean">
+             <varRef name="this-output" slot="2"/>
+             <str val="@ref"/>
+            </ifCall>
+            <ufCall line="3240" name="Q{http://www.w3.org/2002/xforms}getInstanceMap" tailCall="false" bSlot="1" eval="7">
+             <treat as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="0|0||xforms:getInstanceMap">
+              <check card="1" diag="0|0||xforms:getInstanceMap">
+               <cvUntyped to="xs:string">
+                <data>
+                 <ifCall line="3239" name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
                   <varRef name="this-output" slot="2"/>
                   <str val="@ref"/>
                  </ifCall>
-                 <ufCall line="2761" name="Q{http://www.w3.org/2002/xforms}getInstanceMap" tailCall="false" bSlot="2" eval="7">
-                  <treat as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="0|0||xforms:getInstanceMap">
-                   <check card="1" diag="0|0||xforms:getInstanceMap">
-                    <cvUntyped to="xs:string">
-                     <data>
-                      <ifCall line="2760" name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
-                       <varRef name="this-output" slot="2"/>
-                       <str val="@ref"/>
-                      </ifCall>
-                     </data>
-                    </cvUntyped>
-                   </check>
-                  </treat>
-                 </ufCall>
-                 <true/>
-                 <ufCall line="2764" name="Q{http://www.w3.org/2002/xforms}getInstanceMap" tailCall="false" bSlot="3" eval="0">
-                  <str val="saxon-forms-default"/>
-                 </ufCall>
-                </choose>
-                <str val="instance-id"/>
-               </ifCall>
+                </data>
+               </cvUntyped>
               </check>
-             </ufCall>
-             <str role="sa" val="no"/>
-             <map role="wp" size="0"/>
-            </evaluate>
-           </data>
-          </cvUntyped>
+             </treat>
+            </ufCall>
+            <true/>
+            <ufCall line="3243" name="Q{http://www.w3.org/2002/xforms}getInstanceMap" tailCall="false" bSlot="2" eval="0">
+             <str val="saxon-forms-default"/>
+            </ufCall>
+           </choose>
+           <str val="instance-id"/>
+          </ifCall>
          </check>
-        </treat>
-        <let line="2779" var="associated-form-control" as="node()?" slot="4" eval="7">
-         <check card="?" diag="3|0|XTTE0570|associated-form-control">
-          <slash>
-           <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}page" type="document-node()?"/>
-           <fn name="key">
-            <str val="Q{http://saxon.sf.net/}kk103"/>
-            <varRef name="this-key" slot="1"/>
-            <dot type="document-node()"/>
-           </fn>
-          </slash>
-         </check>
-         <choose line="2782">
+        </ufCall>
+        <let line="3258" var="namespace-context-item" as="element()" slot="4" eval="7">
+         <choose>
           <fn name="exists">
-           <varRef name="associated-form-control" slot="4"/>
+           <varRef name="contexti" slot="3"/>
           </fn>
-          <resultDoc line="2783" global="#&#xD;&#xA;#Tue Jul 24 21:04:01 BST 2018&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;" local="#&#xD;&#xA;#Tue Jul 24 21:04:01 BST 2018&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;">
-           <fn role="href" name="concat">
-            <str val="#"/>
-            <varRef name="this-key" slot="1"/>
-           </fn>
-           <valueOf role="content" line="2784">
-            <varRef name="value" slot="3"/>
-           </valueOf>
-          </resultDoc>
+          <check card="1" diag="3|0|XTTE0570|namespace-context-item">
+           <varRef name="contexti" slot="3"/>
+          </check>
+          <true/>
+          <treat as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="3|0|XTTE0570|namespace-context-item">
+           <check card="1" diag="3|0|XTTE0570|namespace-context-item">
+            <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+             <check card="1" diag="0|0||ixsl:call">
+              <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+             </check>
+             <str val="getXForm"/>
+             <arrayBlock/>
+            </ifCall>
+           </check>
+          </treat>
          </choose>
+         <let line="3260" var="value" as="xs:string" slot="5" eval="7">
+          <treat line="3261" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|value">
+           <check card="1" diag="3|0|XTTE0570|value">
+            <cvUntyped to="xs:string">
+             <data>
+              <evaluate dxns="">
+               <ufCall role="xpath" line="3222" name="Q{http://www.w3.org/2002/xforms}impose" tailCall="false" bSlot="3" eval="4">
+                <choose>
+                 <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+                  <varRef name="this-output" slot="2"/>
+                  <str val="@value"/>
+                 </ifCall>
+                 <treat line="3223" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|xpath">
+                  <check card="1" diag="3|0|XTTE0570|xpath">
+                   <cvUntyped to="xs:string">
+                    <data>
+                     <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+                      <varRef name="this-output" slot="2"/>
+                      <str val="@value"/>
+                     </ifCall>
+                    </data>
+                   </cvUntyped>
+                  </check>
+                 </treat>
+                 <ifCall line="3225" name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+                  <varRef name="this-output" slot="2"/>
+                  <str val="@ref"/>
+                 </ifCall>
+                 <treat line="3226" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|xpath">
+                  <check card="1" diag="3|0|XTTE0570|xpath">
+                   <cvUntyped to="xs:string">
+                    <data>
+                     <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+                      <varRef name="this-output" slot="2"/>
+                      <str val="@ref"/>
+                     </ifCall>
+                    </data>
+                   </cvUntyped>
+                  </check>
+                 </treat>
+                 <true/>
+                 <str val=""/>
+                </choose>
+               </ufCall>
+               <varRef role="cxt" name="contexti" slot="3"/>
+               <varRef role="nsCxt" name="namespace-context-item" slot="4"/>
+               <str role="sa" val="no"/>
+               <map role="wp" size="0"/>
+              </evaluate>
+             </data>
+            </cvUntyped>
+           </check>
+          </treat>
+          <let line="3264" var="associated-form-control" as="node()?" slot="6" eval="7">
+           <check card="?" diag="3|0|XTTE0570|associated-form-control">
+            <slash>
+             <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}page" type="document-node()?"/>
+             <fn name="key">
+              <str val="Q{http://saxon.sf.net/}kk102"/>
+              <varRef name="this-key" slot="1"/>
+              <dot type="document-node()"/>
+             </fn>
+            </slash>
+           </check>
+           <choose line="3267">
+            <fn name="exists">
+             <varRef name="associated-form-control" slot="6"/>
+            </fn>
+            <resultDoc line="3268" global="#&#xD;&#xA;#Sun Nov 18 10:50:05 GMT 2018&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;" local="#&#xD;&#xA;#Sun Nov 18 10:50:05 GMT 2018&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;">
+             <fn role="href" name="concat">
+              <str val="#"/>
+              <varRef name="this-key" slot="1"/>
+             </fn>
+             <valueOf role="content" line="3269">
+              <varRef name="value" slot="5"/>
+             </valueOf>
+            </resultDoc>
+           </choose>
+          </let>
+         </let>
         </let>
        </let>
       </let>
@@ -2238,10 +2400,10 @@
    </let>
   </template>
  </co>
- <co id="20" binds="3">
-  <function name="Q{http://www.w3.org/2002/xforms}checkRelevantFields" line="456" module="saxon-xforms.xsl" eval="8" flags="pU" as="item()*" slots="12">
+ <co id="18" binds="3">
+  <function name="Q{http://www.w3.org/2002/xforms}checkRelevantFields" line="581" module="saxon-xforms.xsl" eval="8" flags="pU" as="item()*" slots="13">
    <arg name="refElement" as="xs:string"/>
-   <let role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="459" var="pendingUpdatesi" as="map(xs:string, xs:string)?" slot="1" eval="7">
+   <let role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="584" var="pendingUpdatesi" as="map(xs:string, xs:string)?" slot="1" eval="7">
     <treat as="map(xs:string, xs:string)" jsTest="function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="3|0|XTTE0570|pendingUpdatesi">
      <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
       <check card="1" diag="0|0||ixsl:call">
@@ -2251,7 +2413,7 @@
       <arrayBlock/>
      </ifCall>
     </treat>
-    <let line="462" var="updatesi" as="map(xs:string, xs:string)?" slot="2" eval="7">
+    <let line="587" var="updatesi" as="map(xs:string, xs:string)?" slot="2" eval="7">
      <treat as="map(xs:string, xs:string)" jsTest="function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="3|0|XTTE0570|updatesi">
       <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
        <check card="1" diag="0|0||ixsl:call">
@@ -2261,7 +2423,7 @@
        <arrayBlock/>
       </ifCall>
      </treat>
-     <let line="465" var="relevantMap" as="map(xs:string, xs:string)" slot="3" eval="7">
+     <let line="590" var="relevantMap" as="map(xs:string, xs:string)" slot="3" eval="7">
       <treat as="map(xs:string, xs:string)" jsTest="function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="3|0|XTTE0570|relevantMap">
        <check card="1" diag="3|0|XTTE0570|relevantMap">
         <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
@@ -2273,16 +2435,16 @@
         </ifCall>
        </check>
       </treat>
-      <let line="466" var="mapKeys" as="xs:anyAtomicType*" slot="4" eval="3">
+      <let line="591" var="mapKeys" as="xs:anyAtomicType*" slot="4" eval="3">
        <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}keys" type="xs:anyAtomicType*">
         <varRef name="relevantMap" slot="3"/>
        </ifCall>
-       <sequence line="496">
+       <sequence line="621">
         <forEach>
-         <sequence line="469">
+         <sequence line="594">
           <forEach>
            <varRef name="mapKeys" slot="4"/>
-           <choose line="470">
+           <choose line="595">
             <fn name="matches">
              <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
               <varRef name="relevantMap" slot="3"/>
@@ -2291,10 +2453,10 @@
              <varRef name="refElement" slot="0"/>
              <str val=""/>
             </fn>
-            <dot line="471" type="xs:anyAtomicType"/>
+            <dot line="596" type="xs:anyAtomicType"/>
            </choose>
           </forEach>
-          <forEach line="460">
+          <forEach line="585">
            <choose>
             <fn name="exists">
              <varRef name="pendingUpdatesi" slot="1"/>
@@ -2305,7 +2467,7 @@
              </check>
             </ifCall>
            </choose>
-           <let line="477" var="keyi" as="xs:string?" slot="5" eval="7">
+           <let line="602" var="keyi" as="xs:string?" slot="5" eval="7">
             <lastOf>
              <fn name="tokenize">
               <treat as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="0|0||fn:tokenize">
@@ -2317,13 +2479,13 @@
               <str val=""/>
              </fn>
             </lastOf>
-            <let line="479" var="vv:v0" as="xs:string" slot="6" eval="13">
+            <let line="604" var="vv:v0" as="xs:string" slot="6" eval="13">
              <check card="1" diag="0|1||fn:matches">
               <varRef name="keyi" slot="5"/>
              </check>
-             <forEach line="478">
+             <forEach line="603">
               <varRef name="mapKeys" slot="4"/>
-              <choose line="479">
+              <choose line="604">
                <fn name="matches">
                 <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
                  <varRef name="relevantMap" slot="3"/>
@@ -2332,13 +2494,13 @@
                 <varRef name="vv:v0" slot="6"/>
                 <str val=""/>
                </fn>
-               <dot line="480" type="xs:anyAtomicType"/>
+               <dot line="605" type="xs:anyAtomicType"/>
               </choose>
              </forEach>
             </let>
            </let>
           </forEach>
-          <forEach line="463">
+          <forEach line="588">
            <choose>
             <fn name="exists">
              <varRef name="updatesi" slot="2"/>
@@ -2349,7 +2511,7 @@
              </check>
             </ifCall>
            </choose>
-           <let line="486" var="keyi" as="xs:string?" slot="7" eval="7">
+           <let line="611" var="keyi" as="xs:string?" slot="7" eval="7">
             <lastOf>
              <fn name="tokenize">
               <treat as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="0|0||fn:tokenize">
@@ -2361,13 +2523,13 @@
               <str val=""/>
              </fn>
             </lastOf>
-            <let line="488" var="vv:v1" as="xs:string" slot="8" eval="13">
+            <let line="613" var="vv:v1" as="xs:string" slot="8" eval="13">
              <check card="1" diag="0|1||fn:matches">
               <varRef name="keyi" slot="7"/>
              </check>
-             <forEach line="487">
+             <forEach line="612">
               <varRef name="mapKeys" slot="4"/>
-              <choose line="488">
+              <choose line="613">
                <fn name="matches">
                 <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
                  <varRef name="relevantMap" slot="3"/>
@@ -2376,106 +2538,112 @@
                 <varRef name="vv:v1" slot="8"/>
                 <str val=""/>
                </fn>
-               <dot line="489" type="xs:anyAtomicType"/>
+               <dot line="614" type="xs:anyAtomicType"/>
               </choose>
              </forEach>
             </let>
            </let>
           </forEach>
          </sequence>
-         <let line="497" var="keyi" as="xs:anyAtomicType" slot="9" eval="7">
+         <let line="622" var="keyi" as="xs:anyAtomicType" slot="9" eval="7">
           <dot type="xs:anyAtomicType"/>
-          <let line="498" var="context" as="node()*" slot="10" eval="8">
+          <let line="623" var="context" as="node()*" slot="10" eval="8">
            <slash>
             <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}page" type="document-node()?"/>
             <fn name="key">
-             <str val="Q{http://saxon.sf.net/}kk102"/>
+             <str val="Q{http://saxon.sf.net/}kk101"/>
              <varRef name="keyi" slot="9"/>
              <dot type="document-node()"/>
             </fn>
            </slash>
-           <let line="501" var="relevantCheck" as="xs:boolean" slot="11" eval="7">
-            <treat line="502" as="xs:boolean" jsTest="return SaxonJS.U.Atomic.boolean.matches(item);" diag="3|0|XTTE0570|relevantCheck">
-             <check card="1" diag="3|0|XTTE0570|relevantCheck">
-              <cvUntyped to="xs:boolean">
-               <data>
-                <evaluate dxns="">
-                 <fn role="xpath" name="concat">
-                  <dot type="xs:anyAtomicType"/>
-                  <str val="/"/>
-                  <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
-                   <varRef name="relevantMap" slot="3"/>
-                   <dot type="xs:anyAtomicType"/>
-                  </ifCall>
-                 </fn>
-                 <ufCall role="cxt" line="499" name="Q{http://www.w3.org/2002/xforms}getInstance-JS" tailCall="false" bSlot="0" eval="7">
-                  <treat as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="0|0||xforms:getInstance-JS">
-                   <cvUntyped to="xs:string">
-                    <varRef name="keyi" slot="9"/>
-                   </cvUntyped>
-                  </treat>
-                 </ufCall>
-                 <str role="sa" val="no"/>
-                 <map role="wp" size="0"/>
-                </evaluate>
-               </data>
+           <let line="624" var="updatedInstanceXML4" as="element()?" slot="11" eval="7">
+            <ufCall name="Q{http://www.w3.org/2002/xforms}getInstance-JS" tailCall="false" bSlot="0" eval="7">
+             <treat as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="0|0||xforms:getInstance-JS">
+              <cvUntyped to="xs:string">
+               <varRef name="keyi" slot="9"/>
               </cvUntyped>
-             </check>
-            </treat>
-            <choose line="505">
-             <varRef name="relevantCheck" slot="11"/>
-             <ifCall line="508" name="Q{http://saxonica.com/ns/interactiveXSLT}set-property" type="item()?">
-              <str val="style.display"/>
-              <str val="inline"/>
-              <check card="1" diag="0|2||ixsl:set-property">
-               <conditionalSort>
-                <fn name="exists">
-                 <tail start="2">
-                  <varRef name="context" slot="10"/>
-                 </tail>
-                </fn>
-                <docOrder intra="1">
-                 <slash>
-                  <varRef name="context" slot="10"/>
-                  <axis name="parent" nodeTest="(element()|document-node())" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11||item.nodeType===1);"/>
-                 </slash>
-                </docOrder>
-               </conditionalSort>
+             </treat>
+            </ufCall>
+            <let line="626" var="relevantCheck" as="xs:boolean" slot="12" eval="7">
+             <treat line="627" as="xs:boolean" jsTest="return SaxonJS.U.Atomic.boolean.matches(item);" diag="3|0|XTTE0570|relevantCheck">
+              <check card="1" diag="3|0|XTTE0570|relevantCheck">
+               <cvUntyped to="xs:boolean">
+                <data>
+                 <evaluate dxns="">
+                  <fn role="xpath" name="concat">
+                   <dot type="xs:anyAtomicType"/>
+                   <str val="/"/>
+                   <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+                    <varRef name="relevantMap" slot="3"/>
+                    <dot type="xs:anyAtomicType"/>
+                   </ifCall>
+                  </fn>
+                  <varRef role="cxt" name="updatedInstanceXML4" slot="11"/>
+                  <check role="nsCxt" card="1" diag="4|0|XTTE3170|xsl:evaluate/namespace-context">
+                   <varRef name="updatedInstanceXML4" slot="11"/>
+                  </check>
+                  <str role="sa" val="no"/>
+                  <map role="wp" size="0"/>
+                 </evaluate>
+                </data>
+               </cvUntyped>
               </check>
-             </ifCall>
-             <true/>
-             <ifCall line="511" name="Q{http://saxonica.com/ns/interactiveXSLT}set-property" type="item()?">
-              <str val="style.display"/>
-              <str val="none"/>
-              <check card="1" diag="0|2||ixsl:set-property">
-               <conditionalSort>
-                <fn name="exists">
-                 <tail start="2">
-                  <varRef name="context" slot="10"/>
-                 </tail>
-                </fn>
-                <docOrder intra="1">
-                 <slash>
-                  <varRef name="context" slot="10"/>
-                  <axis name="parent" nodeTest="(element()|document-node())" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11||item.nodeType===1);"/>
-                 </slash>
-                </docOrder>
-               </conditionalSort>
-              </check>
-             </ifCall>
-            </choose>
+             </treat>
+             <choose line="630">
+              <varRef name="relevantCheck" slot="12"/>
+              <ifCall line="633" name="Q{http://saxonica.com/ns/interactiveXSLT}set-property" type="item()?">
+               <str val="style.display"/>
+               <str val="inline"/>
+               <check card="1" diag="0|2||ixsl:set-property">
+                <conditionalSort>
+                 <fn name="exists">
+                  <tail start="2">
+                   <varRef name="context" slot="10"/>
+                  </tail>
+                 </fn>
+                 <docOrder intra="1">
+                  <slash>
+                   <varRef name="context" slot="10"/>
+                   <axis name="parent" nodeTest="(element()|document-node())" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11||item.nodeType===1);"/>
+                  </slash>
+                 </docOrder>
+                </conditionalSort>
+               </check>
+              </ifCall>
+              <true/>
+              <ifCall line="636" name="Q{http://saxonica.com/ns/interactiveXSLT}set-property" type="item()?">
+               <str val="style.display"/>
+               <str val="none"/>
+               <check card="1" diag="0|2||ixsl:set-property">
+                <conditionalSort>
+                 <fn name="exists">
+                  <tail start="2">
+                   <varRef name="context" slot="10"/>
+                  </tail>
+                 </fn>
+                 <docOrder intra="1">
+                  <slash>
+                   <varRef name="context" slot="10"/>
+                   <axis name="parent" nodeTest="(element()|document-node())" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11||item.nodeType===1);"/>
+                  </slash>
+                 </docOrder>
+                </conditionalSort>
+               </check>
+              </ifCall>
+             </choose>
+            </let>
            </let>
           </let>
          </let>
         </forEach>
-        <ifCall line="516" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+        <ifCall line="641" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
          <check card="1" diag="0|0||ixsl:call">
           <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
          </check>
          <str val="clearPendingUpdates"/>
          <arrayBlock/>
         </ifCall>
-        <ifCall line="517" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+        <ifCall line="642" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
          <check card="1" diag="0|0||ixsl:call">
           <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
          </check>
@@ -2489,14 +2657,14 @@
    </let>
   </function>
  </co>
- <co id="36" vis="PUBLIC" binds="">
-  <globalParam name="Q{}xform-html-id" type="xs:string" line="38" module="saxon-xforms.xsl" visibility="PUBLIC" jsAcceptor="return SaxonJS.U.Atomic.string.cast(val);" jsCardCheck="function c(n) {return n==1;};">
+ <co id="35" vis="PUBLIC" binds="">
+  <globalParam name="Q{}xform-html-id" type="xs:string" line="58" module="saxon-xforms.xsl" visibility="PUBLIC" jsAcceptor="return SaxonJS.U.Atomic.string.cast(val);" jsCardCheck="function c(n) {return n==1;};">
    <str val="xForm"/>
   </globalParam>
  </co>
- <co id="37" binds="">
-  <function name="Q{http://www.w3.org/2002/xforms}random" line="93" module="xforms-function-library.xsl" eval="7" flags="pU" as="xs:double" slots="0">
-   <check role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="94" card="1" diag="3|0|XTTE0570|randomNumber">
+ <co id="36" binds="">
+  <function name="Q{http://www.w3.org/2002/xforms}random" line="86" module="xforms-function-library.xsl" eval="7" flags="pU" as="xs:double" slots="0">
+   <check role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="87" card="1" diag="3|0|XTTE0570|randomNumber">
     <convert from="xs:anyAtomicType" to="xs:double" flags="p">
      <cvUntyped to="xs:double">
       <data>
@@ -2513,14 +2681,160 @@
    </check>
   </function>
  </co>
- <co id="38" vis="PUBLIC" binds="">
-  <globalParam name="Q{}xforms-file" type="xs:string?" line="40" module="saxon-xforms.xsl" visibility="PUBLIC" jsAcceptor="return SaxonJS.U.Atomic.string.cast(val);" jsCardCheck="function c(n) {return n&lt;=1;};">
+ <co id="17" binds="3 37 3 28 38">
+  <template name="Q{}xforms-recalculate" flags="os" line="3771" module="saxon-xforms.xsl" slots="3">
+   <let role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="3772" var="instance-keys" as="item()?" slot="0" eval="8">
+    <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+     <check card="1" diag="0|0||ixsl:call">
+      <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+     </check>
+     <str val="getInstanceKeys"/>
+     <arrayBlock/>
+    </ifCall>
+    <forEach line="3773">
+     <varRef name="instance-keys" slot="0"/>
+     <let line="3774" var="refz" as="xs:string" slot="1" eval="8">
+      <fn name="concat">
+       <str val="instance('"/>
+       <atomSing card="?" diag="0|1||fn:concat">
+        <dot/>
+       </atomSing>
+       <str val="')/"/>
+      </fn>
+      <sequence line="3775">
+       <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+        <atomSing diag="0|0||map:entry">
+         <dot/>
+        </atomSing>
+        <ufCall name="Q{http://www.w3.org/2002/xforms}getInstance-JS" tailCall="false" bSlot="0" eval="6">
+         <varRef name="refz" slot="1"/>
+        </ufCall>
+       </ifCall>
+       <let line="3778" var="updatedInstanceXML" as="element()" slot="2" eval="7">
+        <treat line="3779" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="3|0|XTTE0570|updatedInstanceXML">
+         <check card="1" diag="3|0|XTTE0570|updatedInstanceXML">
+          <applyT mode="Q{}binding-calculation-initial" bSlot="1">
+           <check role="select" line="3777" card="1" diag="3|0|XTTE0570|instanceXML">
+            <ufCall name="Q{http://www.w3.org/2002/xforms}getInstance-JS" tailCall="false" bSlot="2" eval="6">
+             <varRef name="refz" slot="1"/>
+            </ufCall>
+           </check>
+           <withParam name="Q{}instance-id" as="item()">
+            <dot line="3780"/>
+           </withParam>
+          </applyT>
+         </check>
+        </treat>
+        <sequence line="3786">
+         <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+          <check card="1" diag="0|0||ixsl:call">
+           <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+          </check>
+          <str val="setInstance"/>
+          <arrayBlock>
+           <dot/>
+           <varRef name="updatedInstanceXML" slot="2"/>
+          </arrayBlock>
+         </ifCall>
+         <callT line="3787" name="refreshOutputs-JS" bSlot="3"/>
+         <callT line="3788" name="refreshElementsUsingIndexFunction-JS" bSlot="4" flags="t"/>
+        </sequence>
+       </let>
+      </sequence>
+     </let>
+    </forEach>
+   </let>
+  </template>
+ </co>
+ <co id="39" vis="PUBLIC" binds="">
+  <globalParam name="Q{}xforms-file" type="xs:string?" line="60" module="saxon-xforms.xsl" visibility="PUBLIC" jsAcceptor="return SaxonJS.U.Atomic.string.cast(val);" jsCardCheck="function c(n) {return n&lt;=1;};">
    <empty/>
   </globalParam>
  </co>
- <co id="39" binds="3 35 14 40 4 41 19">
-  <template name="Q{}xforms-submit" flags="os" line="3239" module="saxon-xforms.xsl" slots="15">
-   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="3240">
+ <co id="40" binds="">
+  <function name="Q{http://www.w3.org/2002/xforms}addNamespaceDeclarations" line="2860" module="saxon-xforms.xsl" eval="7" flags="pU" as="element()" slots="1">
+   <arg name="this" as="element()"/>
+   <compElem role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2862">
+    <fn role="name" name="name">
+     <varRef name="this" slot="0"/>
+    </fn>
+    <sequence role="content" line="2863">
+     <namespace flags="l">
+      <str role="name" val="xforms"/>
+      <str role="select" val="http://www.w3.org/2002/xforms"/>
+     </namespace>
+     <forEach line="2864">
+      <filter flags="b">
+       <filter flags="b">
+        <slash simple="1">
+         <varRef name="this" slot="0"/>
+         <axis name="descendant" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+        </slash>
+        <fn name="boolean">
+         <fn name="namespace-uri">
+          <dot type="element()"/>
+         </fn>
+        </fn>
+       </filter>
+       <fn name="not">
+        <gc op="=" card="N:1" comp="CCC">
+         <sequence>
+          <slash>
+           <fn name="reverse">
+            <axis name="ancestor" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+           </fn>
+           <fn name="namespace-uri">
+            <dot type="element()"/>
+           </fn>
+          </slash>
+          <slash>
+           <fn name="reverse">
+            <axis name="preceding" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+           </fn>
+           <fn name="namespace-uri">
+            <dot type="element()"/>
+           </fn>
+          </slash>
+         </sequence>
+         <fn name="namespace-uri">
+          <dot type="element()"/>
+         </fn>
+        </gc>
+       </fn>
+      </filter>
+      <namespace line="2867" flags="l">
+       <fn role="name" line="2866" name="substring-before">
+        <fn name="name">
+         <dot type="element()"/>
+        </fn>
+        <str val=":"/>
+       </fn>
+       <convert role="select" from="xs:anyURI" to="xs:string">
+        <fn line="2865" name="namespace-uri">
+         <dot type="element()"/>
+        </fn>
+       </convert>
+      </namespace>
+     </forEach>
+     <copyOf line="2869" flags="vc">
+      <sequence>
+       <slash simple="1">
+        <varRef name="this" slot="0"/>
+        <axis name="attribute" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
+       </slash>
+       <slash simple="1">
+        <varRef name="this" slot="0"/>
+        <axis name="child" nodeTest="( element() | text() | comment() | processing-instruction() )" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);"/>
+       </slash>
+      </sequence>
+     </copyOf>
+    </sequence>
+   </compElem>
+  </function>
+ </co>
+ <co id="41" binds="3 34 13 42 4 43 16">
+  <template name="Q{}xforms-submit" flags="os" line="3856" module="saxon-xforms.xsl" slots="15">
+   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="3857">
     <param name="Q{}form-control" slot="0" flags="i" as="node()">
      <treat role="conversion" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="8|0|XTTE0590|form-control">
       <check card="1" diag="8|0|XTTE0590|form-control">
@@ -2528,7 +2842,7 @@
       </check>
      </treat>
     </param>
-    <let line="3242" var="submission" as="map(*)" slot="1" eval="7">
+    <let line="3859" var="submission" as="map(*)" slot="1" eval="7">
      <treat as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|submission">
       <check card="1" diag="3|0|XTTE0570|submission">
        <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
@@ -2547,7 +2861,7 @@
        </ifCall>
       </check>
      </treat>
-     <let line="3243" var="actions" as="map(*)?" slot="2" eval="7">
+     <let line="3860" var="actions" as="map(*)?" slot="2" eval="7">
       <treat as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|actions">
        <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
         <check card="1" diag="0|0||ixsl:call">
@@ -2564,359 +2878,376 @@
         </arrayBlock>
        </ifCall>
       </treat>
-      <let line="3247" var="refi" as="xs:string?" slot="3" eval="7">
-       <treat as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|refi">
-        <check card="?" diag="3|0|XTTE0570|refi">
-         <cvUntyped to="xs:string">
-          <data>
-           <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
-            <varRef name="submission" slot="1"/>
-            <str val="@ref"/>
-           </ifCall>
-          </data>
-         </cvUntyped>
-        </check>
-       </treat>
-       <let line="3249" var="instance-id" as="xs:string" slot="4" eval="7">
-        <choose line="3251">
-         <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
-          <varRef name="submission" slot="1"/>
-          <str val="@instance"/>
-         </ifCall>
-         <treat line="3252" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|instance-id">
-          <check card="1" diag="3|0|XTTE0570|instance-id">
-           <cvUntyped to="xs:string">
-            <data>
-             <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
-              <varRef name="submission" slot="1"/>
-              <str val="@instance"/>
-             </ifCall>
-            </data>
-           </cvUntyped>
-          </check>
-         </treat>
-         <true/>
-         <str val="saxon-forms-default"/>
-        </choose>
-        <let line="3263" var="instanceXML" as="element()" slot="5" eval="7">
-         <choose>
-          <varRef name="refi" slot="3"/>
-          <check card="1" diag="3|0|XTTE0570|instanceXML">
-           <ufCall name="Q{http://www.w3.org/2002/xforms}getInstance-JS" tailCall="false" bSlot="0" eval="7">
-            <check card="1" diag="0|0||xforms:getInstance-JS">
-             <varRef name="refi" slot="3"/>
-            </check>
-           </ufCall>
-          </check>
-          <true/>
-          <check card="1" diag="3|0|XTTE0570|instanceXML">
-           <ufCall name="Q{http://www.w3.org/2002/xforms}instance" tailCall="false" bSlot="1" eval="6">
-            <varRef name="instance-id" slot="4"/>
-           </ufCall>
-          </check>
-         </choose>
-         <let line="3265" var="updatedInstanceXML" as="element()" slot="6" eval="7">
-          <treat line="3266" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="3|0|XTTE0570|updatedInstanceXML">
-           <check card="1" diag="3|0|XTTE0570|updatedInstanceXML">
-            <applyT mode="Q{}form-check-initial" bSlot="2">
-             <varRef role="select" name="instanceXML" slot="5"/>
-             <withParam name="Q{}instance-id" as="xs:string">
-              <varRef line="3267" name="instance-id" slot="4"/>
-             </withParam>
-            </applyT>
+      <sequence line="3862">
+       <message>
+        <sequence role="select">
+         <valueOf>
+          <str val="[xforms-submit] Submitting: "/>
+         </valueOf>
+         <valueOf>
+          <fn name="serialize">
+           <varRef name="submission" slot="1"/>
+          </fn>
+         </valueOf>
+        </sequence>
+        <str role="terminate" val="no"/>
+        <str role="error" val="Q{http://www.w3.org/2005/xqt-errors}XTMM9000"/>
+       </message>
+       <let line="3864" var="refi" as="xs:string?" slot="3" eval="7">
+        <treat as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|refi">
+         <check card="?" diag="3|0|XTTE0570|refi">
+          <cvUntyped to="xs:string">
+           <data>
+            <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+             <varRef name="submission" slot="1"/>
+             <str val="@ref"/>
+            </ifCall>
+           </data>
+          </cvUntyped>
+         </check>
+        </treat>
+        <let line="3866" var="instance-id" as="xs:string" slot="4" eval="7">
+         <choose line="3868">
+          <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+           <varRef name="submission" slot="1"/>
+           <str val="@instance"/>
+          </ifCall>
+          <treat line="3869" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|instance-id">
+           <check card="1" diag="3|0|XTTE0570|instance-id">
+            <cvUntyped to="xs:string">
+             <data>
+              <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+               <varRef name="submission" slot="1"/>
+               <str val="@instance"/>
+              </ifCall>
+             </data>
+            </cvUntyped>
            </check>
           </treat>
-          <let line="3271" var="required-fieldsi" as="element()*" slot="7" eval="8">
-           <filter flags="b">
-            <slash simple="1">
-             <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}page" type="document-node()?"/>
-             <axis name="descendant" nodeTest="element()" jsTest="return item.nodeType===1;"/>
-            </slash>
-            <fn name="exists">
-             <axis name="attribute" nodeTest="attribute(Q{}data-required)" jsTest="return item.name==='data-required'"/>
-            </fn>
-           </filter>
-           <let line="3273" var="required-fields-check" as="element()*" slot="8" eval="3">
-            <ufCall name="Q{http://www.w3.org/2002/xforms}check-required-fields" tailCall="false" bSlot="3" eval="6">
-             <varRef name="updatedInstanceXML" slot="6"/>
+          <true/>
+          <str val="saxon-forms-default"/>
+         </choose>
+         <let line="3880" var="instanceXML" as="element()" slot="5" eval="7">
+          <choose>
+           <varRef name="refi" slot="3"/>
+           <check card="1" diag="3|0|XTTE0570|instanceXML">
+            <ufCall name="Q{http://www.w3.org/2002/xforms}getInstance-JS" tailCall="false" bSlot="0" eval="7">
+             <check card="1" diag="0|0||xforms:getInstance-JS">
+              <varRef name="refi" slot="3"/>
+             </check>
             </ufCall>
-            <choose line="3277">
-             <fn name="empty">
-              <varRef name="required-fields-check" slot="8"/>
+           </check>
+           <true/>
+           <check card="1" diag="3|0|XTTE0570|instanceXML">
+            <ufCall name="Q{http://www.w3.org/2002/xforms}instance" tailCall="false" bSlot="1" eval="6">
+             <varRef name="instance-id" slot="4"/>
+            </ufCall>
+           </check>
+          </choose>
+          <let line="3882" var="updatedInstanceXML" as="element()" slot="6" eval="7">
+           <treat line="3883" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="3|0|XTTE0570|updatedInstanceXML">
+            <check card="1" diag="3|0|XTTE0570|updatedInstanceXML">
+             <applyT mode="Q{}form-check-initial" bSlot="2">
+              <varRef role="select" name="instanceXML" slot="5"/>
+              <withParam name="Q{}instance-id" as="xs:string">
+               <varRef line="3884" name="instance-id" slot="4"/>
+              </withParam>
+             </applyT>
+            </check>
+           </treat>
+           <let line="3888" var="required-fieldsi" as="element()*" slot="7" eval="8">
+            <filter flags="b">
+             <slash simple="1">
+              <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}page" type="document-node()?"/>
+              <axis name="descendant" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+             </slash>
+             <fn name="exists">
+              <axis name="attribute" nodeTest="attribute(Q{}data-required)" jsTest="return item.name==='data-required'"/>
              </fn>
-             <let line="3278" var="requestBodyXML" as="element()" slot="9" eval="7">
-              <choose line="3280">
-               <varRef name="refi" slot="3"/>
-               <treat line="3281" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="3|0|XTTE0570|requestBodyXML">
-                <check card="1" diag="3|0|XTTE0570|requestBodyXML">
-                 <evaluate dxns="">
-                  <ufCall role="xpath" name="Q{http://www.w3.org/2002/xforms}impose" tailCall="false" bSlot="4" eval="7">
-                   <check card="1" diag="0|0||xforms:impose">
-                    <varRef name="refi" slot="3"/>
-                   </check>
-                  </ufCall>
-                  <varRef role="cxt" name="instanceXML" slot="5"/>
-                  <str role="sa" val="no"/>
-                  <map role="wp" size="0"/>
-                 </evaluate>
-                </check>
-               </treat>
-               <true/>
-               <varRef line="3284" name="instanceXML" slot="5"/>
-              </choose>
-              <let line="3298" var="method" as="xs:string" slot="10" eval="7">
-               <treat as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|method">
-                <check card="1" diag="3|0|XTTE0570|method">
-                 <cvUntyped to="xs:string">
-                  <data>
-                   <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
-                    <varRef name="submission" slot="1"/>
-                    <str val="@method"/>
-                   </ifCall>
-                  </data>
-                 </cvUntyped>
-                </check>
-               </treat>
-               <let line="3300" var="serialization" as="xs:string?" slot="11" eval="7">
-                <treat as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|serialization">
-                 <check card="?" diag="3|0|XTTE0570|serialization">
+            </filter>
+            <let line="3890" var="required-fields-check" as="element()*" slot="8" eval="3">
+             <ufCall name="Q{http://www.w3.org/2002/xforms}check-required-fields" tailCall="false" bSlot="3" eval="6">
+              <varRef name="updatedInstanceXML" slot="6"/>
+             </ufCall>
+             <choose line="3894">
+              <fn name="empty">
+               <varRef name="required-fields-check" slot="8"/>
+              </fn>
+              <let line="3895" var="requestBodyXML" as="element()" slot="9" eval="7">
+               <choose line="3897">
+                <varRef name="refi" slot="3"/>
+                <treat line="3898" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="3|0|XTTE0570|requestBodyXML">
+                 <check card="1" diag="3|0|XTTE0570|requestBodyXML">
+                  <evaluate dxns="">
+                   <ufCall role="xpath" name="Q{http://www.w3.org/2002/xforms}impose" tailCall="false" bSlot="4" eval="7">
+                    <check card="1" diag="0|0||xforms:impose">
+                     <varRef name="refi" slot="3"/>
+                    </check>
+                   </ufCall>
+                   <varRef role="cxt" name="instanceXML" slot="5"/>
+                   <varRef role="nsCxt" name="instanceXML" slot="5"/>
+                   <str role="sa" val="no"/>
+                   <map role="wp" size="0"/>
+                  </evaluate>
+                 </check>
+                </treat>
+                <true/>
+                <varRef line="3901" name="instanceXML" slot="5"/>
+               </choose>
+               <let line="3915" var="method" as="xs:string" slot="10" eval="7">
+                <treat as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|method">
+                 <check card="1" diag="3|0|XTTE0570|method">
                   <cvUntyped to="xs:string">
                    <data>
                     <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
                      <varRef name="submission" slot="1"/>
-                     <str val="@serialization"/>
+                     <str val="@method"/>
                     </ifCall>
                    </data>
                   </cvUntyped>
                  </check>
                 </treat>
-                <let line="3302" var="query-parameters" as="xs:string?" slot="12" eval="7">
-                 <choose line="3303">
-                  <and op="and">
-                   <fn name="exists">
-                    <varRef name="serialization" slot="11"/>
-                   </fn>
-                   <gc op="=" card="1:1" comp="CCC">
-                    <varRef name="serialization" slot="11"/>
-                    <str val="application/x-www-form-urlencoded"/>
-                   </gc>
-                  </and>
-                  <fn line="3311" name="string-join">
-                   <forEach line="3305">
-                    <slash simple="1">
-                     <varRef name="requestBodyXML" slot="9"/>
-                     <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
-                    </slash>
-                    <fn line="3306" name="concat">
-                     <fn name="name">
-                      <dot type="element()"/>
-                     </fn>
-                     <str val="="/>
-                     <fn name="string">
-                      <dot type="element()"/>
-                     </fn>
+                <let line="3917" var="serialization" as="xs:string?" slot="11" eval="7">
+                 <treat as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|serialization">
+                  <check card="?" diag="3|0|XTTE0570|serialization">
+                   <cvUntyped to="xs:string">
+                    <data>
+                     <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+                      <varRef name="submission" slot="1"/>
+                      <str val="@serialization"/>
+                     </ifCall>
+                    </data>
+                   </cvUntyped>
+                  </check>
+                 </treat>
+                 <let line="3919" var="query-parameters" as="xs:string?" slot="12" eval="7">
+                  <choose line="3920">
+                   <and op="and">
+                    <fn name="exists">
+                     <varRef name="serialization" slot="11"/>
                     </fn>
-                   </forEach>
-                   <str val="&amp;"/>
-                  </fn>
-                 </choose>
-                 <let line="3315" var="href-base" as="xs:string" slot="13" eval="7">
-                  <treat as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|href-base">
-                   <check card="1" diag="3|0|XTTE0570|href-base">
-                    <cvUntyped to="xs:string">
-                     <data>
-                      <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
-                       <varRef name="submission" slot="1"/>
-                       <str val="@resource"/>
-                      </ifCall>
-                     </data>
-                    </cvUntyped>
-                   </check>
-                  </treat>
-                  <sequence line="3346">
-                   <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}schedule-action" type="item()*">
-                    <int val="0"/>
-                    <empty/>
-                    <callT name="HTTPsubmit" bSlot="5">
-                     <withParam name="Q{}instance-id" flags="c" as="xs:string">
-                      <varRef line="3347" name="instance-id" slot="4"/>
-                     </withParam>
-                     <withParam name="Q{}targetref" flags="c" as="xs:string?">
-                      <treat line="3348" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|targetref">
-                       <check card="?" diag="8|0|XTTE0590|targetref">
-                        <cvUntyped to="xs:string">
-                         <data>
-                          <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
-                           <varRef name="submission" slot="1"/>
-                           <str val="@targetref"/>
-                          </ifCall>
-                         </data>
-                        </cvUntyped>
-                       </check>
-                      </treat>
-                     </withParam>
-                     <withParam name="Q{}replace" flags="c" as="xs:string?">
-                      <treat line="3349" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|replace">
-                       <check card="?" diag="8|0|XTTE0590|replace">
-                        <cvUntyped to="xs:string">
-                         <data>
-                          <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
-                           <varRef name="submission" slot="1"/>
-                           <str val="@replace"/>
-                          </ifCall>
-                         </data>
-                        </cvUntyped>
-                       </check>
-                      </treat>
-                     </withParam>
-                    </callT>
-                    <ifCall line="3333" name="Q{http://www.w3.org/2005/xpath-functions/map}merge" type="map(*)">
-                     <sequence>
-                      <choose>
-                       <vc op="ne" onEmpty="1" comp="CCC">
-                        <fn name="upper-case">
-                         <varRef name="method" slot="10"/>
-                        </fn>
-                        <str val="GET"/>
-                       </vc>
-                       <ifCall line="3334" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
-                        <str val="body"/>
-                        <doc line="3294" validation="preserve">
-                         <doc flags="l">
-                          <varRef name="requestBodyXML" slot="9"/>
-                         </doc>
-                        </doc>
+                    <gc op="=" card="1:1" comp="CCC">
+                     <varRef name="serialization" slot="11"/>
+                     <str val="application/x-www-form-urlencoded"/>
+                    </gc>
+                   </and>
+                   <fn line="3928" name="string-join">
+                    <forEach line="3922">
+                     <slash simple="1">
+                      <varRef name="requestBodyXML" slot="9"/>
+                      <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+                     </slash>
+                     <fn line="3923" name="concat">
+                      <fn name="name">
+                       <dot type="element()"/>
+                      </fn>
+                      <str val="="/>
+                      <fn name="string">
+                       <dot type="element()"/>
+                      </fn>
+                     </fn>
+                    </forEach>
+                    <str val="&amp;"/>
+                   </fn>
+                  </choose>
+                  <let line="3932" var="href-base" as="xs:string" slot="13" eval="7">
+                   <treat as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|href-base">
+                    <check card="1" diag="3|0|XTTE0570|href-base">
+                     <cvUntyped to="xs:string">
+                      <data>
+                       <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+                        <varRef name="submission" slot="1"/>
+                        <str val="@resource"/>
                        </ifCall>
-                      </choose>
-                      <ifCall line="3336" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
-                       <str val="method"/>
-                       <varRef name="method" slot="10"/>
-                      </ifCall>
-                      <ifCall line="3337" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
-                       <str val="href"/>
-                       <choose line="3319">
-                        <fn name="exists">
-                         <varRef name="query-parameters" slot="12"/>
-                        </fn>
-                        <fn line="3320" name="concat">
-                         <varRef name="href-base" slot="13"/>
-                         <str val="?"/>
-                         <varRef name="query-parameters" slot="12"/>
-                        </fn>
-                        <true/>
-                        <varRef line="3323" name="href-base" slot="13"/>
-                       </choose>
-                      </ifCall>
-                      <ifCall line="3338" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
-                       <str val="media-type"/>
-                       <treat line="3328" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|mediatype">
-                        <check card="1" diag="3|0|XTTE0570|mediatype">
+                      </data>
+                     </cvUntyped>
+                    </check>
+                   </treat>
+                   <sequence line="3963">
+                    <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}schedule-action" type="item()*">
+                     <int val="0"/>
+                     <empty/>
+                     <callT name="HTTPsubmit" bSlot="5">
+                      <withParam name="Q{}instance-id" flags="c" as="xs:string">
+                       <varRef line="3964" name="instance-id" slot="4"/>
+                      </withParam>
+                      <withParam name="Q{}targetref" flags="c" as="xs:string?">
+                       <treat line="3965" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|targetref">
+                        <check card="?" diag="8|0|XTTE0590|targetref">
                          <cvUntyped to="xs:string">
                           <data>
                            <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
                             <varRef name="submission" slot="1"/>
-                            <str val="@mediatype"/>
+                            <str val="@targetref"/>
                            </ifCall>
                           </data>
                          </cvUntyped>
                         </check>
                        </treat>
-                      </ifCall>
-                     </sequence>
-                     <map size="2">
-                      <str val="duplicates"/>
-                      <str val="reject"/>
-                      <str val="duplicates-error-code"/>
-                      <str val="XTDE3365"/>
-                     </map>
-                    </ifCall>
-                   </ifCall>
-                   <forEach line="3353">
-                    <varRef name="actions" slot="2"/>
-                    <let line="3354" var="action-map" as="map(*)" slot="14" eval="7">
-                     <dot type="map(*)"/>
-                     <choose line="3357">
-                      <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}contains" type="xs:boolean">
-                       <varRef name="action-map" slot="14"/>
-                       <str val="@event"/>
-                      </ifCall>
-                      <choose line="3358">
-                       <gc op="=" card="N:1" comp="GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint">
-                        <data>
-                         <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
-                          <varRef name="action-map" slot="14"/>
-                          <str val="@event"/>
-                         </ifCall>
-                        </data>
-                        <str val="xforms-submit-done"/>
-                       </gc>
-                       <callT line="3359" name="applyActions" bSlot="6" flags="t">
-                        <withParam name="Q{}action-map" flags="t" as="item()">
-                         <varRef line="3360" name="action-map" slot="14"/>
-                        </withParam>
-                        <withParam name="Q{}nodeset" flags="t" as="xs:string">
-                         <check line="3361" card="1" diag="8|0|XTTE0590|nodeset">
-                          <varRef name="refi" slot="3"/>
+                      </withParam>
+                      <withParam name="Q{}replace" flags="c" as="xs:string?">
+                       <treat line="3966" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|replace">
+                        <check card="?" diag="8|0|XTTE0590|replace">
+                         <cvUntyped to="xs:string">
+                          <data>
+                           <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+                            <varRef name="submission" slot="1"/>
+                            <str val="@replace"/>
+                           </ifCall>
+                          </data>
+                         </cvUntyped>
+                        </check>
+                       </treat>
+                      </withParam>
+                     </callT>
+                     <ifCall line="3950" name="Q{http://www.w3.org/2005/xpath-functions/map}merge" type="map(*)">
+                      <sequence>
+                       <choose>
+                        <vc op="ne" onEmpty="1" comp="CCC">
+                         <fn name="upper-case">
+                          <varRef name="method" slot="10"/>
+                         </fn>
+                         <str val="GET"/>
+                        </vc>
+                        <ifCall line="3951" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+                         <str val="body"/>
+                         <doc line="3911" validation="preserve">
+                          <doc flags="l">
+                           <varRef name="requestBodyXML" slot="9"/>
+                          </doc>
+                         </doc>
+                        </ifCall>
+                       </choose>
+                       <ifCall line="3953" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+                        <str val="method"/>
+                        <varRef name="method" slot="10"/>
+                       </ifCall>
+                       <ifCall line="3954" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+                        <str val="href"/>
+                        <choose line="3936">
+                         <fn name="exists">
+                          <varRef name="query-parameters" slot="12"/>
+                         </fn>
+                         <fn line="3937" name="concat">
+                          <varRef name="href-base" slot="13"/>
+                          <str val="?"/>
+                          <varRef name="query-parameters" slot="12"/>
+                         </fn>
+                         <true/>
+                         <varRef line="3940" name="href-base" slot="13"/>
+                        </choose>
+                       </ifCall>
+                       <ifCall line="3955" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+                        <str val="media-type"/>
+                        <treat line="3945" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|mediatype">
+                         <check card="1" diag="3|0|XTTE0570|mediatype">
+                          <cvUntyped to="xs:string">
+                           <data>
+                            <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+                             <varRef name="submission" slot="1"/>
+                             <str val="@mediatype"/>
+                            </ifCall>
+                           </data>
+                          </cvUntyped>
                          </check>
-                        </withParam>
-                        <withParam name="Q{}instanceXML" flags="t" as="element()">
-                         <varRef line="3362" name="instanceXML" slot="5"/>
-                        </withParam>
-                       </callT>
+                        </treat>
+                       </ifCall>
+                      </sequence>
+                      <map size="2">
+                       <str val="duplicates"/>
+                       <str val="reject"/>
+                       <str val="duplicates-error-code"/>
+                       <str val="XTDE3365"/>
+                      </map>
+                     </ifCall>
+                    </ifCall>
+                    <forEach line="3970">
+                     <varRef name="actions" slot="2"/>
+                     <let line="3971" var="action-map" as="map(*)" slot="14" eval="7">
+                      <dot type="map(*)"/>
+                      <choose line="3974">
+                       <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}contains" type="xs:boolean">
+                        <varRef name="action-map" slot="14"/>
+                        <str val="@event"/>
+                       </ifCall>
+                       <choose line="3975">
+                        <gc op="=" card="N:1" comp="GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint">
+                         <data>
+                          <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+                           <varRef name="action-map" slot="14"/>
+                           <str val="@event"/>
+                          </ifCall>
+                         </data>
+                         <str val="xforms-submit-done"/>
+                        </gc>
+                        <callT line="3976" name="applyActions" bSlot="6" flags="t">
+                         <withParam name="Q{}action-map" flags="t" as="item()">
+                          <varRef line="3977" name="action-map" slot="14"/>
+                         </withParam>
+                         <withParam name="Q{}nodeset" flags="t" as="xs:string">
+                          <check line="3978" card="1" diag="8|0|XTTE0590|nodeset">
+                           <varRef name="refi" slot="3"/>
+                          </check>
+                         </withParam>
+                         <withParam name="Q{}instanceXML" flags="t" as="element()">
+                          <varRef line="3979" name="instanceXML" slot="5"/>
+                         </withParam>
+                        </callT>
+                       </choose>
                       </choose>
-                     </choose>
-                    </let>
-                   </forEach>
-                  </sequence>
+                     </let>
+                    </forEach>
+                   </sequence>
+                  </let>
                  </let>
                 </let>
                </let>
               </let>
-             </let>
-             <true/>
-             <ifCall line="3375" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
-              <check card="1" diag="0|0||ixsl:call">
-               <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
-              </check>
-              <str val="alert"/>
-              <arrayBlock>
-               <fn name="serialize">
-                <doc line="3370" flags="t" validation="preserve">
-                 <forEach>
-                  <varRef name="required-fields-check" slot="8"/>
-                  <valueOf line="3372" flags="l">
-                   <fn name="concat">
-                    <str val="Value error see: "/>
-                    <fn name="serialize">
-                     <slash line="3371" simple="1">
-                      <dot type="element()"/>
-                      <axis line="3372" name="attribute" nodeTest="attribute(Q{}data-ref)" jsTest="return item.name==='data-ref'"/>
-                     </slash>
+              <true/>
+              <ifCall line="3992" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+               <check card="1" diag="0|0||ixsl:call">
+                <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+               </check>
+               <str val="alert"/>
+               <arrayBlock>
+                <fn name="serialize">
+                 <doc line="3987" flags="t" validation="preserve">
+                  <forEach>
+                   <varRef name="required-fields-check" slot="8"/>
+                   <valueOf line="3989" flags="l">
+                    <fn name="concat">
+                     <str val="Value error see: "/>
+                     <fn name="serialize">
+                      <slash line="3988" simple="1">
+                       <dot type="element()"/>
+                       <axis line="3989" name="attribute" nodeTest="attribute(Q{}data-ref)" jsTest="return item.name==='data-ref'"/>
+                      </slash>
+                     </fn>
+                     <str val="&#xA;"/>
                     </fn>
-                    <str val="&#xA;"/>
-                   </fn>
-                  </valueOf>
-                 </forEach>
-                </doc>
-               </fn>
-              </arrayBlock>
-             </ifCall>
-            </choose>
+                   </valueOf>
+                  </forEach>
+                 </doc>
+                </fn>
+               </arrayBlock>
+              </ifCall>
+             </choose>
+            </let>
            </let>
           </let>
          </let>
         </let>
        </let>
-      </let>
+      </sequence>
      </let>
     </let>
    </sequence>
   </template>
  </co>
- <co id="7" binds="3 42 38">
-  <template name="Q{}xforms-rebuild" flags="os" line="3162" module="saxon-xforms.xsl" slots="2">
-   <let role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="3163" var="instanceDocs" as="map(xs:anyAtomicType, element()?)" slot="0" eval="8">
-    <let line="3164" var="instance-keys" as="item()?" slot="1" eval="8">
+ <co id="7" binds="3 44 39">
+  <template name="Q{}xforms-rebuild" flags="os" line="3747" module="saxon-xforms.xsl" slots="2">
+   <let role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="3748" var="instanceDocs" as="map(xs:anyAtomicType, element()?)" slot="0" eval="8">
+    <let line="3749" var="instance-keys" as="item()?" slot="1" eval="8">
      <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
       <check card="1" diag="0|0||ixsl:call">
        <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
@@ -2924,15 +3255,15 @@
       <str val="getInstanceKeys"/>
       <arrayBlock/>
      </ifCall>
-     <ifCall line="3166" name="Q{http://www.w3.org/2005/xpath-functions/map}merge" type="map(*)">
+     <ifCall line="3751" name="Q{http://www.w3.org/2005/xpath-functions/map}merge" type="map(*)">
       <forEach>
        <varRef name="instance-keys" slot="1"/>
-       <ifCall line="3168" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+       <ifCall line="3753" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
         <atomSing diag="0|0||map:entry">
          <dot/>
         </atomSing>
         <ufCall name="Q{http://www.w3.org/2002/xforms}getInstance-JS" tailCall="false" bSlot="0" eval="8">
-         <fn line="3167" name="concat">
+         <fn line="3752" name="concat">
           <str val="instance('"/>
           <atomSing card="?" diag="0|1||fn:concat">
            <dot/>
@@ -2950,12 +3281,12 @@
       </map>
      </ifCall>
     </let>
-    <callT line="3173" name="xformsjs-main" bSlot="1" flags="t">
+    <callT line="3758" name="xformsjs-main" bSlot="1" flags="t">
      <withParam name="Q{}xforms-file" flags="c" as="xs:string?">
-      <gVarRef line="3174" name="Q{}xforms-file" bSlot="2"/>
+      <gVarRef line="3759" name="Q{}xforms-file" bSlot="2"/>
      </withParam>
      <withParam name="Q{}instance-docs" flags="c" as="map(*)">
-      <varRef line="3175" name="instanceDocs" slot="0"/>
+      <varRef line="3760" name="instanceDocs" slot="0"/>
      </withParam>
     </callT>
    </let>
@@ -2963,27 +3294,27 @@
  </co>
  <co id="27" binds="">
   <mode name="Q{}set-field" onNo="TC" flags="W" patternSlots="0">
-   <templateRule prec="0" prio="-0.25" seq="2" rank="0" minImp="0" slots="1" flags="s" line="2413" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="-0.25" seq="2" rank="0" minImp="0" slots="1" flags="s" line="2794" module="saxon-xforms.xsl">
     <p.nodeTest role="match" test="*:textarea" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local==='textarea'"/>
-    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2414">
+    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2795">
      <param name="Q{}value" slot="0" flags="t">
       <str role="select" val=""/>
       <supplied role="conversion" slot="0"/>
      </param>
-     <ifCall line="2416" name="Q{http://saxonica.com/ns/interactiveXSLT}get" type="item()*">
+     <ifCall line="2797" name="Q{http://saxonica.com/ns/interactiveXSLT}get" type="item()*">
       <dot type="*:textarea"/>
       <str val="value"/>
      </ifCall>
     </sequence>
    </templateRule>
-   <templateRule prec="0" prio="-0.25" seq="1" rank="0" minImp="0" slots="1" flags="s" line="2405" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="-0.25" seq="1" rank="0" minImp="0" slots="1" flags="s" line="2786" module="saxon-xforms.xsl">
     <p.nodeTest role="match" test="*:select" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local==='select'"/>
-    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2406">
+    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2787">
      <param name="Q{}value" slot="0" flags="t">
       <str role="select" val=""/>
       <supplied role="conversion" slot="0"/>
      </param>
-     <forEach line="2408">
+     <forEach line="2789">
       <filter flags="b">
        <axis name="child" nodeTest="element(Q{}option)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='option';"/>
        <gc op="=" card="N:1" comp="GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint">
@@ -2993,7 +3324,7 @@
         <attVal name="Q{}value" chk="0"/>
        </gc>
       </filter>
-      <ifCall line="2409" name="Q{http://saxonica.com/ns/interactiveXSLT}set-property" type="item()?">
+      <ifCall line="2790" name="Q{http://saxonica.com/ns/interactiveXSLT}set-property" type="item()?">
        <str val="selected"/>
        <true/>
        <dot type="element(Q{}option)"/>
@@ -3001,16 +3332,16 @@
      </forEach>
     </sequence>
    </templateRule>
-   <templateRule prec="0" prio="-0.25" seq="0" rank="0" minImp="0" slots="1" flags="s" line="2384" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="-0.25" seq="0" rank="0" minImp="0" slots="1" flags="s" line="2765" module="saxon-xforms.xsl">
     <p.nodeTest role="match" test="*:input" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local==='input'"/>
-    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2385">
+    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2766">
      <param name="Q{}value" slot="0" flags="t">
       <str role="select" val=""/>
       <supplied role="conversion" slot="0"/>
      </param>
-     <forEach line="2388">
+     <forEach line="2769">
       <dot type="*:input"/>
-      <choose line="2390">
+      <choose line="2771">
        <and op="and">
         <fn name="exists">
          <axis name="attribute" nodeTest="attribute(Q{}type)" jsTest="return item.name==='type'"/>
@@ -3020,7 +3351,7 @@
          <str val="checkbox"/>
         </gc>
        </and>
-       <ifCall line="2391" name="Q{http://saxonica.com/ns/interactiveXSLT}set-property" type="item()?">
+       <ifCall line="2772" name="Q{http://saxonica.com/ns/interactiveXSLT}set-property" type="item()?">
         <str val="checked"/>
         <choose>
          <gc op="=" card="N:1" comp="GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint">
@@ -3038,7 +3369,7 @@
         <dot type="*:input"/>
        </ifCall>
        <true/>
-       <ifCall line="2394" name="Q{http://saxonica.com/ns/interactiveXSLT}set-property" type="item()?">
+       <ifCall line="2775" name="Q{http://saxonica.com/ns/interactiveXSLT}set-property" type="item()?">
         <str val="value"/>
         <check card="?" diag="0|1||ixsl:set-property">
          <varRef name="value" slot="0"/>
@@ -3051,8 +3382,154 @@
    </templateRule>
   </mode>
  </co>
- <co id="43" binds="">
-  <globalVariable name="Q{}xforms-actions" type="xs:string+" line="64" module="saxon-xforms.xsl" visibility="PRIVATE" jsAcceptor="return SaxonJS.U.Atomic.string.cast(val);" jsCardCheck="function c(n) {return n&gt;=1;};">
+ <co id="38" binds="45">
+  <template name="Q{}refreshElementsUsingIndexFunction-JS" flags="os" line="3283" module="saxon-xforms.xsl" slots="6">
+   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="3284">
+    <message>
+     <valueOf role="select">
+      <str val="[refreshElementsUsingIndexFunction-JS] START"/>
+     </valueOf>
+     <str role="terminate" val="no"/>
+     <str role="error" val="Q{http://www.w3.org/2005/xqt-errors}XTMM9000"/>
+    </message>
+    <let line="3285" var="ElementsUsingIndexFunction-keys" as="item()?" slot="0" eval="8">
+     <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+      <check card="1" diag="0|0||ixsl:call">
+       <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+      </check>
+      <str val="getElementsUsingIndexFunctionKeys"/>
+      <arrayBlock/>
+     </ifCall>
+     <let line="3287" var="instance-keys" as="item()?" slot="1" eval="8">
+      <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+       <check card="1" diag="0|0||ixsl:call">
+        <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+       </check>
+       <str val="getInstanceKeys"/>
+       <arrayBlock/>
+      </ifCall>
+      <let line="3288" var="instances" as="map(xs:string, element())" slot="2" eval="7">
+       <treat line="3290" as="map(xs:string, element())" jsTest="function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="3|0|XTTE0570|instances">
+        <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}merge" type="map(*)">
+         <forEach>
+          <varRef name="instance-keys" slot="1"/>
+          <ifCall line="3291" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+           <atomSing diag="0|0||map:entry">
+            <dot/>
+           </atomSing>
+           <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+            <check card="1" diag="0|0||ixsl:call">
+             <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+            </check>
+            <str val="getInstance"/>
+            <arrayBlock>
+             <dot/>
+            </arrayBlock>
+           </ifCall>
+          </ifCall>
+         </forEach>
+         <map size="2">
+          <str val="duplicates"/>
+          <str val="reject"/>
+          <str val="duplicates-error-code"/>
+          <str val="XTDE3365"/>
+         </map>
+        </ifCall>
+       </treat>
+       <forEach line="3296">
+        <varRef name="ElementsUsingIndexFunction-keys" slot="0"/>
+        <let line="3297" var="this-key" as="xs:string" slot="3" eval="7">
+         <treat as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|this-key">
+          <check card="1" diag="3|0|XTTE0570|this-key">
+           <cvUntyped to="xs:string">
+            <data>
+             <dot/>
+            </data>
+           </cvUntyped>
+          </check>
+         </treat>
+         <let line="3298" var="this-element" as="element()" slot="4" eval="7">
+          <treat as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="3|0|XTTE0570|this-element">
+           <check card="1" diag="3|0|XTTE0570|this-element">
+            <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+             <check card="1" diag="0|0||ixsl:call">
+              <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+             </check>
+             <str val="getElementUsingIndexFunction"/>
+             <arrayBlock>
+              <varRef name="this-key" slot="3"/>
+             </arrayBlock>
+            </ifCall>
+           </check>
+          </treat>
+          <let line="3299" var="this-element-refi" as="xs:string?" slot="5" eval="7">
+           <choose line="3301">
+            <fn name="exists">
+             <slash simple="1">
+              <varRef name="this-element" slot="4"/>
+              <axis name="attribute" nodeTest="attribute(Q{}nodeset)" jsTest="return item.name==='nodeset'"/>
+             </slash>
+            </fn>
+            <cvUntyped to="xs:string">
+             <data>
+              <slash simple="1">
+               <varRef name="this-element" slot="4"/>
+               <axis name="attribute" nodeTest="attribute(Q{}nodeset)" jsTest="return item.name==='nodeset'"/>
+              </slash>
+             </data>
+            </cvUntyped>
+            <fn line="3302" name="exists">
+             <slash simple="1">
+              <varRef name="this-element" slot="4"/>
+              <axis name="attribute" nodeTest="attribute(Q{}ref)" jsTest="return item.name==='ref'"/>
+             </slash>
+            </fn>
+            <cvUntyped line="3302" to="xs:string">
+             <data>
+              <slash simple="1">
+               <varRef name="this-element" slot="4"/>
+               <axis name="attribute" nodeTest="attribute(Q{}ref)" jsTest="return item.name==='ref'"/>
+              </slash>
+             </data>
+            </cvUntyped>
+           </choose>
+           <resultDoc line="3306" global="#&#xD;&#xA;#Sun Nov 18 10:50:05 GMT 2018&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;" local="#&#xD;&#xA;#Sun Nov 18 10:50:05 GMT 2018&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;">
+            <fn role="href" name="concat">
+             <str val="#"/>
+             <varRef name="this-key" slot="3"/>
+            </fn>
+            <applyT role="content" line="3307" bSlot="0">
+             <slash role="select" simple="1">
+              <varRef name="this-element" slot="4"/>
+              <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+             </slash>
+             <withParam name="Q{}instances" flags="t" as="map(xs:string, element())">
+              <varRef line="3308" name="instances" slot="2"/>
+             </withParam>
+             <withParam name="Q{}nodeset" flags="t" as="xs:string?">
+              <choose line="3309">
+               <fn name="exists">
+                <varRef name="this-element-refi" slot="5"/>
+               </fn>
+               <varRef name="this-element-refi" slot="5"/>
+               <true/>
+               <str val=""/>
+              </choose>
+             </withParam>
+            </applyT>
+           </resultDoc>
+          </let>
+         </let>
+        </let>
+       </forEach>
+      </let>
+     </let>
+    </let>
+   </sequence>
+  </template>
+ </co>
+ <co id="46" binds="">
+  <globalVariable name="Q{}xforms-actions" type="xs:string+" line="84" module="saxon-xforms.xsl" visibility="PRIVATE" jsAcceptor="return SaxonJS.U.Atomic.string.cast(val);" jsCardCheck="function c(n) {return n&gt;=1;};">
    <literal count="15">
     <str val="setvalue"/>
     <str val="insert"/>
@@ -3072,7 +3549,7 @@
    </literal>
   </globalVariable>
  </co>
- <co id="44" binds="">
+ <co id="47" binds="">
   <function name="Q{http://www.w3.org/2002/xforms}foo" line="68" module="xforms-function-library.xsl" eval="7" flags="pU" as="xs:boolean" slots="1">
    <arg name="num" as="xs:integer"/>
    <compareToInt role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="71" op="lt" val="5">
@@ -3080,12 +3557,196 @@
    </compareToInt>
   </function>
  </co>
- <co id="45" vis="PUBLIC" binds="">
-  <globalParam name="Q{}xforms-cache-id" type="item()*" line="35" module="saxon-xforms.xsl" visibility="PUBLIC" jsAcceptor="return val;" jsCardCheck="function c() {return true;};">
+ <co id="48" binds="48 4 48 48">
+  <mode name="Q{}binding-calculation" onNo="TC" flags="W" patternSlots="0">
+   <templateRule prec="0" prio="-0.5" seq="0" rank="0" minImp="0" slots="9" flags="s" line="2603" module="saxon-xforms.xsl">
+    <p.nodeTest role="match" test="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;"/>
+    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2604">
+     <param name="Q{}curPath" slot="0">
+      <str role="select" val=""/>
+      <supplied role="conversion" slot="0"/>
+     </param>
+     <param line="2605" name="Q{}position" slot="1">
+      <int role="select" val="0"/>
+      <supplied role="conversion" slot="1"/>
+     </param>
+     <param line="2606" name="Q{}calculationMap" slot="2" flags="ti" as="map(xs:string, xs:string)">
+      <treat role="conversion" as="map(xs:string, xs:string)" jsTest="function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="8|0|XTTE0590|calculationMap">
+       <check card="1" diag="8|0|XTTE0590|calculationMap">
+        <supplied slot="2"/>
+       </check>
+      </treat>
+     </param>
+     <let line="2612" var="updatedPath" as="xs:string" slot="3" eval="7">
+      <choose>
+       <gc op="&gt;" card="N:1" comp="GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint">
+        <data>
+         <varRef name="position" slot="1"/>
+        </data>
+        <int val="0"/>
+       </gc>
+       <fn name="concat">
+        <atomSing card="?" diag="0|0||fn:concat">
+         <varRef name="curPath" slot="0"/>
+        </atomSing>
+        <fn name="name">
+         <dot type="element()"/>
+        </fn>
+        <str val="["/>
+        <atomSing card="?" diag="0|3||fn:concat">
+         <varRef name="position" slot="1"/>
+        </atomSing>
+        <str val="]"/>
+       </fn>
+       <true/>
+       <fn name="concat">
+        <atomSing card="?" diag="0|0||fn:concat">
+         <varRef name="curPath" slot="0"/>
+        </atomSing>
+        <fn name="name">
+         <dot type="element()"/>
+        </fn>
+       </fn>
+      </choose>
+      <copy line="2617" flags="cin">
+       <sequence role="content">
+        <applyT mode="Q{}binding-calculation" bSlot="0">
+         <axis role="select" name="attribute" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
+         <withParam name="Q{}curPath" as="xs:string">
+          <fn line="2618" name="concat">
+           <varRef name="updatedPath" slot="3"/>
+           <str val="/"/>
+          </fn>
+         </withParam>
+        </applyT>
+        <choose line="2627">
+         <fn name="exists">
+          <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+           <varRef name="calculationMap" slot="2"/>
+           <varRef name="updatedPath" slot="3"/>
+          </ifCall>
+         </fn>
+         <evaluate line="2631" dxns="">
+          <ufCall role="xpath" name="Q{http://www.w3.org/2002/xforms}impose" tailCall="false" bSlot="1" eval="7">
+           <check line="2629" card="1" diag="3|0|XTTE0570|calculationXPath">
+            <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+             <varRef name="calculationMap" slot="2"/>
+             <varRef name="updatedPath" slot="3"/>
+            </ifCall>
+           </check>
+          </ufCall>
+          <dot role="cxt" type="element()"/>
+          <dot role="nsCxt" type="element()"/>
+          <str role="sa" val="no"/>
+          <map role="wp" size="0"/>
+         </evaluate>
+         <true/>
+         <valueOf line="2641" flags="l">
+          <fn name="normalize-space">
+           <fn name="string-join">
+            <data>
+             <axis name="child" nodeTest="text()" jsTest="return item.nodeType===3;"/>
+            </data>
+            <str val=""/>
+           </fn>
+          </fn>
+         </valueOf>
+        </choose>
+        <forEachGroup line="2646" algorithm="by">
+         <axis role="select" name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+         <fn role="key" name="local-name">
+          <dot type="element()"/>
+         </fn>
+         <str role="collation" val="http://www.w3.org/2005/xpath-functions/collation/codepoint"/>
+         <let role="content" line="2648" var="updatedChildPath" as="xs:string" slot="4" eval="8">
+          <fn name="concat">
+           <varRef name="updatedPath" slot="3"/>
+           <str val="/"/>
+           <check card="?" diag="0|2||fn:concat">
+            <currentGroupingKey/>
+           </check>
+          </fn>
+          <let line="2653" var="vv:v0" as="xs:string" slot="5" eval="13">
+           <fn name="concat">
+            <varRef name="updatedChildPath" slot="4"/>
+            <str val="["/>
+           </fn>
+           <let var="dataRefWithFilter" as="element()*" slot="6" eval="8">
+            <filter flags="b">
+             <slash simple="1">
+              <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}page" type="document-node()?"/>
+              <axis name="descendant" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+             </slash>
+             <fn name="starts-with">
+              <cvUntyped to="xs:string">
+               <attVal name="Q{}data-ref" chk="0"/>
+              </cvUntyped>
+              <varRef name="vv:v0" slot="5"/>
+             </fn>
+            </filter>
+            <choose line="2656">
+             <or op="or">
+              <fn name="exists">
+               <tail start="2">
+                <currentGroup/>
+               </tail>
+              </fn>
+              <fn name="exists">
+               <varRef name="dataRefWithFilter" slot="6"/>
+              </fn>
+             </or>
+             <let line="2659" var="vv:v1" as="xs:string" slot="7" eval="13">
+              <fn name="concat">
+               <varRef name="updatedPath" slot="3"/>
+               <str val="/"/>
+              </fn>
+              <forEach line="2657">
+               <currentGroup/>
+               <applyT line="2658" mode="Q{}binding-calculation" bSlot="2">
+                <dot role="select"/>
+                <withParam name="Q{}curPath" as="xs:string">
+                 <varRef line="2659" name="vv:v1" slot="7"/>
+                </withParam>
+                <withParam name="Q{}position" as="xs:integer">
+                 <fn line="2660" name="position"/>
+                </withParam>
+               </applyT>
+              </forEach>
+             </let>
+             <true/>
+             <let line="2668" var="vv:v2" as="xs:string" slot="8" eval="13">
+              <fn name="concat">
+               <varRef name="updatedPath" slot="3"/>
+               <str val="/"/>
+              </fn>
+              <forEach line="2666">
+               <currentGroup/>
+               <applyT line="2667" mode="Q{}binding-calculation" bSlot="3">
+                <dot role="select"/>
+                <withParam name="Q{}curPath" as="xs:string">
+                 <varRef line="2668" name="vv:v2" slot="8"/>
+                </withParam>
+               </applyT>
+              </forEach>
+             </let>
+            </choose>
+           </let>
+          </let>
+         </let>
+        </forEachGroup>
+       </sequence>
+      </copy>
+     </let>
+    </sequence>
+   </templateRule>
+  </mode>
+ </co>
+ <co id="49" vis="PUBLIC" binds="">
+  <globalParam name="Q{}xforms-cache-id" type="item()*" line="55" module="saxon-xforms.xsl" visibility="PUBLIC" jsAcceptor="return val;" jsCardCheck="function c() {return true;};">
    <str val="xforms-cache"/>
   </globalParam>
  </co>
- <co id="4" binds="46">
+ <co id="4" binds="50">
   <function name="Q{http://www.w3.org/2002/xforms}impose" line="19" module="xforms-function-library.xsl" eval="8" flags="pU" as="xs:string" slots="3">
    <arg name="input" as="xs:string"/>
    <let role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="33" var="vv:v0" as="xs:anyAtomicType*" slot="1" eval="4">
@@ -3136,7 +3797,7 @@
    </let>
   </function>
  </co>
- <co id="46" binds="">
+ <co id="50" binds="">
   <globalVariable name="Q{}xform-functions" type="item()+" line="17" module="xforms-function-library.xsl" visibility="PRIVATE" jsAcceptor="return val;" jsCardCheck="function c(n) {return n&gt;=1;};">
    <sequence ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="17">
     <literal count="5">
@@ -3155,10 +3816,10 @@
    </sequence>
   </globalVariable>
  </co>
- <co id="40" binds="">
-  <function name="Q{http://www.w3.org/2002/xforms}check-required-fields" line="681" module="saxon-xforms.xsl" eval="8" flags="pU" as="item()*" slots="3">
+ <co id="42" binds="">
+  <function name="Q{http://www.w3.org/2002/xforms}check-required-fields" line="858" module="saxon-xforms.xsl" eval="8" flags="pU" as="item()*" slots="3">
    <arg name="instanceXML" as="element()"/>
-   <let role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="684" var="required-fieldsi" as="element()*" slot="1" eval="8">
+   <let role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="861" var="required-fieldsi" as="element()*" slot="1" eval="8">
     <filter flags="b">
      <slash simple="1">
       <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}page" type="document-node()?"/>
@@ -3168,10 +3829,10 @@
       <axis name="attribute" nodeTest="attribute(Q{}data-required)" jsTest="return item.name==='data-required'"/>
      </fn>
     </filter>
-    <forEach line="686">
+    <forEach line="863">
      <varRef name="required-fieldsi" slot="1"/>
-     <let line="688" var="resulti" as="document-node()" slot="2" eval="7">
-      <doc line="691" validation="preserve">
+     <let line="865" var="resulti" as="document-node()" slot="2" eval="7">
+      <doc line="868" validation="preserve">
        <evaluate dxns="">
         <fn role="xpath" name="concat">
          <str val="boolean(normalize-space("/>
@@ -3183,11 +3844,12 @@
          <attVal name="Q{}data-required" chk="0"/>
         </fn>
         <varRef role="cxt" name="instanceXML" slot="0"/>
+        <varRef role="nsCxt" name="instanceXML" slot="0"/>
         <str role="sa" val="no"/>
         <map role="wp" size="0"/>
        </evaluate>
       </doc>
-      <choose line="697">
+      <choose line="874">
        <vc op="eq" onEmpty="0" comp="CCC">
         <cast as="xs:string" emptiable="0">
          <data>
@@ -3203,55 +3865,34 @@
    </let>
   </function>
  </co>
- <co id="47" binds="">
+ <co id="51" binds="">
   <function name="Q{http://www.w3.org/2002/xforms}index" line="75" module="xforms-function-library.xsl" eval="7" flags="pU" as="xs:integer" slots="2">
    <arg name="repeatID" as="xs:string"/>
-   <let role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="77" var="element" as="node()*" slot="1" eval="8">
-    <slash>
-     <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}page" type="document-node()?"/>
-     <fn name="key">
-      <str val="Q{http://saxon.sf.net/}kk103"/>
-      <varRef name="repeatID" slot="0"/>
-      <dot type="document-node()"/>
+   <let role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="79" var="repeat-index" as="xs:double?" slot="1" eval="7">
+    <check card="?" diag="3|0|XTTE0570|repeat-index">
+     <convert from="xs:anyAtomicType" to="xs:double" flags="p">
+      <cvUntyped to="xs:double">
+       <data>
+        <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+         <check card="1" diag="0|0||ixsl:call">
+          <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+         </check>
+         <str val="getRepeatIndex"/>
+         <arrayBlock>
+          <varRef name="repeatID" slot="0"/>
+         </arrayBlock>
+        </ifCall>
+       </data>
+      </cvUntyped>
+     </convert>
+    </check>
+    <choose line="82">
+     <fn name="exists">
+      <varRef name="repeat-index" slot="1"/>
      </fn>
-    </slash>
-    <choose line="79">
-     <fn name="empty">
-      <varRef name="element" slot="1"/>
-     </fn>
-     <int val="0"/>
-     <fn line="83" name="exists">
-      <conditionalSort>
-       <fn name="exists">
-        <tail start="2">
-         <varRef name="element" slot="1"/>
-        </tail>
-       </fn>
-       <docOrder intra="1">
-        <slash>
-         <varRef name="element" slot="1"/>
-         <axis name="attribute" nodeTest="attribute(Q{}data-count)" jsTest="return item.name==='data-count'"/>
-        </slash>
-       </docOrder>
-      </conditionalSort>
-     </fn>
-     <check line="84" card="1" diag="5|0|XTTE0780|xforms:index">
+     <check card="1" diag="5|0|XTTE0780|xforms:index">
       <cast as="xs:integer" emptiable="1">
-       <atomSing card="?" diag="2|0||cast as">
-        <conditionalSort>
-         <fn name="exists">
-          <tail start="2">
-           <varRef name="element" slot="1"/>
-          </tail>
-         </fn>
-         <docOrder intra="1">
-          <slash>
-           <varRef name="element" slot="1"/>
-           <axis name="attribute" nodeTest="attribute(Q{}data-count)" jsTest="return item.name==='data-count'"/>
-          </slash>
-         </docOrder>
-        </conditionalSort>
-       </atomSing>
+       <varRef name="repeat-index" slot="1"/>
       </cast>
      </check>
      <true/>
@@ -3262,9 +3903,9 @@
  </co>
  <co id="9" binds="9">
   <mode name="Q{}delete-node" onNo="TC" flags="W" patternSlots="0">
-   <templateRule prec="0" prio="-0.5" seq="0" rank="0" minImp="0" slots="1" flags="s" line="1584" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="-0.5" seq="0" rank="0" minImp="0" slots="1" flags="s" line="1798" module="saxon-xforms.xsl">
     <p.nodeTest role="match" test="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;"/>
-    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1585">
+    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1799">
      <param name="Q{}delete-node" slot="0" flags="ti" as="node()">
       <treat role="conversion" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="8|0|XTTE0590|delete-node">
        <check card="1" diag="8|0|XTTE0590|delete-node">
@@ -3272,32 +3913,19 @@
        </check>
       </treat>
      </param>
-     <choose line="1588">
+     <choose line="1802">
       <is op="is">
        <dot type="element()"/>
        <varRef name="delete-node" slot="0"/>
       </is>
-      <message line="1589">
-       <sequence role="select">
-        <valueOf>
-         <str val="[delete-node mode] Found! "/>
-        </valueOf>
-        <valueOf>
-         <fn name="serialize">
-          <varRef name="delete-node" slot="0"/>
-         </fn>
-        </valueOf>
-       </sequence>
-       <str role="terminate" val="no"/>
-       <str role="error" val="Q{http://www.w3.org/2005/xqt-errors}XTMM9000"/>
-      </message>
+      <empty/>
       <true/>
-      <copy line="1602" flags="cin">
+      <copy line="1816" flags="cin">
        <sequence role="content">
         <copyOf flags="vc">
          <axis name="attribute" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
         </copyOf>
-        <applyT line="1603" mode="Q{}delete-node" bSlot="0">
+        <applyT line="1817" mode="Q{}delete-node" bSlot="0">
          <axis role="select" name="child" nodeTest="( element() | text() | comment() | processing-instruction() )" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);"/>
         </applyT>
        </sequence>
@@ -3307,18 +3935,18 @@
    </templateRule>
   </mode>
  </co>
- <co id="13" binds="">
+ <co id="12" binds="">
   <mode name="Q{}get-field" onNo="TC" flags="W" patternSlots="0">
-   <templateRule prec="0" prio="-0.25" seq="2" rank="0" minImp="0" slots="0" flags="s" line="2377" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="-0.25" seq="2" rank="0" minImp="0" slots="0" flags="s" line="2758" module="saxon-xforms.xsl">
     <p.nodeTest role="match" test="*:textarea" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local==='textarea'"/>
-    <ifCall role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2380" name="Q{http://saxonica.com/ns/interactiveXSLT}get" type="item()*">
+    <ifCall role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2761" name="Q{http://saxonica.com/ns/interactiveXSLT}get" type="item()*">
      <dot type="*:textarea"/>
      <str val="value"/>
     </ifCall>
    </templateRule>
-   <templateRule prec="0" prio="-0.25" seq="1" rank="0" minImp="0" slots="0" flags="s" line="2372" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="-0.25" seq="1" rank="0" minImp="0" slots="0" flags="s" line="2753" module="saxon-xforms.xsl">
     <p.nodeTest role="match" test="*:select" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local==='select'"/>
-    <ifCall role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2374" name="Q{http://saxonica.com/ns/interactiveXSLT}get" type="item()*">
+    <ifCall role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2755" name="Q{http://saxonica.com/ns/interactiveXSLT}get" type="item()*">
      <check card="?" diag="0|0||ixsl:get">
       <filter flags="b">
        <axis name="child" nodeTest="element(Q{}option)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='option';"/>
@@ -3336,9 +3964,9 @@
      <str val="value"/>
     </ifCall>
    </templateRule>
-   <templateRule prec="0" prio="-0.25" seq="0" rank="0" minImp="0" slots="0" flags="s" line="2358" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="-0.25" seq="0" rank="0" minImp="0" slots="0" flags="s" line="2739" module="saxon-xforms.xsl">
     <p.nodeTest role="match" test="*:input" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local==='input'"/>
-    <choose role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2362">
+    <choose role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2743">
      <and op="and">
       <fn name="exists">
        <axis name="attribute" nodeTest="attribute(Q{}type)" jsTest="return item.name==='type'"/>
@@ -3348,12 +3976,12 @@
        <str val="checkbox"/>
       </gc>
      </and>
-     <ifCall line="2363" name="Q{http://saxonica.com/ns/interactiveXSLT}get" type="item()*">
+     <ifCall line="2744" name="Q{http://saxonica.com/ns/interactiveXSLT}get" type="item()*">
       <dot type="*:input"/>
       <str val="checked"/>
      </ifCall>
      <true/>
-     <ifCall line="2366" name="Q{http://saxonica.com/ns/interactiveXSLT}get" type="item()*">
+     <ifCall line="2747" name="Q{http://saxonica.com/ns/interactiveXSLT}get" type="item()*">
       <dot type="*:input"/>
       <str val="value"/>
      </ifCall>
@@ -3361,23 +3989,23 @@
    </templateRule>
   </mode>
  </co>
- <co id="11" binds="42 36 48 11 49 50 21 51 11 11 49 50 21 4 51 11 11 11 49 50 21 51 49 50 51 11 11 11 49 50 21 11 49 50 21 4 4 11 11">
+ <co id="45" binds="44 35 52 45 10 10 53 54 19 55 45 33 45 45 10 10 53 54 19 4 40 55 45 33 53 54 19 33 45 10 10 53 54 19 55 10 10 53 54 55 45 10 10 53 54 19 40 4 4 33 45 45 45 10 10 45 45">
   <mode onNo="TC" flags="dW" patternSlots="0">
-   <templateRule prec="0" prio="-0.5" seq="2" rank="0" minImp="0" slots="0" flags="s" line="835" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="-0.5" seq="2" rank="0" minImp="0" slots="0" flags="s" line="1012" module="saxon-xforms.xsl">
     <p.nodeTest role="match" test="document-node()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);"/>
-    <callT role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="836" name="xformsjs-main" bSlot="0" flags="t">
+    <callT role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1013" name="xformsjs-main" bSlot="0" flags="t">
      <withParam name="Q{}xforms-doc" flags="c" as="document-node()">
-      <dot line="837" type="document-node()"/>
+      <dot line="1014" type="document-node()"/>
      </withParam>
      <withParam name="Q{}xFormsId" flags="c" as="xs:string">
-      <gVarRef line="838" name="Q{}xform-html-id" bSlot="1"/>
+      <gVarRef line="1015" name="Q{}xform-html-id" bSlot="1"/>
      </withParam>
     </callT>
    </templateRule>
-   <templateRule prec="0" prio="0.5" seq="17" rank="2" minImp="0" slots="1" flags="s" line="1750" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="0.5" seq="17" rank="2" minImp="0" slots="1" flags="s" line="1973" module="saxon-xforms.xsl">
     <p.withPredicate role="match">
      <p.nodeTest test="Q{http://www.w3.org/2002/xforms}*" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.uri==='http://www.w3.org/2002/xforms'"/>
-     <gc ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1750" op="=" card="N:1" comp="GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint">
+     <gc ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1973" op="=" card="N:1" comp="GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint">
       <literal count="15">
        <str val="setvalue"/>
        <str val="insert"/>
@@ -3400,35 +4028,51 @@
       </fn>
      </gc>
     </p.withPredicate>
-    <let role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1760" var="action-map" as="map(*)" slot="0" eval="7">
-     <treat line="1761" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|action-map">
+    <let role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1979" var="action-map" as="map(*)" slot="0" eval="7">
+     <treat line="1980" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|action-map">
       <check card="1" diag="3|0|XTTE0570|action-map">
        <callT name="setAction" bSlot="2">
         <withParam name="Q{}this" flags="c" as="element()">
-         <dot line="1762" type="element()"/>
+         <dot line="1981" type="element()"/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <choose line="1774">
+     <choose line="1993">
       <fn name="exists">
        <varRef name="action-map" slot="0"/>
       </fn>
-      <varRef line="1775" name="action-map" slot="0"/>
+      <varRef line="1994" name="action-map" slot="0"/>
      </choose>
     </let>
    </templateRule>
-   <templateRule prec="0" prio="0.0" seq="7" rank="1" minImp="0" slots="0" flags="s" line="1257" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="0.0" seq="17" rank="1" minImp="0" slots="1" flags="s" line="1973" module="saxon-xforms.xsl">
+    <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}hide)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='hide';"/>
+    <let role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1979" var="action-map" as="map(*)" slot="0" eval="7">
+     <treat line="1980" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|action-map">
+      <check card="1" diag="3|0|XTTE0570|action-map">
+       <callT name="setAction" bSlot="2">
+        <withParam name="Q{}this" flags="c" as="element()">
+         <dot line="1981" type="element()"/>
+        </withParam>
+       </callT>
+      </check>
+     </treat>
+     <choose line="1993">
+      <fn name="exists">
+       <varRef name="action-map" slot="0"/>
+      </fn>
+      <varRef line="1994" name="action-map" slot="0"/>
+     </choose>
+    </let>
+   </templateRule>
+   <templateRule prec="0" prio="0.0" seq="7" rank="1" minImp="0" slots="0" flags="s" line="1441" module="saxon-xforms.xsl">
     <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}hint)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='hint';"/>
     <empty role="action"/>
    </templateRule>
-   <templateRule prec="0" prio="0.0" seq="1" rank="1" minImp="0" slots="0" flags="s" line="826" module="saxon-xforms.xsl">
-    <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}model)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='model';"/>
-    <empty role="action"/>
-   </templateRule>
-   <templateRule prec="0" prio="0.0" seq="15" rank="1" minImp="0" slots="2" flags="s" line="1524" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="0.0" seq="15" rank="1" minImp="0" slots="2" flags="s" line="1736" module="saxon-xforms.xsl">
     <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}submit)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='submit';"/>
-    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1525">
+    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1737">
      <param name="Q{}submissions" slot="0" flags="t" as="map(xs:string, map(*))">
       <map role="select" size="0"/>
       <treat role="conversion" as="map(xs:string, map(*))" jsTest="function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isMap(item)};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="8|0|XTTE0590|submissions">
@@ -3437,29 +4081,29 @@
        </check>
       </treat>
      </param>
-     <let line="1527" var="innerbody" as="document-node()" slot="1" eval="7">
-      <doc line="1528" validation="preserve">
+     <let line="1739" var="innerbody" as="document-node()" slot="1" eval="7">
+      <doc line="1740" validation="preserve">
        <applyT bSlot="3">
         <axis role="select" name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}label)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='label';"/>
        </applyT>
       </doc>
-      <choose line="1532">
+      <choose line="1744">
        <gc op="=" card="1:1" comp="CCC">
         <attVal name="Q{}appearance" chk="0"/>
         <str val="minimal"/>
        </gc>
-       <elem line="1534" name="a" nsuri="" namespaces="xd rdf xhtml js in fn map array ev r">
+       <elem line="1746" name="a" nsuri="" namespaces="xd rdf xhtml js in fn map array ev">
         <copyOf flags="vc">
          <varRef name="innerbody" slot="1"/>
         </copyOf>
        </elem>
        <true/>
-       <elem line="1538" name="button" nsuri="" namespaces="xd rdf xhtml js in fn map array ev r">
+       <elem line="1750" name="button" nsuri="" namespaces="xd rdf xhtml js in fn map array ev">
         <sequence>
          <att name="type" flags="l">
           <str val="button"/>
          </att>
-         <copyOf line="1539" flags="vc">
+         <copyOf line="1751" flags="vc">
           <filter flags="b">
            <axis name="attribute" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
            <vc op="ne" comp="CCC">
@@ -3470,7 +4114,7 @@
            </vc>
           </filter>
          </copyOf>
-         <choose line="1540">
+         <choose line="1752">
           <and op="and">
            <fn name="exists">
             <axis name="attribute" nodeTest="attribute(Q{}submission)" jsTest="return item.name==='submission'"/>
@@ -3482,13 +4126,13 @@
             </atomSing>
            </ifCall>
           </and>
-          <att line="1541" name="data-submit" flags="l">
+          <att line="1753" name="data-submit" flags="l">
            <convert from="xs:untypedAtomic" to="xs:string">
             <attVal name="Q{}submission" chk="0"/>
            </convert>
           </att>
          </choose>
-         <copyOf line="1543" flags="vc">
+         <copyOf line="1755" flags="vc">
           <varRef name="innerbody" slot="1"/>
          </copyOf>
         </sequence>
@@ -3497,9 +4141,9 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec="0" prio="0.0" seq="8" rank="1" minImp="0" slots="6" flags="s" line="1267" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="0.0" seq="8" rank="1" minImp="0" slots="7" flags="s" line="1452" module="saxon-xforms.xsl">
     <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}select1)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='select1';"/>
-    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1268">
+    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1453">
      <param name="Q{}position" slot="0" as="xs:integer">
       <int role="select" val="0"/>
       <treat role="conversion" as="xs:integer" jsTest="return SaxonJS.U.Atomic.integer.matches(item);" diag="8|0|XTTE0590|position">
@@ -3512,7 +4156,19 @@
        </check>
       </treat>
      </param>
-     <let line="1271" var="myid" as="xs:string" slot="1" eval="7">
+     <param line="1454" name="Q{}context-position" slot="1" as="xs:string">
+      <str role="select" val=""/>
+      <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|context-position">
+       <check card="1" diag="8|0|XTTE0590|context-position">
+        <cvUntyped to="xs:string">
+         <data>
+          <supplied slot="1"/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <let line="1458" var="myid" as="xs:string" slot="2" eval="7">
       <choose>
        <fn name="exists">
         <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
@@ -3528,292 +4184,360 @@
          <dot type="element()"/>
         </fn>
         <str val="-"/>
-        <varRef name="position" slot="0"/>
+        <choose line="1456">
+         <varRef name="context-position" slot="1"/>
+         <varRef name="context-position" slot="1"/>
+         <true/>
+         <fn name="string">
+          <varRef name="position" slot="0"/>
+         </fn>
+        </choose>
        </fn>
       </choose>
-      <let line="1277" var="bindingi" as="node()?" slot="2" eval="7">
-       <treat line="1278" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|bindingi">
-        <check card="?" diag="3|0|XTTE0570|bindingi">
-         <callT name="getBinding" bSlot="4">
-          <withParam name="Q{}this" flags="c" as="element()">
-           <dot line="1279" type="element()"/>
-          </withParam>
-         </callT>
-        </check>
-       </treat>
-       <let line="1284" var="refi" as="xs:string" slot="3" eval="7">
-        <treat line="1285" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|refi">
-         <check card="1" diag="3|0|XTTE0570|refi">
-          <cvUntyped to="xs:string">
-           <data>
-            <callT name="getDataRef" bSlot="5">
-             <withParam name="Q{}this" flags="c" as="element()">
-              <dot line="1286" type="element()"/>
-             </withParam>
-             <withParam name="Q{}bindingi" flags="c" as="node()?">
-              <varRef line="1287" name="bindingi" slot="2"/>
-             </withParam>
-            </callT>
-           </data>
-          </cvUntyped>
+      <sequence line="1460">
+       <choose>
+        <and op="and">
+         <ufCall name="Q{http://www.w3.org/2002/xforms}usesIndexFunction" tailCall="false" bSlot="4" eval="7">
+          <dot type="element()"/>
+         </ufCall>
+         <fn name="empty">
+          <filter flags="b">
+           <slash simple="1">
+            <dot type="element()"/>
+            <axis name="ancestor" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+           </slash>
+           <ufCall name="Q{http://www.w3.org/2002/xforms}usesIndexFunction" tailCall="false" bSlot="5" eval="7">
+            <dot type="element()"/>
+           </ufCall>
+          </filter>
+         </fn>
+        </and>
+        <ifCall line="1461" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+         <check card="1" diag="0|0||ixsl:call">
+          <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+         </check>
+         <str val="setElementUsingIndexFunction"/>
+         <arrayBlock>
+          <varRef name="myid" slot="2"/>
+          <dot type="element()"/>
+         </arrayBlock>
+        </ifCall>
+       </choose>
+       <let line="1468" var="bindingi" as="node()?" slot="3" eval="7">
+        <treat line="1469" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|bindingi">
+         <check card="?" diag="3|0|XTTE0570|bindingi">
+          <callT name="getBinding" bSlot="6">
+           <withParam name="Q{}this" flags="c" as="element()">
+            <dot line="1470" type="element()"/>
+           </withParam>
+          </callT>
          </check>
         </treat>
-        <let line="1292" var="instanceField" as="node()?" slot="4" eval="7">
-         <treat line="1293" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|instanceField">
-          <check card="?" diag="3|0|XTTE0570|instanceField">
-           <callT name="getReferencedInstanceField" bSlot="6">
-            <withParam name="Q{}refi" flags="c" as="xs:string">
-             <varRef line="1294" name="refi" slot="3"/>
-            </withParam>
-           </callT>
+        <let line="1475" var="refi" as="xs:string" slot="4" eval="7">
+         <treat line="1476" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|refi">
+          <check card="1" diag="3|0|XTTE0570|refi">
+           <cvUntyped to="xs:string">
+            <data>
+             <callT name="getDataRef" bSlot="7">
+              <withParam name="Q{}this" flags="c" as="element()">
+               <dot line="1477" type="element()"/>
+              </withParam>
+              <withParam name="Q{}bindingi" flags="c" as="node()?">
+               <varRef line="1478" name="bindingi" slot="3"/>
+              </withParam>
+             </callT>
+            </data>
+           </cvUntyped>
           </check>
          </treat>
-         <let line="1299" var="actions" as="map(*)*" slot="5" eval="8">
-          <treat line="1300" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|actions">
-           <callT name="setActions" bSlot="7">
-            <withParam name="Q{}this" flags="c" as="element()">
-             <dot line="1301" type="element()"/>
-            </withParam>
-            <withParam name="Q{}nodeset" flags="t" as="xs:string">
-             <varRef line="1302" name="refi" slot="3"/>
-            </withParam>
-           </callT>
+         <let line="1483" var="instanceField" as="node()?" slot="5" eval="7">
+          <treat line="1484" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|instanceField">
+           <check card="?" diag="3|0|XTTE0570|instanceField">
+            <callT name="getReferencedInstanceField" bSlot="8">
+             <withParam name="Q{}refi" flags="c" as="xs:string">
+              <varRef line="1485" name="refi" slot="4"/>
+             </withParam>
+            </callT>
+           </check>
           </treat>
-          <sequence line="1306">
-           <choose>
-            <fn name="exists">
-             <varRef name="actions" slot="5"/>
-            </fn>
-            <ifCall line="1307" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
-             <check card="1" diag="0|0||ixsl:call">
-              <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
-             </check>
-             <str val="addAction"/>
-             <arrayBlock>
-              <varRef name="myid" slot="1"/>
-              <varRef name="actions" slot="5"/>
-             </arrayBlock>
-            </ifCall>
-           </choose>
-           <applyT line="1324" bSlot="8">
-            <axis role="select" name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}label)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='label';"/>
-           </applyT>
-           <elem line="1327" name="span" nsuri="" namespaces="xd rdf xhtml js in fn map array ev r">
-            <sequence>
-             <att name="style" flags="l">
-              <str val="display:inline"/>
-             </att>
-             <elem line="1329" name="select" nsuri="" flags="l" namespaces="xd rdf xhtml js in fn map array ev r">
-              <sequence>
-               <copyOf flags="vc">
-                <filter flags="b">
-                 <axis name="attribute" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
-                 <vc op="ne" comp="CCC">
-                  <fn name="local-name">
-                   <dot type="attribute()"/>
+          <let line="1490" var="actions" as="map(*)*" slot="6" eval="8">
+           <treat line="1491" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|actions">
+            <callT name="setActions" bSlot="9">
+             <withParam name="Q{}this" flags="c" as="element()">
+              <dot line="1492" type="element()"/>
+             </withParam>
+             <withParam name="Q{}nodeset" flags="t" as="xs:string">
+              <varRef line="1493" name="refi" slot="4"/>
+             </withParam>
+            </callT>
+           </treat>
+           <sequence line="1497">
+            <choose>
+             <fn name="exists">
+              <varRef name="actions" slot="6"/>
+             </fn>
+             <ifCall line="1498" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+              <check card="1" diag="0|0||ixsl:call">
+               <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+              </check>
+              <str val="addAction"/>
+              <arrayBlock>
+               <varRef name="myid" slot="2"/>
+               <varRef name="actions" slot="6"/>
+              </arrayBlock>
+             </ifCall>
+            </choose>
+            <elem line="1515" name="div" nsuri="" namespaces="xd rdf xhtml js in fn map array ev">
+             <sequence>
+              <att name="class" flags="l">
+               <str val="xforms-select"/>
+              </att>
+              <applyT line="1516" bSlot="10">
+               <axis role="select" name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}label)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='label';"/>
+              </applyT>
+              <elem line="1519" name="select" nsuri="" flags="l" namespaces="xd rdf xhtml js in fn map array ev">
+               <sequence>
+                <ufCall name="Q{http://www.w3.org/2002/xforms}getClass" tailCall="false" bSlot="11" eval="7">
+                 <dot type="element()"/>
+                </ufCall>
+                <copyOf line="1520" flags="vc">
+                 <except op="except">
+                  <axis name="attribute" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
+                  <docOrder intra="1">
+                   <sequence>
+                    <axis name="attribute" nodeTest="attribute(Q{}class)" jsTest="return item.name==='class'"/>
+                    <axis name="attribute" nodeTest="attribute(Q{}ref)" jsTest="return item.name==='ref'"/>
+                    <axis name="attribute" nodeTest="attribute(Q{}incremental)" jsTest="return item.name==='incremental'"/>
+                   </sequence>
+                  </docOrder>
+                 </except>
+                </copyOf>
+                <att line="1522" name="data-ref" flags="l">
+                 <varRef name="refi" slot="4"/>
+                </att>
+                <att line="1523" name="data-element" flags="l">
+                 <lastOf line="1513">
+                  <fn name="tokenize">
+                   <varRef name="refi" slot="4"/>
+                   <str val="/"/>
+                   <str val=""/>
                   </fn>
-                  <str val="ref"/>
-                 </vc>
-                </filter>
-               </copyOf>
-               <att line="1331" name="data-ref" flags="l">
-                <varRef name="refi" slot="3"/>
-               </att>
-               <att line="1332" name="data-element" flags="l">
-                <lastOf line="1322">
-                 <fn name="tokenize">
-                  <varRef name="refi" slot="3"/>
-                  <str val="/"/>
-                  <str val=""/>
-                 </fn>
-                </lastOf>
-               </att>
-               <choose line="1334">
-                <and op="and">
-                 <fn name="exists">
-                  <varRef name="bindingi" slot="2"/>
-                 </fn>
-                 <fn name="exists">
-                  <slash simple="1">
-                   <varRef name="bindingi" slot="2"/>
-                   <axis name="attribute" nodeTest="attribute(Q{}constraint)" jsTest="return item.name==='constraint'"/>
-                  </slash>
-                 </fn>
-                </and>
-                <att line="1335" name="data-constraint" flags="l">
-                 <convert from="xs:untypedAtomic" to="xs:string">
-                  <data>
+                 </lastOf>
+                </att>
+                <choose line="1525">
+                 <and op="and">
+                  <fn name="exists">
+                   <varRef name="bindingi" slot="3"/>
+                  </fn>
+                  <fn name="exists">
                    <slash simple="1">
-                    <varRef name="bindingi" slot="2"/>
+                    <varRef name="bindingi" slot="3"/>
                     <axis name="attribute" nodeTest="attribute(Q{}constraint)" jsTest="return item.name==='constraint'"/>
                    </slash>
-                  </data>
-                 </convert>
-                </att>
-               </choose>
-               <choose line="1338">
-                <vc op="eq" onEmpty="0" comp="CCC">
-                 <fn name="local-name">
-                  <dot type="element()"/>
-                 </fn>
-                 <str val="select"/>
-                </vc>
-                <sequence line="1341">
-                 <att name="multiple" flags="l">
-                  <str val="true"/>
-                 </att>
-                 <att name="size" flags="l">
-                  <convert from="xs:integer" to="xs:string">
-                   <fn name="count">
-                    <axis name="descendant" nodeTest="element(Q{http://www.w3.org/2002/xforms}item)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='item';"/>
-                   </fn>
+                  </fn>
+                 </and>
+                 <att line="1526" name="data-constraint" flags="l">
+                  <convert from="xs:untypedAtomic" to="xs:string">
+                   <data>
+                    <slash simple="1">
+                     <varRef name="bindingi" slot="3"/>
+                     <axis name="attribute" nodeTest="attribute(Q{}constraint)" jsTest="return item.name==='constraint'"/>
+                    </slash>
+                   </data>
                   </convert>
                  </att>
-                </sequence>
-               </choose>
-               <choose line="1344">
-                <fn name="exists">
-                 <varRef name="actions" slot="5"/>
-                </fn>
-                <att line="1345" name="data-action" flags="l">
-                 <varRef name="myid" slot="1"/>
-                </att>
-               </choose>
-               <applyT line="1348" bSlot="9">
-                <axis role="select" name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}item)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='item';"/>
-                <withParam name="Q{}selectedValue" as="xs:string">
-                 <choose line="1313">
-                  <fn name="exists">
-                   <varRef name="instanceField" slot="4"/>
+                </choose>
+                <choose line="1529">
+                 <vc op="eq" onEmpty="0" comp="CCC">
+                  <fn name="local-name">
+                   <dot type="element()"/>
                   </fn>
-                  <cvUntyped line="1314" to="xs:string">
-                   <cast as="xs:untypedAtomic" emptiable="0">
-                    <fn name="string">
-                     <convert from="xs:anyAtomicType" to="xs:string">
-                      <data>
-                       <varRef name="instanceField" slot="4"/>
-                      </data>
-                     </convert>
+                  <str val="select"/>
+                 </vc>
+                 <sequence line="1532">
+                  <att name="multiple" flags="l">
+                   <str val="true"/>
+                  </att>
+                  <att name="size" flags="l">
+                   <convert from="xs:integer" to="xs:string">
+                    <fn name="count">
+                     <axis name="descendant" nodeTest="element(Q{http://www.w3.org/2002/xforms}item)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='item';"/>
                     </fn>
-                   </cast>
-                  </cvUntyped>
-                  <true/>
-                  <str val=""/>
-                 </choose>
-                </withParam>
-               </applyT>
-              </sequence>
-             </elem>
-            </sequence>
-           </elem>
-          </sequence>
+                   </convert>
+                  </att>
+                 </sequence>
+                </choose>
+                <choose line="1535">
+                 <fn name="exists">
+                  <varRef name="actions" slot="6"/>
+                 </fn>
+                 <att line="1536" name="data-action" flags="l">
+                  <varRef name="myid" slot="2"/>
+                 </att>
+                </choose>
+                <applyT line="1539" bSlot="12">
+                 <axis role="select" name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}item)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='item';"/>
+                 <withParam name="Q{}selectedValue" as="xs:string">
+                  <choose line="1504">
+                   <fn name="exists">
+                    <varRef name="instanceField" slot="5"/>
+                   </fn>
+                   <cvUntyped line="1505" to="xs:string">
+                    <cast as="xs:untypedAtomic" emptiable="0">
+                     <fn name="string">
+                      <convert from="xs:anyAtomicType" to="xs:string">
+                       <data>
+                        <varRef name="instanceField" slot="5"/>
+                       </data>
+                      </convert>
+                     </fn>
+                    </cast>
+                   </cvUntyped>
+                   <true/>
+                   <str val=""/>
+                  </choose>
+                 </withParam>
+                </applyT>
+               </sequence>
+              </elem>
+             </sequence>
+            </elem>
+           </sequence>
+          </let>
          </let>
         </let>
        </let>
-      </let>
+      </sequence>
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec="0" prio="0.0" seq="17" rank="1" minImp="0" slots="1" flags="s" line="1750" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="0.0" seq="1" rank="1" minImp="0" slots="0" flags="s" line="1003" module="saxon-xforms.xsl">
+    <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}model)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='model';"/>
+    <empty role="action"/>
+   </templateRule>
+   <templateRule prec="0" prio="0.0" seq="17" rank="1" minImp="0" slots="1" flags="s" line="1973" module="saxon-xforms.xsl">
     <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}unload)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='unload';"/>
-    <let role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1760" var="action-map" as="map(*)" slot="0" eval="7">
-     <treat line="1761" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|action-map">
+    <let role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1979" var="action-map" as="map(*)" slot="0" eval="7">
+     <treat line="1980" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|action-map">
       <check card="1" diag="3|0|XTTE0570|action-map">
        <callT name="setAction" bSlot="2">
         <withParam name="Q{}this" flags="c" as="element()">
-         <dot line="1762" type="element()"/>
+         <dot line="1981" type="element()"/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <choose line="1774">
+     <choose line="1993">
       <fn name="exists">
        <varRef name="action-map" slot="0"/>
       </fn>
-      <varRef line="1775" name="action-map" slot="0"/>
+      <varRef line="1994" name="action-map" slot="0"/>
      </choose>
     </let>
    </templateRule>
-   <templateRule prec="0" prio="0.0" seq="12" rank="1" minImp="0" slots="1" flags="s" line="1403" module="saxon-xforms.xsl">
-    <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}item)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='item';"/>
-    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1404">
-     <param name="Q{}selectedValue" slot="0" as="xs:string">
-      <str role="select" val=""/>
-      <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|selectedValue">
-       <check card="1" diag="8|0|XTTE0590|selectedValue">
-        <cvUntyped to="xs:string">
-         <data>
-          <supplied slot="0"/>
-         </data>
-        </cvUntyped>
-       </check>
-      </treat>
-     </param>
-     <elem line="1406" name="option" nsuri="" namespaces="xd rdf xhtml js in fn map array ev r">
-      <sequence>
-       <att name="value" flags="l">
-        <fn name="string-join">
-         <convert from="xs:untypedAtomic" to="xs:string">
-          <data>
-           <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}value)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='value';"/>
-          </data>
-         </convert>
-         <str val=" "/>
-        </fn>
-       </att>
-       <choose line="1407">
-        <gc op="=" card="1:1" comp="CCC">
-         <varRef name="selectedValue" slot="0"/>
-         <cast as="xs:string" emptiable="1">
-          <atomSing card="?" diag="2|0||cast as">
+   <templateRule prec="0" prio="0.0" seq="3" rank="1" minImp="0" slots="0" flags="s" line="1029" module="saxon-xforms.xsl">
+    <p.nodeTest role="match" test="element(Q{}html)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='html';"/>
+    <elem role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1031" name="html" nsuri="" namespaces="xd rdf xhtml js in fn map array ev">
+     <sequence>
+      <copyOf flags="vc">
+       <axis name="attribute" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
+      </copyOf>
+      <elem line="1033" name="head" nsuri="" flags="l" namespaces="xd rdf xhtml js in fn map array ev">
+       <sequence>
+        <copyOf flags="vc">
+         <union op="|">
+          <slash>
+           <axis name="child" nodeTest="element(Q{http://www.w3.org/1999/xhtml}head)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/1999/xhtml'&amp;&amp;q.local==='head';"/>
+           <axis name="attribute" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
+          </slash>
+          <slash>
+           <axis name="child" nodeTest="element(Q{}head)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='head';"/>
+           <axis name="attribute" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
+          </slash>
+         </union>
+        </copyOf>
+        <elem line="1034" name="meta" nsuri="" flags="l">
+         <sequence>
+          <att name="http-equiv" flags="l">
+           <str val="Content-Type"/>
+          </att>
+          <att name="content" flags="l">
+           <str val="text/html;charset=utf-8"/>
+          </att>
+         </sequence>
+        </elem>
+        <forEach line="1036">
+         <union op="|">
+          <filter flags="b">
            <slash>
-            <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}value)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='value';"/>
-            <axis name="child" nodeTest="text()" jsTest="return item.nodeType===3;"/>
+            <axis name="child" nodeTest="element(Q{http://www.w3.org/1999/xhtml}head)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/1999/xhtml'&amp;&amp;q.local==='head';"/>
+            <axis name="child" nodeTest="element(Q{http://www.w3.org/1999/xhtml}meta)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/1999/xhtml'&amp;&amp;q.local==='meta';"/>
            </slash>
-          </atomSing>
-         </cast>
-        </gc>
-        <att line="1408" name="selected" flags="l">
-         <varRef name="selectedValue" slot="0"/>
-        </att>
-       </choose>
-       <valueOf line="1411" flags="l">
-        <fn name="string-join">
-         <convert from="xs:untypedAtomic" to="xs:string">
-          <data>
-           <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}label)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='label';"/>
-          </data>
-         </convert>
-         <str val=" "/>
-        </fn>
-       </valueOf>
-      </sequence>
-     </elem>
-    </sequence>
+           <vc op="ne" comp="CCC">
+            <fn name="string">
+             <axis name="attribute" nodeTest="attribute(Q{}http-equiv)" jsTest="return item.name==='http-equiv'"/>
+            </fn>
+            <str val="Content-Type"/>
+           </vc>
+          </filter>
+          <filter flags="b">
+           <slash>
+            <axis name="child" nodeTest="element(Q{}head)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='head';"/>
+            <axis name="child" nodeTest="element(Q{}meta)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='meta';"/>
+           </slash>
+           <vc op="ne" comp="CCC">
+            <fn name="string">
+             <axis name="attribute" nodeTest="attribute(Q{}http-equiv)" jsTest="return item.name==='http-equiv'"/>
+            </fn>
+            <str val="Content-Type"/>
+           </vc>
+          </filter>
+         </union>
+         <elem line="1038" name="meta" nsuri="" flags="l" namespaces="xd rdf xhtml js in fn map array ev">
+          <copyOf flags="vc">
+           <axis name="attribute" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
+          </copyOf>
+         </elem>
+        </forEach>
+        <copyOf line="1043" flags="vc">
+         <axis name="child" nodeTest="element(Q{}script)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='script';"/>
+        </copyOf>
+       </sequence>
+      </elem>
+      <elem line="1046" name="body" nsuri="" flags="l" namespaces="xd rdf xhtml js in fn map array ev">
+       <applyT bSlot="13">
+        <slash role="select">
+         <axis name="child" nodeTest="element(Q{}body)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='body';"/>
+         <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+        </slash>
+       </applyT>
+      </elem>
+     </sequence>
+    </elem>
    </templateRule>
-   <templateRule prec="0" prio="0.0" seq="17" rank="1" minImp="0" slots="1" flags="s" line="1750" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="0.0" seq="17" rank="1" minImp="0" slots="1" flags="s" line="1973" module="saxon-xforms.xsl">
     <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}show)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='show';"/>
-    <let role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1760" var="action-map" as="map(*)" slot="0" eval="7">
-     <treat line="1761" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|action-map">
+    <let role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1979" var="action-map" as="map(*)" slot="0" eval="7">
+     <treat line="1980" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|action-map">
       <check card="1" diag="3|0|XTTE0570|action-map">
        <callT name="setAction" bSlot="2">
         <withParam name="Q{}this" flags="c" as="element()">
-         <dot line="1762" type="element()"/>
+         <dot line="1981" type="element()"/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <choose line="1774">
+     <choose line="1993">
       <fn name="exists">
        <varRef name="action-map" slot="0"/>
       </fn>
-      <varRef line="1775" name="action-map" slot="0"/>
+      <varRef line="1994" name="action-map" slot="0"/>
      </choose>
     </let>
    </templateRule>
-   <templateRule prec="0" prio="0.0" seq="5" rank="1" minImp="0" slots="11" flags="s" line="993" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="0.0" seq="5" rank="1" minImp="0" slots="10" flags="s" line="1170" module="saxon-xforms.xsl">
     <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}input)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='input';"/>
-    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="994">
+    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1171">
      <param name="Q{}position" slot="0" as="xs:integer">
       <int role="select" val="0"/>
       <treat role="conversion" as="xs:integer" jsTest="return SaxonJS.U.Atomic.integer.matches(item);" diag="8|0|XTTE0590|position">
@@ -3826,7 +4550,19 @@
        </check>
       </treat>
      </param>
-     <let line="997" var="myid" as="xs:string" slot="1" eval="7">
+     <param line="1172" name="Q{}context-position" slot="1" as="xs:string">
+      <str role="select" val=""/>
+      <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|context-position">
+       <check card="1" diag="8|0|XTTE0590|context-position">
+        <cvUntyped to="xs:string">
+         <data>
+          <supplied slot="1"/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <let line="1176" var="myid" as="xs:string" slot="2" eval="7">
       <choose>
        <fn name="exists">
         <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
@@ -3842,475 +4578,644 @@
          <dot type="element(Q{http://www.w3.org/2002/xforms}input)"/>
         </fn>
         <str val="-"/>
-        <varRef name="position" slot="0"/>
+        <choose line="1174">
+         <varRef name="context-position" slot="1"/>
+         <varRef name="context-position" slot="1"/>
+         <true/>
+         <fn name="string">
+          <varRef name="position" slot="0"/>
+         </fn>
+        </choose>
        </fn>
       </choose>
-      <let line="1003" var="bindingi" as="node()?" slot="2" eval="7">
-       <treat line="1004" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|bindingi">
-        <check card="?" diag="3|0|XTTE0570|bindingi">
-         <callT name="getBinding" bSlot="10">
-          <withParam name="Q{}this" flags="c" as="element()">
-           <dot line="1005" type="element(Q{http://www.w3.org/2002/xforms}input)"/>
-          </withParam>
-         </callT>
-        </check>
-       </treat>
-       <let line="1010" var="refi" as="xs:string" slot="3" eval="7">
-        <treat line="1011" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|refi">
-         <check card="1" diag="3|0|XTTE0570|refi">
-          <cvUntyped to="xs:string">
-           <data>
-            <callT name="getDataRef" bSlot="11">
-             <withParam name="Q{}this" flags="c" as="element()">
-              <dot line="1012" type="element(Q{http://www.w3.org/2002/xforms}input)"/>
-             </withParam>
-             <withParam name="Q{}bindingi" flags="c" as="node()?">
-              <varRef line="1013" name="bindingi" slot="2"/>
-             </withParam>
-            </callT>
-           </data>
-          </cvUntyped>
+      <sequence line="1178">
+       <choose>
+        <and op="and">
+         <ufCall name="Q{http://www.w3.org/2002/xforms}usesIndexFunction" tailCall="false" bSlot="14" eval="7">
+          <dot type="element(Q{http://www.w3.org/2002/xforms}input)"/>
+         </ufCall>
+         <fn name="empty">
+          <filter flags="b">
+           <slash simple="1">
+            <dot type="element(Q{http://www.w3.org/2002/xforms}input)"/>
+            <axis name="ancestor" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+           </slash>
+           <ufCall name="Q{http://www.w3.org/2002/xforms}usesIndexFunction" tailCall="false" bSlot="15" eval="7">
+            <dot type="element()"/>
+           </ufCall>
+          </filter>
+         </fn>
+        </and>
+        <ifCall line="1179" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+         <check card="1" diag="0|0||ixsl:call">
+          <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+         </check>
+         <str val="setElementUsingIndexFunction"/>
+         <arrayBlock>
+          <varRef name="myid" slot="2"/>
+          <dot type="element(Q{http://www.w3.org/2002/xforms}input)"/>
+         </arrayBlock>
+        </ifCall>
+       </choose>
+       <let line="1187" var="bindingi" as="node()?" slot="3" eval="7">
+        <treat line="1188" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|bindingi">
+         <check card="?" diag="3|0|XTTE0570|bindingi">
+          <callT name="getBinding" bSlot="16">
+           <withParam name="Q{}this" flags="c" as="element()">
+            <dot line="1189" type="element(Q{http://www.w3.org/2002/xforms}input)"/>
+           </withParam>
+          </callT>
          </check>
         </treat>
-        <let line="1018" var="instanceField" as="node()?" slot="4" eval="7">
-         <treat line="1019" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|instanceField">
-          <check card="?" diag="3|0|XTTE0570|instanceField">
-           <callT name="getReferencedInstanceField" bSlot="12">
-            <withParam name="Q{}refi" flags="c" as="xs:string">
-             <varRef line="1020" name="refi" slot="3"/>
-            </withParam>
-           </callT>
+        <let line="1197" var="refi" as="xs:string" slot="4" eval="7">
+         <treat line="1198" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|refi">
+          <check card="1" diag="3|0|XTTE0570|refi">
+           <cvUntyped to="xs:string">
+            <data>
+             <callT name="getDataRef" bSlot="17">
+              <withParam name="Q{}this" flags="c" as="element()">
+               <dot line="1199" type="element(Q{http://www.w3.org/2002/xforms}input)"/>
+              </withParam>
+              <withParam name="Q{}bindingi" flags="c" as="node()?">
+               <varRef line="1200" name="bindingi" slot="3"/>
+              </withParam>
+             </callT>
+            </data>
+           </cvUntyped>
           </check>
          </treat>
-         <let line="1026" var="relevantVar" as="xs:boolean" slot="5" eval="7">
-          <choose line="1028">
-           <and op="and">
-            <and op="and">
-             <fn name="exists">
-              <varRef name="bindingi" slot="2"/>
-             </fn>
-             <fn name="exists">
-              <slash simple="1">
-               <varRef name="bindingi" slot="2"/>
-               <axis name="attribute" nodeTest="attribute(Q{}relevant)" jsTest="return item.name==='relevant'"/>
-              </slash>
-             </fn>
-            </and>
-            <fn name="exists">
-             <varRef name="instanceField" slot="4"/>
-            </fn>
-           </and>
-           <treat line="1029" as="xs:boolean" jsTest="return SaxonJS.U.Atomic.boolean.matches(item);" diag="3|0|XTTE0570|relevantVar">
-            <check card="1" diag="3|0|XTTE0570|relevantVar">
-             <cvUntyped to="xs:boolean">
-              <data>
-               <evaluate dxns="">
-                <ufCall role="xpath" name="Q{http://www.w3.org/2002/xforms}impose" tailCall="false" bSlot="13" eval="4">
-                 <check card="1" diag="0|0||xforms:impose">
-                  <cvUntyped to="xs:string">
-                   <data>
-                    <slash simple="1">
-                     <varRef name="bindingi" slot="2"/>
-                     <axis name="attribute" nodeTest="attribute(Q{}relevant)" jsTest="return item.name==='relevant'"/>
-                    </slash>
-                   </data>
-                  </cvUntyped>
-                 </check>
-                </ufCall>
-                <varRef role="cxt" name="instanceField" slot="4"/>
-                <str role="sa" val="no"/>
-                <map role="wp" size="0"/>
-               </evaluate>
-              </data>
-             </cvUntyped>
-            </check>
-           </treat>
-           <true/>
-           <true/>
-          </choose>
-          <let line="1038" var="actions" as="map(*)*" slot="6" eval="8">
-           <treat line="1039" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|actions">
-            <callT name="setActions" bSlot="14">
-             <withParam name="Q{}this" flags="c" as="element()">
-              <dot line="1040" type="element(Q{http://www.w3.org/2002/xforms}input)"/>
-             </withParam>
-             <withParam name="Q{}nodeset" flags="t" as="xs:string">
-              <varRef line="1041" name="refi" slot="3"/>
+         <let line="1207" var="instanceField" as="node()?" slot="5" eval="7">
+          <treat line="1208" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|instanceField">
+           <check card="?" diag="3|0|XTTE0570|instanceField">
+            <callT name="getReferencedInstanceField" bSlot="18">
+             <withParam name="Q{}refi" flags="c" as="xs:string">
+              <varRef line="1209" name="refi" slot="4"/>
              </withParam>
             </callT>
-           </treat>
-           <sequence line="1045">
-            <choose>
+           </check>
+          </treat>
+          <let line="1223" var="relevantVar" as="xs:boolean" slot="6" eval="7">
+           <choose line="1225">
+            <and op="and">
+             <and op="and">
+              <fn name="exists">
+               <varRef name="bindingi" slot="3"/>
+              </fn>
+              <fn name="exists">
+               <slash simple="1">
+                <varRef name="bindingi" slot="3"/>
+                <axis name="attribute" nodeTest="attribute(Q{}relevant)" jsTest="return item.name==='relevant'"/>
+               </slash>
+              </fn>
+             </and>
              <fn name="exists">
-              <varRef name="actions" slot="6"/>
+              <varRef name="instanceField" slot="5"/>
              </fn>
-             <ifCall line="1046" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
-              <check card="1" diag="0|0||ixsl:call">
-               <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
-              </check>
-              <str val="addAction"/>
-              <arrayBlock>
-               <varRef name="myid" slot="1"/>
-               <varRef name="actions" slot="6"/>
-              </arrayBlock>
-             </ifCall>
-            </choose>
-            <elem line="1052" name="div" nsuri="" namespaces="xd rdf xhtml js in fn map array ev r">
-             <let var="class" as="xs:string?" slot="7" eval="7">
-              <choose line="1053">
-               <fn name="exists">
-                <axis name="attribute" nodeTest="attribute(Q{}class)" jsTest="return item.name==='class'"/>
-               </fn>
-               <cvUntyped line="1054" to="xs:string">
-                <cast as="xs:untypedAtomic" emptiable="0">
-                 <fn name="string">
-                  <convert from="xs:untypedAtomic" to="xs:string">
-                   <attVal name="Q{}class" chk="0"/>
-                  </convert>
-                 </fn>
-                </cast>
-               </cvUntyped>
-              </choose>
-              <let line="1057" var="class-mod" as="xs:string?" slot="8" eval="7">
-               <choose line="1059">
-                <fn name="exists">
-                 <axis name="attribute" nodeTest="attribute(Q{}incremental)" jsTest="return item.name==='incremental'"/>
-                </fn>
-                <cvUntyped line="1060" to="xs:string">
-                 <cast as="xs:untypedAtomic" emptiable="0">
-                  <fn name="string-join">
-                   <sequence>
-                    <varRef name="class" slot="7"/>
-                    <str val="incremental"/>
-                   </sequence>
-                   <str val=" "/>
+            </and>
+            <treat line="1226" as="xs:boolean" jsTest="return SaxonJS.U.Atomic.boolean.matches(item);" diag="3|0|XTTE0570|relevantVar">
+             <check card="1" diag="3|0|XTTE0570|relevantVar">
+              <cvUntyped to="xs:boolean">
+               <data>
+                <evaluate dxns="">
+                 <ufCall role="xpath" name="Q{http://www.w3.org/2002/xforms}impose" tailCall="false" bSlot="19" eval="4">
+                  <check card="1" diag="0|0||xforms:impose">
+                   <cvUntyped to="xs:string">
+                    <data>
+                     <slash simple="1">
+                      <varRef name="bindingi" slot="3"/>
+                      <axis name="attribute" nodeTest="attribute(Q{}relevant)" jsTest="return item.name==='relevant'"/>
+                     </slash>
+                    </data>
+                   </cvUntyped>
+                  </check>
+                 </ufCall>
+                 <varRef role="cxt" name="instanceField" slot="5"/>
+                 <choose role="nsCxt" line="1218">
+                  <fn name="exists">
+                   <varRef name="instanceField" slot="5"/>
                   </fn>
-                 </cast>
-                </cvUntyped>
-                <true/>
-                <varRef line="1063" name="class" slot="7"/>
-               </choose>
-               <sequence line="1067">
+                  <treat as="element()" jsTest="return item.nodeType===1;" diag="3|0|XTTE0570|namespace-context-item">
+                   <check card="1" diag="3|0|XTTE0570|namespace-context-item">
+                    <varRef name="instanceField" slot="5"/>
+                   </check>
+                  </treat>
+                  <true/>
+                  <ufCall name="Q{http://www.w3.org/2002/xforms}addNamespaceDeclarations" tailCall="false" bSlot="20" eval="4">
+                   <check card="1" diag="0|0||xforms:addNamespaceDeclarations">
+                    <slash simple="1">
+                     <root/>
+                     <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+                    </slash>
+                   </check>
+                  </ufCall>
+                 </choose>
+                 <str role="sa" val="no"/>
+                 <map role="wp" size="0"/>
+                </evaluate>
+               </data>
+              </cvUntyped>
+             </check>
+            </treat>
+            <true/>
+            <true/>
+           </choose>
+           <let line="1236" var="actions" as="map(*)*" slot="7" eval="8">
+            <treat line="1237" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|actions">
+             <callT name="setActions" bSlot="21">
+              <withParam name="Q{}this" flags="c" as="element()">
+               <dot line="1238" type="element(Q{http://www.w3.org/2002/xforms}input)"/>
+              </withParam>
+              <withParam name="Q{}nodeset" flags="t" as="xs:string">
+               <varRef line="1239" name="refi" slot="4"/>
+              </withParam>
+             </callT>
+            </treat>
+            <sequence line="1244">
+             <choose>
+              <fn name="exists">
+               <varRef name="actions" slot="7"/>
+              </fn>
+              <ifCall line="1245" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+               <check card="1" diag="0|0||ixsl:call">
+                <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+               </check>
+               <str val="addAction"/>
+               <arrayBlock>
+                <varRef name="myid" slot="2"/>
+                <varRef name="actions" slot="7"/>
+               </arrayBlock>
+              </ifCall>
+             </choose>
+             <elem line="1250" name="div" nsuri="" namespaces="xd rdf xhtml js in fn map array ev">
+              <sequence>
+               <att name="class" flags="l">
+                <str val="xforms-input"/>
+               </att>
+               <att line="1251" name="style" flags="l">
                 <choose>
-                 <fn name="exists">
-                  <varRef name="class-mod" slot="8"/>
-                 </fn>
-                 <att line="1068" name="class" flags="l">
-                  <varRef name="class-mod" slot="8"/>
-                 </att>
+                 <varRef name="relevantVar" slot="6"/>
+                 <str val="display:block"/>
+                 <true/>
+                 <str val="display:none"/>
                 </choose>
-                <elem line="1072" name="span" nsuri="" flags="l" namespaces="xd rdf xhtml js in fn map array ev r">
+               </att>
+               <applyT line="1253" bSlot="22">
+                <axis role="select" name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}label)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='label';"/>
+               </applyT>
+               <let line="1255" var="hints" as="text()*" slot="8" eval="3">
+                <slash>
+                 <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}hint)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='hint';"/>
+                 <axis name="child" nodeTest="text()" jsTest="return item.nodeType===3;"/>
+                </slash>
+                <elem line="1260" name="input" nsuri="" flags="l" namespaces="xd rdf xhtml js in fn map array ev">
                  <sequence>
-                  <att name="style" flags="l">
-                   <choose>
-                    <varRef name="relevantVar" slot="5"/>
-                    <str val="display:inline"/>
-                    <true/>
-                    <str val="display:none"/>
-                   </choose>
+                  <ufCall name="Q{http://www.w3.org/2002/xforms}getClass" tailCall="false" bSlot="23" eval="7">
+                   <dot type="element(Q{http://www.w3.org/2002/xforms}input)"/>
+                  </ufCall>
+                  <att line="1261" name="id" flags="l">
+                   <varRef name="myid" slot="2"/>
                   </att>
-                  <applyT line="1074" bSlot="15">
-                   <axis role="select" name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}label)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='label';"/>
-                  </applyT>
-                  <let line="1076" var="hints" as="text()*" slot="9" eval="3">
-                   <slash>
-                    <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}hint)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='hint';"/>
-                    <axis name="child" nodeTest="text()" jsTest="return item.nodeType===3;"/>
-                   </slash>
-                   <elem line="1081" name="input" nsuri="" flags="l" namespaces="xd rdf xhtml js in fn map array ev r">
-                    <sequence>
+                  <att line="1263" name="data-ref" flags="l">
+                   <varRef name="refi" slot="4"/>
+                  </att>
+                  <att line="1264" name="data-element" flags="l">
+                   <lastOf line="1257">
+                    <fn name="tokenize">
+                     <varRef name="refi" slot="4"/>
+                     <str val="/"/>
+                     <str val=""/>
+                    </fn>
+                   </lastOf>
+                  </att>
+                  <choose line="1266">
+                   <and op="and">
+                    <fn name="exists">
+                     <varRef name="bindingi" slot="3"/>
+                    </fn>
+                    <fn name="exists">
+                     <slash simple="1">
+                      <varRef name="bindingi" slot="3"/>
+                      <axis name="attribute" nodeTest="attribute(Q{}required)" jsTest="return item.name==='required'"/>
+                     </slash>
+                    </fn>
+                   </and>
+                   <att line="1267" name="data-required" flags="l">
+                    <convert from="xs:untypedAtomic" to="xs:string">
+                     <data>
+                      <slash simple="1">
+                       <varRef name="bindingi" slot="3"/>
+                       <axis name="attribute" nodeTest="attribute(Q{}required)" jsTest="return item.name==='required'"/>
+                      </slash>
+                     </data>
+                    </convert>
+                   </att>
+                  </choose>
+                  <choose line="1269">
+                   <and op="and">
+                    <fn name="exists">
+                     <varRef name="bindingi" slot="3"/>
+                    </fn>
+                    <fn name="exists">
+                     <slash simple="1">
+                      <varRef name="bindingi" slot="3"/>
+                      <axis name="attribute" nodeTest="attribute(Q{}constraint)" jsTest="return item.name==='constraint'"/>
+                     </slash>
+                    </fn>
+                   </and>
+                   <att line="1270" name="data-constraint" flags="l">
+                    <convert from="xs:untypedAtomic" to="xs:string">
+                     <data>
+                      <slash simple="1">
+                       <varRef name="bindingi" slot="3"/>
+                       <axis name="attribute" nodeTest="attribute(Q{}constraint)" jsTest="return item.name==='constraint'"/>
+                      </slash>
+                     </data>
+                    </convert>
+                   </att>
+                  </choose>
+                  <choose line="1272">
+                   <fn name="exists">
+                    <varRef name="actions" slot="7"/>
+                   </fn>
+                   <att line="1273" name="data-action" flags="l">
+                    <varRef name="myid" slot="2"/>
+                   </att>
+                  </choose>
+                  <choose line="1276">
+                   <and op="and">
+                    <fn name="exists">
+                     <varRef name="bindingi" slot="3"/>
+                    </fn>
+                    <fn name="exists">
+                     <slash simple="1">
+                      <varRef name="bindingi" slot="3"/>
+                      <axis name="attribute" nodeTest="attribute(Q{}relevant)" jsTest="return item.name==='relevant'"/>
+                     </slash>
+                    </fn>
+                   </and>
+                   <att line="1277" name="data-relevant" flags="l">
+                    <convert from="xs:untypedAtomic" to="xs:string">
+                     <data>
+                      <slash simple="1">
+                       <varRef name="bindingi" slot="3"/>
+                       <axis name="attribute" nodeTest="attribute(Q{}relevant)" jsTest="return item.name==='relevant'"/>
+                      </slash>
+                     </data>
+                    </convert>
+                   </att>
+                  </choose>
+                  <let line="1280" var="input-value" as="xs:string" slot="9" eval="7">
+                   <choose line="1282">
+                    <fn name="exists">
+                     <varRef name="instanceField" slot="5"/>
+                    </fn>
+                    <cvUntyped line="1283" to="xs:string">
+                     <cast as="xs:untypedAtomic" emptiable="0">
+                      <fn name="string">
+                       <convert from="xs:anyAtomicType" to="xs:string">
+                        <data>
+                         <varRef name="instanceField" slot="5"/>
+                        </data>
+                       </convert>
+                      </fn>
+                     </cast>
+                    </cvUntyped>
+                    <true/>
+                    <str val=""/>
+                   </choose>
+                   <sequence line="1297">
+                    <choose>
                      <choose>
                       <fn name="exists">
-                       <axis name="attribute" nodeTest="attribute(Q{}incremental)" jsTest="return item.name==='incremental'"/>
+                       <varRef name="bindingi" slot="3"/>
                       </fn>
-                      <att line="1082" name="class" flags="l">
-                       <str val="incremental"/>
-                      </att>
-                     </choose>
-                     <att line="1085" name="data-ref" flags="l">
-                      <varRef name="refi" slot="3"/>
-                     </att>
-                     <att line="1086" name="data-element" flags="l">
-                      <lastOf line="1078">
-                       <fn name="tokenize">
-                        <varRef name="refi" slot="3"/>
-                        <str val="/"/>
-                        <str val=""/>
-                       </fn>
-                      </lastOf>
-                     </att>
-                     <choose line="1088">
-                      <and op="and">
-                       <fn name="exists">
-                        <varRef name="bindingi" slot="2"/>
-                       </fn>
-                       <fn name="exists">
-                        <slash simple="1">
-                         <varRef name="bindingi" slot="2"/>
-                         <axis name="attribute" nodeTest="attribute(Q{}required)" jsTest="return item.name==='required'"/>
-                        </slash>
-                       </fn>
-                      </and>
-                      <att line="1089" name="data-required" flags="l">
-                       <convert from="xs:untypedAtomic" to="xs:string">
+                      <vc op="eq" comp="EQC">
+                       <cast as="xs:QName" emptiable="1">
                         <data>
                          <slash simple="1">
-                          <varRef name="bindingi" slot="2"/>
-                          <axis name="attribute" nodeTest="attribute(Q{}required)" jsTest="return item.name==='required'"/>
+                          <varRef name="bindingi" slot="3"/>
+                          <axis name="attribute" nodeTest="attribute(Q{}type)" jsTest="return item.name==='type'"/>
                          </slash>
                         </data>
-                       </convert>
-                      </att>
+                       </cast>
+                       <qName pre="xs" uri="http://www.w3.org/2001/XMLSchema" loc="date"/>
+                      </vc>
+                      <true/>
+                      <false/>
                      </choose>
-                     <choose line="1091">
-                      <and op="and">
-                       <fn name="exists">
-                        <varRef name="bindingi" slot="2"/>
-                       </fn>
-                       <fn name="exists">
-                        <slash simple="1">
-                         <varRef name="bindingi" slot="2"/>
-                         <axis name="attribute" nodeTest="attribute(Q{}constraint)" jsTest="return item.name==='constraint'"/>
-                        </slash>
-                       </fn>
-                      </and>
-                      <att line="1092" name="data-constraint" flags="l">
-                       <convert from="xs:untypedAtomic" to="xs:string">
-                        <data>
-                         <slash simple="1">
-                          <varRef name="bindingi" slot="2"/>
-                          <axis name="attribute" nodeTest="attribute(Q{}constraint)" jsTest="return item.name==='constraint'"/>
-                         </slash>
-                        </data>
-                       </convert>
+                     <sequence line="1298">
+                      <att name="data-type" flags="l">
+                       <str val="date"/>
                       </att>
-                     </choose>
-                     <choose line="1094">
+                      <att line="1300" name="type" flags="l">
+                       <str val="date"/>
+                      </att>
+                      <att line="1302" name="value" flags="l">
+                       <varRef name="input-value" slot="9"/>
+                      </att>
+                     </sequence>
+                     <choose line="1309">
                       <fn name="exists">
-                       <varRef name="actions" slot="6"/>
+                       <varRef name="bindingi" slot="3"/>
                       </fn>
-                      <att line="1095" name="data-action" flags="l">
-                       <varRef name="myid" slot="1"/>
-                      </att>
-                     </choose>
-                     <choose line="1098">
-                      <and op="and">
-                       <fn name="exists">
-                        <varRef name="bindingi" slot="2"/>
-                       </fn>
-                       <fn name="exists">
-                        <slash simple="1">
-                         <varRef name="bindingi" slot="2"/>
-                         <axis name="attribute" nodeTest="attribute(Q{}relevant)" jsTest="return item.name==='relevant'"/>
-                        </slash>
-                       </fn>
-                      </and>
-                      <att line="1099" name="data-relevant" flags="l">
-                       <convert from="xs:untypedAtomic" to="xs:string">
+                      <vc op="eq" comp="EQC">
+                       <cast as="xs:QName" emptiable="1">
                         <data>
                          <slash simple="1">
-                          <varRef name="bindingi" slot="2"/>
-                          <axis name="attribute" nodeTest="attribute(Q{}relevant)" jsTest="return item.name==='relevant'"/>
+                          <varRef name="bindingi" slot="3"/>
+                          <axis name="attribute" nodeTest="attribute(Q{}type)" jsTest="return item.name==='type'"/>
                          </slash>
                         </data>
-                       </convert>
-                      </att>
+                       </cast>
+                       <qName pre="xs" uri="http://www.w3.org/2001/XMLSchema" loc="time"/>
+                      </vc>
+                      <true/>
+                      <false/>
                      </choose>
-                     <let line="1102" var="input-value" as="xs:string" slot="10" eval="7">
-                      <choose line="1104">
+                     <sequence line="1310">
+                      <att name="data-type" flags="l">
+                       <str val="time"/>
+                      </att>
+                      <att line="1312" name="type" flags="l">
+                       <str val="time"/>
+                      </att>
+                      <att line="1315" name="value" flags="l">
+                       <varRef name="input-value" slot="9"/>
+                      </att>
+                     </sequence>
+                     <choose line="1322">
+                      <fn name="exists">
+                       <varRef name="bindingi" slot="3"/>
+                      </fn>
+                      <vc op="eq" comp="EQC">
+                       <cast as="xs:QName" emptiable="1">
+                        <data>
+                         <slash simple="1">
+                          <varRef name="bindingi" slot="3"/>
+                          <axis name="attribute" nodeTest="attribute(Q{}type)" jsTest="return item.name==='type'"/>
+                         </slash>
+                        </data>
+                       </cast>
+                       <qName pre="xs" uri="http://www.w3.org/2001/XMLSchema" loc="boolean"/>
+                      </vc>
+                      <true/>
+                      <false/>
+                     </choose>
+                     <sequence line="1323">
+                      <att name="data-type" flags="l">
+                       <str val="checkbox"/>
+                      </att>
+                      <att line="1325" name="type" flags="l">
+                       <str val="checkbox"/>
+                      </att>
+                      <choose line="1330">
                        <fn name="exists">
-                        <varRef name="instanceField" slot="4"/>
+                        <varRef name="instanceField" slot="5"/>
                        </fn>
-                       <cvUntyped line="1105" to="xs:string">
-                        <cast as="xs:untypedAtomic" emptiable="0">
-                         <fn name="string">
-                          <convert from="xs:anyAtomicType" to="xs:string">
-                           <data>
-                            <varRef name="instanceField" slot="4"/>
-                           </data>
-                          </convert>
-                         </fn>
-                        </cast>
-                       </cvUntyped>
-                       <true/>
-                       <str val=""/>
+                       <choose line="1331">
+                        <and op="and">
+                         <varRef name="input-value" slot="9"/>
+                         <cast as="xs:boolean" emptiable="0">
+                          <varRef name="input-value" slot="9"/>
+                         </cast>
+                        </and>
+                        <att line="1332" name="checked" flags="l">
+                         <varRef name="input-value" slot="9"/>
+                        </att>
+                       </choose>
                       </choose>
-                      <sequence line="1119">
-                       <choose>
-                        <choose>
-                         <fn name="exists">
-                          <varRef name="bindingi" slot="2"/>
-                         </fn>
-                         <vc op="eq" comp="EQC">
-                          <cast as="xs:QName" emptiable="1">
-                           <data>
-                            <slash simple="1">
-                             <varRef name="bindingi" slot="2"/>
-                             <axis name="attribute" nodeTest="attribute(Q{}type)" jsTest="return item.name==='type'"/>
-                            </slash>
-                           </data>
-                          </cast>
-                          <qName pre="xs" uri="http://www.w3.org/2001/XMLSchema" loc="date"/>
-                         </vc>
-                         <true/>
-                         <false/>
-                        </choose>
-                        <sequence line="1120">
-                         <att name="data-type" flags="l">
-                          <str val="date"/>
-                         </att>
-                         <att line="1122" name="type" flags="l">
-                          <str val="date"/>
-                         </att>
-                         <att line="1124" name="value" flags="l">
-                          <varRef name="input-value" slot="10"/>
-                         </att>
-                        </sequence>
-                        <choose line="1131">
-                         <fn name="exists">
-                          <varRef name="bindingi" slot="2"/>
-                         </fn>
-                         <vc op="eq" comp="EQC">
-                          <cast as="xs:QName" emptiable="1">
-                           <data>
-                            <slash simple="1">
-                             <varRef name="bindingi" slot="2"/>
-                             <axis name="attribute" nodeTest="attribute(Q{}type)" jsTest="return item.name==='type'"/>
-                            </slash>
-                           </data>
-                          </cast>
-                          <qName pre="xs" uri="http://www.w3.org/2001/XMLSchema" loc="time"/>
-                         </vc>
-                         <true/>
-                         <false/>
-                        </choose>
-                        <sequence line="1132">
-                         <att name="data-type" flags="l">
-                          <str val="time"/>
-                         </att>
-                         <att line="1134" name="type" flags="l">
-                          <str val="time"/>
-                         </att>
-                         <att line="1137" name="value" flags="l">
-                          <varRef name="input-value" slot="10"/>
-                         </att>
-                        </sequence>
-                        <choose line="1144">
-                         <fn name="exists">
-                          <varRef name="bindingi" slot="2"/>
-                         </fn>
-                         <vc op="eq" comp="EQC">
-                          <cast as="xs:QName" emptiable="1">
-                           <data>
-                            <slash simple="1">
-                             <varRef name="bindingi" slot="2"/>
-                             <axis name="attribute" nodeTest="attribute(Q{}type)" jsTest="return item.name==='type'"/>
-                            </slash>
-                           </data>
-                          </cast>
-                          <qName pre="xs" uri="http://www.w3.org/2001/XMLSchema" loc="boolean"/>
-                         </vc>
-                         <true/>
-                         <false/>
-                        </choose>
-                        <sequence line="1145">
-                         <att name="data-type" flags="l">
-                          <str val="checkbox"/>
-                         </att>
-                         <att line="1147" name="type" flags="l">
-                          <str val="checkbox"/>
-                         </att>
-                         <choose line="1152">
-                          <fn name="exists">
-                           <varRef name="instanceField" slot="4"/>
-                          </fn>
-                          <choose line="1153">
-                           <and op="and">
-                            <varRef name="input-value" slot="10"/>
-                            <cast as="xs:boolean" emptiable="0">
-                             <varRef name="input-value" slot="10"/>
-                            </cast>
-                           </and>
-                           <att line="1154" name="checked" flags="l">
-                            <varRef name="input-value" slot="10"/>
-                           </att>
-                          </choose>
-                         </choose>
-                        </sequence>
-                        <true/>
-                        <sequence line="1160">
-                         <choose>
-                          <varRef name="relevantVar" slot="5"/>
-                          <att line="1161" name="type" flags="l">
-                           <str val="text"/>
-                          </att>
-                         </choose>
-                         <att line="1163" name="value" flags="l">
-                          <varRef name="input-value" slot="10"/>
-                         </att>
-                        </sequence>
-                       </choose>
-                       <choose line="1167">
-                        <fn name="exists">
-                         <varRef name="hints" slot="9"/>
-                        </fn>
-                        <att line="1168" name="title" flags="l">
-                         <fn name="string-join">
-                          <convert from="xs:untypedAtomic" to="xs:string">
-                           <data>
-                            <mergeAdj>
-                             <varRef name="hints" slot="9"/>
-                            </mergeAdj>
-                           </data>
-                          </convert>
-                          <str val=" "/>
-                         </fn>
-                        </att>
-                       </choose>
-                       <choose line="1170">
-                        <fn name="exists">
-                         <axis name="attribute" nodeTest="attribute(Q{}size)" jsTest="return item.name==='size'"/>
-                        </fn>
-                        <att line="1171" name="size" flags="l">
-                         <convert from="xs:untypedAtomic" to="xs:string">
-                          <attVal name="Q{}size" chk="0"/>
-                         </convert>
-                        </att>
-                       </choose>
-                      </sequence>
-                     </let>
-                    </sequence>
-                   </elem>
+                     </sequence>
+                     <true/>
+                     <sequence line="1338">
+                      <choose>
+                       <varRef name="relevantVar" slot="6"/>
+                       <att line="1339" name="type" flags="l">
+                        <str val="text"/>
+                       </att>
+                      </choose>
+                      <att line="1341" name="value" flags="l">
+                       <varRef name="input-value" slot="9"/>
+                      </att>
+                     </sequence>
+                    </choose>
+                    <choose line="1345">
+                     <fn name="exists">
+                      <varRef name="hints" slot="8"/>
+                     </fn>
+                     <att line="1346" name="title" flags="l">
+                      <fn name="string-join">
+                       <convert from="xs:untypedAtomic" to="xs:string">
+                        <data>
+                         <mergeAdj>
+                          <varRef name="hints" slot="8"/>
+                         </mergeAdj>
+                        </data>
+                       </convert>
+                       <str val=" "/>
+                      </fn>
+                     </att>
+                    </choose>
+                    <choose line="1348">
+                     <fn name="exists">
+                      <axis name="attribute" nodeTest="attribute(Q{}size)" jsTest="return item.name==='size'"/>
+                     </fn>
+                     <att line="1349" name="size" flags="l">
+                      <convert from="xs:untypedAtomic" to="xs:string">
+                       <attVal name="Q{}size" chk="0"/>
+                      </convert>
+                     </att>
+                    </choose>
+                   </sequence>
                   </let>
                  </sequence>
                 </elem>
-               </sequence>
-              </let>
-             </let>
-            </elem>
-           </sequence>
+               </let>
+              </sequence>
+             </elem>
+            </sequence>
+           </let>
           </let>
          </let>
         </let>
+       </let>
+      </sequence>
+     </let>
+    </sequence>
+   </templateRule>
+   <templateRule prec="0" prio="0.0" seq="14" rank="1" minImp="0" slots="8" flags="s" line="1658" module="saxon-xforms.xsl">
+    <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}repeat)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='repeat';"/>
+    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1659">
+     <param name="Q{}position" slot="0" as="xs:integer">
+      <int role="select" val="0"/>
+      <treat role="conversion" as="xs:integer" jsTest="return SaxonJS.U.Atomic.integer.matches(item);" diag="8|0|XTTE0590|position">
+       <check card="1" diag="8|0|XTTE0590|position">
+        <cvUntyped to="xs:integer">
+         <data>
+          <supplied slot="0"/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <param line="1660" name="Q{}context-position" slot="1" as="xs:string">
+      <str role="select" val=""/>
+      <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|context-position">
+       <check card="1" diag="8|0|XTTE0590|context-position">
+        <cvUntyped to="xs:string">
+         <data>
+          <supplied slot="1"/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <let line="1670" var="bindingi" as="node()?" slot="2" eval="7">
+      <treat line="1671" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|bindingi">
+       <check card="?" diag="3|0|XTTE0570|bindingi">
+        <callT name="getBinding" bSlot="24">
+         <withParam name="Q{}this" flags="c" as="element()">
+          <dot line="1672" type="element(Q{http://www.w3.org/2002/xforms}repeat)"/>
+         </withParam>
+        </callT>
+       </check>
+      </treat>
+      <let line="1677" var="refi" as="xs:string" slot="3" eval="7">
+       <treat line="1678" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|refi">
+        <check card="1" diag="3|0|XTTE0570|refi">
+         <cvUntyped to="xs:string">
+          <data>
+           <callT name="getDataRef" bSlot="25">
+            <withParam name="Q{}this" flags="c" as="element()">
+             <dot line="1679" type="element(Q{http://www.w3.org/2002/xforms}repeat)"/>
+            </withParam>
+            <withParam name="Q{}bindingi" flags="c" as="node()?">
+             <varRef line="1680" name="bindingi" slot="2"/>
+            </withParam>
+           </callT>
+          </data>
+         </cvUntyped>
+        </check>
+       </treat>
+       <let line="1686" var="selectedRepeatVar" as="element()*" slot="4" eval="8">
+        <treat line="1688" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="3|0|XTTE0570|selectedRepeatVar">
+         <callT name="getReferencedInstanceField" bSlot="26">
+          <withParam name="Q{}refi" flags="c" as="xs:string">
+           <varRef line="1689" name="refi" slot="3"/>
+          </withParam>
+         </callT>
+        </treat>
+        <choose line="1704">
+         <fn name="exists">
+          <varRef name="selectedRepeatVar" slot="4"/>
+         </fn>
+         <elem line="1706" name="div" nsuri="" namespaces="xd rdf xhtml js in fn map array ev">
+          <sequence>
+           <ufCall name="Q{http://www.w3.org/2002/xforms}getClass" tailCall="false" bSlot="27" eval="7">
+            <dot type="element(Q{http://www.w3.org/2002/xforms}repeat)"/>
+           </ufCall>
+           <att line="1708" name="data-repeatable-context" flags="l">
+            <varRef name="refi" slot="3"/>
+           </att>
+           <att line="1709" name="data-count" flags="l">
+            <convert from="xs:integer" to="xs:string">
+             <fn name="count">
+              <varRef name="selectedRepeatVar" slot="4"/>
+             </fn>
+            </convert>
+           </att>
+           <att line="1710" name="id" flags="l">
+            <choose line="1664">
+             <fn name="exists">
+              <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
+             </fn>
+             <check card="1" diag="3|0|XTTE0570|myid">
+              <cvUntyped to="xs:string">
+               <attVal name="Q{}id" chk="0"/>
+              </cvUntyped>
+             </check>
+             <true/>
+             <fn name="concat">
+              <fn name="generate-id">
+               <dot type="element(Q{http://www.w3.org/2002/xforms}repeat)"/>
+              </fn>
+              <str val="-"/>
+              <choose line="1662">
+               <varRef name="context-position" slot="1"/>
+               <varRef name="context-position" slot="1"/>
+               <true/>
+               <fn name="string">
+                <varRef name="position" slot="0"/>
+               </fn>
+              </choose>
+             </fn>
+            </choose>
+           </att>
+           <let line="1711" var="xf-repeat" as="element(Q{http://www.w3.org/2002/xforms}repeat)" slot="5" eval="7">
+            <dot type="element(Q{http://www.w3.org/2002/xforms}repeat)"/>
+            <let line="1716" var="vv:v0" as="element()*" slot="6" eval="4">
+             <slash simple="1">
+              <varRef name="xf-repeat" slot="5"/>
+              <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+             </slash>
+             <forEach line="1712">
+              <varRef name="selectedRepeatVar" slot="4"/>
+              <let line="1713" var="string-position" as="xs:string" slot="7" eval="8">
+               <fn name="string">
+                <fn name="position"/>
+               </fn>
+               <elem line="1715" name="div" nsuri="" flags="l" namespaces="xd rdf xhtml js in fn map array ev">
+                <sequence>
+                 <att name="data-repeat-item" flags="l">
+                  <str val="true"/>
+                 </att>
+                 <applyT line="1716" bSlot="28">
+                  <varRef role="select" name="vv:v0" slot="6"/>
+                  <withParam name="Q{}position" as="xs:integer">
+                   <fn line="1718" name="position"/>
+                  </withParam>
+                  <withParam name="Q{}context-position" as="xs:string">
+                   <choose line="1714">
+                    <varRef name="context-position" slot="1"/>
+                    <fn name="concat">
+                     <varRef name="context-position" slot="1"/>
+                     <str val="."/>
+                     <varRef name="string-position" slot="7"/>
+                    </fn>
+                    <true/>
+                    <varRef name="string-position" slot="7"/>
+                   </choose>
+                  </withParam>
+                  <withParam name="Q{}nodeset" flags="t" as="xs:string">
+                   <fn line="1717" name="concat">
+                    <varRef name="refi" slot="3"/>
+                    <str val="["/>
+                    <fn name="position"/>
+                    <str val="]"/>
+                   </fn>
+                  </withParam>
+                 </applyT>
+                </sequence>
+               </elem>
+              </let>
+             </forEach>
+            </let>
+           </let>
+          </sequence>
+         </elem>
+        </choose>
        </let>
       </let>
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec="0" prio="0.0" seq="0" rank="1" minImp="0" slots="0" flags="s" line="816" module="saxon-xforms.xsl">
-    <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}xform)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='xform';"/>
-    <applyT role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="817" flags="t" bSlot="16">
-     <axis role="select" name="child" nodeTest="( element() | text() | comment() | processing-instruction() )" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);"/>
-    </applyT>
-   </templateRule>
-   <templateRule prec="0" prio="0.0" seq="3" rank="1" minImp="0" slots="0" flags="s" line="852" module="saxon-xforms.xsl">
-    <p.nodeTest role="match" test="element(Q{}html)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='html';"/>
-    <elem role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="854" name="html" nsuri="" namespaces="xd rdf xhtml js in fn map array ev r">
+   <templateRule prec="0" prio="0.0" seq="3" rank="1" minImp="0" slots="0" flags="s" line="1029" module="saxon-xforms.xsl">
+    <p.nodeTest role="match" test="element(Q{http://www.w3.org/1999/xhtml}html)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/1999/xhtml'&amp;&amp;q.local==='html';"/>
+    <elem role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1031" name="html" nsuri="" namespaces="xd rdf xhtml js in fn map array ev">
      <sequence>
       <copyOf flags="vc">
        <axis name="attribute" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
       </copyOf>
-      <elem line="856" name="head" nsuri="" flags="l" namespaces="xd rdf xhtml js in fn map array ev r">
+      <elem line="1033" name="head" nsuri="" flags="l" namespaces="xd rdf xhtml js in fn map array ev">
        <sequence>
         <copyOf flags="vc">
          <union op="|">
@@ -4324,7 +5229,7 @@
           </slash>
          </union>
         </copyOf>
-        <elem line="857" name="meta" nsuri="" flags="l">
+        <elem line="1034" name="meta" nsuri="" flags="l">
          <sequence>
           <att name="http-equiv" flags="l">
            <str val="Content-Type"/>
@@ -4334,7 +5239,7 @@
           </att>
          </sequence>
         </elem>
-        <forEach line="859">
+        <forEach line="1036">
          <union op="|">
           <filter flags="b">
            <slash>
@@ -4361,19 +5266,19 @@
            </vc>
           </filter>
          </union>
-         <elem line="861" name="meta" nsuri="" flags="l" namespaces="xd rdf xhtml js in fn map array ev r">
+         <elem line="1038" name="meta" nsuri="" flags="l" namespaces="xd rdf xhtml js in fn map array ev">
           <copyOf flags="vc">
            <axis name="attribute" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
           </copyOf>
          </elem>
         </forEach>
-        <copyOf line="866" flags="vc">
+        <copyOf line="1043" flags="vc">
          <axis name="child" nodeTest="element(Q{}script)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='script';"/>
         </copyOf>
        </sequence>
       </elem>
-      <elem line="869" name="body" nsuri="" flags="l" namespaces="xd rdf xhtml js in fn map array ev r">
-       <applyT bSlot="17">
+      <elem line="1046" name="body" nsuri="" flags="l" namespaces="xd rdf xhtml js in fn map array ev">
+       <applyT bSlot="13">
         <slash role="select">
          <axis name="child" nodeTest="element(Q{}body)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='body';"/>
          <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
@@ -4383,9 +5288,9 @@
      </sequence>
     </elem>
    </templateRule>
-   <templateRule prec="0" prio="2.0" seq="6" rank="3" minImp="0" slots="6" flags="s" line="1189" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="2.0" seq="6" rank="3" minImp="0" slots="8" flags="s" line="1367" module="saxon-xforms.xsl">
     <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}textarea)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='textarea';"/>
-    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1190">
+    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1368">
      <param name="Q{}position" slot="0" as="xs:integer">
       <int role="select" val="0"/>
       <treat role="conversion" as="xs:integer" jsTest="return SaxonJS.U.Atomic.integer.matches(item);" diag="8|0|XTTE0590|position">
@@ -4398,168 +5303,220 @@
        </check>
       </treat>
      </param>
-     <let line="1196" var="bindingi" as="node()?" slot="1" eval="7">
-      <treat line="1197" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|bindingi">
-       <check card="?" diag="3|0|XTTE0570|bindingi">
-        <callT name="getBinding" bSlot="18">
-         <withParam name="Q{}this" flags="c" as="element()">
-          <dot line="1198" type="element(Q{http://www.w3.org/2002/xforms}textarea)"/>
-         </withParam>
-        </callT>
+     <param line="1369" name="Q{}context-position" slot="1" as="xs:string">
+      <str role="select" val=""/>
+      <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|context-position">
+       <check card="1" diag="8|0|XTTE0590|context-position">
+        <cvUntyped to="xs:string">
+         <data>
+          <supplied slot="1"/>
+         </data>
+        </cvUntyped>
        </check>
       </treat>
-      <let line="1203" var="refi" as="xs:string" slot="2" eval="7">
-       <treat line="1204" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|refi">
-        <check card="1" diag="3|0|XTTE0570|refi">
-         <cvUntyped to="xs:string">
-          <data>
-           <callT name="getDataRef" bSlot="19">
-            <withParam name="Q{}this" flags="c" as="element()">
-             <dot line="1205" type="element(Q{http://www.w3.org/2002/xforms}textarea)"/>
-            </withParam>
-            <withParam name="Q{}bindingi" flags="c" as="node()?">
-             <varRef line="1206" name="bindingi" slot="1"/>
-            </withParam>
-           </callT>
-          </data>
-         </cvUntyped>
-        </check>
-       </treat>
-       <let line="1211" var="instanceField" as="node()?" slot="3" eval="7">
-        <treat line="1212" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|instanceField">
-         <check card="?" diag="3|0|XTTE0570|instanceField">
-          <callT name="getReferencedInstanceField" bSlot="20">
-           <withParam name="Q{}refi" flags="c" as="xs:string">
-            <varRef line="1213" name="refi" slot="2"/>
+     </param>
+     <let line="1373" var="myid" as="xs:string" slot="2" eval="7">
+      <choose>
+       <fn name="exists">
+        <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
+       </fn>
+       <check card="1" diag="3|0|XTTE0570|myid">
+        <cvUntyped to="xs:string">
+         <attVal name="Q{}id" chk="0"/>
+        </cvUntyped>
+       </check>
+       <true/>
+       <fn name="concat">
+        <fn name="generate-id">
+         <dot type="element(Q{http://www.w3.org/2002/xforms}textarea)"/>
+        </fn>
+        <str val="-"/>
+        <choose line="1371">
+         <varRef name="context-position" slot="1"/>
+         <varRef name="context-position" slot="1"/>
+         <true/>
+         <fn name="string">
+          <varRef name="position" slot="0"/>
+         </fn>
+        </choose>
+       </fn>
+      </choose>
+      <sequence line="1375">
+       <choose>
+        <and op="and">
+         <ufCall name="Q{http://www.w3.org/2002/xforms}usesIndexFunction" tailCall="false" bSlot="29" eval="7">
+          <dot type="element(Q{http://www.w3.org/2002/xforms}textarea)"/>
+         </ufCall>
+         <fn name="empty">
+          <filter flags="b">
+           <slash simple="1">
+            <dot type="element(Q{http://www.w3.org/2002/xforms}textarea)"/>
+            <axis name="ancestor" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+           </slash>
+           <ufCall name="Q{http://www.w3.org/2002/xforms}usesIndexFunction" tailCall="false" bSlot="30" eval="7">
+            <dot type="element()"/>
+           </ufCall>
+          </filter>
+         </fn>
+        </and>
+        <ifCall line="1376" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+         <check card="1" diag="0|0||ixsl:call">
+          <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+         </check>
+         <str val="setElementUsingIndexFunction"/>
+         <arrayBlock>
+          <varRef name="myid" slot="2"/>
+          <dot type="element(Q{http://www.w3.org/2002/xforms}textarea)"/>
+         </arrayBlock>
+        </ifCall>
+       </choose>
+       <let line="1380" var="bindingi" as="node()?" slot="3" eval="7">
+        <treat line="1381" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|bindingi">
+         <check card="?" diag="3|0|XTTE0570|bindingi">
+          <callT name="getBinding" bSlot="31">
+           <withParam name="Q{}this" flags="c" as="element()">
+            <dot line="1382" type="element(Q{http://www.w3.org/2002/xforms}textarea)"/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line="1218" var="actions" as="map(*)*" slot="4" eval="8">
-         <treat line="1219" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|actions">
-          <callT name="setActions" bSlot="21">
-           <withParam name="Q{}this" flags="c" as="element()">
-            <dot line="1220" type="element(Q{http://www.w3.org/2002/xforms}textarea)"/>
-           </withParam>
-           <withParam name="Q{}nodeset" flags="t" as="xs:string">
-            <varRef line="1221" name="refi" slot="2"/>
-           </withParam>
-          </callT>
+        <let line="1387" var="refi" as="xs:string" slot="4" eval="7">
+         <treat line="1388" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|refi">
+          <check card="1" diag="3|0|XTTE0570|refi">
+           <cvUntyped to="xs:string">
+            <data>
+             <callT name="getDataRef" bSlot="32">
+              <withParam name="Q{}this" flags="c" as="element()">
+               <dot line="1389" type="element(Q{http://www.w3.org/2002/xforms}textarea)"/>
+              </withParam>
+              <withParam name="Q{}bindingi" flags="c" as="node()?">
+               <varRef line="1390" name="bindingi" slot="3"/>
+              </withParam>
+             </callT>
+            </data>
+           </cvUntyped>
+          </check>
          </treat>
-         <sequence line="1225">
-          <choose>
-           <fn name="exists">
-            <varRef name="actions" slot="4"/>
-           </fn>
-           <ifCall line="1226" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
-            <check card="1" diag="0|0||ixsl:call">
-             <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
-            </check>
-            <str val="addAction"/>
-            <arrayBlock>
-             <choose line="1193">
-              <fn name="exists">
-               <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
-              </fn>
-              <check card="1" diag="3|0|XTTE0570|myid">
-               <cvUntyped to="xs:string">
-                <attVal name="Q{}id" chk="0"/>
-               </cvUntyped>
+         <let line="1395" var="instanceField" as="node()?" slot="5" eval="7">
+          <treat line="1396" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|instanceField">
+           <check card="?" diag="3|0|XTTE0570|instanceField">
+            <callT name="getReferencedInstanceField" bSlot="33">
+             <withParam name="Q{}refi" flags="c" as="xs:string">
+              <varRef line="1397" name="refi" slot="4"/>
+             </withParam>
+            </callT>
+           </check>
+          </treat>
+          <let line="1402" var="actions" as="map(*)*" slot="6" eval="8">
+           <treat line="1403" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|actions">
+            <callT name="setActions" bSlot="34">
+             <withParam name="Q{}this" flags="c" as="element()">
+              <dot line="1404" type="element(Q{http://www.w3.org/2002/xforms}textarea)"/>
+             </withParam>
+             <withParam name="Q{}nodeset" flags="t" as="xs:string">
+              <varRef line="1405" name="refi" slot="4"/>
+             </withParam>
+            </callT>
+           </treat>
+           <sequence line="1409">
+            <choose>
+             <fn name="exists">
+              <varRef name="actions" slot="6"/>
+             </fn>
+             <ifCall line="1410" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+              <check card="1" diag="0|0||ixsl:call">
+               <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
               </check>
-              <true/>
-              <fn name="concat">
-               <fn name="generate-id">
-                <dot type="element(Q{http://www.w3.org/2002/xforms}textarea)"/>
-               </fn>
-               <str val="-"/>
-               <varRef name="position" slot="0"/>
-              </fn>
-             </choose>
-             <varRef name="actions" slot="4"/>
-            </arrayBlock>
-           </ifCall>
-          </choose>
-          <let line="1231" var="hints" as="text()*" slot="5" eval="3">
-           <slash>
-            <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}hint)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='hint';"/>
-            <axis name="child" nodeTest="text()" jsTest="return item.nodeType===3;"/>
-           </slash>
-           <elem line="1234" name="textarea" nsuri="" namespaces="xd rdf xhtml js in fn map array ev r">
-            <sequence>
-             <copyOf flags="vc">
-              <filter flags="b">
-               <axis name="attribute" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
-               <vc op="ne" comp="CCC">
-                <fn name="local-name">
-                 <dot type="attribute()"/>
+              <str val="addAction"/>
+              <arrayBlock>
+               <varRef name="myid" slot="2"/>
+               <varRef name="actions" slot="6"/>
+              </arrayBlock>
+             </ifCall>
+            </choose>
+            <let line="1415" var="hints" as="text()*" slot="7" eval="3">
+             <slash>
+              <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}hint)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='hint';"/>
+              <axis name="child" nodeTest="text()" jsTest="return item.nodeType===3;"/>
+             </slash>
+             <elem line="1418" name="textarea" nsuri="" namespaces="xd rdf xhtml js in fn map array ev">
+              <sequence>
+               <copyOf flags="vc">
+                <filter flags="b">
+                 <axis name="attribute" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
+                 <vc op="ne" comp="CCC">
+                  <fn name="local-name">
+                   <dot type="attribute()"/>
+                  </fn>
+                  <str val="ref"/>
+                 </vc>
+                </filter>
+               </copyOf>
+               <att line="1419" name="data-element" flags="l">
+                <lastOf line="1413">
+                 <fn name="tokenize">
+                  <varRef name="refi" slot="4"/>
+                  <str val="/"/>
+                  <str val=""/>
+                 </fn>
+                </lastOf>
+               </att>
+               <att line="1420" name="data-ref" flags="l">
+                <varRef name="refi" slot="4"/>
+               </att>
+               <choose line="1422">
+                <fn name="exists">
+                 <varRef name="instanceField" slot="5"/>
                 </fn>
-                <str val="ref"/>
-               </vc>
-              </filter>
-             </copyOf>
-             <att line="1235" name="data-element" flags="l">
-              <lastOf line="1229">
-               <fn name="tokenize">
-                <varRef name="refi" slot="2"/>
-                <str val="/"/>
-                <str val=""/>
-               </fn>
-              </lastOf>
-             </att>
-             <att line="1236" name="data-ref" flags="l">
-              <varRef name="refi" slot="2"/>
-             </att>
-             <choose line="1238">
-              <fn name="exists">
-               <varRef name="instanceField" slot="3"/>
-              </fn>
-              <valueOf line="1239" flags="l">
-               <convert from="xs:anyAtomicType" to="xs:string">
-                <data>
-                 <varRef name="instanceField" slot="3"/>
-                </data>
-               </convert>
-              </valueOf>
-              <true/>
-              <sequence line="1241">
-               <valueOf flags="Sl">
-                <str val=""/>
-               </valueOf>
-               <valueOf flags="l">
-                <str val="  "/>
-               </valueOf>
+                <valueOf line="1423" flags="l">
+                 <convert from="xs:anyAtomicType" to="xs:string">
+                  <data>
+                   <varRef name="instanceField" slot="5"/>
+                  </data>
+                 </convert>
+                </valueOf>
+                <true/>
+                <sequence line="1425">
+                 <valueOf flags="Sl">
+                  <str val=""/>
+                 </valueOf>
+                 <valueOf flags="l">
+                  <str val="  "/>
+                 </valueOf>
+                </sequence>
+               </choose>
+               <choose line="1428">
+                <fn name="exists">
+                 <varRef name="hints" slot="7"/>
+                </fn>
+                <att line="1429" name="title" flags="l">
+                 <fn name="string-join">
+                  <convert from="xs:untypedAtomic" to="xs:string">
+                   <data>
+                    <mergeAdj>
+                     <varRef name="hints" slot="7"/>
+                    </mergeAdj>
+                   </data>
+                  </convert>
+                  <str val=" "/>
+                 </fn>
+                </att>
+               </choose>
               </sequence>
-             </choose>
-             <choose line="1244">
-              <fn name="exists">
-               <varRef name="hints" slot="5"/>
-              </fn>
-              <att line="1245" name="title" flags="l">
-               <fn name="string-join">
-                <convert from="xs:untypedAtomic" to="xs:string">
-                 <data>
-                  <mergeAdj>
-                   <varRef name="hints" slot="5"/>
-                  </mergeAdj>
-                 </data>
-                </convert>
-                <str val=" "/>
-               </fn>
-              </att>
-             </choose>
-            </sequence>
-           </elem>
+             </elem>
+            </let>
+           </sequence>
           </let>
-         </sequence>
+         </let>
         </let>
        </let>
-      </let>
+      </sequence>
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec="0" prio="0.0" seq="16" rank="1" minImp="0" slots="6" flags="s" line="1676" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="0.0" seq="16" rank="1" minImp="0" slots="7" flags="s" line="1891" module="saxon-xforms.xsl">
     <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}trigger)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='trigger';"/>
-    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1677">
+    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1892">
      <param name="Q{}position" slot="0" as="xs:integer">
       <int role="select" val="0"/>
       <treat role="conversion" as="xs:integer" jsTest="return SaxonJS.U.Atomic.integer.matches(item);" diag="8|0|XTTE0590|position">
@@ -4572,7 +5529,19 @@
        </check>
       </treat>
      </param>
-     <let line="1680" var="myid" as="xs:string" slot="1" eval="7">
+     <param line="1893" name="Q{}context-position" slot="1" as="xs:string">
+      <str role="select" val=""/>
+      <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|context-position">
+       <check card="1" diag="8|0|XTTE0590|context-position">
+        <cvUntyped to="xs:string">
+         <data>
+          <supplied slot="1"/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <let line="1897" var="myid" as="xs:string" slot="2" eval="7">
       <choose>
        <fn name="exists">
         <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
@@ -4588,662 +5557,164 @@
          <dot type="element(Q{http://www.w3.org/2002/xforms}trigger)"/>
         </fn>
         <str val="-"/>
-        <varRef name="position" slot="0"/>
+        <choose line="1895">
+         <varRef name="context-position" slot="1"/>
+         <varRef name="context-position" slot="1"/>
+         <true/>
+         <fn name="string">
+          <varRef name="position" slot="0"/>
+         </fn>
+        </choose>
        </fn>
       </choose>
-      <let line="1683" var="bindingi" as="node()?" slot="2" eval="7">
-       <treat line="1684" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|bindingi">
-        <check card="?" diag="3|0|XTTE0570|bindingi">
-         <callT name="getBinding" bSlot="22">
-          <withParam name="Q{}this" flags="c" as="element()">
-           <dot line="1685" type="element(Q{http://www.w3.org/2002/xforms}trigger)"/>
-          </withParam>
-         </callT>
-        </check>
-       </treat>
-       <let line="1690" var="refi" as="xs:string" slot="3" eval="7">
-        <treat line="1691" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|refi">
-         <check card="1" diag="3|0|XTTE0570|refi">
-          <cvUntyped to="xs:string">
-           <data>
-            <callT name="getDataRef" bSlot="23">
-             <withParam name="Q{}this" flags="c" as="element()">
-              <dot line="1692" type="element(Q{http://www.w3.org/2002/xforms}trigger)"/>
-             </withParam>
-             <withParam name="Q{}bindingi" flags="c" as="node()?">
-              <varRef line="1693" name="bindingi" slot="2"/>
-             </withParam>
-            </callT>
-           </data>
-          </cvUntyped>
+      <sequence line="1899">
+       <choose>
+        <and op="and">
+         <ufCall name="Q{http://www.w3.org/2002/xforms}usesIndexFunction" tailCall="false" bSlot="35" eval="7">
+          <dot type="element(Q{http://www.w3.org/2002/xforms}trigger)"/>
+         </ufCall>
+         <fn name="empty">
+          <filter flags="b">
+           <slash simple="1">
+            <dot type="element(Q{http://www.w3.org/2002/xforms}trigger)"/>
+            <axis name="ancestor" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+           </slash>
+           <ufCall name="Q{http://www.w3.org/2002/xforms}usesIndexFunction" tailCall="false" bSlot="36" eval="7">
+            <dot type="element()"/>
+           </ufCall>
+          </filter>
+         </fn>
+        </and>
+        <ifCall line="1900" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+         <check card="1" diag="0|0||ixsl:call">
+          <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
          </check>
-        </treat>
-        <let line="1698" var="actions" as="map(*)*" slot="4" eval="8">
-         <treat line="1699" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|actions">
-          <callT name="setActions" bSlot="24">
+         <str val="setElementUsingIndexFunction"/>
+         <arrayBlock>
+          <varRef name="myid" slot="2"/>
+          <dot type="element(Q{http://www.w3.org/2002/xforms}trigger)"/>
+         </arrayBlock>
+        </ifCall>
+       </choose>
+       <let line="1904" var="bindingi" as="node()?" slot="3" eval="7">
+        <treat line="1905" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|bindingi">
+         <check card="?" diag="3|0|XTTE0570|bindingi">
+          <callT name="getBinding" bSlot="37">
            <withParam name="Q{}this" flags="c" as="element()">
-            <dot line="1700" type="element(Q{http://www.w3.org/2002/xforms}trigger)"/>
-           </withParam>
-           <withParam name="Q{}nodeset" flags="t" as="xs:string">
-            <varRef line="1701" name="refi" slot="3"/>
+            <dot line="1906" type="element(Q{http://www.w3.org/2002/xforms}trigger)"/>
            </withParam>
           </callT>
-         </treat>
-         <sequence line="1705">
-          <choose>
-           <fn name="exists">
-            <varRef name="actions" slot="4"/>
-           </fn>
-           <ifCall line="1706" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
-            <check card="1" diag="0|0||ixsl:call">
-             <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
-            </check>
-            <str val="addAction"/>
-            <arrayBlock>
-             <varRef name="myid" slot="1"/>
-             <varRef name="actions" slot="4"/>
-            </arrayBlock>
-           </ifCall>
-          </choose>
-          <let line="1709" var="innerbody" as="document-node()" slot="5" eval="7">
-           <doc line="1711" validation="preserve">
-            <choose>
-             <fn name="exists">
-              <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}label)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='label';"/>
-             </fn>
-             <applyT line="1712" bSlot="25">
-              <axis role="select" name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}label)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='label';"/>
-             </applyT>
-             <true/>
-             <valueOf line="1714" flags="l">
-              <str val=" "/>
-             </valueOf>
-            </choose>
-           </doc>
-           <elem line="1718" name="span" nsuri="" namespaces="xd rdf xhtml js in fn map array ev r">
-            <sequence>
-             <att name="style" flags="l">
-              <str val="display:'inline'"/>
-             </att>
-             <compElem line="1729" flags="l">
-              <choose role="name" line="1721">
-               <gc op="=" card="1:1" comp="CCC">
-                <attVal name="Q{}appearance" chk="0"/>
-                <str val="minimal"/>
-               </gc>
-               <str val="a"/>
-               <true/>
-               <str val="button"/>
-              </choose>
-              <sequence role="content" line="1730">
-               <choose>
-                <gc op="=" card="1:1" comp="CCC">
-                 <attVal name="Q{}appearance" chk="0"/>
-                 <str val="minimal"/>
-                </gc>
-                <att line="1731" name="type" flags="l">
-                 <str val="button"/>
-                </att>
-               </choose>
-               <att line="1734" name="data-ref" flags="l">
-                <varRef name="refi" slot="3"/>
-               </att>
-               <att line="1735" name="data-action" flags="l">
-                <varRef name="myid" slot="1"/>
-               </att>
-               <copyOf line="1736" flags="vc">
-                <varRef name="innerbody" slot="5"/>
-               </copyOf>
-              </sequence>
-             </compElem>
-            </sequence>
-           </elem>
-          </let>
-         </sequence>
-        </let>
-       </let>
-      </let>
-     </let>
-    </sequence>
-   </templateRule>
-   <templateRule prec="0" prio="0.0" seq="13" rank="1" minImp="0" slots="1" flags="s" line="1421" module="saxon-xforms.xsl">
-    <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}group)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='group';"/>
-    <let role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1423" var="refi" as="xs:string?" slot="0" eval="7">
-     <choose line="1425">
-      <fn name="exists">
-       <axis name="attribute" nodeTest="attribute(Q{}nodeset)" jsTest="return item.name==='nodeset'"/>
-      </fn>
-      <cvUntyped to="xs:string">
-       <attVal name="Q{}nodeset" chk="0"/>
-      </cvUntyped>
-      <fn line="1426" name="exists">
-       <axis name="attribute" nodeTest="attribute(Q{}ref)" jsTest="return item.name==='ref'"/>
-      </fn>
-      <cvUntyped line="1426" to="xs:string">
-       <attVal name="Q{}ref" chk="0"/>
-      </cvUntyped>
-     </choose>
-     <elem line="1432" name="div" nsuri="" namespaces="xd rdf xhtml js in fn map array ev r">
-      <sequence>
-       <choose>
-        <fn name="exists">
-         <varRef name="refi" slot="0"/>
-        </fn>
-        <att line="1433" name="data-group-ref" flags="l">
-         <varRef name="refi" slot="0"/>
-        </att>
-       </choose>
-       <choose line="1435">
-        <fn name="exists">
-         <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
-        </fn>
-        <att line="1436" name="id" flags="l">
-         <convert from="xs:untypedAtomic" to="xs:string">
-          <attVal name="Q{}id" chk="0"/>
-         </convert>
-        </att>
-       </choose>
-       <applyT line="1438" bSlot="26">
-        <axis role="select" name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
-        <withParam name="Q{}nodeset" flags="t" as="xs:string?">
-         <choose line="1439">
-          <fn name="exists">
-           <varRef name="refi" slot="0"/>
-          </fn>
-          <varRef name="refi" slot="0"/>
-          <true/>
-          <str val=""/>
-         </choose>
-        </withParam>
-       </applyT>
-      </sequence>
-     </elem>
-    </let>
-   </templateRule>
-   <templateRule prec="0" prio="0.0" seq="17" rank="1" minImp="0" slots="1" flags="s" line="1750" module="saxon-xforms.xsl">
-    <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}script)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='script';"/>
-    <let role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1760" var="action-map" as="map(*)" slot="0" eval="7">
-     <treat line="1761" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|action-map">
-      <check card="1" diag="3|0|XTTE0570|action-map">
-       <callT name="setAction" bSlot="2">
-        <withParam name="Q{}this" flags="c" as="element()">
-         <dot line="1762" type="element()"/>
-        </withParam>
-       </callT>
-      </check>
-     </treat>
-     <choose line="1774">
-      <fn name="exists">
-       <varRef name="action-map" slot="0"/>
-      </fn>
-      <varRef line="1775" name="action-map" slot="0"/>
-     </choose>
-    </let>
-   </templateRule>
-   <templateRule prec="0" prio="0.0" seq="8" rank="1" minImp="0" slots="6" flags="s" line="1267" module="saxon-xforms.xsl">
-    <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}select)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='select';"/>
-    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1268">
-     <param name="Q{}position" slot="0" as="xs:integer">
-      <int role="select" val="0"/>
-      <treat role="conversion" as="xs:integer" jsTest="return SaxonJS.U.Atomic.integer.matches(item);" diag="8|0|XTTE0590|position">
-       <check card="1" diag="8|0|XTTE0590|position">
-        <cvUntyped to="xs:integer">
-         <data>
-          <supplied slot="0"/>
-         </data>
-        </cvUntyped>
-       </check>
-      </treat>
-     </param>
-     <let line="1271" var="myid" as="xs:string" slot="1" eval="7">
-      <choose>
-       <fn name="exists">
-        <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
-       </fn>
-       <check card="1" diag="3|0|XTTE0570|myid">
-        <cvUntyped to="xs:string">
-         <attVal name="Q{}id" chk="0"/>
-        </cvUntyped>
-       </check>
-       <true/>
-       <fn name="concat">
-        <fn name="generate-id">
-         <dot type="element()"/>
-        </fn>
-        <str val="-"/>
-        <varRef name="position" slot="0"/>
-       </fn>
-      </choose>
-      <let line="1277" var="bindingi" as="node()?" slot="2" eval="7">
-       <treat line="1278" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|bindingi">
-        <check card="?" diag="3|0|XTTE0570|bindingi">
-         <callT name="getBinding" bSlot="4">
-          <withParam name="Q{}this" flags="c" as="element()">
-           <dot line="1279" type="element()"/>
-          </withParam>
-         </callT>
-        </check>
-       </treat>
-       <let line="1284" var="refi" as="xs:string" slot="3" eval="7">
-        <treat line="1285" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|refi">
-         <check card="1" diag="3|0|XTTE0570|refi">
-          <cvUntyped to="xs:string">
-           <data>
-            <callT name="getDataRef" bSlot="5">
-             <withParam name="Q{}this" flags="c" as="element()">
-              <dot line="1286" type="element()"/>
-             </withParam>
-             <withParam name="Q{}bindingi" flags="c" as="node()?">
-              <varRef line="1287" name="bindingi" slot="2"/>
-             </withParam>
-            </callT>
-           </data>
-          </cvUntyped>
          </check>
         </treat>
-        <let line="1292" var="instanceField" as="node()?" slot="4" eval="7">
-         <treat line="1293" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|instanceField">
-          <check card="?" diag="3|0|XTTE0570|instanceField">
-           <callT name="getReferencedInstanceField" bSlot="6">
-            <withParam name="Q{}refi" flags="c" as="xs:string">
-             <varRef line="1294" name="refi" slot="3"/>
-            </withParam>
-           </callT>
+        <let line="1911" var="refi" as="xs:string" slot="4" eval="7">
+         <treat line="1912" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|refi">
+          <check card="1" diag="3|0|XTTE0570|refi">
+           <cvUntyped to="xs:string">
+            <data>
+             <callT name="getDataRef" bSlot="38">
+              <withParam name="Q{}this" flags="c" as="element()">
+               <dot line="1913" type="element(Q{http://www.w3.org/2002/xforms}trigger)"/>
+              </withParam>
+              <withParam name="Q{}bindingi" flags="c" as="node()?">
+               <varRef line="1914" name="bindingi" slot="3"/>
+              </withParam>
+             </callT>
+            </data>
+           </cvUntyped>
           </check>
          </treat>
-         <let line="1299" var="actions" as="map(*)*" slot="5" eval="8">
-          <treat line="1300" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|actions">
-           <callT name="setActions" bSlot="7">
+         <let line="1921" var="actions" as="map(*)*" slot="5" eval="8">
+          <treat line="1922" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|actions">
+           <callT name="setActions" bSlot="39">
             <withParam name="Q{}this" flags="c" as="element()">
-             <dot line="1301" type="element()"/>
+             <dot line="1923" type="element(Q{http://www.w3.org/2002/xforms}trigger)"/>
             </withParam>
             <withParam name="Q{}nodeset" flags="t" as="xs:string">
-             <varRef line="1302" name="refi" slot="3"/>
+             <varRef line="1924" name="refi" slot="4"/>
             </withParam>
            </callT>
           </treat>
-          <sequence line="1306">
+          <sequence line="1928">
            <choose>
             <fn name="exists">
              <varRef name="actions" slot="5"/>
             </fn>
-            <ifCall line="1307" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+            <ifCall line="1929" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
              <check card="1" diag="0|0||ixsl:call">
               <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
              </check>
              <str val="addAction"/>
              <arrayBlock>
-              <varRef name="myid" slot="1"/>
+              <varRef name="myid" slot="2"/>
               <varRef name="actions" slot="5"/>
              </arrayBlock>
             </ifCall>
            </choose>
-           <applyT line="1324" bSlot="8">
-            <axis role="select" name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}label)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='label';"/>
-           </applyT>
-           <elem line="1327" name="span" nsuri="" namespaces="xd rdf xhtml js in fn map array ev r">
-            <sequence>
-             <att name="style" flags="l">
-              <str val="display:inline"/>
-             </att>
-             <elem line="1329" name="select" nsuri="" flags="l" namespaces="xd rdf xhtml js in fn map array ev r">
-              <sequence>
-               <copyOf flags="vc">
-                <filter flags="b">
-                 <axis name="attribute" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
-                 <vc op="ne" comp="CCC">
-                  <fn name="local-name">
-                   <dot type="attribute()"/>
-                  </fn>
-                  <str val="ref"/>
-                 </vc>
-                </filter>
-               </copyOf>
-               <att line="1331" name="data-ref" flags="l">
-                <varRef name="refi" slot="3"/>
-               </att>
-               <att line="1332" name="data-element" flags="l">
-                <lastOf line="1322">
-                 <fn name="tokenize">
-                  <varRef name="refi" slot="3"/>
-                  <str val="/"/>
-                  <str val=""/>
-                 </fn>
-                </lastOf>
-               </att>
-               <choose line="1334">
-                <and op="and">
-                 <fn name="exists">
-                  <varRef name="bindingi" slot="2"/>
-                 </fn>
-                 <fn name="exists">
-                  <slash simple="1">
-                   <varRef name="bindingi" slot="2"/>
-                   <axis name="attribute" nodeTest="attribute(Q{}constraint)" jsTest="return item.name==='constraint'"/>
-                  </slash>
-                 </fn>
-                </and>
-                <att line="1335" name="data-constraint" flags="l">
-                 <convert from="xs:untypedAtomic" to="xs:string">
-                  <data>
-                   <slash simple="1">
-                    <varRef name="bindingi" slot="2"/>
-                    <axis name="attribute" nodeTest="attribute(Q{}constraint)" jsTest="return item.name==='constraint'"/>
-                   </slash>
-                  </data>
-                 </convert>
-                </att>
+           <let line="1932" var="innerbody" as="document-node()" slot="6" eval="7">
+            <doc line="1934" validation="preserve">
+             <choose>
+              <fn name="exists">
+               <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}label)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='label';"/>
+              </fn>
+              <applyT line="1935" bSlot="40">
+               <axis role="select" name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}label)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='label';"/>
+              </applyT>
+              <true/>
+              <valueOf line="1937" flags="l">
+               <str val=" "/>
+              </valueOf>
+             </choose>
+            </doc>
+            <elem line="1941" name="span" nsuri="" namespaces="xd rdf xhtml js in fn map array ev">
+             <sequence>
+              <att name="style" flags="l">
+               <str val="display:'inline'"/>
+              </att>
+              <compElem line="1952" flags="l">
+               <choose role="name" line="1944">
+                <gc op="=" card="1:1" comp="CCC">
+                 <attVal name="Q{}appearance" chk="0"/>
+                 <str val="minimal"/>
+                </gc>
+                <str val="a"/>
+                <true/>
+                <str val="button"/>
                </choose>
-               <choose line="1338">
-                <vc op="eq" onEmpty="0" comp="CCC">
-                 <fn name="local-name">
-                  <dot type="element()"/>
-                 </fn>
-                 <str val="select"/>
-                </vc>
-                <sequence line="1341">
-                 <att name="multiple" flags="l">
-                  <str val="true"/>
+               <sequence role="content" line="1953">
+                <choose>
+                 <gc op="=" card="1:1" comp="CCC">
+                  <attVal name="Q{}appearance" chk="0"/>
+                  <str val="minimal"/>
+                 </gc>
+                 <att line="1954" name="type" flags="l">
+                  <str val="button"/>
                  </att>
-                 <att name="size" flags="l">
-                  <convert from="xs:integer" to="xs:string">
-                   <fn name="count">
-                    <axis name="descendant" nodeTest="element(Q{http://www.w3.org/2002/xforms}item)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='item';"/>
-                   </fn>
-                  </convert>
-                 </att>
-                </sequence>
-               </choose>
-               <choose line="1344">
-                <fn name="exists">
-                 <varRef name="actions" slot="5"/>
-                </fn>
-                <att line="1345" name="data-action" flags="l">
-                 <varRef name="myid" slot="1"/>
+                </choose>
+                <att line="1957" name="data-ref" flags="l">
+                 <varRef name="refi" slot="4"/>
                 </att>
-               </choose>
-               <applyT line="1348" bSlot="9">
-                <axis role="select" name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}item)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='item';"/>
-                <withParam name="Q{}selectedValue" as="xs:string">
-                 <choose line="1313">
-                  <fn name="exists">
-                   <varRef name="instanceField" slot="4"/>
-                  </fn>
-                  <cvUntyped line="1314" to="xs:string">
-                   <cast as="xs:untypedAtomic" emptiable="0">
-                    <fn name="string">
-                     <convert from="xs:anyAtomicType" to="xs:string">
-                      <data>
-                       <varRef name="instanceField" slot="4"/>
-                      </data>
-                     </convert>
-                    </fn>
-                   </cast>
-                  </cvUntyped>
-                  <true/>
-                  <str val=""/>
-                 </choose>
-                </withParam>
-               </applyT>
-              </sequence>
-             </elem>
-            </sequence>
-           </elem>
+                <att line="1958" name="data-action" flags="l">
+                 <varRef name="myid" slot="2"/>
+                </att>
+                <copyOf line="1959" flags="vc">
+                 <varRef name="innerbody" slot="6"/>
+                </copyOf>
+               </sequence>
+              </compElem>
+             </sequence>
+            </elem>
+           </let>
           </sequence>
          </let>
         </let>
        </let>
-      </let>
+      </sequence>
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec="0" prio="0.0" seq="17" rank="1" minImp="0" slots="1" flags="s" line="1750" module="saxon-xforms.xsl">
-    <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}action)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='action';"/>
-    <let role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1760" var="action-map" as="map(*)" slot="0" eval="7">
-     <treat line="1761" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|action-map">
-      <check card="1" diag="3|0|XTTE0570|action-map">
-       <callT name="setAction" bSlot="2">
-        <withParam name="Q{}this" flags="c" as="element()">
-         <dot line="1762" type="element()"/>
-        </withParam>
-       </callT>
-      </check>
-     </treat>
-     <choose line="1774">
-      <fn name="exists">
-       <varRef name="action-map" slot="0"/>
-      </fn>
-      <varRef line="1775" name="action-map" slot="0"/>
-     </choose>
-    </let>
-   </templateRule>
-   <templateRule prec="0" prio="0.0" seq="11" rank="1" minImp="0" slots="0" flags="s" line="1385" module="saxon-xforms.xsl">
-    <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}label)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='label';"/>
-    <elem role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1388" name="label" nsuri="" namespaces="xd rdf xhtml js in fn map array ev r">
-     <choose>
-      <fn name="exists">
-       <axis name="child" nodeTest="( element() | text() | comment() | processing-instruction() )" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);"/>
-      </fn>
-      <applyT line="1389" bSlot="27">
-       <axis role="select" name="child" nodeTest="( element() | text() | comment() | processing-instruction() )" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);"/>
-      </applyT>
-      <true/>
-      <valueOf flags="l">
-       <str val=" "/>
-      </valueOf>
-     </choose>
-    </elem>
-   </templateRule>
-   <templateRule prec="0" prio="0.0" seq="14" rank="1" minImp="0" slots="6" flags="s" line="1453" module="saxon-xforms.xsl">
-    <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}repeat)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='repeat';"/>
-    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1454">
-     <param name="Q{}position" slot="0" as="xs:integer">
-      <int role="select" val="0"/>
-      <treat role="conversion" as="xs:integer" jsTest="return SaxonJS.U.Atomic.integer.matches(item);" diag="8|0|XTTE0590|position">
-       <check card="1" diag="8|0|XTTE0590|position">
-        <cvUntyped to="xs:integer">
-         <data>
-          <supplied slot="0"/>
-         </data>
-        </cvUntyped>
-       </check>
-      </treat>
-     </param>
-     <let line="1463" var="bindingi" as="node()?" slot="1" eval="7">
-      <treat line="1464" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|bindingi">
-       <check card="?" diag="3|0|XTTE0570|bindingi">
-        <callT name="getBinding" bSlot="28">
-         <withParam name="Q{}this" flags="c" as="element()">
-          <dot line="1465" type="element(Q{http://www.w3.org/2002/xforms}repeat)"/>
-         </withParam>
-        </callT>
-       </check>
-      </treat>
-      <let line="1470" var="refi" as="xs:string" slot="2" eval="7">
-       <treat line="1471" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|refi">
-        <check card="1" diag="3|0|XTTE0570|refi">
-         <cvUntyped to="xs:string">
-          <data>
-           <callT name="getDataRef" bSlot="29">
-            <withParam name="Q{}this" flags="c" as="element()">
-             <dot line="1472" type="element(Q{http://www.w3.org/2002/xforms}repeat)"/>
-            </withParam>
-            <withParam name="Q{}bindingi" flags="c" as="node()?">
-             <varRef line="1473" name="bindingi" slot="1"/>
-            </withParam>
-           </callT>
-          </data>
-         </cvUntyped>
-        </check>
-       </treat>
-       <let line="1479" var="selectedRepeatVar" as="element()*" slot="3" eval="8">
-        <treat line="1481" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="3|0|XTTE0570|selectedRepeatVar">
-         <callT name="getReferencedInstanceField" bSlot="30">
-          <withParam name="Q{}refi" flags="c" as="xs:string">
-           <varRef line="1482" name="refi" slot="2"/>
-          </withParam>
-         </callT>
-        </treat>
-        <choose line="1497">
-         <fn name="exists">
-          <varRef name="selectedRepeatVar" slot="3"/>
-         </fn>
-         <elem line="1499" name="div" nsuri="" namespaces="xd rdf xhtml js in fn map array ev r">
-          <sequence>
-           <att name="data-repeatable-context" flags="l">
-            <varRef name="refi" slot="2"/>
-           </att>
-           <att line="1500" name="data-count" flags="l">
-            <convert from="xs:integer" to="xs:string">
-             <fn name="count">
-              <varRef name="selectedRepeatVar" slot="3"/>
-             </fn>
-            </convert>
-           </att>
-           <att line="1501" name="id" flags="l">
-            <choose line="1457">
-             <fn name="exists">
-              <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
-             </fn>
-             <check card="1" diag="3|0|XTTE0570|myid">
-              <cvUntyped to="xs:string">
-               <attVal name="Q{}id" chk="0"/>
-              </cvUntyped>
-             </check>
-             <true/>
-             <fn name="concat">
-              <fn name="generate-id">
-               <dot type="element(Q{http://www.w3.org/2002/xforms}repeat)"/>
-              </fn>
-              <str val="-"/>
-              <varRef name="position" slot="0"/>
-             </fn>
-            </choose>
-           </att>
-           <let line="1502" var="xf-repeat" as="element(Q{http://www.w3.org/2002/xforms}repeat)" slot="4" eval="7">
-            <dot type="element(Q{http://www.w3.org/2002/xforms}repeat)"/>
-            <let line="1505" var="vv:v0" as="element()*" slot="5" eval="4">
-             <slash simple="1">
-              <varRef name="xf-repeat" slot="4"/>
-              <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
-             </slash>
-             <forEach line="1503">
-              <varRef name="selectedRepeatVar" slot="3"/>
-              <elem line="1504" name="div" nsuri="" flags="l" namespaces="xd rdf xhtml js in fn map array ev r">
-               <sequence>
-                <att name="data-repeat-item" flags="l">
-                 <str val="true"/>
-                </att>
-                <applyT line="1505" bSlot="31">
-                 <varRef role="select" name="vv:v0" slot="5"/>
-                 <withParam name="Q{}position" as="xs:integer">
-                  <fn line="1507" name="position"/>
-                 </withParam>
-                 <withParam name="Q{}nodeset" flags="t" as="xs:string">
-                  <fn line="1506" name="concat">
-                   <varRef name="refi" slot="2"/>
-                   <str val="["/>
-                   <fn name="position"/>
-                   <str val="]"/>
-                  </fn>
-                 </withParam>
-                </applyT>
-               </sequence>
-              </elem>
-             </forEach>
-            </let>
-           </let>
-          </sequence>
-         </elem>
-        </choose>
-       </let>
-      </let>
-     </let>
-    </sequence>
-   </templateRule>
-   <templateRule prec="0" prio="0.0" seq="3" rank="1" minImp="0" slots="0" flags="s" line="852" module="saxon-xforms.xsl">
-    <p.nodeTest role="match" test="element(Q{http://www.w3.org/1999/xhtml}html)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/1999/xhtml'&amp;&amp;q.local==='html';"/>
-    <elem role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="854" name="html" nsuri="" namespaces="xd rdf xhtml js in fn map array ev r">
-     <sequence>
-      <copyOf flags="vc">
-       <axis name="attribute" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
-      </copyOf>
-      <elem line="856" name="head" nsuri="" flags="l" namespaces="xd rdf xhtml js in fn map array ev r">
-       <sequence>
-        <copyOf flags="vc">
-         <union op="|">
-          <slash>
-           <axis name="child" nodeTest="element(Q{http://www.w3.org/1999/xhtml}head)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/1999/xhtml'&amp;&amp;q.local==='head';"/>
-           <axis name="attribute" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
-          </slash>
-          <slash>
-           <axis name="child" nodeTest="element(Q{}head)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='head';"/>
-           <axis name="attribute" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
-          </slash>
-         </union>
-        </copyOf>
-        <elem line="857" name="meta" nsuri="" flags="l">
-         <sequence>
-          <att name="http-equiv" flags="l">
-           <str val="Content-Type"/>
-          </att>
-          <att name="content" flags="l">
-           <str val="text/html;charset=utf-8"/>
-          </att>
-         </sequence>
-        </elem>
-        <forEach line="859">
-         <union op="|">
-          <filter flags="b">
-           <slash>
-            <axis name="child" nodeTest="element(Q{http://www.w3.org/1999/xhtml}head)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/1999/xhtml'&amp;&amp;q.local==='head';"/>
-            <axis name="child" nodeTest="element(Q{http://www.w3.org/1999/xhtml}meta)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/1999/xhtml'&amp;&amp;q.local==='meta';"/>
-           </slash>
-           <vc op="ne" comp="CCC">
-            <fn name="string">
-             <axis name="attribute" nodeTest="attribute(Q{}http-equiv)" jsTest="return item.name==='http-equiv'"/>
-            </fn>
-            <str val="Content-Type"/>
-           </vc>
-          </filter>
-          <filter flags="b">
-           <slash>
-            <axis name="child" nodeTest="element(Q{}head)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='head';"/>
-            <axis name="child" nodeTest="element(Q{}meta)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='meta';"/>
-           </slash>
-           <vc op="ne" comp="CCC">
-            <fn name="string">
-             <axis name="attribute" nodeTest="attribute(Q{}http-equiv)" jsTest="return item.name==='http-equiv'"/>
-            </fn>
-            <str val="Content-Type"/>
-           </vc>
-          </filter>
-         </union>
-         <elem line="861" name="meta" nsuri="" flags="l" namespaces="xd rdf xhtml js in fn map array ev r">
-          <copyOf flags="vc">
-           <axis name="attribute" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
-          </copyOf>
-         </elem>
-        </forEach>
-        <copyOf line="866" flags="vc">
-         <axis name="child" nodeTest="element(Q{}script)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='script';"/>
-        </copyOf>
-       </sequence>
-      </elem>
-      <elem line="869" name="body" nsuri="" flags="l" namespaces="xd rdf xhtml js in fn map array ev r">
-       <applyT bSlot="17">
-        <slash role="select">
-         <axis name="child" nodeTest="element(Q{}body)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='body';"/>
-         <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
-        </slash>
-       </applyT>
-      </elem>
-     </sequence>
-    </elem>
-   </templateRule>
-   <templateRule prec="0" prio="0.0" seq="4" rank="1" minImp="0" slots="9" flags="s" line="883" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="0.0" seq="4" rank="1" minImp="0" slots="9" flags="s" line="1061" module="saxon-xforms.xsl">
     <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}output)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='output';"/>
-    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="884">
+    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1062">
      <param name="Q{}position" slot="0" as="xs:integer">
       <int role="select" val="0"/>
       <treat role="conversion" as="xs:integer" jsTest="return SaxonJS.U.Atomic.integer.matches(item);" diag="8|0|XTTE0590|position">
@@ -5256,7 +5727,19 @@
        </check>
       </treat>
      </param>
-     <let line="887" var="myid" as="xs:string" slot="1" eval="7">
+     <param line="1063" name="Q{}context-position" slot="1" as="xs:string">
+      <str role="select" val=""/>
+      <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|context-position">
+       <check card="1" diag="8|0|XTTE0590|context-position">
+        <cvUntyped to="xs:string">
+         <data>
+          <supplied slot="1"/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <let line="1067" var="myid" as="xs:string" slot="2" eval="7">
       <choose>
        <fn name="exists">
         <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
@@ -5272,263 +5755,799 @@
          <dot type="element(Q{http://www.w3.org/2002/xforms}output)"/>
         </fn>
         <str val="-"/>
-        <varRef name="position" slot="0"/>
+        <choose line="1065">
+         <varRef name="context-position" slot="1"/>
+         <varRef name="context-position" slot="1"/>
+         <true/>
+         <fn name="string">
+          <varRef name="position" slot="0"/>
+         </fn>
+        </choose>
        </fn>
       </choose>
-      <let line="891" var="bindingi" as="node()?" slot="2" eval="7">
-       <treat line="892" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|bindingi">
-        <check card="?" diag="3|0|XTTE0570|bindingi">
-         <callT name="getBinding" bSlot="32">
-          <withParam name="Q{}this" flags="c" as="element()">
-           <dot line="893" type="element(Q{http://www.w3.org/2002/xforms}output)"/>
-          </withParam>
-         </callT>
-        </check>
-       </treat>
-       <let line="898" var="refi" as="xs:string" slot="3" eval="7">
-        <treat line="899" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|refi">
-         <check card="1" diag="3|0|XTTE0570|refi">
-          <cvUntyped to="xs:string">
-           <data>
-            <callT name="getDataRef" bSlot="33">
-             <withParam name="Q{}this" flags="c" as="element()">
-              <dot line="900" type="element(Q{http://www.w3.org/2002/xforms}output)"/>
-             </withParam>
-             <withParam name="Q{}bindingi" flags="c" as="node()?">
-              <varRef line="901" name="bindingi" slot="2"/>
-             </withParam>
-            </callT>
-           </data>
-          </cvUntyped>
+      <sequence line="1069">
+       <choose>
+        <and op="and">
+         <ufCall name="Q{http://www.w3.org/2002/xforms}usesIndexFunction" tailCall="false" bSlot="41" eval="7">
+          <dot type="element(Q{http://www.w3.org/2002/xforms}output)"/>
+         </ufCall>
+         <fn name="empty">
+          <filter flags="b">
+           <slash simple="1">
+            <dot type="element(Q{http://www.w3.org/2002/xforms}output)"/>
+            <axis name="ancestor" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+           </slash>
+           <ufCall name="Q{http://www.w3.org/2002/xforms}usesIndexFunction" tailCall="false" bSlot="42" eval="7">
+            <dot type="element()"/>
+           </ufCall>
+          </filter>
+         </fn>
+        </and>
+        <ifCall line="1070" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+         <check card="1" diag="0|0||ixsl:call">
+          <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+         </check>
+         <str val="setElementUsingIndexFunction"/>
+         <arrayBlock>
+          <varRef name="myid" slot="2"/>
+          <dot type="element(Q{http://www.w3.org/2002/xforms}output)"/>
+         </arrayBlock>
+        </ifCall>
+       </choose>
+       <let line="1075" var="bindingi" as="node()?" slot="3" eval="7">
+        <treat line="1076" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|bindingi">
+         <check card="?" diag="3|0|XTTE0570|bindingi">
+          <callT name="getBinding" bSlot="43">
+           <withParam name="Q{}this" flags="c" as="element()">
+            <dot line="1077" type="element(Q{http://www.w3.org/2002/xforms}output)"/>
+           </withParam>
+          </callT>
          </check>
         </treat>
-        <let line="906" var="instanceField" as="node()?" slot="4" eval="7">
-         <treat line="907" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|instanceField">
-          <check card="?" diag="3|0|XTTE0570|instanceField">
-           <callT name="getReferencedInstanceField" bSlot="34">
-            <withParam name="Q{}refi" flags="c" as="xs:string">
-             <varRef line="908" name="refi" slot="3"/>
-            </withParam>
-           </callT>
+        <let line="1082" var="refi" as="xs:string" slot="4" eval="7">
+         <treat line="1083" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|refi">
+          <check card="1" diag="3|0|XTTE0570|refi">
+           <cvUntyped to="xs:string">
+            <data>
+             <callT name="getDataRef" bSlot="44">
+              <withParam name="Q{}this" flags="c" as="element()">
+               <dot line="1084" type="element(Q{http://www.w3.org/2002/xforms}output)"/>
+              </withParam>
+              <withParam name="Q{}bindingi" flags="c" as="node()?">
+               <varRef line="1085" name="bindingi" slot="3"/>
+              </withParam>
+             </callT>
+            </data>
+           </cvUntyped>
           </check>
          </treat>
-         <let line="912" var="valueExecuted" as="xs:string" slot="5" eval="7">
-          <choose line="914">
-           <fn name="exists">
-            <axis name="attribute" nodeTest="attribute(Q{}value)" jsTest="return item.name==='value'"/>
-           </fn>
-           <evaluate line="915" as="xs:string" dxns="">
-            <ufCall role="xpath" name="Q{http://www.w3.org/2002/xforms}impose" tailCall="false" bSlot="35" eval="7">
-             <check card="1" diag="0|0||xforms:impose">
-              <cvUntyped to="xs:string">
-               <attVal name="Q{}value" chk="0"/>
-              </cvUntyped>
+         <let line="1090" var="instanceField" as="node()?" slot="5" eval="7">
+          <treat line="1091" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|instanceField">
+           <check card="?" diag="3|0|XTTE0570|instanceField">
+            <callT name="getReferencedInstanceField" bSlot="45">
+             <withParam name="Q{}refi" flags="c" as="xs:string">
+              <varRef line="1092" name="refi" slot="4"/>
+             </withParam>
+            </callT>
+           </check>
+          </treat>
+          <let line="1103" var="namespace-context-item" as="element()" slot="6" eval="7">
+           <choose>
+            <fn name="exists">
+             <varRef name="instanceField" slot="5"/>
+            </fn>
+            <choose>
+             <fn name="exists">
+              <filter flags="b">
+               <varRef name="instanceField" slot="5"/>
+               <fn name="exists">
+                <axis name="self" nodeTest="text()" jsTest="return item.nodeType===3;"/>
+               </fn>
+              </filter>
+             </fn>
+             <check card="1" diag="3|0|XTTE0570|namespace-context-item">
+              <slash simple="1">
+               <varRef name="instanceField" slot="5"/>
+               <axis name="parent" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+              </slash>
+             </check>
+             <true/>
+             <treat as="element()" jsTest="return item.nodeType===1;" diag="3|0|XTTE0570|namespace-context-item">
+              <check card="1" diag="3|0|XTTE0570|namespace-context-item">
+               <varRef name="instanceField" slot="5"/>
+              </check>
+             </treat>
+            </choose>
+            <true/>
+            <ufCall name="Q{http://www.w3.org/2002/xforms}addNamespaceDeclarations" tailCall="false" bSlot="46" eval="4">
+             <check card="1" diag="0|0||xforms:addNamespaceDeclarations">
+              <slash simple="1">
+               <root/>
+               <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+              </slash>
              </check>
             </ufCall>
-            <varRef role="cxt" name="instanceField" slot="4"/>
-            <str role="sa" val="no"/>
-            <map role="wp" size="0"/>
-           </evaluate>
-           <true/>
-           <cvUntyped line="918" to="xs:string">
-            <cast as="xs:untypedAtomic" emptiable="0">
-             <fn name="string">
-              <convert from="xs:anyAtomicType" to="xs:string">
-               <data>
-                <varRef name="instanceField" slot="4"/>
-               </data>
-              </convert>
-             </fn>
-            </cast>
-           </cvUntyped>
-          </choose>
-          <let line="924" var="relevantVar" as="xs:boolean" slot="6" eval="7">
-           <choose line="926">
-            <and op="and">
-             <and op="and">
-              <fn name="exists">
-               <varRef name="bindingi" slot="2"/>
-              </fn>
-              <fn name="exists">
-               <slash simple="1">
-                <varRef name="bindingi" slot="2"/>
-                <axis name="attribute" nodeTest="attribute(Q{}relevant)" jsTest="return item.name==='relevant'"/>
-               </slash>
-              </fn>
-             </and>
-             <fn name="exists">
-              <varRef name="instanceField" slot="4"/>
-             </fn>
-            </and>
-            <treat line="927" as="xs:boolean" jsTest="return SaxonJS.U.Atomic.boolean.matches(item);" diag="3|0|XTTE0570|relevantVar">
-             <check card="1" diag="3|0|XTTE0570|relevantVar">
-              <cvUntyped to="xs:boolean">
-               <data>
-                <evaluate dxns="">
-                 <ufCall role="xpath" name="Q{http://www.w3.org/2002/xforms}impose" tailCall="false" bSlot="36" eval="4">
-                  <check card="1" diag="0|0||xforms:impose">
-                   <cvUntyped to="xs:string">
-                    <data>
-                     <slash simple="1">
-                      <varRef name="bindingi" slot="2"/>
-                      <axis name="attribute" nodeTest="attribute(Q{}relevant)" jsTest="return item.name==='relevant'"/>
-                     </slash>
-                    </data>
-                   </cvUntyped>
-                  </check>
-                 </ufCall>
-                 <varRef role="cxt" name="instanceField" slot="4"/>
-                 <str role="sa" val="no"/>
-                 <map role="wp" size="0"/>
-                </evaluate>
-               </data>
-              </cvUntyped>
-             </check>
-            </treat>
-            <true/>
-            <true/>
            </choose>
-           <sequence line="939">
-            <elem name="div" nsuri="" namespaces="xd rdf xhtml js in fn map array ev r">
-             <let var="class" as="xs:string?" slot="7" eval="7">
-              <choose line="940">
-               <fn name="exists">
-                <axis name="attribute" nodeTest="attribute(Q{}class)" jsTest="return item.name==='class'"/>
-               </fn>
-               <cvUntyped line="941" to="xs:string">
-                <cast as="xs:untypedAtomic" emptiable="0">
-                 <fn name="string">
-                  <convert from="xs:untypedAtomic" to="xs:string">
-                   <attVal name="Q{}class" chk="0"/>
-                  </convert>
-                 </fn>
-                </cast>
-               </cvUntyped>
-              </choose>
-              <let line="944" var="class-mod" as="xs:string?" slot="8" eval="7">
-               <choose line="946">
-                <fn name="exists">
-                 <axis name="attribute" nodeTest="attribute(Q{}incremental)" jsTest="return item.name==='incremental'"/>
-                </fn>
-                <cvUntyped line="947" to="xs:string">
-                 <cast as="xs:untypedAtomic" emptiable="0">
-                  <fn name="string-join">
-                   <sequence>
-                    <varRef name="class" slot="7"/>
-                    <str val="incremental"/>
-                   </sequence>
-                   <str val=" "/>
-                  </fn>
-                 </cast>
+           <let line="1105" var="valueExecuted" as="xs:string" slot="7" eval="7">
+            <choose line="1107">
+             <fn name="exists">
+              <axis name="attribute" nodeTest="attribute(Q{}value)" jsTest="return item.name==='value'"/>
+             </fn>
+             <evaluate line="1108" as="xs:string" dxns="">
+              <ufCall role="xpath" name="Q{http://www.w3.org/2002/xforms}impose" tailCall="false" bSlot="47" eval="7">
+               <check card="1" diag="0|0||xforms:impose">
+                <cvUntyped to="xs:string">
+                 <attVal name="Q{}value" chk="0"/>
                 </cvUntyped>
-                <true/>
-                <varRef line="950" name="class" slot="7"/>
-               </choose>
-               <sequence line="954">
-                <choose>
-                 <fn name="exists">
-                  <varRef name="class-mod" slot="8"/>
-                 </fn>
-                 <att line="955" name="class" flags="l">
-                  <varRef name="class-mod" slot="8"/>
-                 </att>
-                </choose>
-                <applyT line="958" bSlot="37">
+               </check>
+              </ufCall>
+              <varRef role="cxt" name="instanceField" slot="5"/>
+              <varRef role="nsCxt" name="namespace-context-item" slot="6"/>
+              <str role="sa" val="no"/>
+              <map role="wp" size="0"/>
+             </evaluate>
+             <true/>
+             <cvUntyped line="1111" to="xs:string">
+              <cast as="xs:untypedAtomic" emptiable="0">
+               <fn name="string">
+                <convert from="xs:anyAtomicType" to="xs:string">
+                 <data>
+                  <varRef name="instanceField" slot="5"/>
+                 </data>
+                </convert>
+               </fn>
+              </cast>
+             </cvUntyped>
+            </choose>
+            <let line="1117" var="relevantVar" as="xs:boolean" slot="8" eval="7">
+             <choose line="1119">
+              <and op="and">
+               <and op="and">
+                <fn name="exists">
+                 <varRef name="bindingi" slot="3"/>
+                </fn>
+                <fn name="exists">
+                 <slash simple="1">
+                  <varRef name="bindingi" slot="3"/>
+                  <axis name="attribute" nodeTest="attribute(Q{}relevant)" jsTest="return item.name==='relevant'"/>
+                 </slash>
+                </fn>
+               </and>
+               <fn name="exists">
+                <varRef name="instanceField" slot="5"/>
+               </fn>
+              </and>
+              <treat line="1120" as="xs:boolean" jsTest="return SaxonJS.U.Atomic.boolean.matches(item);" diag="3|0|XTTE0570|relevantVar">
+               <check card="1" diag="3|0|XTTE0570|relevantVar">
+                <cvUntyped to="xs:boolean">
+                 <data>
+                  <evaluate dxns="">
+                   <ufCall role="xpath" name="Q{http://www.w3.org/2002/xforms}impose" tailCall="false" bSlot="48" eval="4">
+                    <check card="1" diag="0|0||xforms:impose">
+                     <cvUntyped to="xs:string">
+                      <data>
+                       <slash simple="1">
+                        <varRef name="bindingi" slot="3"/>
+                        <axis name="attribute" nodeTest="attribute(Q{}relevant)" jsTest="return item.name==='relevant'"/>
+                       </slash>
+                      </data>
+                     </cvUntyped>
+                    </check>
+                   </ufCall>
+                   <varRef role="cxt" name="instanceField" slot="5"/>
+                   <varRef role="nsCxt" name="namespace-context-item" slot="6"/>
+                   <str role="sa" val="no"/>
+                   <map role="wp" size="0"/>
+                  </evaluate>
+                 </data>
+                </cvUntyped>
+               </check>
+              </treat>
+              <true/>
+              <true/>
+             </choose>
+             <sequence line="1132">
+              <elem name="div" nsuri="" namespaces="xd rdf xhtml js in fn map array ev">
+               <sequence>
+                <ufCall name="Q{http://www.w3.org/2002/xforms}getClass" tailCall="false" bSlot="49" eval="7">
+                 <dot type="element(Q{http://www.w3.org/2002/xforms}output)"/>
+                </ufCall>
+                <applyT line="1134" bSlot="50">
                  <axis role="select" name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}label)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='label';"/>
                 </applyT>
-                <elem line="961" name="span" nsuri="" flags="l" namespaces="xd rdf xhtml js in fn map array ev r">
+                <elem line="1137" name="span" nsuri="" flags="l">
                  <sequence>
                   <att name="id" flags="l">
-                   <varRef name="myid" slot="1"/>
+                   <varRef name="myid" slot="2"/>
                   </att>
-                  <att line="962" name="style" flags="l">
+                  <att line="1138" name="style" flags="l">
                    <choose>
-                    <varRef name="relevantVar" slot="6"/>
+                    <varRef name="relevantVar" slot="8"/>
                     <str val="display:inline"/>
                     <true/>
                     <str val="display:none"/>
                    </choose>
                   </att>
-                  <att line="963" name="data-ref" flags="l">
-                   <varRef name="refi" slot="3"/>
+                  <att line="1139" name="data-ref" flags="l">
+                   <varRef name="refi" slot="4"/>
                   </att>
-                  <varRef line="965" name="valueExecuted" slot="5"/>
+                  <varRef line="1141" name="valueExecuted" slot="7"/>
                  </sequence>
                 </elem>
                </sequence>
-              </let>
-             </let>
-            </elem>
-            <ifCall line="982" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
-             <check card="1" diag="0|0||ixsl:call">
-              <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
-             </check>
-             <str val="addOutput"/>
-             <arrayBlock>
-              <varRef name="myid" slot="1"/>
-              <ifCall line="972" name="Q{http://www.w3.org/2005/xpath-functions/map}merge" type="map(*)">
-               <sequence>
-                <choose>
-                 <varRef name="refi" slot="3"/>
-                 <ifCall line="973" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
-                  <str val="@ref"/>
-                  <varRef name="refi" slot="3"/>
-                 </ifCall>
-                </choose>
-                <choose line="976">
-                 <fn name="exists">
-                  <axis name="attribute" nodeTest="attribute(Q{}value)" jsTest="return item.name==='value'"/>
-                 </fn>
-                 <ifCall line="977" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
-                  <str val="@value"/>
-                  <cast as="xs:string" emptiable="1">
-                   <attVal name="Q{}value" chk="0"/>
-                  </cast>
-                 </ifCall>
-                </choose>
-               </sequence>
-               <map size="2">
-                <str val="duplicates"/>
-                <str val="reject"/>
-                <str val="duplicates-error-code"/>
-                <str val="XTDE3365"/>
-               </map>
+              </elem>
+              <ifCall line="1158" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+               <check card="1" diag="0|0||ixsl:call">
+                <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+               </check>
+               <str val="addOutput"/>
+               <arrayBlock>
+                <varRef name="myid" slot="2"/>
+                <ifCall line="1148" name="Q{http://www.w3.org/2005/xpath-functions/map}merge" type="map(*)">
+                 <sequence>
+                  <choose>
+                   <varRef name="refi" slot="4"/>
+                   <ifCall line="1149" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+                    <str val="@ref"/>
+                    <varRef name="refi" slot="4"/>
+                   </ifCall>
+                  </choose>
+                  <choose line="1152">
+                   <fn name="exists">
+                    <axis name="attribute" nodeTest="attribute(Q{}value)" jsTest="return item.name==='value'"/>
+                   </fn>
+                   <ifCall line="1153" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+                    <str val="@value"/>
+                    <cast as="xs:string" emptiable="1">
+                     <attVal name="Q{}value" chk="0"/>
+                    </cast>
+                   </ifCall>
+                  </choose>
+                 </sequence>
+                 <map size="2">
+                  <str val="duplicates"/>
+                  <str val="reject"/>
+                  <str val="duplicates-error-code"/>
+                  <str val="XTDE3365"/>
+                 </map>
+                </ifCall>
+               </arrayBlock>
               </ifCall>
-             </arrayBlock>
-            </ifCall>
+             </sequence>
+            </let>
+           </let>
+          </let>
+         </let>
+        </let>
+       </let>
+      </sequence>
+     </let>
+    </sequence>
+   </templateRule>
+   <templateRule prec="0" prio="0.0" seq="0" rank="1" minImp="0" slots="0" flags="s" line="993" module="saxon-xforms.xsl">
+    <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}xform)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='xform';"/>
+    <applyT role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="994" flags="t" bSlot="51">
+     <axis role="select" name="child" nodeTest="( element() | text() | comment() | processing-instruction() )" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);"/>
+    </applyT>
+   </templateRule>
+   <templateRule prec="0" prio="0.0" seq="12" rank="1" minImp="0" slots="1" flags="s" line="1595" module="saxon-xforms.xsl">
+    <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}item)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='item';"/>
+    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1596">
+     <param name="Q{}selectedValue" slot="0" as="xs:string">
+      <str role="select" val=""/>
+      <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|selectedValue">
+       <check card="1" diag="8|0|XTTE0590|selectedValue">
+        <cvUntyped to="xs:string">
+         <data>
+          <supplied slot="0"/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <elem line="1598" name="option" nsuri="" namespaces="xd rdf xhtml js in fn map array ev">
+      <sequence>
+       <att name="value" flags="l">
+        <fn name="string-join">
+         <convert from="xs:untypedAtomic" to="xs:string">
+          <data>
+           <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}value)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='value';"/>
+          </data>
+         </convert>
+         <str val=" "/>
+        </fn>
+       </att>
+       <choose line="1599">
+        <gc op="=" card="1:1" comp="CCC">
+         <varRef name="selectedValue" slot="0"/>
+         <cast as="xs:string" emptiable="1">
+          <atomSing card="?" diag="2|0||cast as">
+           <slash>
+            <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}value)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='value';"/>
+            <axis name="child" nodeTest="text()" jsTest="return item.nodeType===3;"/>
+           </slash>
+          </atomSing>
+         </cast>
+        </gc>
+        <att line="1600" name="selected" flags="l">
+         <varRef name="selectedValue" slot="0"/>
+        </att>
+       </choose>
+       <valueOf line="1603" flags="l">
+        <fn name="string-join">
+         <convert from="xs:untypedAtomic" to="xs:string">
+          <data>
+           <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}label)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='label';"/>
+          </data>
+         </convert>
+         <str val=" "/>
+        </fn>
+       </valueOf>
+      </sequence>
+     </elem>
+    </sequence>
+   </templateRule>
+   <templateRule prec="0" prio="0.0" seq="17" rank="1" minImp="0" slots="1" flags="s" line="1973" module="saxon-xforms.xsl">
+    <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}script)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='script';"/>
+    <let role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1979" var="action-map" as="map(*)" slot="0" eval="7">
+     <treat line="1980" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|action-map">
+      <check card="1" diag="3|0|XTTE0570|action-map">
+       <callT name="setAction" bSlot="2">
+        <withParam name="Q{}this" flags="c" as="element()">
+         <dot line="1981" type="element()"/>
+        </withParam>
+       </callT>
+      </check>
+     </treat>
+     <choose line="1993">
+      <fn name="exists">
+       <varRef name="action-map" slot="0"/>
+      </fn>
+      <varRef line="1994" name="action-map" slot="0"/>
+     </choose>
+    </let>
+   </templateRule>
+   <templateRule prec="0" prio="0.0" seq="8" rank="1" minImp="0" slots="7" flags="s" line="1452" module="saxon-xforms.xsl">
+    <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}select)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='select';"/>
+    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1453">
+     <param name="Q{}position" slot="0" as="xs:integer">
+      <int role="select" val="0"/>
+      <treat role="conversion" as="xs:integer" jsTest="return SaxonJS.U.Atomic.integer.matches(item);" diag="8|0|XTTE0590|position">
+       <check card="1" diag="8|0|XTTE0590|position">
+        <cvUntyped to="xs:integer">
+         <data>
+          <supplied slot="0"/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <param line="1454" name="Q{}context-position" slot="1" as="xs:string">
+      <str role="select" val=""/>
+      <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|context-position">
+       <check card="1" diag="8|0|XTTE0590|context-position">
+        <cvUntyped to="xs:string">
+         <data>
+          <supplied slot="1"/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <let line="1458" var="myid" as="xs:string" slot="2" eval="7">
+      <choose>
+       <fn name="exists">
+        <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
+       </fn>
+       <check card="1" diag="3|0|XTTE0570|myid">
+        <cvUntyped to="xs:string">
+         <attVal name="Q{}id" chk="0"/>
+        </cvUntyped>
+       </check>
+       <true/>
+       <fn name="concat">
+        <fn name="generate-id">
+         <dot type="element()"/>
+        </fn>
+        <str val="-"/>
+        <choose line="1456">
+         <varRef name="context-position" slot="1"/>
+         <varRef name="context-position" slot="1"/>
+         <true/>
+         <fn name="string">
+          <varRef name="position" slot="0"/>
+         </fn>
+        </choose>
+       </fn>
+      </choose>
+      <sequence line="1460">
+       <choose>
+        <and op="and">
+         <ufCall name="Q{http://www.w3.org/2002/xforms}usesIndexFunction" tailCall="false" bSlot="4" eval="7">
+          <dot type="element()"/>
+         </ufCall>
+         <fn name="empty">
+          <filter flags="b">
+           <slash simple="1">
+            <dot type="element()"/>
+            <axis name="ancestor" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+           </slash>
+           <ufCall name="Q{http://www.w3.org/2002/xforms}usesIndexFunction" tailCall="false" bSlot="5" eval="7">
+            <dot type="element()"/>
+           </ufCall>
+          </filter>
+         </fn>
+        </and>
+        <ifCall line="1461" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+         <check card="1" diag="0|0||ixsl:call">
+          <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+         </check>
+         <str val="setElementUsingIndexFunction"/>
+         <arrayBlock>
+          <varRef name="myid" slot="2"/>
+          <dot type="element()"/>
+         </arrayBlock>
+        </ifCall>
+       </choose>
+       <let line="1468" var="bindingi" as="node()?" slot="3" eval="7">
+        <treat line="1469" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|bindingi">
+         <check card="?" diag="3|0|XTTE0570|bindingi">
+          <callT name="getBinding" bSlot="6">
+           <withParam name="Q{}this" flags="c" as="element()">
+            <dot line="1470" type="element()"/>
+           </withParam>
+          </callT>
+         </check>
+        </treat>
+        <let line="1475" var="refi" as="xs:string" slot="4" eval="7">
+         <treat line="1476" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|refi">
+          <check card="1" diag="3|0|XTTE0570|refi">
+           <cvUntyped to="xs:string">
+            <data>
+             <callT name="getDataRef" bSlot="7">
+              <withParam name="Q{}this" flags="c" as="element()">
+               <dot line="1477" type="element()"/>
+              </withParam>
+              <withParam name="Q{}bindingi" flags="c" as="node()?">
+               <varRef line="1478" name="bindingi" slot="3"/>
+              </withParam>
+             </callT>
+            </data>
+           </cvUntyped>
+          </check>
+         </treat>
+         <let line="1483" var="instanceField" as="node()?" slot="5" eval="7">
+          <treat line="1484" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|instanceField">
+           <check card="?" diag="3|0|XTTE0570|instanceField">
+            <callT name="getReferencedInstanceField" bSlot="8">
+             <withParam name="Q{}refi" flags="c" as="xs:string">
+              <varRef line="1485" name="refi" slot="4"/>
+             </withParam>
+            </callT>
+           </check>
+          </treat>
+          <let line="1490" var="actions" as="map(*)*" slot="6" eval="8">
+           <treat line="1491" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|actions">
+            <callT name="setActions" bSlot="9">
+             <withParam name="Q{}this" flags="c" as="element()">
+              <dot line="1492" type="element()"/>
+             </withParam>
+             <withParam name="Q{}nodeset" flags="t" as="xs:string">
+              <varRef line="1493" name="refi" slot="4"/>
+             </withParam>
+            </callT>
+           </treat>
+           <sequence line="1497">
+            <choose>
+             <fn name="exists">
+              <varRef name="actions" slot="6"/>
+             </fn>
+             <ifCall line="1498" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+              <check card="1" diag="0|0||ixsl:call">
+               <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+              </check>
+              <str val="addAction"/>
+              <arrayBlock>
+               <varRef name="myid" slot="2"/>
+               <varRef name="actions" slot="6"/>
+              </arrayBlock>
+             </ifCall>
+            </choose>
+            <elem line="1515" name="div" nsuri="" namespaces="xd rdf xhtml js in fn map array ev">
+             <sequence>
+              <att name="class" flags="l">
+               <str val="xforms-select"/>
+              </att>
+              <applyT line="1516" bSlot="10">
+               <axis role="select" name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}label)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='label';"/>
+              </applyT>
+              <elem line="1519" name="select" nsuri="" flags="l" namespaces="xd rdf xhtml js in fn map array ev">
+               <sequence>
+                <ufCall name="Q{http://www.w3.org/2002/xforms}getClass" tailCall="false" bSlot="11" eval="7">
+                 <dot type="element()"/>
+                </ufCall>
+                <copyOf line="1520" flags="vc">
+                 <except op="except">
+                  <axis name="attribute" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
+                  <docOrder intra="1">
+                   <sequence>
+                    <axis name="attribute" nodeTest="attribute(Q{}class)" jsTest="return item.name==='class'"/>
+                    <axis name="attribute" nodeTest="attribute(Q{}ref)" jsTest="return item.name==='ref'"/>
+                    <axis name="attribute" nodeTest="attribute(Q{}incremental)" jsTest="return item.name==='incremental'"/>
+                   </sequence>
+                  </docOrder>
+                 </except>
+                </copyOf>
+                <att line="1522" name="data-ref" flags="l">
+                 <varRef name="refi" slot="4"/>
+                </att>
+                <att line="1523" name="data-element" flags="l">
+                 <lastOf line="1513">
+                  <fn name="tokenize">
+                   <varRef name="refi" slot="4"/>
+                   <str val="/"/>
+                   <str val=""/>
+                  </fn>
+                 </lastOf>
+                </att>
+                <choose line="1525">
+                 <and op="and">
+                  <fn name="exists">
+                   <varRef name="bindingi" slot="3"/>
+                  </fn>
+                  <fn name="exists">
+                   <slash simple="1">
+                    <varRef name="bindingi" slot="3"/>
+                    <axis name="attribute" nodeTest="attribute(Q{}constraint)" jsTest="return item.name==='constraint'"/>
+                   </slash>
+                  </fn>
+                 </and>
+                 <att line="1526" name="data-constraint" flags="l">
+                  <convert from="xs:untypedAtomic" to="xs:string">
+                   <data>
+                    <slash simple="1">
+                     <varRef name="bindingi" slot="3"/>
+                     <axis name="attribute" nodeTest="attribute(Q{}constraint)" jsTest="return item.name==='constraint'"/>
+                    </slash>
+                   </data>
+                  </convert>
+                 </att>
+                </choose>
+                <choose line="1529">
+                 <vc op="eq" onEmpty="0" comp="CCC">
+                  <fn name="local-name">
+                   <dot type="element()"/>
+                  </fn>
+                  <str val="select"/>
+                 </vc>
+                 <sequence line="1532">
+                  <att name="multiple" flags="l">
+                   <str val="true"/>
+                  </att>
+                  <att name="size" flags="l">
+                   <convert from="xs:integer" to="xs:string">
+                    <fn name="count">
+                     <axis name="descendant" nodeTest="element(Q{http://www.w3.org/2002/xforms}item)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='item';"/>
+                    </fn>
+                   </convert>
+                  </att>
+                 </sequence>
+                </choose>
+                <choose line="1535">
+                 <fn name="exists">
+                  <varRef name="actions" slot="6"/>
+                 </fn>
+                 <att line="1536" name="data-action" flags="l">
+                  <varRef name="myid" slot="2"/>
+                 </att>
+                </choose>
+                <applyT line="1539" bSlot="12">
+                 <axis role="select" name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}item)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='item';"/>
+                 <withParam name="Q{}selectedValue" as="xs:string">
+                  <choose line="1504">
+                   <fn name="exists">
+                    <varRef name="instanceField" slot="5"/>
+                   </fn>
+                   <cvUntyped line="1505" to="xs:string">
+                    <cast as="xs:untypedAtomic" emptiable="0">
+                     <fn name="string">
+                      <convert from="xs:anyAtomicType" to="xs:string">
+                       <data>
+                        <varRef name="instanceField" slot="5"/>
+                       </data>
+                      </convert>
+                     </fn>
+                    </cast>
+                   </cvUntyped>
+                   <true/>
+                   <str val=""/>
+                  </choose>
+                 </withParam>
+                </applyT>
+               </sequence>
+              </elem>
+             </sequence>
+            </elem>
            </sequence>
           </let>
          </let>
         </let>
        </let>
-      </let>
+      </sequence>
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec="0" prio="0.0" seq="17" rank="1" minImp="0" slots="1" flags="s" line="1750" module="saxon-xforms.xsl">
-    <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}hide)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='hide';"/>
-    <let role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1760" var="action-map" as="map(*)" slot="0" eval="7">
-     <treat line="1761" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|action-map">
+   <templateRule prec="0" prio="0.0" seq="17" rank="1" minImp="0" slots="1" flags="s" line="1973" module="saxon-xforms.xsl">
+    <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}action)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='action';"/>
+    <let role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1979" var="action-map" as="map(*)" slot="0" eval="7">
+     <treat line="1980" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|action-map">
       <check card="1" diag="3|0|XTTE0570|action-map">
        <callT name="setAction" bSlot="2">
         <withParam name="Q{}this" flags="c" as="element()">
-         <dot line="1762" type="element()"/>
+         <dot line="1981" type="element()"/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <choose line="1774">
+     <choose line="1993">
       <fn name="exists">
        <varRef name="action-map" slot="0"/>
       </fn>
-      <varRef line="1775" name="action-map" slot="0"/>
+      <varRef line="1994" name="action-map" slot="0"/>
      </choose>
     </let>
    </templateRule>
-   <templateRule prec="0" prio="-0.5" seq="9" rank="0" minImp="0" slots="0" flags="s" line="1364" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="0.0" seq="11" rank="1" minImp="0" slots="0" flags="s" line="1577" module="saxon-xforms.xsl">
+    <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}label)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='label';"/>
+    <elem role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1580" name="label" nsuri="" namespaces="xd rdf xhtml js in fn map array ev">
+     <choose>
+      <fn name="exists">
+       <axis name="child" nodeTest="( element() | text() | comment() | processing-instruction() )" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);"/>
+      </fn>
+      <applyT line="1581" bSlot="52">
+       <axis role="select" name="child" nodeTest="( element() | text() | comment() | processing-instruction() )" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);"/>
+      </applyT>
+      <true/>
+      <valueOf flags="l">
+       <str val=" "/>
+      </valueOf>
+     </choose>
+    </elem>
+   </templateRule>
+   <templateRule prec="0" prio="0.0" seq="13" rank="1" minImp="0" slots="4" flags="s" line="1616" module="saxon-xforms.xsl">
+    <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}group)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='group';"/>
+    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1617">
+     <param name="Q{}position" slot="0" as="xs:integer">
+      <int role="select" val="0"/>
+      <treat role="conversion" as="xs:integer" jsTest="return SaxonJS.U.Atomic.integer.matches(item);" diag="8|0|XTTE0590|position">
+       <check card="1" diag="8|0|XTTE0590|position">
+        <cvUntyped to="xs:integer">
+         <data>
+          <supplied slot="0"/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <param line="1618" name="Q{}context-position" slot="1" as="xs:string">
+      <str role="select" val=""/>
+      <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|context-position">
+       <check card="1" diag="8|0|XTTE0590|context-position">
+        <cvUntyped to="xs:string">
+         <data>
+          <supplied slot="1"/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <let line="1622" var="myid" as="xs:string" slot="2" eval="7">
+      <choose>
+       <fn name="exists">
+        <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
+       </fn>
+       <check card="1" diag="3|0|XTTE0570|myid">
+        <cvUntyped to="xs:string">
+         <attVal name="Q{}id" chk="0"/>
+        </cvUntyped>
+       </check>
+       <true/>
+       <fn name="concat">
+        <fn name="generate-id">
+         <dot type="element(Q{http://www.w3.org/2002/xforms}group)"/>
+        </fn>
+        <str val="-"/>
+        <choose line="1620">
+         <varRef name="context-position" slot="1"/>
+         <varRef name="context-position" slot="1"/>
+         <true/>
+         <fn name="string">
+          <varRef name="position" slot="0"/>
+         </fn>
+        </choose>
+       </fn>
+      </choose>
+      <sequence line="1624">
+       <choose>
+        <and op="and">
+         <ufCall name="Q{http://www.w3.org/2002/xforms}usesIndexFunction" tailCall="false" bSlot="53" eval="7">
+          <dot type="element(Q{http://www.w3.org/2002/xforms}group)"/>
+         </ufCall>
+         <fn name="empty">
+          <filter flags="b">
+           <slash simple="1">
+            <dot type="element(Q{http://www.w3.org/2002/xforms}group)"/>
+            <axis name="ancestor" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+           </slash>
+           <ufCall name="Q{http://www.w3.org/2002/xforms}usesIndexFunction" tailCall="false" bSlot="54" eval="7">
+            <dot type="element()"/>
+           </ufCall>
+          </filter>
+         </fn>
+        </and>
+        <ifCall line="1625" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+         <check card="1" diag="0|0||ixsl:call">
+          <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+         </check>
+         <str val="setElementUsingIndexFunction"/>
+         <arrayBlock>
+          <varRef name="myid" slot="2"/>
+          <dot type="element(Q{http://www.w3.org/2002/xforms}group)"/>
+         </arrayBlock>
+        </ifCall>
+       </choose>
+       <let line="1628" var="refi" as="xs:string?" slot="3" eval="7">
+        <choose line="1630">
+         <fn name="exists">
+          <axis name="attribute" nodeTest="attribute(Q{}nodeset)" jsTest="return item.name==='nodeset'"/>
+         </fn>
+         <cvUntyped to="xs:string">
+          <attVal name="Q{}nodeset" chk="0"/>
+         </cvUntyped>
+         <fn line="1631" name="exists">
+          <axis name="attribute" nodeTest="attribute(Q{}ref)" jsTest="return item.name==='ref'"/>
+         </fn>
+         <cvUntyped line="1631" to="xs:string">
+          <attVal name="Q{}ref" chk="0"/>
+         </cvUntyped>
+        </choose>
+        <elem line="1638" name="div" nsuri="" namespaces="xd rdf xhtml js in fn map array ev">
+         <sequence>
+          <att name="id" flags="l">
+           <varRef name="myid" slot="2"/>
+          </att>
+          <choose line="1639">
+           <fn name="exists">
+            <varRef name="refi" slot="3"/>
+           </fn>
+           <att line="1640" name="data-group-ref" flags="l">
+            <varRef name="refi" slot="3"/>
+           </att>
+          </choose>
+          <applyT line="1642" bSlot="55">
+           <axis role="select" name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+           <withParam name="Q{}nodeset" flags="t" as="xs:string?">
+            <choose line="1643">
+             <fn name="exists">
+              <varRef name="refi" slot="3"/>
+             </fn>
+             <varRef name="refi" slot="3"/>
+             <true/>
+             <str val=""/>
+            </choose>
+           </withParam>
+          </applyT>
+         </sequence>
+        </elem>
+       </let>
+      </sequence>
+     </let>
+    </sequence>
+   </templateRule>
+   <templateRule prec="0" prio="-0.5" seq="9" rank="0" minImp="0" slots="0" flags="s" line="1556" module="saxon-xforms.xsl">
     <p.nodeTest role="match" test="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
-    <copy role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1366" flags="cin">
-     <applyT role="content" bSlot="38">
+    <copy role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1558" flags="cin">
+     <applyT role="content" bSlot="56">
       <sequence role="select">
        <axis name="attribute" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
        <axis name="child" nodeTest="( element() | text() | comment() | processing-instruction() )" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);"/>
@@ -5536,17 +6555,17 @@
      </applyT>
     </copy>
    </templateRule>
-   <templateRule prec="0" prio="0.5" seq="10" rank="2" minImp="0" slots="0" flags="s" line="1375" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="0.5" seq="10" rank="2" minImp="0" slots="0" flags="s" line="1567" module="saxon-xforms.xsl">
     <p.withPredicate role="match">
      <p.nodeTest test="text()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===3;"/>
-     <axis ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1375" name="ancestor" nodeTest="element(Q{http://www.w3.org/2002/xforms}model)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='model';"/>
+     <axis ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1567" name="ancestor" nodeTest="element(Q{http://www.w3.org/2002/xforms}model)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='model';"/>
     </p.withPredicate>
     <empty role="action"/>
    </templateRule>
-   <templateRule prec="0" prio="-0.5" seq="9" rank="0" minImp="0" slots="0" flags="s" line="1364" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="-0.5" seq="9" rank="0" minImp="0" slots="0" flags="s" line="1556" module="saxon-xforms.xsl">
     <p.nodeTest role="match" test="( element() | text() | comment() | processing-instruction() )" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);"/>
-    <copy role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1366" flags="cin">
-     <applyT role="content" bSlot="38">
+    <copy role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1558" flags="cin">
+     <applyT role="content" bSlot="56">
       <sequence role="select">
        <axis name="attribute" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
        <axis name="child" nodeTest="( element() | text() | comment() | processing-instruction() )" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);"/>
@@ -5556,9 +6575,9 @@
    </templateRule>
   </mode>
  </co>
- <co id="50" binds="1">
-  <template name="Q{}getDataRef" flags="os" line="2637" module="saxon-xforms.xsl" slots="4">
-   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2638">
+ <co id="54" binds="1 1 1">
+  <template name="Q{}getDataRef" flags="os" line="3093" module="saxon-xforms.xsl" slots="4">
+   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="3094">
     <param name="Q{}this" slot="0" flags="r" as="element()">
      <treat role="conversion" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="8|0|XTTE0590|this">
       <check card="1" diag="8|0|XTTE0590|this">
@@ -5566,7 +6585,7 @@
       </check>
      </treat>
     </param>
-    <param line="2639" name="Q{}nodeset" slot="1" flags="t" as="xs:string">
+    <param line="3095" name="Q{}nodeset" slot="1" flags="t" as="xs:string">
      <str role="select" val=""/>
      <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|nodeset">
       <check card="1" diag="8|0|XTTE0590|nodeset">
@@ -5578,7 +6597,7 @@
       </check>
      </treat>
     </param>
-    <param line="2640" name="Q{}bindingi" slot="2" as="node()?">
+    <param line="3096" name="Q{}bindingi" slot="2" as="node()?">
      <empty role="select"/>
      <treat role="conversion" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="8|0|XTTE0590|bindingi">
       <check card="?" diag="8|0|XTTE0590|bindingi">
@@ -5586,7 +6605,7 @@
       </check>
      </treat>
     </param>
-    <let line="2648" var="this-ref" as="xs:string?" slot="3" eval="7">
+    <let line="3104" var="this-ref" as="xs:string?" slot="3" eval="7">
      <choose>
       <fn name="exists">
        <slash simple="1">
@@ -5621,51 +6640,69 @@
        </cast>
       </fn>
      </choose>
-     <choose line="2652">
+     <choose line="3129">
       <fn name="exists">
        <varRef name="bindingi" slot="2"/>
       </fn>
-      <cvUntyped line="2663" to="xs:string">
-       <cast as="xs:untypedAtomic" emptiable="0">
-        <fn name="string-join">
-         <convert from="xs:anyAtomicType" to="xs:string">
-          <choose>
-           <fn name="exists">
-            <slash simple="1">
-             <varRef name="bindingi" slot="2"/>
-             <axis name="attribute" nodeTest="attribute(Q{}nodeset)" jsTest="return item.name==='nodeset'"/>
-            </slash>
-           </fn>
-           <data>
-            <slash simple="1">
-             <varRef name="bindingi" slot="2"/>
-             <axis name="attribute" nodeTest="attribute(Q{}nodeset)" jsTest="return item.name==='nodeset'"/>
-            </slash>
-           </data>
-           <true/>
-           <data>
-            <slash simple="1">
-             <varRef name="bindingi" slot="2"/>
-             <axis name="attribute" nodeTest="attribute(Q{}ref)" jsTest="return item.name==='ref'"/>
-            </slash>
-           </data>
-          </choose>
-         </convert>
-         <str val=" "/>
-        </fn>
-       </cast>
-      </cvUntyped>
-      <fn line="2665" name="exists">
+      <ufCall line="3131" name="Q{http://www.w3.org/2002/xforms}resolveXPathStrings" tailCall="false" bSlot="0" eval="0 4">
+       <str val=""/>
+       <check card="1" diag="0|1||xforms:resolveXPathStrings">
+        <choose line="3109">
+         <fn name="exists">
+          <varRef name="bindingi" slot="2"/>
+         </fn>
+         <cvUntyped line="3120" to="xs:string">
+          <cast as="xs:untypedAtomic" emptiable="0">
+           <choose>
+            <fn name="exists">
+             <slash simple="1">
+              <varRef name="bindingi" slot="2"/>
+              <axis name="attribute" nodeTest="attribute(Q{}nodeset)" jsTest="return item.name==='nodeset'"/>
+             </slash>
+            </fn>
+            <fn name="normalize-space">
+             <cast as="xs:string" emptiable="1">
+              <data>
+               <slash simple="1">
+                <varRef name="bindingi" slot="2"/>
+                <axis name="attribute" nodeTest="attribute(Q{}nodeset)" jsTest="return item.name==='nodeset'"/>
+               </slash>
+              </data>
+             </cast>
+            </fn>
+            <true/>
+            <fn name="normalize-space">
+             <cast as="xs:string" emptiable="1">
+              <data>
+               <slash simple="1">
+                <varRef name="bindingi" slot="2"/>
+                <axis name="attribute" nodeTest="attribute(Q{}ref)" jsTest="return item.name==='ref'"/>
+               </slash>
+              </data>
+             </cast>
+            </fn>
+           </choose>
+          </cast>
+         </cvUntyped>
+        </choose>
+       </check>
+      </ufCall>
+      <fn line="3133" name="exists">
        <varRef name="this-ref" slot="3"/>
       </fn>
-      <ufCall line="2666" name="Q{http://www.w3.org/2002/xforms}resolveXPathStrings" tailCall="false" bSlot="0" eval="6 7">
+      <ufCall line="3135" name="Q{http://www.w3.org/2002/xforms}resolveXPathStrings" tailCall="false" bSlot="1" eval="6 7">
        <varRef name="nodeset" slot="1"/>
        <check card="1" diag="0|1||xforms:resolveXPathStrings">
         <varRef name="this-ref" slot="3"/>
        </check>
       </ufCall>
+      <varRef line="3137" name="nodeset" slot="1"/>
+      <ufCall line="3140" name="Q{http://www.w3.org/2002/xforms}resolveXPathStrings" tailCall="false" bSlot="2" eval="0 6">
+       <str val=""/>
+       <varRef name="nodeset" slot="1"/>
+      </ufCall>
       <true/>
-      <cvUntyped line="2669" to="xs:string">
+      <cvUntyped line="3144" to="xs:string">
        <cast as="xs:untypedAtomic" emptiable="0">
         <varRef name="nodeset" slot="1"/>
        </cast>
@@ -5675,602 +6712,18 @@
    </sequence>
   </template>
  </co>
- <co id="52" binds="">
-  <mode name="Q{}xforms-action" onNo="TC" flags="W" patternSlots="0">
-   <templateRule prec="0" prio="0.0" seq="3" rank="0" minImp="0" slots="1" flags="s" line="1952" module="saxon-xforms.xsl">
-    <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}reset)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='reset';"/>
-    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1953">
-     <param name="Q{}nodeset" slot="0" flags="t">
-      <str role="select" val=""/>
-      <supplied role="conversion" slot="0"/>
-     </param>
-     <elem line="1955" name="reset" nsuri="" namespaces="xd rdf xhtml js in fn map array ev r">
-      <sequence>
-       <choose>
-        <fn name="exists">
-         <axis name="attribute" nodeTest="attribute(Q{}ref)" jsTest="return item.name==='ref'"/>
-        </fn>
-        <elem line="1958" name="ref" nsuri="" flags="l">
-         <choose>
-          <gc op="=" card="1:1" comp="CCC">
-           <attVal name="Q{}nodeset" chk="0"/>
-           <str val="."/>
-          </gc>
-          <valueOf line="1959" flags="l">
-           <fn name="string-join">
-            <convert from="xs:anyAtomicType" to="xs:string">
-             <data>
-              <mergeAdj>
-               <varRef name="nodeset" slot="0"/>
-              </mergeAdj>
-             </data>
-            </convert>
-            <str val=" "/>
-           </fn>
-          </valueOf>
-          <true/>
-          <valueOf line="1962" flags="l">
-           <convert from="xs:untypedAtomic" to="xs:string">
-            <attVal name="Q{}ref" chk="0"/>
-           </convert>
-          </valueOf>
-         </choose>
-        </elem>
-       </choose>
-       <choose line="1967">
-        <fn name="exists">
-         <axis name="attribute" nodeTest="attribute(Q{}nodeset)" jsTest="return item.name==='nodeset'"/>
-        </fn>
-        <elem line="1970" name="ref" nsuri="" flags="l">
-         <choose>
-          <gc op="=" card="1:1" comp="CCC">
-           <attVal name="Q{}nodeset" chk="0"/>
-           <str val="."/>
-          </gc>
-          <valueOf line="1971" flags="l">
-           <fn name="string-join">
-            <convert from="xs:anyAtomicType" to="xs:string">
-             <data>
-              <mergeAdj>
-               <varRef name="nodeset" slot="0"/>
-              </mergeAdj>
-             </data>
-            </convert>
-            <str val=" "/>
-           </fn>
-          </valueOf>
-          <true/>
-          <valueOf line="1974" flags="l">
-           <convert from="xs:untypedAtomic" to="xs:string">
-            <attVal name="Q{}nodeset" chk="0"/>
-           </convert>
-          </valueOf>
-         </choose>
-        </elem>
-       </choose>
-       <choose line="1980">
-        <fn name="exists">
-         <axis name="attribute" nodeTest="attribute(Q{}position)" jsTest="return item.name==='position'"/>
-        </fn>
-        <elem line="1982" name="position" nsuri="" flags="l">
-         <valueOf flags="l">
-          <convert from="xs:untypedAtomic" to="xs:string">
-           <attVal name="Q{}position" chk="0"/>
-          </convert>
-         </valueOf>
-        </elem>
-       </choose>
-       <choose line="1985">
-        <fn name="exists">
-         <axis name="attribute" nodeTest="attribute(Q{}at)" jsTest="return item.name==='at'"/>
-        </fn>
-        <elem line="1987" name="at" nsuri="" flags="l">
-         <valueOf flags="l">
-          <convert from="xs:untypedAtomic" to="xs:string">
-           <attVal name="Q{}at" chk="0"/>
-          </convert>
-         </valueOf>
-        </elem>
-       </choose>
-       <choose line="1990">
-        <fn name="exists">
-         <axis name="attribute" nodeTest="attribute(Q{}if)" jsTest="return item.name==='if'"/>
-        </fn>
-        <elem line="1992" name="if" nsuri="" flags="l">
-         <valueOf flags="l">
-          <convert from="xs:untypedAtomic" to="xs:string">
-           <attVal name="Q{}if" chk="0"/>
-          </convert>
-         </valueOf>
-        </elem>
-       </choose>
-       <choose line="1995">
-        <fn name="exists">
-         <axis name="attribute" nodeTest="attribute(Q{}while)" jsTest="return item.name==='while'"/>
-        </fn>
-        <elem line="1997" name="while" nsuri="" flags="l">
-         <valueOf flags="l">
-          <convert from="xs:untypedAtomic" to="xs:string">
-           <attVal name="Q{}while" chk="0"/>
-          </convert>
-         </valueOf>
-        </elem>
-       </choose>
-       <choose line="2000">
-        <fn name="exists">
-         <axis name="attribute" nodeTest="@*:event" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===2&amp;&amp;q.local==='event'"/>
-        </fn>
-        <elem line="2002" name="event" nsuri="" flags="l">
-         <valueOf flags="l">
-          <fn name="string-join">
-           <convert from="xs:untypedAtomic" to="xs:string">
-            <data>
-             <axis name="attribute" nodeTest="@*:event" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===2&amp;&amp;q.local==='event'"/>
-            </data>
-           </convert>
-           <str val=" "/>
-          </fn>
-         </valueOf>
-        </elem>
-       </choose>
-      </sequence>
-     </elem>
-    </sequence>
-   </templateRule>
-   <templateRule prec="0" prio="0.0" seq="2" rank="0" minImp="0" slots="1" flags="s" line="1888" module="saxon-xforms.xsl">
-    <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}setvalue)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='setvalue';"/>
-    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1889">
-     <param name="Q{}nodeset" slot="0" flags="t">
-      <str role="select" val=""/>
-      <supplied role="conversion" slot="0"/>
-     </param>
-     <elem line="1892" name="setvalue" nsuri="" namespaces="xd rdf xhtml js in fn map array ev r">
-      <sequence>
-       <choose>
-        <fn name="exists">
-         <axis name="attribute" nodeTest="attribute(Q{}value)" jsTest="return item.name==='value'"/>
-        </fn>
-        <att line="1894" name="value" flags="l">
-         <convert from="xs:untypedAtomic" to="xs:string">
-          <cast as="xs:untypedAtomic" emptiable="0">
-           <fn name="string">
-            <convert from="xs:untypedAtomic" to="xs:string">
-             <attVal name="Q{}value" chk="0"/>
-            </convert>
-           </fn>
-          </cast>
-         </convert>
-        </att>
-       </choose>
-       <choose line="1897">
-        <fn name="exists">
-         <axis name="attribute" nodeTest="attribute(Q{}ref)" jsTest="return item.name==='ref'"/>
-        </fn>
-        <elem line="1900" name="ref" nsuri="" flags="l">
-         <choose>
-          <gc op="=" card="1:1" comp="CCC">
-           <attVal name="Q{}nodeset" chk="0"/>
-           <str val="."/>
-          </gc>
-          <valueOf line="1901" flags="l">
-           <fn name="string-join">
-            <convert from="xs:anyAtomicType" to="xs:string">
-             <data>
-              <mergeAdj>
-               <varRef name="nodeset" slot="0"/>
-              </mergeAdj>
-             </data>
-            </convert>
-            <str val=" "/>
-           </fn>
-          </valueOf>
-          <true/>
-          <valueOf line="1904" flags="l">
-           <convert from="xs:untypedAtomic" to="xs:string">
-            <attVal name="Q{}ref" chk="0"/>
-           </convert>
-          </valueOf>
-         </choose>
-        </elem>
-       </choose>
-       <choose line="1909">
-        <fn name="exists">
-         <axis name="attribute" nodeTest="attribute(Q{}nodeset)" jsTest="return item.name==='nodeset'"/>
-        </fn>
-        <elem line="1912" name="ref" nsuri="" flags="l">
-         <choose>
-          <gc op="=" card="1:1" comp="CCC">
-           <attVal name="Q{}nodeset" chk="0"/>
-           <str val="."/>
-          </gc>
-          <valueOf line="1913" flags="l">
-           <fn name="string-join">
-            <convert from="xs:anyAtomicType" to="xs:string">
-             <data>
-              <mergeAdj>
-               <varRef name="nodeset" slot="0"/>
-              </mergeAdj>
-             </data>
-            </convert>
-            <str val=" "/>
-           </fn>
-          </valueOf>
-          <true/>
-          <valueOf line="1916" flags="l">
-           <convert from="xs:untypedAtomic" to="xs:string">
-            <attVal name="Q{}nodeset" chk="0"/>
-           </convert>
-          </valueOf>
-         </choose>
-        </elem>
-       </choose>
-       <choose line="1922">
-        <fn name="exists">
-         <axis name="attribute" nodeTest="attribute(Q{}position)" jsTest="return item.name==='position'"/>
-        </fn>
-        <elem line="1924" name="position" nsuri="" flags="l">
-         <valueOf flags="l">
-          <convert from="xs:untypedAtomic" to="xs:string">
-           <attVal name="Q{}position" chk="0"/>
-          </convert>
-         </valueOf>
-        </elem>
-       </choose>
-       <choose line="1927">
-        <fn name="exists">
-         <axis name="attribute" nodeTest="attribute(Q{}at)" jsTest="return item.name==='at'"/>
-        </fn>
-        <elem line="1929" name="at" nsuri="" flags="l">
-         <valueOf flags="l">
-          <convert from="xs:untypedAtomic" to="xs:string">
-           <attVal name="Q{}at" chk="0"/>
-          </convert>
-         </valueOf>
-        </elem>
-       </choose>
-       <choose line="1932">
-        <fn name="exists">
-         <axis name="attribute" nodeTest="attribute(Q{}if)" jsTest="return item.name==='if'"/>
-        </fn>
-        <elem line="1934" name="if" nsuri="" flags="l">
-         <valueOf flags="l">
-          <convert from="xs:untypedAtomic" to="xs:string">
-           <attVal name="Q{}if" chk="0"/>
-          </convert>
-         </valueOf>
-        </elem>
-       </choose>
-       <choose line="1937">
-        <fn name="exists">
-         <axis name="attribute" nodeTest="attribute(Q{}while)" jsTest="return item.name==='while'"/>
-        </fn>
-        <elem line="1939" name="while" nsuri="" flags="l">
-         <valueOf flags="l">
-          <convert from="xs:untypedAtomic" to="xs:string">
-           <attVal name="Q{}while" chk="0"/>
-          </convert>
-         </valueOf>
-        </elem>
-       </choose>
-       <choose line="1943">
-        <fn name="exists">
-         <axis name="child" nodeTest="text()" jsTest="return item.nodeType===3;"/>
-        </fn>
-        <elem line="1945" name="value" nsuri="" flags="l">
-         <valueOf flags="l">
-          <convert from="xs:untypedAtomic" to="xs:string">
-           <data>
-            <dot type="element(Q{http://www.w3.org/2002/xforms}setvalue)"/>
-           </data>
-          </convert>
-         </valueOf>
-        </elem>
-       </choose>
-      </sequence>
-     </elem>
-    </sequence>
-   </templateRule>
-   <templateRule prec="0" prio="0.0" seq="0" rank="0" minImp="0" slots="1" flags="s" line="1786" module="saxon-xforms.xsl">
-    <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}insert)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='insert';"/>
-    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1787">
-     <param name="Q{}nodeset" slot="0" flags="t">
-      <str role="select" val=""/>
-      <supplied role="conversion" slot="0"/>
-     </param>
-     <elem line="1789" name="insert" nsuri="" namespaces="xd rdf xhtml js in fn map array ev r">
-      <sequence>
-       <choose>
-        <fn name="exists">
-         <axis name="attribute" nodeTest="attribute(Q{}ref)" jsTest="return item.name==='ref'"/>
-        </fn>
-        <elem line="1792" name="ref" nsuri="" flags="l">
-         <choose>
-          <gc op="=" card="1:1" comp="CCC">
-           <attVal name="Q{}nodeset" chk="0"/>
-           <str val="."/>
-          </gc>
-          <valueOf line="1793" flags="l">
-           <fn name="string-join">
-            <convert from="xs:anyAtomicType" to="xs:string">
-             <data>
-              <mergeAdj>
-               <varRef name="nodeset" slot="0"/>
-              </mergeAdj>
-             </data>
-            </convert>
-            <str val=" "/>
-           </fn>
-          </valueOf>
-          <true/>
-          <valueOf line="1796" flags="l">
-           <convert from="xs:untypedAtomic" to="xs:string">
-            <attVal name="Q{}ref" chk="0"/>
-           </convert>
-          </valueOf>
-         </choose>
-        </elem>
-       </choose>
-       <choose line="1801">
-        <fn name="exists">
-         <axis name="attribute" nodeTest="attribute(Q{}nodeset)" jsTest="return item.name==='nodeset'"/>
-        </fn>
-        <elem line="1804" name="ref" nsuri="" flags="l">
-         <choose>
-          <gc op="=" card="1:1" comp="CCC">
-           <attVal name="Q{}nodeset" chk="0"/>
-           <str val="."/>
-          </gc>
-          <valueOf line="1805" flags="l">
-           <fn name="string-join">
-            <convert from="xs:anyAtomicType" to="xs:string">
-             <data>
-              <mergeAdj>
-               <varRef name="nodeset" slot="0"/>
-              </mergeAdj>
-             </data>
-            </convert>
-            <str val=" "/>
-           </fn>
-          </valueOf>
-          <true/>
-          <valueOf line="1808" flags="l">
-           <convert from="xs:untypedAtomic" to="xs:string">
-            <attVal name="Q{}nodeset" chk="0"/>
-           </convert>
-          </valueOf>
-         </choose>
-        </elem>
-       </choose>
-       <choose line="1814">
-        <fn name="exists">
-         <axis name="attribute" nodeTest="attribute(Q{}position)" jsTest="return item.name==='position'"/>
-        </fn>
-        <elem line="1816" name="position" nsuri="" flags="l">
-         <valueOf flags="l">
-          <convert from="xs:untypedAtomic" to="xs:string">
-           <attVal name="Q{}position" chk="0"/>
-          </convert>
-         </valueOf>
-        </elem>
-       </choose>
-       <choose line="1819">
-        <fn name="exists">
-         <axis name="attribute" nodeTest="attribute(Q{}at)" jsTest="return item.name==='at'"/>
-        </fn>
-        <elem line="1821" name="at" nsuri="" flags="l">
-         <valueOf flags="l">
-          <convert from="xs:untypedAtomic" to="xs:string">
-           <attVal name="Q{}at" chk="0"/>
-          </convert>
-         </valueOf>
-        </elem>
-       </choose>
-       <choose line="1824">
-        <fn name="exists">
-         <axis name="attribute" nodeTest="attribute(Q{}if)" jsTest="return item.name==='if'"/>
-        </fn>
-        <elem line="1826" name="if" nsuri="" flags="l">
-         <valueOf flags="l">
-          <convert from="xs:untypedAtomic" to="xs:string">
-           <attVal name="Q{}if" chk="0"/>
-          </convert>
-         </valueOf>
-        </elem>
-       </choose>
-       <choose line="1829">
-        <fn name="exists">
-         <axis name="attribute" nodeTest="attribute(Q{}while)" jsTest="return item.name==='while'"/>
-        </fn>
-        <elem line="1831" name="while" nsuri="" flags="l">
-         <valueOf flags="l">
-          <convert from="xs:untypedAtomic" to="xs:string">
-           <attVal name="Q{}while" chk="0"/>
-          </convert>
-         </valueOf>
-        </elem>
-       </choose>
-      </sequence>
-     </elem>
-    </sequence>
-   </templateRule>
-   <templateRule prec="0" prio="0.0" seq="1" rank="0" minImp="0" slots="1" flags="s" line="1837" module="saxon-xforms.xsl">
-    <p.nodeTest role="match" test="element(Q{http://www.w3.org/2002/xforms}delete)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='delete';"/>
-    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1838">
-     <param name="Q{}nodeset" slot="0" flags="t">
-      <str role="select" val=""/>
-      <supplied role="conversion" slot="0"/>
-     </param>
-     <elem line="1840" name="delete" nsuri="" namespaces="xd rdf xhtml js in fn map array ev r">
-      <sequence>
-       <choose>
-        <fn name="exists">
-         <axis name="attribute" nodeTest="attribute(Q{}ref)" jsTest="return item.name==='ref'"/>
-        </fn>
-        <elem line="1843" name="ref" nsuri="" flags="l">
-         <choose>
-          <gc op="=" card="1:1" comp="CCC">
-           <attVal name="Q{}nodeset" chk="0"/>
-           <str val="."/>
-          </gc>
-          <valueOf line="1844" flags="l">
-           <fn name="string-join">
-            <convert from="xs:anyAtomicType" to="xs:string">
-             <data>
-              <mergeAdj>
-               <varRef name="nodeset" slot="0"/>
-              </mergeAdj>
-             </data>
-            </convert>
-            <str val=" "/>
-           </fn>
-          </valueOf>
-          <true/>
-          <valueOf line="1847" flags="l">
-           <convert from="xs:untypedAtomic" to="xs:string">
-            <attVal name="Q{}ref" chk="0"/>
-           </convert>
-          </valueOf>
-         </choose>
-        </elem>
-       </choose>
-       <choose line="1852">
-        <fn name="exists">
-         <axis name="attribute" nodeTest="attribute(Q{}nodeset)" jsTest="return item.name==='nodeset'"/>
-        </fn>
-        <elem line="1855" name="ref" nsuri="" flags="l">
-         <choose>
-          <gc op="=" card="1:1" comp="CCC">
-           <attVal name="Q{}nodeset" chk="0"/>
-           <str val="."/>
-          </gc>
-          <valueOf line="1856" flags="l">
-           <fn name="string-join">
-            <convert from="xs:anyAtomicType" to="xs:string">
-             <data>
-              <mergeAdj>
-               <varRef name="nodeset" slot="0"/>
-              </mergeAdj>
-             </data>
-            </convert>
-            <str val=" "/>
-           </fn>
-          </valueOf>
-          <true/>
-          <valueOf line="1859" flags="l">
-           <convert from="xs:untypedAtomic" to="xs:string">
-            <attVal name="Q{}nodeset" chk="0"/>
-           </convert>
-          </valueOf>
-         </choose>
-        </elem>
-       </choose>
-       <choose line="1865">
-        <fn name="exists">
-         <axis name="attribute" nodeTest="attribute(Q{}position)" jsTest="return item.name==='position'"/>
-        </fn>
-        <elem line="1867" name="position" nsuri="" flags="l">
-         <valueOf flags="l">
-          <convert from="xs:untypedAtomic" to="xs:string">
-           <attVal name="Q{}position" chk="0"/>
-          </convert>
-         </valueOf>
-        </elem>
-       </choose>
-       <choose line="1870">
-        <fn name="exists">
-         <axis name="attribute" nodeTest="attribute(Q{}at)" jsTest="return item.name==='at'"/>
-        </fn>
-        <elem line="1872" name="at" nsuri="" flags="l">
-         <valueOf flags="l">
-          <convert from="xs:untypedAtomic" to="xs:string">
-           <attVal name="Q{}at" chk="0"/>
-          </convert>
-         </valueOf>
-        </elem>
-       </choose>
-       <choose line="1875">
-        <fn name="exists">
-         <axis name="attribute" nodeTest="attribute(Q{}if)" jsTest="return item.name==='if'"/>
-        </fn>
-        <elem line="1877" name="if" nsuri="" flags="l">
-         <valueOf flags="l">
-          <convert from="xs:untypedAtomic" to="xs:string">
-           <attVal name="Q{}if" chk="0"/>
-          </convert>
-         </valueOf>
-        </elem>
-       </choose>
-       <choose line="1880">
-        <fn name="exists">
-         <axis name="attribute" nodeTest="attribute(Q{}while)" jsTest="return item.name==='while'"/>
-        </fn>
-        <elem line="1882" name="while" nsuri="" flags="l">
-         <valueOf flags="l">
-          <convert from="xs:untypedAtomic" to="xs:string">
-           <attVal name="Q{}while" chk="0"/>
-          </convert>
-         </valueOf>
-        </elem>
-       </choose>
-      </sequence>
-     </elem>
-    </sequence>
-   </templateRule>
-  </mode>
- </co>
- <co id="29" binds="19">
-  <template name="Q{}applyNestedActions" flags="os" line="2924" module="saxon-xforms.xsl" slots="2">
-   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2925">
-    <param name="Q{}action-map" slot="0" flags="tr" as="map(*)">
-     <treat role="conversion" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="8|0|XTTE0590|action-map">
-      <check card="1" diag="8|0|XTTE0590|action-map">
-       <supplied slot="0"/>
-      </check>
-     </treat>
-    </param>
-    <param line="2926" name="Q{}action-name" slot="1" flags="r" as="xs:string">
-     <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|action-name">
-      <check card="1" diag="8|0|XTTE0590|action-name">
-       <cvUntyped to="xs:string">
-        <data>
-         <supplied slot="1"/>
-        </data>
-       </cvUntyped>
-      </check>
-     </treat>
-    </param>
-    <choose line="2928">
-     <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}contains" type="xs:boolean">
-      <varRef name="action-map" slot="0"/>
-      <varRef name="action-name" slot="1"/>
-     </ifCall>
-     <forEach line="2933">
-      <ifCall line="2929" name="Q{http://www.w3.org/2005/xpath-functions/array}flatten" type="item()*">
-       <treat as="array(map(*))" jsTest="function v(item) {return SaxonJS.U.isMap(item)};function c(n) {return n==1;};return SaxonJS.U.isArray(item) &amp;&amp; SaxonJS.U.ForArray(item.value).every(function(seq){return c(seq.length) &amp;&amp; SaxonJS.U.ForArray(seq).every(v)});" diag="3|0|XTTE0570|actionsArray">
-        <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}find" type="function(*)">
-         <varRef name="action-map" slot="0"/>
-         <varRef name="action-name" slot="1"/>
-        </ifCall>
-       </treat>
-      </ifCall>
-      <callT line="2934" name="applyActions" bSlot="0"/>
-     </forEach>
-    </choose>
-   </sequence>
-  </template>
- </co>
- <co id="6" binds="22">
-  <function name="Q{http://www.w3.org/2002/xforms}setInstance-JS" line="2530" module="saxon-xforms.xsl" eval="7" flags="pU" as="empty-sequence()" slots="2">
+ <co id="6" binds="20">
+  <function name="Q{http://www.w3.org/2002/xforms}setInstance-JS" line="3007" module="saxon-xforms.xsl" eval="7" flags="pU" as="empty-sequence()" slots="2">
    <arg name="ref" as="xs:string"/>
    <arg name="updatedInstance" as="element()"/>
-   <check role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2538" card="°" diag="5|0|XTTE0780|xforms:setInstance-JS">
+   <check role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="3015" card="°" diag="5|0|XTTE0780|xforms:setInstance-JS">
     <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
      <check card="1" diag="0|0||ixsl:call">
       <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
      </check>
      <str val="setInstance"/>
      <arrayBlock>
-      <check line="2536" card="1" diag="3|0|XTTE0570|this-instance-id">
+      <check line="3013" card="1" diag="3|0|XTTE0570|this-instance-id">
        <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
         <ufCall name="Q{http://www.w3.org/2002/xforms}getInstanceMap" tailCall="false" bSlot="0" eval="6">
          <varRef name="ref" slot="0"/>
@@ -6284,18 +6737,26 @@
    </check>
   </function>
  </co>
- <co id="3" binds="35 22">
-  <function name="Q{http://www.w3.org/2002/xforms}getInstance-JS" line="2505" module="saxon-xforms.xsl" eval="7" flags="pU" as="element()?" slots="1">
+ <co id="3" binds="34 20">
+  <function name="Q{http://www.w3.org/2002/xforms}getInstance-JS" line="2982" module="saxon-xforms.xsl" eval="7" flags="pU" as="element()?" slots="1">
    <arg name="ref" as="xs:string"/>
-   <tailCallLoop role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2509">
+   <tailCallLoop role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2986">
     <choose>
      <fn name="not">
       <varRef name="ref" slot="0"/>
      </fn>
-     <empty/>
+     <treat line="2987" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="5|0|XTTE0780|xforms:getInstance-JS">
+      <message>
+       <valueOf role="select">
+        <str val="[xforms:getInstance-JS] Empty ref supplied, no instance will be returned"/>
+       </valueOf>
+       <str role="terminate" val="no"/>
+       <str role="error" val="Q{http://www.w3.org/2005/xqt-errors}XTMM9000"/>
+      </message>
+     </treat>
      <true/>
-     <ufCall line="2515" name="Q{http://www.w3.org/2002/xforms}instance" tailCall="foreign" bSlot="0" eval="7">
-      <check line="2513" card="1" diag="3|0|XTTE0570|this-instance-id">
+     <ufCall line="2992" name="Q{http://www.w3.org/2002/xforms}instance" tailCall="foreign" bSlot="0" eval="7">
+      <check line="2990" card="1" diag="3|0|XTTE0570|this-instance-id">
        <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
         <ufCall name="Q{http://www.w3.org/2002/xforms}getInstanceMap" tailCall="false" bSlot="1" eval="6">
          <varRef name="ref" slot="0"/>
@@ -6308,54 +6769,54 @@
    </tailCallLoop>
   </function>
  </co>
- <co id="22" binds="">
-  <function name="Q{http://www.w3.org/2002/xforms}getInstanceMap" line="2468" module="saxon-xforms.xsl" eval="8" flags="pU" as="map(xs:string, xs:string)" slots="3">
+ <co id="20" binds="">
+  <function name="Q{http://www.w3.org/2002/xforms}getInstanceMap" line="2945" module="saxon-xforms.xsl" eval="8" flags="pU" as="map(xs:string, xs:string)" slots="3">
    <arg name="nodeset" as="xs:string"/>
-   <let role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2489" var="vv:v0" as="map(xs:string, xs:string)+" slot="1" eval="4">
+   <let role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2966" var="vv:v0" as="map(xs:string, xs:string)+" slot="1" eval="4">
     <sequence>
      <map size="1">
       <str val="instance-id"/>
       <str val="saxon-forms-default"/>
      </map>
-     <ifCall line="2490" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+     <ifCall line="2967" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
       <str val="xpath"/>
       <fn name="normalize-space">
        <varRef name="nodeset" slot="0"/>
       </fn>
      </ifCall>
     </sequence>
-    <ifCall line="2473" name="Q{http://www.w3.org/2005/xpath-functions/map}merge" type="map(*)">
+    <ifCall line="2950" name="Q{http://www.w3.org/2005/xpath-functions/map}merge" type="map(*)">
      <analyzeString>
       <fn role="select" name="normalize-space">
        <varRef name="nodeset" slot="0"/>
       </fn>
       <str role="regex" val="^instance\s*\(\s*'(.*)'\s*\)\s*(/\s*(.*)|)$"/>
       <str role="flags" val=""/>
-      <let role="matching" line="2475" var="xpath" as="xs:string" slot="2" eval="7">
-       <choose line="2477">
+      <let role="matching" line="2952" var="xpath" as="xs:string" slot="2" eval="7">
+       <choose line="2954">
         <fn name="regex-group">
          <int val="2"/>
         </fn>
-        <fn line="2478" name="regex-group">
+        <fn line="2955" name="regex-group">
          <int val="3"/>
         </fn>
         <true/>
-        <str val=""/>
+        <str val="."/>
        </choose>
-       <sequence line="2485">
+       <sequence line="2962">
         <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
          <str val="instance-id"/>
          <fn name="regex-group">
           <int val="1"/>
          </fn>
         </ifCall>
-        <ifCall line="2486" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+        <ifCall line="2963" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
          <str val="xpath"/>
          <varRef name="xpath" slot="2"/>
         </ifCall>
        </sequence>
       </let>
-      <varRef role="nonMatching" line="2489" name="vv:v0" slot="1"/>
+      <varRef role="nonMatching" line="2966" name="vv:v0" slot="1"/>
      </analyzeString>
      <map size="2">
       <str val="duplicates"/>
@@ -6367,14 +6828,14 @@
    </let>
   </function>
  </co>
- <co id="2" binds="22">
-  <function name="Q{http://www.w3.org/2002/xforms}getInstanceId" line="2455" module="saxon-xforms.xsl" eval="8" flags="pU" as="xs:string" slots="1">
+ <co id="2" binds="20">
+  <function name="Q{http://www.w3.org/2002/xforms}getInstanceId" line="2932" module="saxon-xforms.xsl" eval="8" flags="pU" as="xs:string" slots="1">
    <arg name="nodeset" as="xs:string"/>
-   <cvUntyped role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2458" to="xs:string">
+   <cvUntyped role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2935" to="xs:string">
     <cast as="xs:untypedAtomic" emptiable="0">
      <fn name="string">
       <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
-       <ufCall line="2457" name="Q{http://www.w3.org/2002/xforms}getInstanceMap" tailCall="false" bSlot="0" eval="6">
+       <ufCall line="2934" name="Q{http://www.w3.org/2002/xforms}getInstanceMap" tailCall="false" bSlot="0" eval="6">
         <varRef name="nodeset" slot="0"/>
        </ufCall>
        <str val="instance-id"/>
@@ -6384,20 +6845,20 @@
    </cvUntyped>
   </function>
  </co>
- <co id="53" binds="">
-  <globalVariable name="Q{}debugMode" type="xs:boolean" line="42" module="saxon-xforms.xsl" visibility="PRIVATE" jsAcceptor="return SaxonJS.U.Atomic.boolean.cast(val);" jsCardCheck="function c(n) {return n==1;};">
-   <false/>
+ <co id="56" binds="">
+  <globalVariable name="Q{}debugMode" type="xs:boolean" line="62" module="saxon-xforms.xsl" visibility="PRIVATE" jsAcceptor="return SaxonJS.U.Atomic.boolean.cast(val);" jsCardCheck="function c(n) {return n==1;};">
+   <true/>
   </globalVariable>
  </co>
- <co id="54" binds="">
-  <function name="Q{http://www.w3.org/2002/xforms}getWhileStatement" line="579" module="saxon-xforms.xsl" eval="7" flags="pU" as="xs:string?" slots="3">
+ <co id="57" binds="">
+  <function name="Q{http://www.w3.org/2002/xforms}getWhileStatement" line="731" module="saxon-xforms.xsl" eval="7" flags="pU" as="xs:string?" slots="3">
    <arg name="map" as="map(*)"/>
-   <choose role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="582">
+   <choose role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="734">
     <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}contains" type="xs:boolean">
      <varRef name="map" slot="0"/>
      <str val="@while"/>
     </ifCall>
-    <treat line="583" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="5|0|XTTE0780|xforms:getWhileStatement">
+    <treat line="735" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="5|0|XTTE0780|xforms:getWhileStatement">
      <check card="?" diag="5|0|XTTE0780|xforms:getWhileStatement">
       <cvUntyped to="xs:string">
        <data>
@@ -6410,22 +6871,22 @@
      </check>
     </treat>
     <true/>
-    <treat line="586" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="5|0|XTTE0780|xforms:getWhileStatement">
+    <treat line="738" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="5|0|XTTE0780|xforms:getWhileStatement">
      <check card="?" diag="5|0|XTTE0780|xforms:getWhileStatement">
       <cvUntyped to="xs:string">
        <data>
         <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
          <treat as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="0|0||map:get">
           <check card="1" diag="0|0||map:get">
-           <let var="vv:LHS107500617" as="map(*)" slot="1" eval="1">
+           <let var="vv:LHS730663242" as="map(*)" slot="1" eval="1">
             <varRef name="map" slot="0"/>
-            <for var="vv:STAR145730292" as="xs:anyAtomicType" slot="2">
+            <for var="vv:STAR625668683" as="xs:anyAtomicType" slot="2">
              <ifCall role="in" name="Q{http://www.w3.org/2005/xpath-functions/map}keys" type="xs:anyAtomicType*">
-              <varRef name="vv:LHS107500617" slot="1"/>
+              <varRef name="vv:LHS730663242" slot="1"/>
              </ifCall>
              <ifCall role="return" name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
-              <varRef name="vv:LHS107500617" slot="1"/>
-              <varRef name="vv:STAR145730292" slot="2"/>
+              <varRef name="vv:LHS730663242" slot="1"/>
+              <varRef name="vv:STAR625668683" slot="2"/>
              </ifCall>
             </for>
            </let>
@@ -6440,9 +6901,9 @@
    </choose>
   </function>
  </co>
- <co id="55" binds="3 14 2 19">
-  <template name="Q{}DOMActivate" flags="os" line="3388" module="saxon-xforms.xsl" slots="6">
-   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="3389">
+ <co id="58" binds="3 13 2 16">
+  <template name="Q{}DOMActivate" flags="os" line="4005" module="saxon-xforms.xsl" slots="6">
+   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="4006">
     <param name="Q{}form-control" slot="0" flags="i" as="node()">
      <treat role="conversion" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="8|0|XTTE0590|form-control">
       <check card="1" diag="8|0|XTTE0590|form-control">
@@ -6450,7 +6911,7 @@
       </check>
      </treat>
     </param>
-    <let line="3391" var="actions" as="map(*)?" slot="1" eval="7">
+    <let line="4008" var="actions" as="map(*)?" slot="1" eval="7">
      <treat as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|actions">
       <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
        <check card="1" diag="0|0||ixsl:call">
@@ -6467,12 +6928,12 @@
        </arrayBlock>
       </ifCall>
      </treat>
-     <let line="3393" var="refi" as="attribute(Q{}data-ref)?" slot="2" eval="8">
+     <let line="4010" var="refi" as="attribute(Q{}data-ref)?" slot="2" eval="8">
       <slash simple="1">
        <varRef name="form-control" slot="0"/>
        <axis name="attribute" nodeTest="attribute(Q{}data-ref)" jsTest="return item.name==='data-ref'"/>
       </slash>
-      <let line="3396" var="instanceXML" as="element()?" slot="3" eval="7">
+      <let line="4014" var="instanceXML" as="element()?" slot="3" eval="7">
        <ufCall name="Q{http://www.w3.org/2002/xforms}getInstance-JS" tailCall="false" bSlot="0" eval="7">
         <check card="1" diag="0|0||xforms:getInstance-JS">
          <cvUntyped to="xs:string">
@@ -6482,17 +6943,17 @@
          </cvUntyped>
         </check>
        </ufCall>
-       <let line="3398" var="updatedInstanceXML" as="element()?" slot="4" eval="7">
-        <choose line="3399">
+       <let line="4016" var="updatedInstanceXML" as="element()?" slot="4" eval="7">
+        <choose line="4017">
          <fn name="exists">
           <varRef name="instanceXML" slot="3"/>
          </fn>
-         <treat line="3400" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="3|0|XTTE0570|updatedInstanceXML">
+         <treat line="4018" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="3|0|XTTE0570|updatedInstanceXML">
           <check card="?" diag="3|0|XTTE0570|updatedInstanceXML">
            <applyT mode="Q{}form-check-initial" bSlot="1">
             <varRef role="select" name="instanceXML" slot="3"/>
             <withParam name="Q{}instance-id" as="xs:string">
-             <ufCall line="3394" name="Q{http://www.w3.org/2002/xforms}getInstanceId" tailCall="false" bSlot="2" eval="7">
+             <ufCall line="4012" name="Q{http://www.w3.org/2002/xforms}getInstanceId" tailCall="false" bSlot="2" eval="7">
               <check card="1" diag="0|0||xforms:getInstanceId">
                <cvUntyped to="xs:string">
                 <data>
@@ -6506,16 +6967,16 @@
           </check>
          </treat>
         </choose>
-        <forEach line="3406">
+        <forEach line="4024">
          <varRef name="actions" slot="1"/>
-         <let line="3407" var="action-map" as="map(*)" slot="5" eval="7">
+         <let line="4025" var="action-map" as="map(*)" slot="5" eval="7">
           <dot type="map(*)"/>
-          <choose line="3410">
+          <choose line="4028">
            <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}contains" type="xs:boolean">
             <varRef name="action-map" slot="5"/>
             <str val="@event"/>
            </ifCall>
-           <choose line="3411">
+           <choose line="4029">
             <gc op="=" card="N:1" comp="GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint">
              <data>
               <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
@@ -6525,12 +6986,12 @@
              </data>
              <str val="DOMActivate"/>
             </gc>
-            <callT line="3412" name="applyActions" bSlot="3" flags="t">
+            <callT line="4030" name="applyActions" bSlot="3" flags="t">
              <withParam name="Q{}action-map" flags="t" as="item()">
-              <varRef line="3413" name="action-map" slot="5"/>
+              <varRef line="4031" name="action-map" slot="5"/>
              </withParam>
              <withParam name="Q{}instanceXML" flags="t" as="element()?">
-              <varRef line="3414" name="updatedInstanceXML" slot="4"/>
+              <varRef line="4032" name="updatedInstanceXML" slot="4"/>
              </withParam>
             </callT>
            </choose>
@@ -6544,9 +7005,9 @@
    </sequence>
   </template>
  </co>
- <co id="51" binds="11">
-  <template name="Q{}setActions" flags="os" line="2800" module="saxon-xforms.xsl" slots="1">
-   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2801">
+ <co id="55" binds="45">
+  <template name="Q{}setActions" flags="os" line="3323" module="saxon-xforms.xsl" slots="1">
+   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="3324">
     <param name="Q{}this" slot="0" flags="i" as="element()">
      <treat role="conversion" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="8|0|XTTE0590|this">
       <check card="1" diag="8|0|XTTE0590|this">
@@ -6554,7 +7015,7 @@
       </check>
      </treat>
     </param>
-    <applyT line="2803" flags="t" bSlot="0">
+    <applyT line="3326" flags="t" bSlot="0">
      <union role="select" op="|">
       <union op="|">
        <union op="|">
@@ -6617,9 +7078,9 @@
    </sequence>
   </template>
  </co>
- <co id="56" binds="">
-  <template name="Q{}serverError" flags="os" line="805" module="saxon-xforms.xsl" slots="1">
-   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="806">
+ <co id="59" binds="">
+  <template name="Q{}serverError" flags="os" line="982" module="saxon-xforms.xsl" slots="1">
+   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="983">
     <param name="Q{}responseMap" slot="0" flags="i" as="map(*)">
      <treat role="conversion" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="8|0|XTTE0590|responseMap">
       <check card="1" diag="8|0|XTTE0590|responseMap">
@@ -6627,7 +7088,7 @@
       </check>
      </treat>
     </param>
-    <message line="807">
+    <message line="984">
      <sequence role="select">
       <valueOf>
        <str val="Server side error HTTP response - "/>
@@ -6656,24 +7117,9 @@
    </sequence>
   </template>
  </co>
- <co id="57" binds="58">
-  <function name="Q{http://www.w3.org/2002/xforms}convert-xml-to-jxml" line="2034" module="saxon-xforms.xsl" eval="7" flags="pU" as="node()" slots="2">
-   <arg name="xinstance" as="node()"/>
-   <let role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2036" var="rep-xml" as="document-node()" slot="1" eval="7">
-    <doc line="2038" validation="preserve">
-     <elem name="map" nsuri="http://www.w3.org/2005/xpath-functions" flags="dl">
-      <applyT mode="Q{}json-xml" bSlot="0">
-       <varRef role="select" name="xinstance" slot="0"/>
-      </applyT>
-     </elem>
-    </doc>
-    <varRef line="2041" name="rep-xml" slot="1"/>
-   </let>
-  </function>
- </co>
- <co id="48" binds="10">
-  <template name="Q{}setAction" flags="os" line="2946" module="saxon-xforms.xsl" slots="2">
-   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2947">
+ <co id="52" binds="53 54 19 4 19 1 1 45">
+  <template name="Q{}setAction" flags="os" line="3462" module="saxon-xforms.xsl" slots="9">
+   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="3463">
     <param name="Q{}this" slot="0" flags="i" as="element()">
      <treat role="conversion" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="8|0|XTTE0590|this">
       <check card="1" diag="8|0|XTTE0590|this">
@@ -6681,264 +7127,460 @@
       </check>
      </treat>
     </param>
-    <param line="2948" name="Q{}nodeset" slot="1" flags="t">
+    <param line="3464" name="Q{}nodeset" slot="1" flags="t">
      <str role="select" val=""/>
      <supplied role="conversion" slot="1"/>
     </param>
-    <ifCall line="2951" name="Q{http://www.w3.org/2005/xpath-functions/map}merge" type="map(*)">
-     <sequence>
-      <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
-       <str val="name"/>
-       <fn name="local-name">
-        <treat as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="0|0||fn:local-name">
-         <dot flags="a"/>
-        </treat>
-       </fn>
-      </ifCall>
-      <choose line="2953">
-       <fn name="exists">
-        <slash simple="1">
-         <treat as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="14|2|XPTY0020|">
+    <let line="3467" var="bindingi" as="node()?" slot="2" eval="7">
+     <treat line="3468" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|bindingi">
+      <check card="?" diag="3|0|XTTE0570|bindingi">
+       <callT name="getBinding" bSlot="0">
+        <withParam name="Q{}this" flags="c" as="element()">
+         <treat line="3469" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="8|0|XTTE0590|this">
           <dot flags="a"/>
          </treat>
-         <axis name="attribute" nodeTest="attribute(Q{}value)" jsTest="return item.name==='value'"/>
-        </slash>
-       </fn>
-       <ifCall line="2954" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
-        <str val="@value"/>
-        <fn name="string">
-         <slash simple="1">
-          <treat as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="14|2|XPTY0020|">
+        </withParam>
+       </callT>
+      </check>
+     </treat>
+     <let line="3474" var="refi" as="xs:string" slot="3" eval="7">
+      <treat line="3475" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|refi">
+       <check card="1" diag="3|0|XTTE0570|refi">
+        <cvUntyped to="xs:string">
+         <data>
+          <callT name="getDataRef" bSlot="1">
+           <withParam name="Q{}this" flags="c" as="element()">
+            <treat line="3476" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="8|0|XTTE0590|this">
+             <dot flags="a"/>
+            </treat>
+           </withParam>
+           <withParam name="Q{}bindingi" flags="c" as="node()?">
+            <varRef line="3477" name="bindingi" slot="2"/>
+           </withParam>
+          </callT>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+      <ifCall line="3485" name="Q{http://www.w3.org/2005/xpath-functions/map}merge" type="map(*)">
+       <sequence>
+        <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+         <str val="name"/>
+         <fn name="local-name">
+          <treat as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="0|0||fn:local-name">
            <dot flags="a"/>
           </treat>
-          <axis name="attribute" nodeTest="attribute(Q{}value)" jsTest="return item.name==='value'"/>
-         </slash>
-        </fn>
-       </ifCall>
-      </choose>
-      <choose line="2956">
-       <and op="and">
-        <fn name="empty">
-         <slash simple="1">
-          <treat as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="14|2|XPTY0020|">
-           <dot flags="a"/>
-          </treat>
-          <axis name="attribute" nodeTest="attribute(Q{}value)" jsTest="return item.name==='value'"/>
-         </slash>
-        </fn>
-        <fn name="exists">
-         <slash simple="1">
-          <treat as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="1|0|XPTY0019|/">
-           <dot flags="a"/>
-          </treat>
-          <axis name="child" nodeTest="text()" jsTest="return item.nodeType===3;"/>
-         </slash>
-        </fn>
-       </and>
-       <ifCall line="2957" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
-        <str val="value"/>
-        <fn name="string">
-         <dot flags="a"/>
-        </fn>
-       </ifCall>
-      </choose>
-      <ifCall line="2960" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
-       <str val="@ref"/>
-       <choose line="2962">
-        <fn name="exists">
-         <slash simple="1">
-          <treat as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="14|2|XPTY0020|">
-           <dot flags="a"/>
-          </treat>
-          <axis name="attribute" nodeTest="attribute(Q{}ref)" jsTest="return item.name==='ref'"/>
-         </slash>
-        </fn>
-        <fn line="2963" name="string">
-         <slash simple="1">
-          <treat as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="14|2|XPTY0020|">
-           <dot flags="a"/>
-          </treat>
-          <axis name="attribute" nodeTest="attribute(Q{}ref)" jsTest="return item.name==='ref'"/>
-         </slash>
-        </fn>
-        <fn line="2965" name="exists">
-         <slash simple="1">
-          <treat as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="14|2|XPTY0020|">
-           <dot flags="a"/>
-          </treat>
-          <axis name="attribute" nodeTest="attribute(Q{}nodeset)" jsTest="return item.name==='nodeset'"/>
-         </slash>
-        </fn>
-        <fn line="2966" name="string">
-         <slash simple="1">
-          <treat as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="14|2|XPTY0020|">
-           <dot flags="a"/>
-          </treat>
-          <axis name="attribute" nodeTest="attribute(Q{}nodeset)" jsTest="return item.name==='nodeset'"/>
-         </slash>
-        </fn>
-        <true/>
-        <str val=""/>
-       </choose>
-      </ifCall>
-      <choose line="2979">
-       <fn name="exists">
-        <slash simple="1">
-         <treat as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="14|2|XPTY0020|">
-          <dot flags="a"/>
-         </treat>
-         <axis name="attribute" nodeTest="attribute(Q{}position)" jsTest="return item.name==='position'"/>
-        </slash>
-       </fn>
-       <ifCall line="2980" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
-        <str val="@position"/>
-        <fn name="string">
-         <slash simple="1">
-          <treat as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="14|2|XPTY0020|">
-           <dot flags="a"/>
-          </treat>
-          <axis name="attribute" nodeTest="attribute(Q{}position)" jsTest="return item.name==='position'"/>
-         </slash>
-        </fn>
-       </ifCall>
-      </choose>
-      <choose line="2982">
-       <fn name="exists">
-        <slash simple="1">
-         <treat as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="14|2|XPTY0020|">
-          <dot flags="a"/>
-         </treat>
-         <axis name="attribute" nodeTest="attribute(Q{}at)" jsTest="return item.name==='at'"/>
-        </slash>
-       </fn>
-       <ifCall line="2983" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
-        <str val="@at"/>
-        <fn name="string">
-         <slash simple="1">
-          <treat as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="14|2|XPTY0020|">
-           <dot flags="a"/>
-          </treat>
-          <axis name="attribute" nodeTest="attribute(Q{}at)" jsTest="return item.name==='at'"/>
-         </slash>
-        </fn>
-       </ifCall>
-      </choose>
-      <choose line="2987">
-       <fn name="exists">
-        <slash simple="1">
-         <treat as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="14|2|XPTY0020|">
-          <dot flags="a"/>
-         </treat>
-         <axis name="attribute" nodeTest="attribute(Q{}if)" jsTest="return item.name==='if'"/>
-        </slash>
-       </fn>
-       <ifCall line="2988" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
-        <str val="@if"/>
-        <fn name="string">
-         <slash simple="1">
-          <treat as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="14|2|XPTY0020|">
-           <dot flags="a"/>
-          </treat>
-          <axis name="attribute" nodeTest="attribute(Q{}if)" jsTest="return item.name==='if'"/>
-         </slash>
-        </fn>
-       </ifCall>
-      </choose>
-      <choose line="2992">
-       <fn name="exists">
-        <slash simple="1">
-         <treat as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="14|2|XPTY0020|">
-          <dot flags="a"/>
-         </treat>
-         <axis name="attribute" nodeTest="attribute(Q{}while)" jsTest="return item.name==='while'"/>
-        </slash>
-       </fn>
-       <ifCall line="2993" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
-        <str val="@while"/>
-        <fn name="string">
-         <slash simple="1">
-          <treat as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="14|2|XPTY0020|">
-           <dot flags="a"/>
-          </treat>
-          <axis name="attribute" nodeTest="attribute(Q{}while)" jsTest="return item.name==='while'"/>
-         </slash>
-        </fn>
-       </ifCall>
-      </choose>
-      <choose line="2996">
-       <fn name="exists">
-        <slash simple="1">
-         <treat as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="14|2|XPTY0020|">
-          <dot flags="a"/>
-         </treat>
-         <axis name="attribute" nodeTest="@*:event" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===2&amp;&amp;q.local==='event'"/>
-        </slash>
-       </fn>
-       <ifCall line="2997" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
-        <str val="@event"/>
-        <fn name="string">
-         <check card="?" diag="0|0||fn:string">
+         </fn>
+        </ifCall>
+        <choose line="3487">
+         <fn name="exists">
           <slash simple="1">
-           <treat as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="14|2|XPTY0020|">
-            <dot flags="a"/>
-           </treat>
+           <varRef name="this" slot="0"/>
+           <axis name="attribute" nodeTest="attribute(Q{}value)" jsTest="return item.name==='value'"/>
+          </slash>
+         </fn>
+         <ifCall line="3488" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+          <str val="@value"/>
+          <fn name="string">
+           <slash simple="1">
+            <varRef name="this" slot="0"/>
+            <axis name="attribute" nodeTest="attribute(Q{}value)" jsTest="return item.name==='value'"/>
+           </slash>
+          </fn>
+         </ifCall>
+        </choose>
+        <choose line="3490">
+         <and op="and">
+          <fn name="empty">
+           <slash simple="1">
+            <varRef name="this" slot="0"/>
+            <axis name="attribute" nodeTest="attribute(Q{}value)" jsTest="return item.name==='value'"/>
+           </slash>
+          </fn>
+          <fn name="exists">
+           <slash simple="1">
+            <treat as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="1|0|XPTY0019|/">
+             <dot flags="a"/>
+            </treat>
+            <axis name="child" nodeTest="text()" jsTest="return item.nodeType===3;"/>
+           </slash>
+          </fn>
+         </and>
+         <ifCall line="3491" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+          <str val="value"/>
+          <fn name="string">
+           <dot flags="a"/>
+          </fn>
+         </ifCall>
+        </choose>
+        <ifCall line="3494" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+         <str val="@ref"/>
+         <varRef name="refi" slot="3"/>
+        </ifCall>
+        <choose line="3500">
+         <fn name="exists">
+          <slash simple="1">
+           <varRef name="this" slot="0"/>
+           <axis name="attribute" nodeTest="attribute(Q{}position)" jsTest="return item.name==='position'"/>
+          </slash>
+         </fn>
+         <ifCall line="3501" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+          <str val="@position"/>
+          <fn name="string">
+           <slash simple="1">
+            <varRef name="this" slot="0"/>
+            <axis name="attribute" nodeTest="attribute(Q{}position)" jsTest="return item.name==='position'"/>
+           </slash>
+          </fn>
+         </ifCall>
+        </choose>
+        <choose line="3503">
+         <fn name="exists">
+          <slash simple="1">
+           <varRef name="this" slot="0"/>
+           <axis name="attribute" nodeTest="attribute(Q{}at)" jsTest="return item.name==='at'"/>
+          </slash>
+         </fn>
+         <ifCall line="3504" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+          <str val="@at"/>
+          <fn name="string">
+           <slash simple="1">
+            <varRef name="this" slot="0"/>
+            <axis name="attribute" nodeTest="attribute(Q{}at)" jsTest="return item.name==='at'"/>
+           </slash>
+          </fn>
+         </ifCall>
+        </choose>
+        <choose line="3508">
+         <fn name="exists">
+          <slash simple="1">
+           <varRef name="this" slot="0"/>
+           <axis name="attribute" nodeTest="attribute(Q{}if)" jsTest="return item.name==='if'"/>
+          </slash>
+         </fn>
+         <ifCall line="3509" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+          <str val="@if"/>
+          <fn name="string">
+           <slash simple="1">
+            <varRef name="this" slot="0"/>
+            <axis name="attribute" nodeTest="attribute(Q{}if)" jsTest="return item.name==='if'"/>
+           </slash>
+          </fn>
+         </ifCall>
+        </choose>
+        <choose line="3513">
+         <fn name="exists">
+          <slash simple="1">
+           <varRef name="this" slot="0"/>
+           <axis name="attribute" nodeTest="attribute(Q{}while)" jsTest="return item.name==='while'"/>
+          </slash>
+         </fn>
+         <ifCall line="3514" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+          <str val="@while"/>
+          <fn name="string">
+           <slash simple="1">
+            <varRef name="this" slot="0"/>
+            <axis name="attribute" nodeTest="attribute(Q{}while)" jsTest="return item.name==='while'"/>
+           </slash>
+          </fn>
+         </ifCall>
+        </choose>
+        <choose line="3517">
+         <fn name="exists">
+          <slash simple="1">
+           <varRef name="this" slot="0"/>
            <axis name="attribute" nodeTest="@*:event" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===2&amp;&amp;q.local==='event'"/>
           </slash>
-         </check>
-        </fn>
-       </ifCall>
-      </choose>
-      <choose line="2999">
-       <fn name="exists">
-        <slash simple="1">
-         <treat as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="14|2|XPTY0020|">
-          <dot flags="a"/>
-         </treat>
-         <axis name="attribute" nodeTest="attribute(Q{}submission)" jsTest="return item.name==='submission'"/>
-        </slash>
-       </fn>
-       <ifCall line="3000" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
-        <str val="@submission"/>
-        <fn name="string">
-         <slash simple="1">
-          <treat as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="14|2|XPTY0020|">
-           <dot flags="a"/>
+         </fn>
+         <ifCall line="3518" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+          <str val="@event"/>
+          <fn name="string">
+           <check card="?" diag="0|0||fn:string">
+            <slash simple="1">
+             <varRef name="this" slot="0"/>
+             <axis name="attribute" nodeTest="@*:event" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===2&amp;&amp;q.local==='event'"/>
+            </slash>
+           </check>
+          </fn>
+         </ifCall>
+        </choose>
+        <choose line="3520">
+         <fn name="exists">
+          <slash simple="1">
+           <varRef name="this" slot="0"/>
+           <axis name="attribute" nodeTest="attribute(Q{}submission)" jsTest="return item.name==='submission'"/>
+          </slash>
+         </fn>
+         <ifCall line="3521" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+          <str val="@submission"/>
+          <fn name="string">
+           <slash simple="1">
+            <varRef name="this" slot="0"/>
+            <axis name="attribute" nodeTest="attribute(Q{}submission)" jsTest="return item.name==='submission'"/>
+           </slash>
+          </fn>
+         </ifCall>
+        </choose>
+        <choose line="3524">
+         <fn name="exists">
+          <slash simple="1">
+           <varRef name="this" slot="0"/>
+           <axis name="attribute" nodeTest="attribute(Q{}model)" jsTest="return item.name==='model'"/>
+          </slash>
+         </fn>
+         <ifCall line="3525" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+          <str val="@model"/>
+          <fn name="string">
+           <slash simple="1">
+            <varRef name="this" slot="0"/>
+            <axis name="attribute" nodeTest="attribute(Q{}model)" jsTest="return item.name==='model'"/>
+           </slash>
+          </fn>
+         </ifCall>
+        </choose>
+        <choose line="3528">
+         <fn name="exists">
+          <slash simple="1">
+           <varRef name="this" slot="0"/>
+           <axis name="attribute" nodeTest="attribute(Q{}control)" jsTest="return item.name==='control'"/>
+          </slash>
+         </fn>
+         <ifCall line="3529" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+          <str val="@control"/>
+          <fn name="string">
+           <slash simple="1">
+            <varRef name="this" slot="0"/>
+            <axis name="attribute" nodeTest="attribute(Q{}control)" jsTest="return item.name==='control'"/>
+           </slash>
+          </fn>
+         </ifCall>
+        </choose>
+        <choose line="3532">
+         <fn name="exists">
+          <slash simple="1">
+           <varRef name="this" slot="0"/>
+           <axis name="attribute" nodeTest="attribute(Q{}repeat)" jsTest="return item.name==='repeat'"/>
+          </slash>
+         </fn>
+         <ifCall line="3533" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+          <str val="@repeat"/>
+          <fn name="string">
+           <slash simple="1">
+            <varRef name="this" slot="0"/>
+            <axis name="attribute" nodeTest="attribute(Q{}repeat)" jsTest="return item.name==='repeat'"/>
+           </slash>
+          </fn>
+         </ifCall>
+        </choose>
+        <choose line="3536">
+         <fn name="exists">
+          <slash simple="1">
+           <varRef name="this" slot="0"/>
+           <axis name="attribute" nodeTest="attribute(Q{}index)" jsTest="return item.name==='index'"/>
+          </slash>
+         </fn>
+         <let line="3539" var="instanceField" as="node()?" slot="4" eval="7">
+          <treat line="3540" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|instanceField">
+           <check card="?" diag="3|0|XTTE0570|instanceField">
+            <callT name="getReferencedInstanceField" bSlot="2">
+             <withParam name="Q{}refi" flags="c" as="xs:string">
+              <varRef line="3541" name="refi" slot="3"/>
+             </withParam>
+            </callT>
+           </check>
           </treat>
-          <axis name="attribute" nodeTest="attribute(Q{}submission)" jsTest="return item.name==='submission'"/>
-         </slash>
-        </fn>
-       </ifCall>
-      </choose>
-      <treat line="3003" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="18|0|XTTE3375|">
-       <forEachGroup algorithm="by">
-        <slash role="select" simple="1">
-         <varRef name="this" slot="0"/>
-         <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
-        </slash>
-        <fn role="key" name="local-name">
-         <dot type="element()"/>
-        </fn>
-        <str role="collation" val="http://www.w3.org/2005/xpath-functions/collation/codepoint"/>
-        <applyT role="content" line="3004" mode="Q{}xforms-action-map" bSlot="0">
-         <dot role="select" type="element()"/>
-        </applyT>
-       </forEachGroup>
-      </treat>
-     </sequence>
-     <map size="2">
-      <str val="duplicates"/>
-      <str val="reject"/>
-      <str val="duplicates-error-code"/>
-      <str val="XTDE3365"/>
-     </map>
-    </ifCall>
+          <let line="3552" var="namespace-context-item" as="element()" slot="5" eval="7">
+           <choose>
+            <fn name="exists">
+             <varRef name="instanceField" slot="4"/>
+            </fn>
+            <choose>
+             <fn name="exists">
+              <filter flags="b">
+               <varRef name="instanceField" slot="4"/>
+               <fn name="exists">
+                <axis name="self" nodeTest="text()" jsTest="return item.nodeType===3;"/>
+               </fn>
+              </filter>
+             </fn>
+             <check card="1" diag="3|0|XTTE0570|namespace-context-item">
+              <slash simple="1">
+               <varRef name="instanceField" slot="4"/>
+               <axis name="parent" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+              </slash>
+             </check>
+             <true/>
+             <treat as="element()" jsTest="return item.nodeType===1;" diag="3|0|XTTE0570|namespace-context-item">
+              <check card="1" diag="3|0|XTTE0570|namespace-context-item">
+               <varRef name="instanceField" slot="4"/>
+              </check>
+             </treat>
+            </choose>
+            <true/>
+            <treat as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="3|0|XTTE0570|namespace-context-item">
+             <check card="1" diag="3|0|XTTE0570|namespace-context-item">
+              <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+               <check card="1" diag="0|0||ixsl:call">
+                <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+               </check>
+               <str val="getXForm"/>
+               <arrayBlock/>
+              </ifCall>
+             </check>
+            </treat>
+           </choose>
+           <let line="3554" var="index" as="xs:integer" slot="6" eval="7">
+            <treat line="3555" as="xs:integer" jsTest="return SaxonJS.U.Atomic.integer.matches(item);" diag="3|0|XTTE0570|index">
+             <check card="1" diag="3|0|XTTE0570|index">
+              <cvUntyped to="xs:integer">
+               <data>
+                <evaluate dxns="">
+                 <ufCall role="xpath" name="Q{http://www.w3.org/2002/xforms}impose" tailCall="false" bSlot="3" eval="4">
+                  <check card="1" diag="0|0||xforms:impose">
+                   <cvUntyped to="xs:string">
+                    <data>
+                     <slash simple="1">
+                      <varRef name="this" slot="0"/>
+                      <axis name="attribute" nodeTest="attribute(Q{}index)" jsTest="return item.name==='index'"/>
+                     </slash>
+                    </data>
+                   </cvUntyped>
+                  </check>
+                 </ufCall>
+                 <varRef role="cxt" name="instanceField" slot="4"/>
+                 <varRef role="nsCxt" name="namespace-context-item" slot="5"/>
+                 <str role="sa" val="no"/>
+                 <map role="wp" size="0"/>
+                </evaluate>
+               </data>
+              </cvUntyped>
+             </check>
+            </treat>
+            <ifCall line="3558" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+             <str val="@index"/>
+             <varRef name="index" slot="6"/>
+            </ifCall>
+           </let>
+          </let>
+         </let>
+        </choose>
+        <choose line="3561">
+         <fn name="exists">
+          <slash simple="1">
+           <varRef name="this" slot="0"/>
+           <axis name="attribute" nodeTest="attribute(Q{}origin)" jsTest="return item.name==='origin'"/>
+          </slash>
+         </fn>
+         <let line="3570" var="origin" as="node()?" slot="7" eval="7">
+          <treat line="3571" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|origin">
+           <check card="?" diag="3|0|XTTE0570|origin">
+            <callT name="getReferencedInstanceField" bSlot="4">
+             <withParam name="Q{}refi" flags="c" as="xs:string">
+              <ufCall line="3568" name="Q{http://www.w3.org/2002/xforms}resolveXPathStrings" tailCall="false" bSlot="5" eval="7 4">
+               <choose>
+                <fn name="exists">
+                 <slash simple="1">
+                  <varRef name="this" slot="0"/>
+                  <axis name="attribute" nodeTest="attribute(Q{}context)" jsTest="return item.name==='context'"/>
+                 </slash>
+                </fn>
+                <ufCall name="Q{http://www.w3.org/2002/xforms}resolveXPathStrings" tailCall="false" bSlot="6" eval="7 4">
+                 <treat as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="0|0||xforms:resolveXPathStrings">
+                  <check card="1" diag="0|0||xforms:resolveXPathStrings">
+                   <cvUntyped to="xs:string">
+                    <data>
+                     <varRef name="nodeset" slot="1"/>
+                    </data>
+                   </cvUntyped>
+                  </check>
+                 </treat>
+                 <check card="1" diag="0|1||xforms:resolveXPathStrings">
+                  <cvUntyped to="xs:string">
+                   <data>
+                    <slash simple="1">
+                     <varRef name="this" slot="0"/>
+                     <axis name="attribute" nodeTest="attribute(Q{}context)" jsTest="return item.name==='context'"/>
+                    </slash>
+                   </data>
+                  </cvUntyped>
+                 </check>
+                </ufCall>
+                <true/>
+                <treat as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|origin-context">
+                 <check card="1" diag="3|0|XTTE0570|origin-context">
+                  <cvUntyped to="xs:string">
+                   <data>
+                    <varRef name="nodeset" slot="1"/>
+                   </data>
+                  </cvUntyped>
+                 </check>
+                </treat>
+               </choose>
+               <check line="3569" card="1" diag="0|1||xforms:resolveXPathStrings">
+                <cvUntyped to="xs:string">
+                 <data>
+                  <slash simple="1">
+                   <varRef name="this" slot="0"/>
+                   <axis name="attribute" nodeTest="attribute(Q{}origin)" jsTest="return item.name==='origin'"/>
+                  </slash>
+                 </data>
+                </cvUntyped>
+               </check>
+              </ufCall>
+             </withParam>
+            </callT>
+           </check>
+          </treat>
+          <ifCall line="3576" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+           <str val="@origin"/>
+           <varRef name="origin" slot="7"/>
+          </ifCall>
+         </let>
+        </choose>
+        <choose line="3580">
+         <fn name="exists">
+          <slash simple="1">
+           <varRef name="this" slot="0"/>
+           <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+          </slash>
+         </fn>
+         <ifCall line="3581" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+          <str val="nested-actions"/>
+          <let line="3582" var="array" as="map(*)*" slot="8" eval="3">
+           <treat line="3583" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|array">
+            <forEach>
+             <slash simple="1">
+              <varRef name="this" slot="0"/>
+              <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+             </slash>
+             <applyT line="3584" bSlot="7">
+              <dot role="select" type="element()"/>
+             </applyT>
+            </forEach>
+           </treat>
+           <ifCall line="3587" name="Q{http://www.w3.org/2005/xpath-functions/array}_from-sequence" type="array(*)">
+            <varRef name="array" slot="8"/>
+           </ifCall>
+          </let>
+         </ifCall>
+        </choose>
+       </sequence>
+       <map size="2">
+        <str val="duplicates"/>
+        <str val="reject"/>
+        <str val="duplicates-error-code"/>
+        <str val="XTDE3365"/>
+       </map>
+      </ifCall>
+     </let>
+    </let>
    </sequence>
   </template>
  </co>
- <co id="59" binds="">
-  <function name="Q{http://www.w3.org/2002/xforms}check-constraints-on-fields" line="703" module="saxon-xforms.xsl" eval="8" flags="pU" as="item()*" slots="4">
+ <co id="60" binds="">
+  <function name="Q{http://www.w3.org/2002/xforms}check-constraints-on-fields" line="880" module="saxon-xforms.xsl" eval="8" flags="pU" as="item()*" slots="4">
    <arg name="updatedInstanceXML" as="document-node()"/>
-   <let role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="706" var="constraint-fieldsi" as="element()*" slot="1" eval="8">
+   <let role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="883" var="constraint-fieldsi" as="element()*" slot="1" eval="8">
     <filter flags="b">
      <slash simple="1">
       <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}page" type="document-node()?"/>
@@ -6948,10 +7590,10 @@
       <axis name="attribute" nodeTest="attribute(Q{}data-constraint)" jsTest="return item.name==='data-constraint'"/>
      </fn>
     </filter>
-    <forEach line="710">
+    <forEach line="887">
      <varRef name="constraint-fieldsi" slot="1"/>
-     <let line="711" var="contexti" as="node()" slot="2" eval="7">
-      <treat line="712" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|contexti">
+     <let line="888" var="contexti" as="node()" slot="2" eval="7">
+      <treat line="889" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|contexti">
        <check card="1" diag="3|0|XTTE0570|contexti">
         <evaluate dxns="">
          <check role="xpath" card="1" diag="4|0||xsl:evaluate/xpath">
@@ -6960,13 +7602,14 @@
           </cvUntyped>
          </check>
          <varRef role="cxt" name="updatedInstanceXML" slot="0"/>
+         <varRef role="nsCxt" name="updatedInstanceXML" slot="0"/>
          <str role="sa" val="no"/>
          <map role="wp" size="0"/>
         </evaluate>
        </check>
       </treat>
-      <let line="715" var="resulti" as="xs:boolean" slot="3" eval="7">
-       <treat line="718" as="xs:boolean" jsTest="return SaxonJS.U.Atomic.boolean.matches(item);" diag="3|0|XTTE0570|resulti">
+      <let line="892" var="resulti" as="xs:boolean" slot="3" eval="7">
+       <treat line="895" as="xs:boolean" jsTest="return SaxonJS.U.Atomic.boolean.matches(item);" diag="3|0|XTTE0570|resulti">
         <check card="1" diag="3|0|XTTE0570|resulti">
          <cvUntyped to="xs:boolean">
           <data>
@@ -6977,6 +7620,7 @@
              </cvUntyped>
             </check>
             <varRef role="cxt" name="contexti" slot="2"/>
+            <varRef role="nsCxt" name="contexti" slot="2"/>
             <str role="sa" val="no"/>
             <map role="wp" size="0"/>
            </evaluate>
@@ -6984,7 +7628,7 @@
          </cvUntyped>
         </check>
        </treat>
-       <choose line="726">
+       <choose line="903">
         <fn name="not">
          <varRef name="resulti" slot="3"/>
         </fn>
@@ -6996,37 +7640,98 @@
    </let>
   </function>
  </co>
- <co id="60" binds="17 17">
+ <co id="37" binds="48">
+  <mode name="Q{}binding-calculation-initial" onNo="TC" flags="W" patternSlots="0">
+   <templateRule prec="0" prio="-0.5" seq="0" rank="0" minImp="0" slots="2" flags="s" line="2571" module="saxon-xforms.xsl">
+    <p.nodeTest role="match" test="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;"/>
+    <sequence role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2572">
+     <param name="Q{}instance-id" slot="0" as="xs:string">
+      <str role="select" val="saxon-forms-default"/>
+      <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|instance-id">
+       <check card="1" diag="8|0|XTTE0590|instance-id">
+        <cvUntyped to="xs:string">
+         <data>
+          <supplied slot="0"/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <let line="2574" var="calculationMap" as="map(xs:string, xs:string)" slot="1" eval="7">
+      <treat as="map(xs:string, xs:string)" jsTest="function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="3|0|XTTE0570|calculationMap">
+       <check card="1" diag="3|0|XTTE0570|calculationMap">
+        <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+         <check card="1" diag="0|0||ixsl:call">
+          <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+         </check>
+         <str val="getCalculationMap"/>
+         <arrayBlock/>
+        </ifCall>
+       </check>
+      </treat>
+      <copy line="2588" flags="cin">
+       <applyT role="content" mode="Q{}binding-calculation" bSlot="0">
+        <axis role="select" name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+        <withParam name="Q{}curPath" as="xs:string">
+         <choose line="2578">
+          <vc op="eq" onEmpty="0" comp="CCC">
+           <varRef name="instance-id" slot="0"/>
+           <str val="saxon-forms-default"/>
+          </vc>
+          <str val=""/>
+          <true/>
+          <cvUntyped line="2582" to="xs:string">
+           <cast as="xs:untypedAtomic" emptiable="0">
+            <fn name="concat">
+             <str val="instance('"/>
+             <varRef name="instance-id" slot="0"/>
+             <str val="')/"/>
+            </fn>
+           </cast>
+          </cvUntyped>
+         </choose>
+        </withParam>
+        <withParam name="Q{}calculationMap" flags="t" as="map(xs:string, xs:string)">
+         <varRef line="2590" name="calculationMap" slot="1"/>
+        </withParam>
+       </applyT>
+      </copy>
+     </let>
+    </sequence>
+   </templateRule>
+  </mode>
+ </co>
+ <co id="61" binds="15 15">
   <mode name="Q{http://saxonica.com/ns/interactiveXSLT}onchange" onNo="TC" flags="W" patternSlots="0">
-   <templateRule prec="0" prio="0.0" seq="0" rank="0" minImp="0" slots="0" flags="s" line="535" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="0.0" seq="0" rank="0" minImp="0" slots="0" flags="s" line="660" module="saxon-xforms.xsl">
     <p.nodeTest role="match" test="element(Q{}input)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='input';"/>
-    <callT role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="536" name="xforms-value-changed" bSlot="0" flags="t">
+    <callT role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="661" name="xforms-value-changed" bSlot="0" flags="t">
      <withParam name="Q{}form-control" flags="c" as="node()">
-      <dot line="537" type="element(Q{}input)"/>
+      <dot line="662" type="element(Q{}input)"/>
      </withParam>
     </callT>
    </templateRule>
-   <templateRule prec="0" prio="0.0" seq="1" rank="0" minImp="0" slots="0" flags="s" line="545" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="0.0" seq="1" rank="0" minImp="0" slots="0" flags="s" line="670" module="saxon-xforms.xsl">
     <p.nodeTest role="match" test="element(Q{}select)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='select';"/>
-    <callT role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="546" name="xforms-value-changed" bSlot="1" flags="t">
+    <callT role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="671" name="xforms-value-changed" bSlot="1" flags="t">
      <withParam name="Q{}form-control" flags="c" as="node()">
-      <dot line="547" type="element(Q{}select)"/>
+      <dot line="672" type="element(Q{}select)"/>
      </withParam>
     </callT>
    </templateRule>
   </mode>
  </co>
- <co id="42" binds="36 45 45 61 11">
-  <template name="Q{}xformsjs-main" flags="os" line="80" module="saxon-xforms.xsl" slots="16">
-   <let role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="435" var="vv:v1" as="item()" slot="5" eval="13">
+ <co id="44" binds="35 40 62 49 49 63 45">
+  <template name="Q{}xformsjs-main" flags="os" line="100" module="saxon-xforms.xsl" slots="21">
+   <let role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="558" var="vv:v1" as="item()" slot="5" eval="13">
     <check card="1" diag="0|0||ixsl:call">
      <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
     </check>
-    <let line="405" var="vv:v0" as="item()" slot="6" eval="13">
+    <let line="528" var="vv:v0" as="item()" slot="6" eval="13">
      <check card="1" diag="0|0||ixsl:call">
       <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
      </check>
-     <sequence line="81">
+     <sequence line="101">
       <param name="Q{}xforms-doc" slot="0" as="document-node()?">
        <empty role="select"/>
        <treat role="conversion" as="document-node()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);" diag="8|0|XTTE0590|xforms-doc">
@@ -7035,7 +7740,7 @@
         </check>
        </treat>
       </param>
-      <param line="82" name="Q{}xforms-file" slot="1" as="xs:string?">
+      <param line="102" name="Q{}xforms-file" slot="1" as="xs:string?">
        <empty role="select"/>
        <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|xforms-file">
         <check card="?" diag="8|0|XTTE0590|xforms-file">
@@ -7047,13 +7752,13 @@
         </check>
        </treat>
       </param>
-      <param line="91" name="Q{}instance-xml" slot="2" as="document-node()*">
+      <param line="111" name="Q{}instance-xml" slot="2" as="document-node()*">
        <empty role="select"/>
        <treat role="conversion" as="document-node()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);" diag="8|0|XTTE0590|instance-xml">
         <supplied slot="2"/>
        </treat>
       </param>
-      <param line="92" name="Q{}instance-docs" slot="3" as="map(*)?">
+      <param line="112" name="Q{}instance-docs" slot="3" as="map(*)?">
        <empty role="select"/>
        <treat role="conversion" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="8|0|XTTE0590|instance-docs">
         <check card="?" diag="8|0|XTTE0590|instance-docs">
@@ -7061,7 +7766,7 @@
         </check>
        </treat>
       </param>
-      <param line="94" name="Q{}xFormsId" slot="4" as="xs:string">
+      <param line="114" name="Q{}xFormsId" slot="4" as="xs:string">
        <gVarRef role="select" name="Q{}xform-html-id" bSlot="0"/>
        <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|xFormsId">
         <check card="1" diag="8|0|XTTE0590|xFormsId">
@@ -7073,7 +7778,7 @@
         </check>
        </treat>
       </param>
-      <let line="102" var="xforms-doci" as="document-node()?" slot="7" eval="7">
+      <let line="122" var="xforms-doci" as="document-node()?" slot="7" eval="7">
        <choose>
         <fn name="empty">
          <varRef name="xforms-doc" slot="0"/>
@@ -7084,18 +7789,208 @@
         <true/>
         <varRef name="xforms-doc" slot="0"/>
        </choose>
-       <let line="106" var="xforms-instances" as="map(xs:string, element())" slot="8" eval="7">
-        <choose line="108">
-         <fn name="empty">
-          <varRef name="instance-docs" slot="3"/>
-         </fn>
-         <treat line="111" as="map(xs:string, element())" jsTest="function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="3|0|XTTE0570|xforms-instances">
-          <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}merge" type="map(*)">
-           <choose>
-            <fn name="empty">
-             <varRef name="instance-xml" slot="2"/>
+       <let line="124" var="xform" as="element(Q{http://www.w3.org/2002/xforms}xform)" slot="8" eval="7">
+        <treat as="element(Q{http://www.w3.org/2002/xforms}xform)" jsTest="var q=SaxonJS.U.nameOfNode(item); return q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='xform';" diag="3|0|XTTE0570|xform">
+         <ufCall name="Q{http://www.w3.org/2002/xforms}addNamespaceDeclarations" tailCall="false" bSlot="1" eval="4">
+          <check card="1" diag="0|0||xforms:addNamespaceDeclarations">
+           <slash simple="1">
+            <varRef name="xforms-doci" slot="7"/>
+            <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+           </slash>
+          </check>
+         </ufCall>
+        </treat>
+        <let line="128" var="xforms-instances" as="map(xs:string, element())" slot="9" eval="7">
+         <choose line="130">
+          <fn name="empty">
+           <varRef name="instance-docs" slot="3"/>
+          </fn>
+          <treat line="133" as="map(xs:string, element())" jsTest="function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="3|0|XTTE0570|xforms-instances">
+           <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}merge" type="map(*)">
+            <choose>
+             <fn name="empty">
+              <varRef name="instance-xml" slot="2"/>
+             </fn>
+             <forEach line="134">
+              <slash>
+               <slash simple="1">
+                <varRef name="xform" slot="8"/>
+                <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}model)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='model';"/>
+               </slash>
+               <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}instance)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='instance';"/>
+              </slash>
+              <let line="135" var="instance-with-explicit-namespaces" as="element()" slot="10" eval="7">
+               <treat line="136" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="3|0|XTTE0570|instance-with-explicit-namespaces">
+                <check card="1" diag="3|0|XTTE0570|instance-with-explicit-namespaces">
+                 <applyT mode="Q{}namespace-fix" bSlot="2">
+                  <axis role="select" name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+                 </applyT>
+                </check>
+               </treat>
+               <ifCall line="145" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+                <check card="1" diag="0|0||map:entry">
+                 <cast as="xs:string" emptiable="1">
+                  <choose>
+                   <fn name="exists">
+                    <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
+                   </fn>
+                   <attVal name="Q{}id" chk="0"/>
+                   <true/>
+                   <str val="saxon-forms-default"/>
+                  </choose>
+                 </cast>
+                </check>
+                <varRef name="instance-with-explicit-namespaces" slot="10"/>
+               </ifCall>
+              </let>
+             </forEach>
+             <true/>
+             <ifCall line="155" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+              <check card="1" diag="0|0||map:entry">
+               <cast as="xs:string" emptiable="1">
+                <choose>
+                 <fn name="exists">
+                  <slash>
+                   <conditionalSort>
+                    <fn name="exists">
+                     <tail start="2">
+                      <varRef name="instance-xml" slot="2"/>
+                     </tail>
+                    </fn>
+                    <docOrder intra="0">
+                     <slash>
+                      <varRef name="instance-xml" slot="2"/>
+                      <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+                     </slash>
+                    </docOrder>
+                   </conditionalSort>
+                   <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
+                  </slash>
+                 </fn>
+                 <atomSing card="?" diag="2|0||cast as">
+                  <slash>
+                   <conditionalSort>
+                    <fn name="exists">
+                     <tail start="2">
+                      <varRef name="instance-xml" slot="2"/>
+                     </tail>
+                    </fn>
+                    <docOrder intra="0">
+                     <slash>
+                      <varRef name="instance-xml" slot="2"/>
+                      <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+                     </slash>
+                    </docOrder>
+                   </conditionalSort>
+                   <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
+                  </slash>
+                 </atomSing>
+                 <true/>
+                 <str val="saxon-forms-default"/>
+                </choose>
+               </cast>
+              </check>
+              <conditionalSort>
+               <fn name="exists">
+                <tail start="2">
+                 <varRef name="instance-xml" slot="2"/>
+                </tail>
+               </fn>
+               <docOrder intra="0">
+                <slash>
+                 <varRef name="instance-xml" slot="2"/>
+                 <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+                </slash>
+               </docOrder>
+              </conditionalSort>
+             </ifCall>
+            </choose>
+            <map size="2">
+             <str val="duplicates"/>
+             <str val="reject"/>
+             <str val="duplicates-error-code"/>
+             <str val="XTDE3365"/>
+            </map>
+           </ifCall>
+          </treat>
+          <true/>
+          <treat line="161" as="map(xs:string, element())" jsTest="function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="3|0|XTTE0570|xforms-instances">
+           <check card="1" diag="3|0|XTTE0570|xforms-instances">
+            <varRef name="instance-docs" slot="3"/>
+           </check>
+          </treat>
+         </choose>
+         <let line="167" var="default-instance" as="element()" slot="11" eval="7">
+          <choose line="169">
+           <fn name="empty">
+            <varRef name="instance-docs" slot="3"/>
+           </fn>
+           <choose line="171">
+            <fn name="exists">
+             <filter flags="b">
+              <slash>
+               <slash simple="1">
+                <varRef name="xform" slot="8"/>
+                <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}model)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='model';"/>
+               </slash>
+               <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}instance)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='instance';"/>
+              </slash>
+              <fn name="empty">
+               <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
+              </fn>
+             </filter>
             </fn>
-            <forEach line="112">
+            <check line="172" card="1" diag="3|0|XTTE0570|default-instance">
+             <slash>
+              <slash>
+               <slash simple="1">
+                <varRef name="xform" slot="8"/>
+                <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}model)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='model';"/>
+               </slash>
+               <first>
+                <filter flags="b">
+                 <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}instance)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='instance';"/>
+                 <fn name="empty">
+                  <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
+                 </fn>
+                </filter>
+               </first>
+              </slash>
+              <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+             </slash>
+            </check>
+            <true/>
+            <check line="175" card="1" diag="3|0|XTTE0570|default-instance">
+             <slash>
+              <slash>
+               <slash simple="1">
+                <varRef name="xform" slot="8"/>
+                <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}model)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='model';"/>
+               </slash>
+               <first>
+                <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}instance)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='instance';"/>
+               </first>
+              </slash>
+              <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+             </slash>
+            </check>
+           </choose>
+           <true/>
+           <treat line="181" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="3|0|XTTE0570|default-instance">
+            <check card="1" diag="3|0|XTTE0570|default-instance">
+             <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+              <check card="1" diag="0|0||ixsl:call">
+               <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+              </check>
+              <str val="getDefaultInstance"/>
+              <arrayBlock/>
+             </ifCall>
+            </check>
+           </treat>
+          </choose>
+          <let line="187" var="bindings" as="map(xs:string, element(Q{http://www.w3.org/2002/xforms}bind))" slot="12" eval="8">
+           <ifCall line="189" name="Q{http://www.w3.org/2005/xpath-functions/map}merge" type="map(*)">
+            <forEach>
              <slash>
               <slash>
                <slash simple="1">
@@ -7104,9 +7999,9 @@
                </slash>
                <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}model)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='model';"/>
               </slash>
-              <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}instance)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='instance';"/>
+              <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}bind)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='bind';"/>
              </slash>
-             <ifCall line="119" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+             <ifCall line="197" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
               <check card="1" diag="0|0||map:entry">
                <cast as="xs:string" emptiable="1">
                 <choose>
@@ -7115,518 +8010,448 @@
                  </fn>
                  <attVal name="Q{}id" chk="0"/>
                  <true/>
-                 <str val="saxon-forms-default"/>
+                 <attVal name="Q{}nodeset" chk="0"/>
                 </choose>
                </cast>
               </check>
-              <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+              <dot type="element(Q{http://www.w3.org/2002/xforms}bind)"/>
              </ifCall>
             </forEach>
-            <true/>
-            <ifCall line="129" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
-             <check card="1" diag="0|0||map:entry">
-              <cast as="xs:string" emptiable="1">
-               <choose>
-                <fn name="exists">
-                 <slash>
-                  <conditionalSort>
-                   <fn name="exists">
-                    <tail start="2">
-                     <varRef name="instance-xml" slot="2"/>
-                    </tail>
-                   </fn>
-                   <docOrder intra="0">
-                    <slash>
-                     <varRef name="instance-xml" slot="2"/>
-                     <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
-                    </slash>
-                   </docOrder>
-                  </conditionalSort>
-                  <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
-                 </slash>
-                </fn>
-                <atomSing card="?" diag="2|0||cast as">
-                 <slash>
-                  <conditionalSort>
-                   <fn name="exists">
-                    <tail start="2">
-                     <varRef name="instance-xml" slot="2"/>
-                    </tail>
-                   </fn>
-                   <docOrder intra="0">
-                    <slash>
-                     <varRef name="instance-xml" slot="2"/>
-                     <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
-                    </slash>
-                   </docOrder>
-                  </conditionalSort>
-                  <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
-                 </slash>
-                </atomSing>
-                <true/>
-                <str val="saxon-forms-default"/>
-               </choose>
-              </cast>
-             </check>
-             <conditionalSort>
-              <fn name="exists">
-               <tail start="2">
-                <varRef name="instance-xml" slot="2"/>
-               </tail>
-              </fn>
-              <docOrder intra="0">
-               <slash>
-                <varRef name="instance-xml" slot="2"/>
-                <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
-               </slash>
-              </docOrder>
-             </conditionalSort>
+            <map size="2">
+             <str val="duplicates"/>
+             <str val="reject"/>
+             <str val="duplicates-error-code"/>
+             <str val="XTDE3365"/>
+            </map>
+           </ifCall>
+           <let line="211" var="bindingKeys" as="xs:anyAtomicType*" slot="13" eval="3">
+            <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}keys" type="xs:anyAtomicType*">
+             <varRef name="bindings" slot="12"/>
             </ifCall>
-           </choose>
-           <map size="2">
-            <str val="duplicates"/>
-            <str val="reject"/>
-            <str val="duplicates-error-code"/>
-            <str val="XTDE3365"/>
-           </map>
-          </ifCall>
-         </treat>
-         <true/>
-         <treat line="135" as="map(xs:string, element())" jsTest="function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="3|0|XTTE0570|xforms-instances">
-          <check card="1" diag="3|0|XTTE0570|xforms-instances">
-           <varRef name="instance-docs" slot="3"/>
-          </check>
-         </treat>
-        </choose>
-        <let line="141" var="default-instance" as="element()" slot="9" eval="7">
-         <choose line="143">
-          <fn name="empty">
-           <varRef name="instance-docs" slot="3"/>
-          </fn>
-          <choose line="145">
-           <fn name="exists">
-            <filter flags="b">
-             <slash>
-              <slash>
-               <slash simple="1">
-                <varRef name="xforms-doci" slot="7"/>
-                <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}xform)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='xform';"/>
-               </slash>
-               <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}model)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='model';"/>
-              </slash>
-              <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}instance)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='instance';"/>
-             </slash>
-             <fn name="empty">
-              <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
-             </fn>
-            </filter>
-           </fn>
-           <check line="146" card="1" diag="3|0|XTTE0570|default-instance">
-            <slash>
-             <slash>
-              <slash>
-               <slash simple="1">
-                <varRef name="xforms-doci" slot="7"/>
-                <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}xform)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='xform';"/>
-               </slash>
-               <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}model)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='model';"/>
-              </slash>
-              <first>
-               <filter flags="b">
-                <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}instance)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='instance';"/>
-                <fn name="empty">
-                 <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
-                </fn>
-               </filter>
-              </first>
-             </slash>
-             <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
-            </slash>
-           </check>
-           <true/>
-           <check line="149" card="1" diag="3|0|XTTE0570|default-instance">
-            <slash>
-             <slash>
-              <slash>
-               <slash simple="1">
-                <varRef name="xforms-doci" slot="7"/>
-                <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}xform)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='xform';"/>
-               </slash>
-               <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}model)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='model';"/>
-              </slash>
-              <first>
-               <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}instance)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='instance';"/>
-              </first>
-             </slash>
-             <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
-            </slash>
-           </check>
-          </choose>
-          <true/>
-          <treat line="155" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="3|0|XTTE0570|default-instance">
-           <check card="1" diag="3|0|XTTE0570|default-instance">
-            <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
-             <check card="1" diag="0|0||ixsl:call">
-              <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
-             </check>
-             <str val="getDefaultInstance"/>
-             <arrayBlock/>
-            </ifCall>
-           </check>
-          </treat>
-         </choose>
-         <let line="161" var="bindings" as="map(xs:string, element(Q{http://www.w3.org/2002/xforms}bind))" slot="10" eval="8">
-          <ifCall line="163" name="Q{http://www.w3.org/2005/xpath-functions/map}merge" type="map(*)">
-           <forEach>
-            <slash>
-             <slash>
-              <slash simple="1">
-               <varRef name="xforms-doci" slot="7"/>
-               <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}xform)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='xform';"/>
-              </slash>
-              <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}model)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='model';"/>
-             </slash>
-             <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}bind)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='bind';"/>
-            </slash>
-            <ifCall line="170" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
-             <check card="1" diag="0|0||map:entry">
-              <cast as="xs:string" emptiable="1">
-               <choose>
-                <fn name="exists">
-                 <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
-                </fn>
-                <attVal name="Q{}id" chk="0"/>
-                <true/>
-                <attVal name="Q{}nodeset" chk="0"/>
-               </choose>
-              </cast>
-             </check>
-             <dot type="element(Q{http://www.w3.org/2002/xforms}bind)"/>
-            </ifCall>
-           </forEach>
-           <map size="2">
-            <str val="duplicates"/>
-            <str val="reject"/>
-            <str val="duplicates-error-code"/>
-            <str val="XTDE3365"/>
-           </map>
-          </ifCall>
-          <let line="186" var="RelevantBindings" as="map(xs:string, xs:string)" slot="11" eval="7">
-           <treat line="188" as="map(xs:string, xs:string)" jsTest="function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="3|0|XTTE0570|RelevantBindings">
-            <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}merge" type="map(*)">
-             <forEach>
-              <ifCall line="184" name="Q{http://www.w3.org/2005/xpath-functions/map}keys" type="xs:anyAtomicType*">
-               <varRef name="bindings" slot="10"/>
-              </ifCall>
-              <let line="189" var="bindingNode" as="element(Q{http://www.w3.org/2002/xforms}bind)" slot="12" eval="7">
-               <check card="1" diag="3|0|XTTE0570|bindingNode">
-                <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
-                 <varRef name="bindings" slot="10"/>
-                 <cast as="xs:string" emptiable="0">
-                  <dot type="xs:anyAtomicType"/>
-                 </cast>
-                </ifCall>
-               </check>
-               <choose line="191">
-                <fn name="exists">
-                 <filter flags="b">
-                  <varRef name="bindingNode" slot="12"/>
-                  <fn name="exists">
-                   <axis name="attribute" nodeTest="attribute(Q{}relevant)" jsTest="return item.name==='relevant'"/>
-                  </fn>
-                 </filter>
-                </fn>
-                <ifCall line="193" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
-                 <check line="192" card="1" diag="3|0|XTTE0570|keyi">
-                  <cast as="xs:string" emptiable="1">
-                   <data>
-                    <slash simple="1">
-                     <varRef name="bindingNode" slot="12"/>
-                     <axis name="attribute" nodeTest="attribute(Q{}nodeset)" jsTest="return item.name==='nodeset'"/>
-                    </slash>
-                   </data>
-                  </cast>
-                 </check>
-                 <cast as="xs:string" emptiable="1">
-                  <data>
-                   <slash simple="1">
-                    <varRef name="bindingNode" slot="12"/>
-                    <axis name="attribute" nodeTest="attribute(Q{}relevant)" jsTest="return item.name==='relevant'"/>
-                   </slash>
-                  </data>
-                 </cast>
-                </ifCall>
-               </choose>
-              </let>
-             </forEach>
-             <map size="2">
-              <str val="duplicates"/>
-              <str val="reject"/>
-              <str val="duplicates-error-code"/>
-              <str val="XTDE3365"/>
-             </map>
-            </ifCall>
-           </treat>
-           <sequence line="205">
-            <choose>
-             <gc op="=" card="M:N" comp="GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint">
-              <data>
-               <slash>
-                <slash simple="1">
-                 <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}page" type="document-node()?"/>
-                 <axis name="descendant" nodeTest="element(Q{}script)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='script';"/>
-                </slash>
-                <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
-               </slash>
-              </data>
-              <data>
-               <gVarRef name="Q{}xforms-cache-id" bSlot="1"/>
-              </data>
-             </gc>
-             <sequence line="206">
-              <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
-               <check card="1" diag="0|0||ixsl:call">
-                <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
-               </check>
-               <str val="setXFormsDoc"/>
-               <arrayBlock>
-                <varRef name="xforms-doc" slot="0"/>
-               </arrayBlock>
-              </ifCall>
-              <ifCall line="207" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
-               <check card="1" diag="0|0||ixsl:call">
-                <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
-               </check>
-               <str val="setXFormsID"/>
-               <arrayBlock>
-                <varRef name="xFormsId" slot="4"/>
-               </arrayBlock>
-              </ifCall>
-              <ifCall line="208" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
-               <check card="1" diag="0|0||ixsl:call">
-                <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
-               </check>
-               <str val="setRelevantMap"/>
-               <arrayBlock>
-                <varRef name="RelevantBindings" slot="11"/>
-               </arrayBlock>
-              </ifCall>
-             </sequence>
-             <true/>
-             <sequence line="219">
-              <forEach>
-               <slash simple="1">
-                <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}page" type="document-node()?"/>
-                <axis name="descendant" nodeTest="element(Q{}head)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='head';"/>
-               </slash>
-               <resultDoc line="228" global="#&#xD;&#xA;#Tue Jul 24 21:04:01 BST 2018&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;" local="#&#xD;&#xA;#Tue Jul 24 21:04:01 BST 2018&#xD;&#xA;">
-                <str role="href" val="?."/>
-                <elem role="content" line="229" name="script" nsuri="" namespaces="xd rdf xhtml js in fn map array ev r">
-                 <sequence>
-                  <att name="type" flags="l">
-                   <str val="text/javascript"/>
-                  </att>
-                  <att name="id" flags="l">
-                   <fn name="string-join">
-                    <convert from="xs:anyAtomicType" to="xs:string">
-                     <data>
-                      <mergeAdj>
-                       <gVarRef name="Q{}xforms-cache-id" bSlot="2"/>
-                      </mergeAdj>
-                     </data>
-                    </convert>
-                    <str val=" "/>
-                   </fn>
-                  </att>
-                  <valueOf flags="l">
-                   <str val="                &#xA;                            var XFormsDoc = null;&#xA;                            var defaultInstanceDoc = null;&#xA;                            &#xA;                            // MD 2018: OND's suggestion for multiple instances&#xA;                            var instanceDocs = {};&#xA;                            &#xA;                            var pendingUpdatesMap = null;&#xA;                            var updatesMap = null;&#xA;                            var XFormsID = '"/>
-                  </valueOf>
-                  <valueOf line="238" flags="l">
-                   <varRef name="xFormsId" slot="4"/>
-                  </valueOf>
-                  <valueOf flags="l">
-                   <str val="';&#xA;                            var actions = {};&#xA;                            var submissions = {};&#xA;                            var outputs = {};&#xA;                            var relevantMap = {};&#xA;                            &#xA;                            var getCurrentDate = function(){&#xA;                                var today = new Date();&#xA;                                var dd = today.getDate();&#xA;                                var mm = today.getMonth()+1; //January is 0!&#xA;                                var yyyy = today.getFullYear();&#xA;                            &#xA;                                if(dd &lt; 10) {&#xA;                                    dd = '0' + dd;&#xA;                                } &#xA;                            &#xA;                                if(mm &lt; 10) {&#xA;                                    mm = '0' + mm;&#xA;                                } &#xA;                            &#xA;                                today = yyyy + '-' + mm + '-' + dd;&#xA;                                return today;&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var setXFormsDoc = function(doc) {&#xA;                                XFormsDoc = doc;&#xA;                            }&#xA;                            &#xA;                            var getXFormsDoc = function() {&#xA;                                return XFormsDoc;&#xA;                            }&#xA;                            var setXFormsID = function(id) {&#xA;                                XFormsID = id;&#xA;                            }&#xA;                            &#xA;                            var getXFormsID = function() {&#xA;                                return XFormsID;&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var setInstance = function(name, value) {&#xA;                                instanceDocs[name] = value;&#xA;                            } &#xA;                            &#xA;                            var getInstance = function(name) {&#xA;                                return instanceDocs[name];&#xA;                            }&#xA;                            &#xA;                            &#xA;                            //[OND] Maybe we can just set the key-&gt; value without having to copy the entire instanceDocs object.&#xA;                            var updateInstance = function(instanceDocs, key, value){&#xA;                                instanceDocs[key] = value;&#xA;                                return instanceDocs;&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var setDefaultInstance = function(doc) {&#xA;                                defaultInstanceDoc = doc;&#xA;                            }&#xA;                            &#xA;                            var getDefaultInstance = function() {&#xA;                                return defaultInstanceDoc;&#xA;                            }&#xA;                            &#xA;                           &#xA;                            var getInstanceKeys = function() {&#xA;                                return Object.keys(instanceDocs);&#xA;                            }&#xA;                            &#xA;                            var setPendingUpdates = function(map1) {&#xA;                                pendingUpdatesMap = map1;&#xA;                            }&#xA;                            &#xA;                            var clearPendingUpdates = function() {&#xA;                                pendingUpdatesMap = null;&#xA;                            }&#xA;                            &#xA;                            var getPendingUpdates = function() {&#xA;                                return pendingUpdatesMap;&#xA;                            }&#xA;                            &#xA;                            var setUpdates = function(map1) {&#xA;                                updatesMap = map1;&#xA;                            }&#xA;                            &#xA;                            var clearUpdates = function() {&#xA;                                updatesMap = null;&#xA;                            }&#xA;                            &#xA;                            var getUpdates = function() {&#xA;                                return updatesMap;&#xA;                            }&#xA;                            &#xA;                            var addAction = function(name, value){&#xA;                                actions[name] = value;&#xA;                            }&#xA;&#xA;                            var getAction = function(name){&#xA;                                return actions[name];&#xA;                            }&#xA;                            &#xA;                            var updateAction = function(actioni, key, value){&#xA;                                actioni[key] = value;&#xA;                                return actioni;&#xA;                            }&#xA;                            &#xA;                            var addSubmission = function(name, value){&#xA;                                submissions[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getSubmission = function(name){&#xA;                                return submissions[name];&#xA;                            }     &#xA;                            &#xA;                            var addOutput = function(name, value){&#xA;                                outputs[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getOutput = function(name){&#xA;                                return outputs[name];&#xA;                            }&#xA;                            &#xA;                            var getOutputKeys = function() {&#xA;                                return Object.keys(outputs);&#xA;                            }&#xA;                            &#xA;                            var setRelevantMap = function(map1) {&#xA;                                relevantMap = map1;                            &#xA;                            }&#xA;                            &#xA;                            var getRelevantMap = function() {&#xA;                                return relevantMap;&#xA;                            }&#xA;                            &#xA;  &#xA;                            var startTime = function(name) {&#xA;                                console.time(name);&#xA;                            }&#xA;                            &#xA;                            var endTime = function(name) {&#xA;                                console.timeEnd(name);&#xA;                            }&#xA;                            &#xA;                        "/>
-                  </valueOf>
-                 </sequence>
-                </elem>
-               </resultDoc>
-              </forEach>
-              <ifCall line="386" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
-               <check card="1" diag="0|0||ixsl:call">
-                <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
-               </check>
-               <str val="setXFormsDoc"/>
-               <arrayBlock>
-                <varRef name="xforms-doc" slot="0"/>
-               </arrayBlock>
-              </ifCall>
-              <ifCall line="387" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
-               <check card="1" diag="0|0||ixsl:call">
-                <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
-               </check>
-               <str val="setDefaultInstance"/>
-               <arrayBlock>
-                <varRef name="default-instance" slot="9"/>
-               </arrayBlock>
-              </ifCall>
-              <ifCall line="388" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
-               <check card="1" diag="0|0||ixsl:call">
-                <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
-               </check>
-               <str val="setRelevantMap"/>
-               <arrayBlock>
-                <varRef name="RelevantBindings" slot="11"/>
-               </arrayBlock>
-              </ifCall>
-              <ifCall line="393" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
-               <check card="1" diag="0|0||ixsl:call">
-                <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
-               </check>
-               <str val="setPendingUpdates"/>
-               <arrayBlock>
-                <treat line="390" as="map(°)" jsTest="function k(item) {return SaxonJS.U.Atomic.anyAtomicType.matches(item);};function v(item) {return true;};function c() {return true;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="3|0||pendingInstanceUpdates">
-                 <map size="0"/>
-                </treat>
-               </arrayBlock>
-              </ifCall>
-              <ifCall line="394" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
-               <check card="1" diag="0|0||ixsl:call">
-                <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
-               </check>
-               <str val="setUpdates"/>
-               <arrayBlock>
-                <treat line="391" as="map(°)" jsTest="function k(item) {return SaxonJS.U.Atomic.anyAtomicType.matches(item);};function v(item) {return true;};function c() {return true;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="3|0||instanceUpdates">
-                 <map size="0"/>
-                </treat>
-               </arrayBlock>
-              </ifCall>
-             </sequence>
-            </choose>
-            <forEach line="403">
-             <treat line="401" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|instanceKeys">
-              <cvUntyped to="xs:string">
-               <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}keys" type="xs:anyAtomicType*">
-                <varRef name="xforms-instances" slot="8"/>
-               </ifCall>
-              </cvUntyped>
-             </treat>
-             <ifCall line="405" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
-              <varRef name="vv:v0" slot="6"/>
-              <str val="setInstance"/>
-              <arrayBlock>
-               <dot type="xs:string"/>
-               <check line="404" card="1" diag="3|0|XTTE0570|instance">
-                <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
-                 <varRef name="xforms-instances" slot="8"/>
-                 <dot type="xs:string"/>
-                </ifCall>
-               </check>
-              </arrayBlock>
-             </ifCall>
-            </forEach>
-            <let line="410" var="submissions" as="map(xs:string, map(*))" slot="13" eval="8">
-             <ifCall line="412" name="Q{http://www.w3.org/2005/xpath-functions/map}merge" type="map(*)">
-              <forEach>
-               <slash>
-                <slash>
-                 <slash simple="1">
-                  <varRef name="xforms-doci" slot="7"/>
-                  <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}xform)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='xform';"/>
-                 </slash>
-                 <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}model)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='model';"/>
-                </slash>
-                <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}submission)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='submission';"/>
-               </slash>
-               <let line="416" var="map-key" as="xs:string" slot="14" eval="7">
-                <choose>
-                 <fn name="exists">
-                  <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
-                 </fn>
-                 <check card="1" diag="3|0|XTTE0570|map-key">
-                  <cast as="xs:string" emptiable="1">
-                   <attVal name="Q{}id" chk="0"/>
-                  </cast>
-                 </check>
-                 <true/>
-                 <str val="saxon-forms-default-submission"/>
-                </choose>
-                <let line="417" var="map-value" as="map(*)" slot="15" eval="7">
-                 <treat line="418" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|map-value">
-                  <check card="1" diag="3|0|XTTE0570|map-value">
-                   <callT name="setSubmission" bSlot="3">
-                    <withParam name="Q{}this" flags="c" as="element()">
-                     <dot line="419" type="element(Q{http://www.w3.org/2002/xforms}submission)"/>
-                    </withParam>
-                    <withParam name="Q{}submission-id" flags="c" as="xs:string">
-                     <varRef line="420" name="map-key" slot="14"/>
-                    </withParam>
-                   </callT>
-                  </check>
-                 </treat>
-                 <ifCall line="423" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
-                  <varRef name="map-key" slot="14"/>
-                  <varRef name="map-value" slot="15"/>
-                 </ifCall>
-                </let>
-               </let>
-              </forEach>
-              <map size="2">
-               <str val="duplicates"/>
-               <str val="reject"/>
-               <str val="duplicates-error-code"/>
-               <str val="XTDE3365"/>
-              </map>
-             </ifCall>
-             <sequence line="432">
-              <forEach>
-               <treat line="430" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|submissionKeys">
-                <cvUntyped to="xs:string">
-                 <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}keys" type="xs:anyAtomicType*">
-                  <varRef name="submissions" slot="13"/>
-                 </ifCall>
-                </cvUntyped>
-               </treat>
-               <ifCall line="435" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
-                <varRef name="vv:v1" slot="5"/>
-                <str val="addSubmission"/>
-                <arrayBlock>
-                 <dot type="xs:string"/>
-                 <check line="433" card="1" diag="3|0|XTTE0570|submission">
+            <let line="213" var="RelevantBindings" as="map(xs:string, xs:string)" slot="14" eval="7">
+             <treat line="215" as="map(xs:string, xs:string)" jsTest="function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="3|0|XTTE0570|RelevantBindings">
+              <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}merge" type="map(*)">
+               <forEach>
+                <varRef name="bindingKeys" slot="13"/>
+                <let line="216" var="bindingNode" as="element(Q{http://www.w3.org/2002/xforms}bind)" slot="15" eval="7">
+                 <check card="1" diag="3|0|XTTE0570|bindingNode">
                   <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
-                   <varRef name="submissions" slot="13"/>
-                   <dot type="xs:string"/>
+                   <varRef name="bindings" slot="12"/>
+                   <cast as="xs:string" emptiable="0">
+                    <dot type="xs:anyAtomicType"/>
+                   </cast>
                   </ifCall>
                  </check>
-                </arrayBlock>
+                 <choose line="218">
+                  <fn name="exists">
+                   <filter flags="b">
+                    <varRef name="bindingNode" slot="15"/>
+                    <fn name="exists">
+                     <axis name="attribute" nodeTest="attribute(Q{}relevant)" jsTest="return item.name==='relevant'"/>
+                    </fn>
+                   </filter>
+                  </fn>
+                  <ifCall line="220" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+                   <check line="219" card="1" diag="3|0|XTTE0570|keyi">
+                    <cast as="xs:string" emptiable="1">
+                     <data>
+                      <slash simple="1">
+                       <varRef name="bindingNode" slot="15"/>
+                       <axis name="attribute" nodeTest="attribute(Q{}nodeset)" jsTest="return item.name==='nodeset'"/>
+                      </slash>
+                     </data>
+                    </cast>
+                   </check>
+                   <cast as="xs:string" emptiable="1">
+                    <data>
+                     <slash simple="1">
+                      <varRef name="bindingNode" slot="15"/>
+                      <axis name="attribute" nodeTest="attribute(Q{}relevant)" jsTest="return item.name==='relevant'"/>
+                     </slash>
+                    </data>
+                   </cast>
+                  </ifCall>
+                 </choose>
+                </let>
+               </forEach>
+               <map size="2">
+                <str val="duplicates"/>
+                <str val="reject"/>
+                <str val="duplicates-error-code"/>
+                <str val="XTDE3365"/>
+               </map>
+              </ifCall>
+             </treat>
+             <let line="229" var="CalculationBindings" as="map(xs:string, xs:string)" slot="16" eval="7">
+              <treat line="231" as="map(xs:string, xs:string)" jsTest="function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="3|0|XTTE0570|CalculationBindings">
+               <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}merge" type="map(*)">
+                <forEach>
+                 <varRef name="bindingKeys" slot="13"/>
+                 <let line="232" var="bindingNode" as="element(Q{http://www.w3.org/2002/xforms}bind)" slot="17" eval="7">
+                  <check card="1" diag="3|0|XTTE0570|bindingNode">
+                   <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+                    <varRef name="bindings" slot="12"/>
+                    <cast as="xs:string" emptiable="0">
+                     <dot type="xs:anyAtomicType"/>
+                    </cast>
+                   </ifCall>
+                  </check>
+                  <choose line="234">
+                   <fn name="exists">
+                    <filter flags="b">
+                     <varRef name="bindingNode" slot="17"/>
+                     <fn name="exists">
+                      <axis name="attribute" nodeTest="attribute(Q{}calculate)" jsTest="return item.name==='calculate'"/>
+                     </fn>
+                    </filter>
+                   </fn>
+                   <ifCall line="236" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+                    <check line="235" card="1" diag="3|0|XTTE0570|keyi">
+                     <cast as="xs:string" emptiable="1">
+                      <data>
+                       <slash simple="1">
+                        <varRef name="bindingNode" slot="17"/>
+                        <axis name="attribute" nodeTest="attribute(Q{}nodeset)" jsTest="return item.name==='nodeset'"/>
+                       </slash>
+                      </data>
+                     </cast>
+                    </check>
+                    <cast as="xs:string" emptiable="1">
+                     <data>
+                      <slash simple="1">
+                       <varRef name="bindingNode" slot="17"/>
+                       <axis name="attribute" nodeTest="attribute(Q{}calculate)" jsTest="return item.name==='calculate'"/>
+                      </slash>
+                     </data>
+                    </cast>
+                   </ifCall>
+                  </choose>
+                 </let>
+                </forEach>
+                <map size="2">
+                 <str val="duplicates"/>
+                 <str val="reject"/>
+                 <str val="duplicates-error-code"/>
+                 <str val="XTDE3365"/>
+                </map>
                </ifCall>
-              </forEach>
-              <resultDoc line="442" global="#&#xD;&#xA;#Tue Jul 24 21:04:01 BST 2018&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;" local="#&#xD;&#xA;#Tue Jul 24 21:04:01 BST 2018&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;">
-               <fn role="href" name="concat">
-                <str val="#"/>
-                <varRef name="xFormsId" slot="4"/>
-               </fn>
-               <applyT role="content" line="443" bSlot="4">
-                <slash role="select" simple="1">
-                 <varRef name="xforms-doci" slot="7"/>
-                 <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}xform)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='xform';"/>
-                </slash>
-                <withParam name="Q{}instances" flags="t" as="map(xs:string, element())">
-                 <varRef line="444" name="xforms-instances" slot="8"/>
-                </withParam>
-                <withParam name="Q{}bindings" flags="t" as="map(xs:string, node())">
-                 <varRef line="445" name="bindings" slot="10"/>
-                </withParam>
-                <withParam name="Q{}submissions" flags="t" as="map(xs:string, map(*))">
-                 <varRef line="446" name="submissions" slot="13"/>
-                </withParam>
-                <withParam name="Q{}nodeset" flags="t" as="xs:string">
-                 <str val=""/>
-                </withParam>
-               </applyT>
-              </resultDoc>
-             </sequence>
+              </treat>
+              <sequence line="248">
+               <choose>
+                <gc op="=" card="M:N" comp="GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint">
+                 <data>
+                  <slash>
+                   <slash simple="1">
+                    <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}page" type="document-node()?"/>
+                    <axis name="descendant" nodeTest="element(Q{}script)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='script';"/>
+                   </slash>
+                   <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
+                  </slash>
+                 </data>
+                 <data>
+                  <gVarRef name="Q{}xforms-cache-id" bSlot="3"/>
+                 </data>
+                </gc>
+                <sequence line="249">
+                 <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+                  <check card="1" diag="0|0||ixsl:call">
+                   <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+                  </check>
+                  <str val="setXFormsDoc"/>
+                  <arrayBlock>
+                   <varRef name="xforms-doc" slot="0"/>
+                  </arrayBlock>
+                 </ifCall>
+                 <ifCall line="250" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+                  <check card="1" diag="0|0||ixsl:call">
+                   <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+                  </check>
+                  <str val="setXForm"/>
+                  <arrayBlock>
+                   <varRef name="xform" slot="8"/>
+                  </arrayBlock>
+                 </ifCall>
+                 <ifCall line="251" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+                  <check card="1" diag="0|0||ixsl:call">
+                   <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+                  </check>
+                  <str val="setXFormsID"/>
+                  <arrayBlock>
+                   <varRef name="xFormsId" slot="4"/>
+                  </arrayBlock>
+                 </ifCall>
+                 <ifCall line="252" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+                  <check card="1" diag="0|0||ixsl:call">
+                   <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+                  </check>
+                  <str val="setRelevantMap"/>
+                  <arrayBlock>
+                   <varRef name="RelevantBindings" slot="14"/>
+                  </arrayBlock>
+                 </ifCall>
+                 <ifCall line="253" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+                  <check card="1" diag="0|0||ixsl:call">
+                   <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+                  </check>
+                  <str val="setCalculationMap"/>
+                  <arrayBlock>
+                   <varRef name="CalculationBindings" slot="16"/>
+                  </arrayBlock>
+                 </ifCall>
+                </sequence>
+                <true/>
+                <sequence line="264">
+                 <forEach>
+                  <slash simple="1">
+                   <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}page" type="document-node()?"/>
+                   <axis name="descendant" nodeTest="element(Q{}head)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='head';"/>
+                  </slash>
+                  <resultDoc line="273" global="#&#xD;&#xA;#Sun Nov 18 10:50:05 GMT 2018&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;" local="#&#xD;&#xA;#Sun Nov 18 10:50:05 GMT 2018&#xD;&#xA;">
+                   <str role="href" val="?."/>
+                   <elem role="content" line="274" name="script" nsuri="" namespaces="xd rdf xhtml js in fn map array ev">
+                    <sequence>
+                     <att name="type" flags="l">
+                      <str val="text/javascript"/>
+                     </att>
+                     <att name="id" flags="l">
+                      <fn name="string-join">
+                       <convert from="xs:anyAtomicType" to="xs:string">
+                        <data>
+                         <mergeAdj>
+                          <gVarRef name="Q{}xforms-cache-id" bSlot="4"/>
+                         </mergeAdj>
+                        </data>
+                       </convert>
+                       <str val=" "/>
+                      </fn>
+                     </att>
+                     <valueOf flags="l">
+                      <str val="                &#xA;                            var XFormsDoc = null;&#xA;                            var XForm = null;&#xA;                            var defaultInstanceDoc = null;&#xA;                            &#xA;                            // MD 2018: OND's suggestion for multiple instances&#xA;                            var instanceDocs = {};&#xA;                            &#xA;                            var pendingUpdatesMap = null;&#xA;                            var updatesMap = null;&#xA;                            var XFormsID = '"/>
+                     </valueOf>
+                     <valueOf line="284" flags="l">
+                      <varRef name="xFormsId" slot="4"/>
+                     </valueOf>
+                     <valueOf flags="l">
+                      <str val="';&#xA;                            var actions = {};&#xA;                            var submissions = {};&#xA;                            var outputs = {};&#xA;                            var relevantMap = {};&#xA;                            var calculationMap = {};&#xA;                            var repeatIndexMap = {};&#xA;                            var elementsUsingIndexFunction = {};&#xA;                            &#xA;                            var getCurrentDate = function(){&#xA;                                var today = new Date();&#xA;                                var dd = today.getDate();&#xA;                                var mm = today.getMonth()+1; //January is 0!&#xA;                                var yyyy = today.getFullYear();&#xA;                            &#xA;                                if(dd &lt; 10) {&#xA;                                    dd = '0' + dd;&#xA;                                } &#xA;                            &#xA;                                if(mm &lt; 10) {&#xA;                                    mm = '0' + mm;&#xA;                                } &#xA;                            &#xA;                                today = yyyy + '-' + mm + '-' + dd;&#xA;                                return today;&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var setXFormsDoc = function(doc) {&#xA;                                XFormsDoc = doc;&#xA;                            }&#xA;                            &#xA;                            var getXFormsDoc = function() {&#xA;                                return XFormsDoc;&#xA;                            }&#xA;                            &#xA;                            var setXForm = function(element) {&#xA;                                XForm = element;&#xA;                            }&#xA;                            &#xA;                            var getXForm = function() {&#xA;                                return XForm;&#xA;                            }&#xA;                            &#xA;                            var setXFormsID = function(id) {&#xA;                                XFormsID = id;&#xA;                            }&#xA;                            &#xA;                            var getXFormsID = function() {&#xA;                                return XFormsID;&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var setInstance = function(name, value) {&#xA;                                instanceDocs[name] = value;&#xA;                            } &#xA;                            &#xA;                            var getInstance = function(name) {&#xA;                                return instanceDocs[name];&#xA;                            }&#xA;                            &#xA;                            &#xA;                            //[OND] Maybe we can just set the key-&gt; value without having to copy the entire instanceDocs object.&#xA;                            var updateInstance = function(instanceDocs, key, value){&#xA;                                instanceDocs[key] = value;&#xA;                                return instanceDocs;&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var setDefaultInstance = function(doc) {&#xA;                                defaultInstanceDoc = doc;&#xA;                            }&#xA;                            &#xA;                            var getDefaultInstance = function() {&#xA;                                return defaultInstanceDoc;&#xA;                            }&#xA;                            &#xA;                           &#xA;                            var getInstanceKeys = function() {&#xA;                                return Object.keys(instanceDocs);&#xA;                            }&#xA;                            &#xA;                            var getInstances = function() {&#xA;                                return instanceDocs;&#xA;                            }&#xA;                            &#xA;                            var setPendingUpdates = function(map1) {&#xA;                                pendingUpdatesMap = map1;&#xA;                            }&#xA;                            &#xA;                            var clearPendingUpdates = function() {&#xA;                                pendingUpdatesMap = null;&#xA;                            }&#xA;                            &#xA;                            var getPendingUpdates = function() {&#xA;                                return pendingUpdatesMap;&#xA;                            }&#xA;                            &#xA;                            var setUpdates = function(map1) {&#xA;                                updatesMap = map1;&#xA;                            }&#xA;                            &#xA;                            var clearUpdates = function() {&#xA;                                updatesMap = null;&#xA;                            }&#xA;                            &#xA;                            var getUpdates = function() {&#xA;                                return updatesMap;&#xA;                            }&#xA;                            &#xA;                            var addAction = function(name, value){&#xA;                                actions[name] = value;&#xA;                            }&#xA;&#xA;                            var getAction = function(name){&#xA;                                return actions[name];&#xA;                            }&#xA;                            &#xA;                            var updateAction = function(actioni, key, value){&#xA;                                actioni[key] = value;&#xA;                                return actioni;&#xA;                            }&#xA;                            &#xA;                            var addSubmission = function(name, value){&#xA;                                submissions[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getSubmission = function(name){&#xA;                                return submissions[name];&#xA;                            }     &#xA;                            &#xA;                            var addOutput = function(name, value){&#xA;                                outputs[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getOutput = function(name){&#xA;                                return outputs[name];&#xA;                            }&#xA;                            &#xA;                            var getOutputKeys = function() {&#xA;                                return Object.keys(outputs);&#xA;                            }&#xA;                            &#xA;                            var setRelevantMap = function(map1) {&#xA;                                relevantMap = map1;                            &#xA;                            }&#xA;                            &#xA;                            var getRelevantMap = function() {&#xA;                                return relevantMap;&#xA;                            }&#xA;                            &#xA;  &#xA;                            var setCalculationMap = function(map1) {&#xA;                                calculationMap = map1;                            &#xA;                            }&#xA;  &#xA;                            var getCalculationMap = function() {&#xA;                                return calculationMap;&#xA;                            }&#xA;  &#xA;                            &#xA;                            var setRepeatIndex = function(name, value) {&#xA;                                repeatIndexMap[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getRepeatIndex = function(name) {&#xA;                                if ( typeof(repeatIndexMap[name]) != 'undefined' ) {&#xA;                                    return repeatIndexMap[name];&#xA;                                }&#xA;                                else {&#xA;                                    return 0;&#xA;                                }&#xA;                            } &#xA;                            &#xA;                            var setElementUsingIndexFunction = function(name, value) {&#xA;                                elementsUsingIndexFunction[name] = value;&#xA;                            } &#xA;                            &#xA;                            var getElementUsingIndexFunction = function(name) {&#xA;                                return elementsUsingIndexFunction[name];&#xA;                            }&#xA;                            &#xA;                            var getElementsUsingIndexFunctionKeys = function() {&#xA;                            return Object.keys(elementsUsingIndexFunction);&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var startTime = function(name) {&#xA;                                console.time(name);&#xA;                            }&#xA;                            &#xA;                            var endTime = function(name) {&#xA;                                console.timeEnd(name);&#xA;                            }&#xA;                            &#xA;                            var highlightClicked = function(id) {&#xA;                                var item = document.getElementById(id);&#xA;                                toggleClass(item);&#xA;                            }&#xA;                            &#xA;                            var toggleClass = function(element) {&#xA;                                if (element.className == 'selected') {&#xA;                                    element.classList.remove('selected');&#xA;                                }&#xA;                                else {&#xA;                                    var x = document.getElementsByClassName('selected');&#xA;                                    var i;&#xA;                                    for (i = 0; i &lt; x.length; i++) {&#xA;                                        x[i].classList.remove('selected');&#xA;                                    } &#xA;                                    element.classList.add('selected');&#xA;                                }&#xA;                            }&#xA;                            &#xA;                            var setFocus = function(id) {&#xA;                                var item = document.getElementById(id);&#xA;                                item.select();&#xA;                            }&#xA;                            &#xA;                        "/>
+                     </valueOf>
+                    </sequence>
+                   </elem>
+                  </resultDoc>
+                 </forEach>
+                 <ifCall line="507" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+                  <check card="1" diag="0|0||ixsl:call">
+                   <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+                  </check>
+                  <str val="setXFormsDoc"/>
+                  <arrayBlock>
+                   <varRef name="xforms-doc" slot="0"/>
+                  </arrayBlock>
+                 </ifCall>
+                 <ifCall line="508" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+                  <check card="1" diag="0|0||ixsl:call">
+                   <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+                  </check>
+                  <str val="setXForm"/>
+                  <arrayBlock>
+                   <varRef name="xform" slot="8"/>
+                  </arrayBlock>
+                 </ifCall>
+                 <ifCall line="509" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+                  <check card="1" diag="0|0||ixsl:call">
+                   <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+                  </check>
+                  <str val="setDefaultInstance"/>
+                  <arrayBlock>
+                   <varRef name="default-instance" slot="11"/>
+                  </arrayBlock>
+                 </ifCall>
+                 <ifCall line="510" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+                  <check card="1" diag="0|0||ixsl:call">
+                   <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+                  </check>
+                  <str val="setRelevantMap"/>
+                  <arrayBlock>
+                   <varRef name="RelevantBindings" slot="14"/>
+                  </arrayBlock>
+                 </ifCall>
+                 <ifCall line="511" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+                  <check card="1" diag="0|0||ixsl:call">
+                   <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+                  </check>
+                  <str val="setCalculationMap"/>
+                  <arrayBlock>
+                   <varRef name="CalculationBindings" slot="16"/>
+                  </arrayBlock>
+                 </ifCall>
+                 <ifCall line="516" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+                  <check card="1" diag="0|0||ixsl:call">
+                   <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+                  </check>
+                  <str val="setPendingUpdates"/>
+                  <arrayBlock>
+                   <treat line="513" as="map(°)" jsTest="function k(item) {return SaxonJS.U.Atomic.anyAtomicType.matches(item);};function v(item) {return true;};function c() {return true;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="3|0||pendingInstanceUpdates">
+                    <map size="0"/>
+                   </treat>
+                  </arrayBlock>
+                 </ifCall>
+                 <ifCall line="517" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+                  <check card="1" diag="0|0||ixsl:call">
+                   <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+                  </check>
+                  <str val="setUpdates"/>
+                  <arrayBlock>
+                   <treat line="514" as="map(°)" jsTest="function k(item) {return SaxonJS.U.Atomic.anyAtomicType.matches(item);};function v(item) {return true;};function c() {return true;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="3|0||instanceUpdates">
+                    <map size="0"/>
+                   </treat>
+                  </arrayBlock>
+                 </ifCall>
+                </sequence>
+               </choose>
+               <forEach line="526">
+                <treat line="524" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|instanceKeys">
+                 <cvUntyped to="xs:string">
+                  <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}keys" type="xs:anyAtomicType*">
+                   <varRef name="xforms-instances" slot="9"/>
+                  </ifCall>
+                 </cvUntyped>
+                </treat>
+                <ifCall line="528" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+                 <varRef name="vv:v0" slot="6"/>
+                 <str val="setInstance"/>
+                 <arrayBlock>
+                  <dot type="xs:string"/>
+                  <check line="527" card="1" diag="3|0|XTTE0570|instance">
+                   <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+                    <varRef name="xforms-instances" slot="9"/>
+                    <dot type="xs:string"/>
+                   </ifCall>
+                  </check>
+                 </arrayBlock>
+                </ifCall>
+               </forEach>
+               <let line="533" var="submissions" as="map(xs:string, map(*))" slot="18" eval="8">
+                <ifCall line="535" name="Q{http://www.w3.org/2005/xpath-functions/map}merge" type="map(*)">
+                 <forEach>
+                  <slash>
+                   <slash>
+                    <slash simple="1">
+                     <varRef name="xforms-doci" slot="7"/>
+                     <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}xform)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='xform';"/>
+                    </slash>
+                    <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}model)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='model';"/>
+                   </slash>
+                   <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}submission)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='submission';"/>
+                  </slash>
+                  <let line="539" var="map-key" as="xs:string" slot="19" eval="7">
+                   <choose>
+                    <fn name="exists">
+                     <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
+                    </fn>
+                    <check card="1" diag="3|0|XTTE0570|map-key">
+                     <cast as="xs:string" emptiable="1">
+                      <attVal name="Q{}id" chk="0"/>
+                     </cast>
+                    </check>
+                    <true/>
+                    <str val="saxon-forms-default-submission"/>
+                   </choose>
+                   <let line="540" var="map-value" as="map(*)" slot="20" eval="7">
+                    <treat line="541" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|map-value">
+                     <check card="1" diag="3|0|XTTE0570|map-value">
+                      <callT name="setSubmission" bSlot="5">
+                       <withParam name="Q{}this" flags="c" as="element()">
+                        <dot line="542" type="element(Q{http://www.w3.org/2002/xforms}submission)"/>
+                       </withParam>
+                       <withParam name="Q{}submission-id" flags="c" as="xs:string">
+                        <varRef line="543" name="map-key" slot="19"/>
+                       </withParam>
+                      </callT>
+                     </check>
+                    </treat>
+                    <ifCall line="546" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+                     <varRef name="map-key" slot="19"/>
+                     <varRef name="map-value" slot="20"/>
+                    </ifCall>
+                   </let>
+                  </let>
+                 </forEach>
+                 <map size="2">
+                  <str val="duplicates"/>
+                  <str val="reject"/>
+                  <str val="duplicates-error-code"/>
+                  <str val="XTDE3365"/>
+                 </map>
+                </ifCall>
+                <sequence line="555">
+                 <forEach>
+                  <treat line="553" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|submissionKeys">
+                   <cvUntyped to="xs:string">
+                    <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}keys" type="xs:anyAtomicType*">
+                     <varRef name="submissions" slot="18"/>
+                    </ifCall>
+                   </cvUntyped>
+                  </treat>
+                  <sequence line="557">
+                   <message>
+                    <sequence role="select">
+                     <valueOf>
+                      <str val="Setting submission with ID '"/>
+                     </valueOf>
+                     <valueOf>
+                      <dot type="xs:string"/>
+                     </valueOf>
+                     <valueOf flags="S">
+                      <str val="'"/>
+                     </valueOf>
+                    </sequence>
+                    <str role="terminate" val="no"/>
+                    <str role="error" val="Q{http://www.w3.org/2005/xqt-errors}XTMM9000"/>
+                   </message>
+                   <ifCall line="558" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+                    <varRef name="vv:v1" slot="5"/>
+                    <str val="addSubmission"/>
+                    <arrayBlock>
+                     <dot type="xs:string"/>
+                     <check line="556" card="1" diag="3|0|XTTE0570|submission">
+                      <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+                       <varRef name="submissions" slot="18"/>
+                       <dot type="xs:string"/>
+                      </ifCall>
+                     </check>
+                    </arrayBlock>
+                   </ifCall>
+                  </sequence>
+                 </forEach>
+                 <resultDoc line="567" global="#&#xD;&#xA;#Sun Nov 18 10:50:05 GMT 2018&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;" local="#&#xD;&#xA;#Sun Nov 18 10:50:05 GMT 2018&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;">
+                  <fn role="href" name="concat">
+                   <str val="#"/>
+                   <varRef name="xFormsId" slot="4"/>
+                  </fn>
+                  <applyT role="content" line="568" bSlot="6">
+                   <slash role="select" simple="1">
+                    <varRef name="xforms-doci" slot="7"/>
+                    <axis name="child" nodeTest="element(Q{http://www.w3.org/2002/xforms}xform)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri==='http://www.w3.org/2002/xforms'&amp;&amp;q.local==='xform';"/>
+                   </slash>
+                   <withParam name="Q{}instances" flags="t" as="map(xs:string, element())">
+                    <varRef line="569" name="xforms-instances" slot="9"/>
+                   </withParam>
+                   <withParam name="Q{}bindings" flags="t" as="map(xs:string, node())">
+                    <varRef line="570" name="bindings" slot="12"/>
+                   </withParam>
+                   <withParam name="Q{}submissions" flags="t" as="map(xs:string, map(*))">
+                    <varRef line="571" name="submissions" slot="18"/>
+                   </withParam>
+                   <withParam name="Q{}nodeset" flags="t" as="xs:string">
+                    <str val=""/>
+                   </withParam>
+                  </applyT>
+                 </resultDoc>
+                </sequence>
+               </let>
+              </sequence>
+             </let>
             </let>
-           </sequence>
+           </let>
           </let>
          </let>
         </let>
@@ -7637,9 +8462,46 @@
    </let>
   </template>
  </co>
- <co id="41" binds="56 6 7">
-  <template name="Q{}HTTPsubmit" cxt="map(*)" jsTest="return SaxonJS.U.isMap(item)" flags="s" line="755" module="saxon-xforms.xsl" slots="4">
-   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="761">
+ <co id="62" binds="62">
+  <mode name="Q{}namespace-fix" onNo="TC" flags="W" patternSlots="0">
+   <templateRule prec="0" prio="-0.5" seq="0" rank="0" minImp="0" slots="1" flags="s" line="2726" module="saxon-xforms.xsl">
+    <p.nodeTest role="match" test="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;"/>
+    <let role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2727" var="current-namespace" as="xs:anyURI" slot="0" eval="8">
+     <fn name="namespace-uri">
+      <dot type="element()"/>
+     </fn>
+     <compElem line="2729">
+      <convert role="name" from="xs:QName" to="xs:string">
+       <fn line="2728" name="QName">
+        <varRef name="current-namespace" slot="0"/>
+        <fn name="name">
+         <dot type="element()"/>
+        </fn>
+       </fn>
+      </convert>
+      <convert role="namespace" from="xs:anyURI" to="xs:string">
+       <varRef name="current-namespace" slot="0"/>
+      </convert>
+      <sequence role="content" line="2730">
+       <namespace flags="l">
+        <str role="name" val="xforms"/>
+        <str role="select" val="http://www.w3.org/2002/xforms"/>
+       </namespace>
+       <applyT line="2732" mode="Q{}namespace-fix" bSlot="0">
+        <sequence role="select">
+         <axis name="attribute" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
+         <axis name="child" nodeTest="( element() | text() | comment() | processing-instruction() )" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);"/>
+        </sequence>
+       </applyT>
+      </sequence>
+     </compElem>
+    </let>
+   </templateRule>
+  </mode>
+ </co>
+ <co id="43" binds="59 6 7">
+  <template name="Q{}HTTPsubmit" cxt="map(*)" jsTest="return SaxonJS.U.isMap(item)" flags="s" line="932" module="saxon-xforms.xsl" slots="4">
+   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="938">
     <param name="Q{}instance-id" slot="0" as="xs:string">
      <str role="select" val="saxon-forms-default"/>
      <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|instance-id">
@@ -7652,7 +8514,7 @@
       </check>
      </treat>
     </param>
-    <param line="762" name="Q{}targetref" slot="1" as="xs:string?">
+    <param line="939" name="Q{}targetref" slot="1" as="xs:string?">
      <empty role="select"/>
      <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|targetref">
       <check card="?" diag="8|0|XTTE0590|targetref">
@@ -7664,7 +8526,7 @@
       </check>
      </treat>
     </param>
-    <param line="763" name="Q{}replace" slot="2" as="xs:string?">
+    <param line="940" name="Q{}replace" slot="2" as="xs:string?">
      <empty role="select"/>
      <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|replace">
       <check card="?" diag="8|0|XTTE0590|replace">
@@ -7676,7 +8538,7 @@
       </check>
      </treat>
     </param>
-    <let line="767" var="responseXML" as="document-node()" slot="3" eval="7">
+    <let line="944" var="responseXML" as="document-node()" slot="3" eval="7">
      <treat as="document-node()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);" diag="3|0|XTTE0570|responseXML">
       <check card="1" diag="3|0|XTTE0570|responseXML">
        <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
@@ -7685,22 +8547,22 @@
        </ifCall>
       </check>
      </treat>
-     <choose line="770">
+     <choose line="947">
       <fn name="empty">
        <varRef name="responseXML" slot="3"/>
       </fn>
-      <callT line="771" name="serverError" bSlot="0" flags="t">
+      <callT line="948" name="serverError" bSlot="0" flags="t">
        <withParam name="Q{}responseMap" flags="c" as="map(*)">
-        <dot line="772" type="map(*)"/>
+        <dot line="949" type="map(*)"/>
        </withParam>
       </callT>
-      <gc line="784" op="=" card="1:1" comp="CCC">
+      <gc line="961" op="=" card="1:1" comp="CCC">
        <varRef name="replace" slot="2"/>
        <str val="instance"/>
       </gc>
-      <sequence line="785">
+      <sequence line="962">
        <ufCall name="Q{http://www.w3.org/2002/xforms}setInstance-JS" tailCall="false" bSlot="1" eval="8 4">
-        <fn line="765" name="concat">
+        <fn line="942" name="concat">
          <str val="instance('"/>
          <varRef name="instance-id" slot="0"/>
          <str val="')/"/>
@@ -7712,17 +8574,31 @@
          </slash>
         </check>
        </ufCall>
-       <callT line="787" name="xforms-rebuild" bSlot="2" flags="t"/>
+       <callT line="964" name="xforms-rebuild" bSlot="2"/>
+       <message line="965">
+        <sequence role="select">
+         <valueOf>
+          <str val="[HTTPsubmit] response body: "/>
+         </valueOf>
+         <valueOf>
+          <fn name="serialize">
+           <varRef name="responseXML" slot="3"/>
+          </fn>
+         </valueOf>
+        </sequence>
+        <str role="terminate" val="no"/>
+        <str role="error" val="Q{http://www.w3.org/2005/xqt-errors}XTMM9000"/>
+       </message>
       </sequence>
      </choose>
     </let>
    </sequence>
   </template>
  </co>
- <co id="35" binds="">
-  <function name="Q{http://www.w3.org/2002/xforms}instance" line="111" module="xforms-function-library.xsl" eval="7" flags="pU" as="element()?" slots="1">
+ <co id="34" binds="">
+  <function name="Q{http://www.w3.org/2002/xforms}instance" line="104" module="xforms-function-library.xsl" eval="7" flags="pU" as="element()?" slots="1">
    <arg name="instance-id" as="xs:string"/>
-   <treat role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="113" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="5|0|XTTE0780|xforms:instance">
+   <treat role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="106" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="5|0|XTTE0780|xforms:instance">
     <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
      <check card="1" diag="0|0||ixsl:call">
       <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
@@ -7735,39 +8611,149 @@
    </treat>
   </function>
  </co>
- <co id="62" binds="55 39">
+ <co id="64" binds="38 58 41">
   <mode name="Q{http://saxonica.com/ns/interactiveXSLT}onclick" onNo="TC" flags="W" patternSlots="0">
-   <templateRule prec="0" prio="0.5" seq="1" rank="0" minImp="0" slots="0" flags="s" line="1659" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="0.5" seq="0" rank="0" minImp="0" slots="1" flags="s" line="682" module="saxon-xforms.xsl">
+    <p.withUpper role="match" axis="ancestor" upFirst="false">
+     <p.withPredicate>
+      <p.nodeTest test="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;"/>
+      <or ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="682" op="or">
+       <axis name="self" nodeTest="element(Q{}span)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='span';"/>
+       <axis name="self" nodeTest="element(Q{}input)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='input';"/>
+      </or>
+     </p.withPredicate>
+     <p.withPredicate>
+      <p.nodeTest test="element(Q{}div)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='div';"/>
+      <gc ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="682" op="=" card="M:N" comp="CCC">
+       <data>
+        <axis name="attribute" nodeTest="attribute(Q{}data-repeat-item)" jsTest="return item.name==='data-repeat-item'"/>
+       </data>
+       <str val="true"/>
+      </gc>
+     </p.withPredicate>
+    </p.withUpper>
+    <let role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="691" var="vv:v0" as="item()" slot="0" eval="13">
+     <check card="1" diag="0|0||ixsl:call">
+      <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+     </check>
+     <sequence line="683">
+      <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+       <check card="1" diag="0|0||ixsl:call">
+        <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+       </check>
+       <str val="highlightClicked"/>
+       <arrayBlock>
+        <fn name="string">
+         <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
+        </fn>
+       </arrayBlock>
+      </ifCall>
+      <forEach line="686">
+       <fn name="reverse">
+        <filter flags="b">
+         <slash simple="1">
+          <dot type="element()"/>
+          <axis name="ancestor" nodeTest="element(Q{}div)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='div';"/>
+         </slash>
+         <gc op="=" card="1:1" comp="CCC">
+          <attVal name="Q{}data-repeat-item" chk="0"/>
+          <str val="true"/>
+         </gc>
+        </filter>
+       </fn>
+       <ifCall line="691" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+        <varRef name="vv:v0" slot="0"/>
+        <str val="setRepeatIndex"/>
+        <arrayBlock>
+         <check line="687" card="1" diag="3|0|XTTE0570|repeat-id">
+          <cvUntyped to="xs:string">
+           <data>
+            <slash simple="1">
+             <first>
+              <filter flags="b">
+               <slash simple="1">
+                <dot type="element(Q{}div)"/>
+                <axis name="ancestor" nodeTest="element(Q{}div)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='div';"/>
+               </slash>
+               <fn name="exists">
+                <axis name="attribute" nodeTest="attribute(Q{}data-repeatable-context)" jsTest="return item.name==='data-repeatable-context'"/>
+               </fn>
+              </filter>
+             </first>
+             <axis name="attribute" nodeTest="attribute(Q{}id)" jsTest="return item.name==='id'"/>
+            </slash>
+           </data>
+          </cvUntyped>
+         </check>
+         <arith line="688" op="+" calc="i+i">
+          <fn name="count">
+           <filter flags="b">
+            <slash simple="1">
+             <dot type="element(Q{}div)"/>
+             <axis name="preceding-sibling" nodeTest="element(Q{}div)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='div';"/>
+            </slash>
+            <gc op="=" card="1:1" comp="CCC">
+             <attVal name="Q{}data-repeat-item" chk="0"/>
+             <str val="true"/>
+            </gc>
+           </filter>
+          </fn>
+          <int val="1"/>
+         </arith>
+        </arrayBlock>
+       </ifCall>
+      </forEach>
+      <callT line="694" name="refreshElementsUsingIndexFunction-JS" bSlot="0"/>
+      <choose line="696">
+       <fn name="exists">
+        <axis name="self" nodeTest="element(Q{}input)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='input';"/>
+       </fn>
+       <ifCall line="697" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+        <check card="1" diag="0|0||ixsl:call">
+         <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
+        </check>
+        <str val="setFocus"/>
+        <arrayBlock>
+         <cast as="xs:string" emptiable="1">
+          <attVal name="Q{}id" chk="0"/>
+         </cast>
+        </arrayBlock>
+       </ifCall>
+      </choose>
+     </sequence>
+    </let>
+   </templateRule>
+   <templateRule prec="0" prio="0.5" seq="2" rank="0" minImp="0" slots="0" flags="s" line="1873" module="saxon-xforms.xsl">
     <p.withPredicate role="match">
      <p.nodeTest test="element(Q{}button)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='button';"/>
-     <fn ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1659" name="exists">
+     <fn ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1873" name="exists">
       <axis name="attribute" nodeTest="attribute(Q{}data-action)" jsTest="return item.name==='data-action'"/>
      </fn>
     </p.withPredicate>
-    <callT role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1661" name="DOMActivate" bSlot="0" flags="t">
+    <callT role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1875" name="DOMActivate" bSlot="1" flags="t">
      <withParam name="Q{}form-control" flags="c" as="node()">
-      <dot line="1662" type="element(Q{}button)"/>
+      <dot line="1876" type="element(Q{}button)"/>
      </withParam>
     </callT>
    </templateRule>
-   <templateRule prec="0" prio="0.5" seq="0" rank="0" minImp="0" slots="0" flags="s" line="738" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="0.5" seq="1" rank="0" minImp="0" slots="0" flags="s" line="915" module="saxon-xforms.xsl">
     <p.withPredicate role="match">
      <p.nodeTest test="element(Q{}button)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='button';"/>
-     <fn ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="738" name="exists">
+     <fn ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="915" name="exists">
       <axis name="attribute" nodeTest="attribute(Q{}data-submit)" jsTest="return item.name==='data-submit'"/>
      </fn>
     </p.withPredicate>
-    <callT role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="740" name="xforms-submit" bSlot="1" flags="t">
+    <callT role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="917" name="xforms-submit" bSlot="2" flags="t">
      <withParam name="Q{}form-control" flags="c" as="node()">
-      <dot line="741" type="element(Q{}button)"/>
+      <dot line="918" type="element(Q{}button)"/>
      </withParam>
     </callT>
    </templateRule>
   </mode>
  </co>
- <co id="61" binds="49 50 51 10">
-  <template name="Q{}setSubmission" flags="os" line="3020" module="saxon-xforms.xsl" slots="5">
-   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="3021">
+ <co id="63" binds="53 54 55">
+  <template name="Q{}setSubmission" flags="os" line="3605" module="saxon-xforms.xsl" slots="5">
+   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="3606">
     <param name="Q{}this" slot="0" flags="i" as="element()">
      <treat role="conversion" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="8|0|XTTE0590|this">
       <check card="1" diag="8|0|XTTE0590|this">
@@ -7775,7 +8761,7 @@
       </check>
      </treat>
     </param>
-    <param line="3022" name="Q{}submission-id" slot="1" flags="i" as="xs:string">
+    <param line="3607" name="Q{}submission-id" slot="1" flags="i" as="xs:string">
      <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|submission-id">
       <check card="1" diag="8|0|XTTE0590|submission-id">
        <cvUntyped to="xs:string">
@@ -7786,52 +8772,52 @@
       </check>
      </treat>
     </param>
-    <let line="3025" var="bindingi" as="node()?" slot="2" eval="7">
-     <treat line="3026" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|bindingi">
+    <let line="3610" var="bindingi" as="node()?" slot="2" eval="7">
+     <treat line="3611" as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="3|0|XTTE0570|bindingi">
       <check card="?" diag="3|0|XTTE0570|bindingi">
        <callT name="getBinding" bSlot="0">
         <withParam name="Q{}this" flags="c" as="element()">
-         <varRef line="3027" name="this" slot="0"/>
+         <varRef line="3612" name="this" slot="0"/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <let line="3032" var="refi" as="xs:string" slot="3" eval="7">
-      <treat line="3033" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|refi">
+     <let line="3617" var="refi" as="xs:string" slot="3" eval="7">
+      <treat line="3618" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|refi">
        <check card="1" diag="3|0|XTTE0570|refi">
         <cvUntyped to="xs:string">
          <data>
           <callT name="getDataRef" bSlot="1">
            <withParam name="Q{}this" flags="c" as="element()">
-            <varRef line="3034" name="this" slot="0"/>
+            <varRef line="3619" name="this" slot="0"/>
            </withParam>
            <withParam name="Q{}bindingi" flags="c" as="node()?">
-            <varRef line="3035" name="bindingi" slot="2"/>
+            <varRef line="3620" name="bindingi" slot="2"/>
            </withParam>
           </callT>
          </data>
         </cvUntyped>
        </check>
       </treat>
-      <let line="3040" var="actions" as="map(*)*" slot="4" eval="8">
-       <treat line="3041" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|actions">
+      <let line="3625" var="actions" as="map(*)*" slot="4" eval="8">
+       <treat line="3626" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="3|0|XTTE0570|actions">
         <callT name="setActions" bSlot="2">
          <withParam name="Q{}this" flags="c" as="element()">
-          <treat line="3042" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="8|0|XTTE0590|this">
+          <treat line="3627" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="8|0|XTTE0590|this">
            <dot flags="a"/>
           </treat>
          </withParam>
          <withParam name="Q{}nodeset" flags="t" as="xs:string">
-          <varRef line="3043" name="refi" slot="3"/>
+          <varRef line="3628" name="refi" slot="3"/>
          </withParam>
         </callT>
        </treat>
-       <sequence line="3047">
+       <sequence line="3632">
         <choose>
          <fn name="exists">
           <varRef name="actions" slot="4"/>
          </fn>
-         <ifCall line="3048" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
+         <ifCall line="3633" name="Q{http://saxonica.com/ns/interactiveXSLT}call" type="item()?">
           <check card="1" diag="0|0||ixsl:call">
            <ifCall name="Q{http://saxonica.com/ns/interactiveXSLT}window" type="item()?"/>
           </check>
@@ -7842,25 +8828,25 @@
           </arrayBlock>
          </ifCall>
         </choose>
-        <ifCall line="3053" name="Q{http://www.w3.org/2005/xpath-functions/map}merge" type="map(*)">
+        <ifCall line="3638" name="Q{http://www.w3.org/2005/xpath-functions/map}merge" type="map(*)">
          <sequence>
           <choose>
            <fn name="exists">
             <varRef name="refi" slot="3"/>
            </fn>
-           <ifCall line="3054" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+           <ifCall line="3639" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
             <str val="@ref"/>
             <varRef name="refi" slot="3"/>
            </ifCall>
           </choose>
-          <choose line="3057">
+          <choose line="3642">
            <fn name="exists">
             <slash simple="1">
              <varRef name="this" slot="0"/>
              <axis name="attribute" nodeTest="attribute(Q{}resource)" jsTest="return item.name==='resource'"/>
             </slash>
            </fn>
-           <ifCall line="3058" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+           <ifCall line="3643" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
             <str val="@resource"/>
             <cast as="xs:string" emptiable="1">
              <data>
@@ -7872,14 +8858,14 @@
             </cast>
            </ifCall>
           </choose>
-          <choose line="3060">
+          <choose line="3645">
            <fn name="exists">
             <slash simple="1">
              <varRef name="this" slot="0"/>
              <axis name="attribute" nodeTest="attribute(Q{}mode)" jsTest="return item.name==='mode'"/>
             </slash>
            </fn>
-           <ifCall line="3061" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+           <ifCall line="3646" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
             <str val="@mode"/>
             <cast as="xs:string" emptiable="1">
              <data>
@@ -7891,16 +8877,16 @@
             </cast>
            </ifCall>
           </choose>
-          <ifCall line="3064" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+          <ifCall line="3649" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
            <str val="@method"/>
-           <choose line="3066">
+           <choose line="3651">
             <fn name="exists">
              <slash simple="1">
               <varRef name="this" slot="0"/>
               <axis name="attribute" nodeTest="attribute(Q{}method)" jsTest="return item.name==='method'"/>
              </slash>
             </fn>
-            <fn line="3067" name="string">
+            <fn line="3652" name="string">
              <slash simple="1">
               <varRef name="this" slot="0"/>
               <axis name="attribute" nodeTest="attribute(Q{}method)" jsTest="return item.name==='method'"/>
@@ -7910,14 +8896,14 @@
             <str val="POST"/>
            </choose>
           </ifCall>
-          <choose line="3076">
+          <choose line="3661">
            <fn name="exists">
             <slash simple="1">
              <varRef name="this" slot="0"/>
              <axis name="attribute" nodeTest="attribute(Q{}validate)" jsTest="return item.name==='validate'"/>
             </slash>
            </fn>
-           <ifCall line="3077" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+           <ifCall line="3662" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
             <str val="@validate"/>
             <fn name="string">
              <slash simple="1">
@@ -7927,14 +8913,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line="3079">
+          <choose line="3664">
            <fn name="exists">
             <slash simple="1">
              <varRef name="this" slot="0"/>
              <axis name="attribute" nodeTest="attribute(Q{}relevant)" jsTest="return item.name==='relevant'"/>
             </slash>
            </fn>
-           <ifCall line="3080" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+           <ifCall line="3665" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
             <str val="@relevant"/>
             <fn name="string">
              <slash simple="1">
@@ -7944,14 +8930,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line="3082">
+          <choose line="3667">
            <fn name="exists">
             <slash simple="1">
              <varRef name="this" slot="0"/>
              <axis name="attribute" nodeTest="attribute(Q{}serialization)" jsTest="return item.name==='serialization'"/>
             </slash>
            </fn>
-           <ifCall line="3083" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+           <ifCall line="3668" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
             <str val="@serialization"/>
             <fn name="string">
              <slash simple="1">
@@ -7961,14 +8947,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line="3085">
+          <choose line="3670">
            <fn name="exists">
             <slash simple="1">
              <varRef name="this" slot="0"/>
              <axis name="attribute" nodeTest="attribute(Q{}version)" jsTest="return item.name==='version'"/>
             </slash>
            </fn>
-           <ifCall line="3086" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+           <ifCall line="3671" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
             <str val="@version"/>
             <fn name="string">
              <slash simple="1">
@@ -7978,14 +8964,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line="3088">
+          <choose line="3673">
            <fn name="exists">
             <slash simple="1">
              <varRef name="this" slot="0"/>
              <axis name="attribute" nodeTest="attribute(Q{}indent)" jsTest="return item.name==='indent'"/>
             </slash>
            </fn>
-           <ifCall line="3089" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+           <ifCall line="3674" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
             <str val="@indent"/>
             <fn name="string">
              <slash simple="1">
@@ -7995,16 +8981,16 @@
             </fn>
            </ifCall>
           </choose>
-          <ifCall line="3093" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+          <ifCall line="3678" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
            <str val="@mediatype"/>
-           <choose line="3095">
+           <choose line="3680">
             <fn name="exists">
              <slash simple="1">
               <varRef name="this" slot="0"/>
               <axis name="attribute" nodeTest="attribute(Q{}mediatype)" jsTest="return item.name==='mediatype'"/>
              </slash>
             </fn>
-            <fn line="3096" name="string">
+            <fn line="3681" name="string">
              <slash simple="1">
               <varRef name="this" slot="0"/>
               <axis name="attribute" nodeTest="attribute(Q{}mediatype)" jsTest="return item.name==='mediatype'"/>
@@ -8014,14 +9000,14 @@
             <str val="text/plain"/>
            </choose>
           </ifCall>
-          <choose line="3106">
+          <choose line="3691">
            <fn name="exists">
             <slash simple="1">
              <varRef name="this" slot="0"/>
              <axis name="attribute" nodeTest="attribute(Q{}encoding)" jsTest="return item.name==='encoding'"/>
             </slash>
            </fn>
-           <ifCall line="3107" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+           <ifCall line="3692" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
             <str val="@encoding"/>
             <fn name="string">
              <slash simple="1">
@@ -8031,14 +9017,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line="3109">
+          <choose line="3694">
            <fn name="exists">
             <slash simple="1">
              <varRef name="this" slot="0"/>
              <axis name="attribute" nodeTest="attribute(Q{}omit-xml-declaration)" jsTest="return item.name==='omit-xml-declaration'"/>
             </slash>
            </fn>
-           <ifCall line="3110" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+           <ifCall line="3695" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
             <str val="@omit-xml-declaration"/>
             <fn name="string">
              <slash simple="1">
@@ -8048,14 +9034,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line="3112">
+          <choose line="3697">
            <fn name="exists">
             <slash simple="1">
              <varRef name="this" slot="0"/>
              <axis name="attribute" nodeTest="attribute(Q{}standalone)" jsTest="return item.name==='standalone'"/>
             </slash>
            </fn>
-           <ifCall line="3113" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+           <ifCall line="3698" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
             <str val="@standalone"/>
             <fn name="string">
              <slash simple="1">
@@ -8065,14 +9051,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line="3115">
+          <choose line="3700">
            <fn name="exists">
             <slash simple="1">
              <varRef name="this" slot="0"/>
              <axis name="attribute" nodeTest="attribute(Q{}cdata-section-elements)" jsTest="return item.name==='cdata-section-elements'"/>
             </slash>
            </fn>
-           <ifCall line="3116" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+           <ifCall line="3701" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
             <str val="@cdata-section-elements"/>
             <fn name="string">
              <slash simple="1">
@@ -8082,16 +9068,16 @@
             </fn>
            </ifCall>
           </choose>
-          <ifCall line="3119" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+          <ifCall line="3704" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
            <str val="@replace"/>
-           <choose line="3121">
+           <choose line="3706">
             <fn name="exists">
              <slash simple="1">
               <varRef name="this" slot="0"/>
               <axis name="attribute" nodeTest="attribute(Q{}replace)" jsTest="return item.name==='replace'"/>
              </slash>
             </fn>
-            <fn line="3122" name="string">
+            <fn line="3707" name="string">
              <slash simple="1">
               <varRef name="this" slot="0"/>
               <axis name="attribute" nodeTest="attribute(Q{}replace)" jsTest="return item.name==='replace'"/>
@@ -8101,14 +9087,14 @@
             <str val="all"/>
            </choose>
           </ifCall>
-          <choose line="3133">
+          <choose line="3718">
            <fn name="exists">
             <slash simple="1">
              <varRef name="this" slot="0"/>
              <axis name="attribute" nodeTest="attribute(Q{}instance)" jsTest="return item.name==='instance'"/>
             </slash>
            </fn>
-           <ifCall line="3134" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+           <ifCall line="3719" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
             <str val="@instance"/>
             <fn name="string">
              <slash simple="1">
@@ -8118,14 +9104,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line="3136">
+          <choose line="3721">
            <fn name="exists">
             <slash simple="1">
              <varRef name="this" slot="0"/>
              <axis name="attribute" nodeTest="attribute(Q{}targetref)" jsTest="return item.name==='targetref'"/>
             </slash>
            </fn>
-           <ifCall line="3137" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+           <ifCall line="3722" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
             <str val="@targetref"/>
             <fn name="string">
              <slash simple="1">
@@ -8135,14 +9121,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line="3139">
+          <choose line="3724">
            <fn name="exists">
             <slash simple="1">
              <varRef name="this" slot="0"/>
              <axis name="attribute" nodeTest="attribute(Q{}separator)" jsTest="return item.name==='separator'"/>
             </slash>
            </fn>
-           <ifCall line="3140" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+           <ifCall line="3725" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
             <str val="@separator"/>
             <fn name="string">
              <slash simple="1">
@@ -8152,14 +9138,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line="3142">
+          <choose line="3727">
            <fn name="exists">
             <slash simple="1">
              <varRef name="this" slot="0"/>
              <axis name="attribute" nodeTest="attribute(Q{}includenamespaceprefixes)" jsTest="return item.name==='includenamespaceprefixes'"/>
             </slash>
            </fn>
-           <ifCall line="3143" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
+           <ifCall line="3728" name="Q{http://www.w3.org/2005/xpath-functions/map}entry" type="map(*)">
             <str val="@includenamespaceprefixes"/>
             <fn name="string">
              <slash simple="1">
@@ -8169,21 +9155,6 @@
             </fn>
            </ifCall>
           </choose>
-          <treat line="3146" as="map(*)" jsTest="return SaxonJS.U.isMap(item)" diag="18|0|XTTE3375|">
-           <forEachGroup algorithm="by">
-            <slash role="select" simple="1">
-             <varRef name="this" slot="0"/>
-             <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
-            </slash>
-            <fn role="key" name="local-name">
-             <dot type="element()"/>
-            </fn>
-            <str role="collation" val="http://www.w3.org/2005/xpath-functions/collation/codepoint"/>
-            <applyT role="content" line="3147" mode="Q{}xforms-action-map" bSlot="3">
-             <dot role="select" type="element()"/>
-            </applyT>
-           </forEachGroup>
-          </treat>
          </sequence>
          <map size="2">
           <str val="duplicates"/>
@@ -8199,34 +9170,27 @@
    </sequence>
   </template>
  </co>
- <co id="63" binds="32 17">
+ <co id="65" binds="30 15">
   <mode name="Q{http://saxonica.com/ns/interactiveXSLT}onkeyup" onNo="TC" flags="W" patternSlots="1">
-   <templateRule prec="0" prio="0.5" seq="0" rank="0" minImp="0" slots="0" flags="s" line="524" module="saxon-xforms.xsl">
+   <templateRule prec="0" prio="0.5" seq="0" rank="0" minImp="0" slots="0" flags="s" line="649" module="saxon-xforms.xsl">
     <p.withPredicate role="match">
      <p.nodeTest test="element(Q{}input)" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='input';"/>
-     <and ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="524" op="and">
-      <fn name="exists">
-       <axis name="attribute" nodeTest="attribute(Q{}class)" jsTest="return item.name==='class'"/>
-      </fn>
-      <ufCall name="Q{http://www.w3.org/2002/xforms}hasClass" tailCall="false" bSlot="0">
-       <check card="1" diag="0|0||xforms:hasClass">
-        <axis name="attribute" nodeTest="attribute(Q{}class)" jsTest="return item.name==='class'"/>
-       </check>
-       <str val="incremental"/>
-      </ufCall>
-     </and>
+     <ufCall ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="649" name="Q{http://www.w3.org/2002/xforms}hasClass" tailCall="false" bSlot="0">
+      <dot type="element(Q{}input)"/>
+      <str val="incremental"/>
+     </ufCall>
     </p.withPredicate>
-    <callT role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="526" name="xforms-value-changed" bSlot="1" flags="t">
+    <callT role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="651" name="xforms-value-changed" bSlot="1" flags="t">
      <withParam name="Q{}form-control" flags="c" as="node()">
-      <dot line="527" type="element(Q{}input)"/>
+      <dot line="652" type="element(Q{}input)"/>
      </withParam>
     </callT>
    </templateRule>
   </mode>
  </co>
- <co id="49" binds="64">
-  <template name="Q{}getBinding" flags="os" line="2576" module="saxon-xforms.xsl" slots="4">
-   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2577">
+ <co id="53" binds="">
+  <template name="Q{}getBinding" flags="os" line="3054" module="saxon-xforms.xsl" slots="4">
+   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="3055">
     <param name="Q{}this" slot="0" flags="r" as="element()">
      <treat role="conversion" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="8|0|XTTE0590|this">
       <check card="1" diag="8|0|XTTE0590|this">
@@ -8234,7 +9198,7 @@
       </check>
      </treat>
     </param>
-    <param line="2578" name="Q{}bindings" slot="1" flags="t" as="map(xs:string, node())">
+    <param line="3056" name="Q{}bindings" slot="1" flags="t" as="map(xs:string, node())">
      <map role="select" size="0"/>
      <treat role="conversion" as="map(xs:string, node())" jsTest="function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="8|0|XTTE0590|bindings">
       <check card="1" diag="8|0|XTTE0590|bindings">
@@ -8242,24 +9206,45 @@
       </check>
      </treat>
     </param>
-    <let line="2580" var="ref-binding" as="xs:string" slot="2" eval="7">
-     <treat line="2581" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="3|0|XTTE0570|ref-binding">
+    <let line="3065" var="ref-binding" as="xs:string" slot="2" eval="7">
+     <choose>
+      <fn name="exists">
+       <slash simple="1">
+        <varRef name="this" slot="0"/>
+        <axis name="attribute" nodeTest="attribute(Q{}bind)" jsTest="return item.name==='bind'"/>
+       </slash>
+      </fn>
       <check card="1" diag="3|0|XTTE0570|ref-binding">
-       <cvUntyped to="xs:string">
+       <cast as="xs:string" emptiable="1">
         <data>
-         <callT name="getBindingRef" bSlot="0">
-          <withParam name="Q{}this" flags="c" as="element()">
-           <treat line="2582" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="8|0|XTTE0590|this">
-            <dot flags="a"/>
-           </treat>
-          </withParam>
-         </callT>
+         <slash simple="1">
+          <varRef name="this" slot="0"/>
+          <axis name="attribute" nodeTest="attribute(Q{}bind)" jsTest="return item.name==='bind'"/>
+         </slash>
         </data>
-       </cvUntyped>
+       </cast>
       </check>
-     </treat>
-     <let line="2586" var="binding" as="element()?" slot="3" eval="7">
-      <choose line="2591">
+      <fn name="exists">
+       <slash simple="1">
+        <varRef name="this" slot="0"/>
+        <axis name="attribute" nodeTest="attribute(Q{}ref)" jsTest="return item.name==='ref'"/>
+       </slash>
+      </fn>
+      <check card="1" diag="3|0|XTTE0570|ref-binding">
+       <cast as="xs:string" emptiable="1">
+        <data>
+         <slash simple="1">
+          <varRef name="this" slot="0"/>
+          <axis name="attribute" nodeTest="attribute(Q{}ref)" jsTest="return item.name==='ref'"/>
+         </slash>
+        </data>
+       </cast>
+      </check>
+      <true/>
+      <str val=""/>
+     </choose>
+     <let line="3067" var="binding" as="element()?" slot="3" eval="7">
+      <choose line="3072">
        <fn name="empty">
         <varRef name="ref-binding" slot="2"/>
        </fn>
@@ -8272,248 +9257,54 @@
         </ifCall>
        </treat>
       </choose>
-      <choose line="2595">
-       <fn name="exists">
-        <varRef name="binding" slot="3"/>
-       </fn>
-       <varRef line="2597" name="binding" slot="3"/>
-      </choose>
+      <sequence line="3075">
+       <choose>
+        <fn name="exists">
+         <varRef name="binding" slot="3"/>
+        </fn>
+        <message line="3076">
+         <sequence role="select">
+          <valueOf>
+           <str val="[getBinding for "/>
+          </valueOf>
+          <valueOf>
+           <fn name="name">
+            <varRef name="this" slot="0"/>
+           </fn>
+          </valueOf>
+          <valueOf>
+           <str val="] Binding found: "/>
+          </valueOf>
+          <valueOf>
+           <fn name="serialize">
+            <varRef name="binding" slot="3"/>
+           </fn>
+          </valueOf>
+         </sequence>
+         <str role="terminate" val="no"/>
+         <str role="error" val="Q{http://www.w3.org/2005/xqt-errors}XTMM9000"/>
+        </message>
+       </choose>
+       <varRef line="3080" name="binding" slot="3"/>
+      </sequence>
      </let>
     </let>
-   </sequence>
-  </template>
- </co>
- <co id="65" binds="">
-  <globalVariable name="Q{}default-instance-id" type="xs:string" line="44" module="saxon-xforms.xsl" visibility="PRIVATE" jsAcceptor="return SaxonJS.U.Atomic.string.cast(val);" jsCardCheck="function c(n) {return n==1;};">
-   <str val="saxon-forms-default"/>
-  </globalVariable>
- </co>
- <co id="64" binds="">
-  <template name="Q{}getBindingRef" flags="os" line="2608" module="saxon-xforms.xsl" slots="1">
-   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2609">
-    <param name="Q{}this" slot="0" flags="r" as="element()">
-     <treat role="conversion" as="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;" diag="8|0|XTTE0590|this">
-      <check card="1" diag="8|0|XTTE0590|this">
-       <supplied slot="0"/>
-      </check>
-     </treat>
-    </param>
-    <choose line="2616">
-     <fn name="exists">
-      <slash simple="1">
-       <varRef name="this" slot="0"/>
-       <axis name="attribute" nodeTest="attribute(Q{}bind)" jsTest="return item.name==='bind'"/>
-      </slash>
-     </fn>
-     <valueOf line="2617">
-      <convert from="xs:untypedAtomic" to="xs:string">
-       <data>
-        <slash simple="1">
-         <varRef name="this" slot="0"/>
-         <axis name="attribute" nodeTest="attribute(Q{}bind)" jsTest="return item.name==='bind'"/>
-        </slash>
-       </data>
-      </convert>
-     </valueOf>
-     <fn line="2620" name="exists">
-      <slash simple="1">
-       <varRef name="this" slot="0"/>
-       <axis name="attribute" nodeTest="attribute(Q{}ref)" jsTest="return item.name==='ref'"/>
-      </slash>
-     </fn>
-     <valueOf line="2621">
-      <convert from="xs:untypedAtomic" to="xs:string">
-       <data>
-        <slash simple="1">
-         <varRef name="this" slot="0"/>
-         <axis name="attribute" nodeTest="attribute(Q{}ref)" jsTest="return item.name==='ref'"/>
-        </slash>
-       </data>
-      </convert>
-     </valueOf>
-     <true/>
-     <valueOf line="2624" flags="S">
-      <str val=""/>
-     </valueOf>
-    </choose>
    </sequence>
   </template>
  </co>
  <co id="66" binds="">
-  <globalVariable name="Q{}debugTiming" type="xs:boolean" line="43" module="saxon-xforms.xsl" visibility="PRIVATE" jsAcceptor="return SaxonJS.U.Atomic.boolean.cast(val);" jsCardCheck="function c(n) {return n==1;};">
+  <globalVariable name="Q{}default-instance-id" type="xs:string" line="64" module="saxon-xforms.xsl" visibility="PRIVATE" jsAcceptor="return SaxonJS.U.Atomic.string.cast(val);" jsCardCheck="function c(n) {return n==1;};">
+   <str val="saxon-forms-default"/>
+  </globalVariable>
+ </co>
+ <co id="67" binds="">
+  <globalVariable name="Q{}debugTiming" type="xs:boolean" line="63" module="saxon-xforms.xsl" visibility="PRIVATE" jsAcceptor="return SaxonJS.U.Atomic.boolean.cast(val);" jsCardCheck="function c(n) {return n==1;};">
    <false/>
   </globalVariable>
  </co>
- <co id="31" binds="31 31 31">
-  <mode name="Q{}jxml-xml" onNo="TC" flags="W" patternSlots="0">
-   <templateRule prec="0" prio="-0.25" seq="2" rank="0" minImp="0" slots="2" flags="s" line="2163" module="saxon-xforms.xsl">
-    <p.nodeTest role="match" test="*:array" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local==='array'"/>
-    <let role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2164" var="keyVar" as="attribute(Q{}key)?" slot="0" eval="8">
-     <axis name="attribute" nodeTest="attribute(Q{}key)" jsTest="return item.name==='key'"/>
-     <let line="2167" var="vv:v0" as="xs:string" slot="1" eval="13">
-      <fn name="string">
-       <convert from="xs:untypedAtomic" to="xs:string">
-        <data>
-         <varRef name="keyVar" slot="0"/>
-        </data>
-       </convert>
-      </fn>
-      <forEach line="2166">
-       <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
-       <compElem line="2167">
-        <varRef role="name" name="vv:v0" slot="1"/>
-        <applyT role="content" line="2168" mode="Q{}jxml-xml" bSlot="0">
-         <dot role="select" type="element()"/>
-        </applyT>
-       </compElem>
-      </forEach>
-     </let>
-    </let>
-   </templateRule>
-   <templateRule prec="0" prio="-0.25" seq="1" rank="0" minImp="0" slots="0" flags="s" line="2149" module="saxon-xforms.xsl">
-    <p.nodeTest role="match" test="*:number" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local==='number'"/>
-    <choose role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2151">
-     <fn name="starts-with">
-      <cvUntyped to="xs:string">
-       <attVal name="Q{}key" chk="0"/>
-      </cvUntyped>
-      <str val="@"/>
-     </fn>
-     <compAtt line="2152">
-      <fn role="name" name="substring">
-       <cvUntyped to="xs:string">
-        <attVal name="Q{}key" chk="0"/>
-       </cvUntyped>
-       <int val="2"/>
-      </fn>
-      <fn role="select" name="string-join">
-       <convert from="xs:untypedAtomic" to="xs:string">
-        <data>
-         <mergeAdj>
-          <axis name="child" nodeTest="text()" jsTest="return item.nodeType===3;"/>
-         </mergeAdj>
-        </data>
-       </convert>
-       <str val=" "/>
-      </fn>
-     </compAtt>
-     <true/>
-     <compElem line="2155">
-      <fn role="name" name="string">
-       <convert from="xs:untypedAtomic" to="xs:string">
-        <attVal name="Q{}key" chk="0"/>
-       </convert>
-      </fn>
-      <valueOf role="content" line="2156" flags="l">
-       <fn name="string-join">
-        <convert from="xs:untypedAtomic" to="xs:string">
-         <data>
-          <mergeAdj>
-           <axis name="child" nodeTest="text()" jsTest="return item.nodeType===3;"/>
-          </mergeAdj>
-         </data>
-        </convert>
-        <str val=" "/>
-       </fn>
-      </valueOf>
-     </compElem>
-    </choose>
-   </templateRule>
-   <templateRule prec="0" prio="-0.25" seq="1" rank="0" minImp="0" slots="0" flags="s" line="2149" module="saxon-xforms.xsl">
-    <p.nodeTest role="match" test="*:string" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local==='string'"/>
-    <choose role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2151">
-     <fn name="starts-with">
-      <cvUntyped to="xs:string">
-       <attVal name="Q{}key" chk="0"/>
-      </cvUntyped>
-      <str val="@"/>
-     </fn>
-     <compAtt line="2152">
-      <fn role="name" name="substring">
-       <cvUntyped to="xs:string">
-        <attVal name="Q{}key" chk="0"/>
-       </cvUntyped>
-       <int val="2"/>
-      </fn>
-      <fn role="select" name="string-join">
-       <convert from="xs:untypedAtomic" to="xs:string">
-        <data>
-         <mergeAdj>
-          <axis name="child" nodeTest="text()" jsTest="return item.nodeType===3;"/>
-         </mergeAdj>
-        </data>
-       </convert>
-       <str val=" "/>
-      </fn>
-     </compAtt>
-     <true/>
-     <compElem line="2155">
-      <fn role="name" name="string">
-       <convert from="xs:untypedAtomic" to="xs:string">
-        <attVal name="Q{}key" chk="0"/>
-       </convert>
-      </fn>
-      <valueOf role="content" line="2156" flags="l">
-       <fn name="string-join">
-        <convert from="xs:untypedAtomic" to="xs:string">
-         <data>
-          <mergeAdj>
-           <axis name="child" nodeTest="text()" jsTest="return item.nodeType===3;"/>
-          </mergeAdj>
-         </data>
-        </convert>
-        <str val=" "/>
-       </fn>
-      </valueOf>
-     </compElem>
-    </choose>
-   </templateRule>
-   <templateRule prec="0" prio="-0.25" seq="0" rank="0" minImp="0" slots="0" flags="s" line="2125" module="saxon-xforms.xsl">
-    <p.nodeTest role="match" test="*:map" jsTest="var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local==='map'"/>
-    <choose role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2127">
-     <fn name="empty">
-      <axis name="attribute" nodeTest="attribute(Q{}key)" jsTest="return item.name==='key'"/>
-     </fn>
-     <applyT line="2129" mode="Q{}jxml-xml" flags="t" bSlot="1">
-      <axis role="select" name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
-     </applyT>
-     <fn line="2134" name="starts-with">
-      <cvUntyped to="xs:string">
-       <attVal name="Q{}key" chk="0"/>
-      </cvUntyped>
-      <str val="@"/>
-     </fn>
-     <compAtt line="2135">
-      <fn role="name" name="substring">
-       <cvUntyped to="xs:string">
-        <attVal name="Q{}key" chk="0"/>
-       </cvUntyped>
-       <int val="2"/>
-      </fn>
-      <convert role="select" from="xs:untypedAtomic" to="xs:string">
-       <data>
-        <dot type="*:map"/>
-       </data>
-      </convert>
-     </compAtt>
-     <true/>
-     <compElem line="2138">
-      <fn role="name" name="string">
-       <convert from="xs:untypedAtomic" to="xs:string">
-        <attVal name="Q{}key" chk="0"/>
-       </convert>
-      </fn>
-      <applyT role="content" line="2139" mode="Q{}jxml-xml" bSlot="2">
-       <axis role="select" name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
-      </applyT>
-     </compElem>
-    </choose>
-   </templateRule>
-  </mode>
- </co>
- <co id="23" binds="">
-  <template name="Q{}getInstance" flags="os" as="element()?" line="2551" module="saxon-xforms.xsl" slots="2">
-   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2552">
+ <co id="21" binds="">
+  <template name="Q{}getInstance" flags="os" as="element()?" line="3028" module="saxon-xforms.xsl" slots="2">
+   <sequence role="body" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="3029">
     <param name="Q{}instance-id" slot="0" as="xs:string">
      <str role="select" val=""/>
      <treat role="conversion" as="xs:string" jsTest="return SaxonJS.U.Atomic.string.matches(item);" diag="8|0|XTTE0590|instance-id">
@@ -8526,21 +9317,21 @@
       </check>
      </treat>
     </param>
-    <param line="2553" name="Q{}instances" slot="1" flags="ti" as="map(xs:string, element())">
+    <param line="3030" name="Q{}instances" slot="1" flags="ti" as="map(xs:string, element())">
      <treat role="conversion" as="map(xs:string, element())" jsTest="function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);" diag="8|0|XTTE0590|instances">
       <check card="1" diag="8|0|XTTE0590|instances">
        <supplied slot="1"/>
       </check>
      </treat>
     </param>
-    <choose line="2557">
+    <choose line="3034">
      <varRef name="instance-id" slot="0"/>
-     <ifCall line="2558" name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
+     <ifCall line="3035" name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
       <varRef name="instances" slot="1"/>
       <varRef name="instance-id" slot="0"/>
      </ifCall>
      <true/>
-     <copyOf line="2562" flags="vc">
+     <copyOf line="3039" flags="vc">
       <ifCall name="Q{http://www.w3.org/2005/xpath-functions/map}get" type="item()*">
        <varRef name="instances" slot="1"/>
        <str val="saxon-forms-default"/>
@@ -8550,182 +9341,18 @@
    </sequence>
   </template>
  </co>
- <co id="58" binds="58 58 58">
-  <mode name="Q{}json-xml" onNo="TC" flags="W" patternSlots="0">
-   <templateRule prec="0" prio="-0.5" seq="0" rank="0" minImp="0" slots="0" flags="s" line="2045" module="saxon-xforms.xsl">
-    <p.nodeTest role="match" test="element()" jsTest="return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;"/>
-    <choose role="action" ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2050">
-     <fn name="exists">
-      <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
-     </fn>
-     <forEachGroup line="2051" algorithm="by">
-      <sequence role="select">
-       <axis name="attribute" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
-       <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
-      </sequence>
-      <fn role="key" name="local-name">
-       <dot type="node()"/>
-      </fn>
-      <str role="collation" val="http://www.w3.org/2005/xpath-functions/collation/codepoint"/>
-      <choose role="content" line="2053">
-       <fn name="exists">
-        <tail start="2">
-         <currentGroup/>
-        </tail>
-       </fn>
-       <elem line="2056" name="array" nsuri="http://www.w3.org/2005/xpath-functions" flags="d">
-        <sequence>
-         <att name="key" flags="l">
-          <fn name="string-join">
-           <convert from="xs:anyAtomicType" to="xs:string">
-            <currentGroupingKey/>
-           </convert>
-           <str val=" "/>
-          </fn>
-         </att>
-         <forEach line="2057">
-          <currentGroup/>
-          <elem line="2060" name="map" nsuri="http://www.w3.org/2005/xpath-functions" flags="dl">
-           <applyT mode="Q{}json-xml" bSlot="0">
-            <dot role="select"/>
-           </applyT>
-          </elem>
-         </forEach>
-        </sequence>
-       </elem>
-       <filter line="2067" flags="b">
-        <currentGroup/>
-        <fn name="exists">
-         <slash simple="1">
-          <treat as="node()" jsTest="return SaxonJS.U.isNode(item);" diag="14|12|XPTY0020|">
-           <dot/>
-          </treat>
-          <axis name="self" nodeTest="attribute()" jsTest="return SaxonJS.U.isAttr(item)"/>
-         </slash>
-        </fn>
-       </filter>
-       <elem line="2072" name="string" nsuri="http://www.w3.org/2005/xpath-functions" flags="d">
-        <sequence>
-         <att name="key" flags="l">
-          <fn name="concat">
-           <str val="@"/>
-           <check card="?" diag="0|1||fn:concat">
-            <currentGroupingKey/>
-           </check>
-          </fn>
-         </att>
-         <valueOf line="2073" flags="l">
-          <convert from="xs:anyAtomicType" to="xs:string">
-           <data>
-            <dot type="node()"/>
-           </data>
-          </convert>
-         </valueOf>
-        </sequence>
-       </elem>
-       <fn line="2078" name="exists">
-        <slash>
-         <currentGroup/>
-         <axis name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
-        </slash>
-       </fn>
-       <elem line="2081" name="map" nsuri="http://www.w3.org/2005/xpath-functions" flags="d">
-        <sequence>
-         <att name="key" flags="l">
-          <fn name="string-join">
-           <convert from="xs:anyAtomicType" to="xs:string">
-            <currentGroupingKey/>
-           </convert>
-           <str val=" "/>
-          </fn>
-         </att>
-         <applyT line="2082" mode="Q{}json-xml" bSlot="1">
-          <currentGroup role="select"/>
-         </applyT>
-        </sequence>
-       </elem>
-       <true/>
-       <applyT line="2087" mode="Q{}json-xml" bSlot="2">
-        <currentGroup role="select"/>
-       </applyT>
-      </choose>
-     </forEachGroup>
-     <fn line="2093" name="matches">
-      <cvUntyped to="xs:string">
-       <data>
-        <dot type="element()"/>
-       </data>
-      </cvUntyped>
-      <str val="^[0-9]+$"/>
-      <str val=""/>
-     </fn>
-     <elem line="2095" name="number" nsuri="http://www.w3.org/2005/xpath-functions" flags="d">
-      <sequence>
-       <att name="key" flags="l">
-        <fn name="local-name">
-         <dot type="element()"/>
-        </fn>
-       </att>
-       <valueOf line="2096" flags="l">
-        <fn name="string-join">
-         <convert from="xs:untypedAtomic" to="xs:string">
-          <data>
-           <mergeAdj>
-            <axis name="child" nodeTest="text()" jsTest="return item.nodeType===3;"/>
-           </mergeAdj>
-          </data>
-         </convert>
-         <str val=" "/>
-        </fn>
-       </valueOf>
-      </sequence>
-     </elem>
-     <true/>
-     <elem line="2101" name="string" nsuri="http://www.w3.org/2005/xpath-functions" flags="d">
-      <sequence>
-       <att name="key" flags="l">
-        <fn name="local-name">
-         <dot type="element()"/>
-        </fn>
-       </att>
-       <valueOf line="2102" flags="l">
-        <fn name="string-join">
-         <convert from="xs:untypedAtomic" to="xs:string">
-          <data>
-           <mergeAdj>
-            <axis name="child" nodeTest="text()" jsTest="return item.nodeType===3;"/>
-           </mergeAdj>
-          </data>
-         </convert>
-         <str val=" "/>
-        </fn>
-       </valueOf>
-      </sequence>
-     </elem>
-    </choose>
-   </templateRule>
-  </mode>
- </co>
  <overridden/>
  <key name="Q{http://saxon.sf.net/}kk101" line="0" binds="" flags="u">
   <p.nodeSet type="element()">
-   <axis ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1618" name="child" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+   <axis ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2700" name="descendant" nodeTest="element()" jsTest="return item.nodeType===1;"/>
   </p.nodeSet>
-  <data ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="1618">
-   <axis name="child" nodeTest="element(Q{}data-action)" jsTest="var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===''&amp;&amp;q.local==='data-action';"/>
-  </data>
+  <attVal ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="-1" name="Q{}data-ref" chk="0"/>
  </key>
  <key name="Q{http://saxon.sf.net/}kk102" line="0" binds="" flags="u">
   <p.nodeSet type="element()">
-   <axis ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2245" name="descendant" nodeTest="element()" jsTest="return item.nodeType===1;"/>
+   <axis ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="3264" name="descendant" nodeTest="element()" jsTest="return item.nodeType===1;"/>
   </p.nodeSet>
-  <attVal ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="-1" name="Q{}data-ref" chk="0"/>
- </key>
- <key name="Q{http://saxon.sf.net/}kk103" line="0" binds="" flags="u">
-  <p.nodeSet type="element()">
-   <axis ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="2779" name="descendant" nodeTest="element()" jsTest="return item.nodeType===1;"/>
-  </p.nodeSet>
-  <attVal ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events r=http://ns.datacraft.co.uk/recipe rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="-1" name="Q{}id" chk="0"/>
+  <attVal ns="xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=http://www.w3.org/2005/xpath-functions/array sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=http://www.w3.org/2005/xpath-functions/math map=http://www.w3.org/2005/xpath-functions/map" line="-1" name="Q{}id" chk="0"/>
  </key>
  <output>
   <property name="indent" value="no"/>
@@ -8738,4 +9365,4 @@
  </output>
  <decimalFormat/>
 </package>
-<?Σ 74194459?>
+<?Σ e709fc56?>

--- a/demos/css/style.css
+++ b/demos/css/style.css
@@ -18,6 +18,10 @@
     margin-left: 1em;
 }
 
+span.selected {
+    background-color: #e4eef0;
+}
+
 /* 
 Text blue: #3D5B96
 Dark blue: #c1cede

--- a/demos/xml/demo-repeat-xform.xml
+++ b/demos/xml/demo-repeat-xform.xml
@@ -99,15 +99,17 @@
                 </xf:action>
             </xf:trigger>
             
-            <xf:trigger>
+           
+              
+              <xf:trigger>
                 <xf:label>Move selected ingredient Up</xf:label>
                 <!-- xf:action groups a sequence of actions -->
                 <xf:action ev:event="DOMActivate" if="index('edit-ingredient-repeat') != 1">
                     <!-- insert changes "focus" index to the newly inserted node -->
                     <xf:insert context="." nodeset="demo:ingredients/demo:ingredient" at="index('edit-ingredient-repeat') - 1" position="before" origin="demo:ingredients/demo:ingredient[index('edit-ingredient-repeat')]"/>
-                    <!-- push focus back to original node -->
-                    <xf:setindex repeat="edit-ingredient-repeat" index="index('edit-ingredient-repeat') + 2"/>
-                    <xf:setfocus control="edit-ingredient-repeat"/>
+                    <!-- original node is now at index() + 1 -->
+                    <xf:setindex repeat="edit-ingredient-repeat" index="index('edit-ingredient-repeat') + 1"/>
+<!--                    <xf:setfocus control="edit-ingredient-repeat"/>-->
                     <xf:delete context="." nodeset="demo:ingredients/demo:ingredient" at="index('edit-ingredient-repeat')"/>
                     <xf:rebuild model="m-recipes"/>
                 </xf:action>
@@ -126,9 +128,7 @@
                      weirdly, this doesn't work properly using the REST URL
                      -->
                     <xf:insert context="." nodeset="demo:ingredients/demo:ingredient" at="index('edit-ingredient-repeat') + 1" position="after" origin="demo:ingredients/demo:ingredient[index('edit-ingredient-repeat')]"/>
-                    <!-- push focus back to original node -->
-                    <xf:setindex repeat="edit-ingredient-repeat" index="index('edit-ingredient-repeat') - 2"/>
-                    <xf:setfocus control="edit-ingredient-repeat"/>
+<!--                    <xf:setfocus control="edit-ingredient-repeat"/>-->
                     <xf:delete context="." nodeset="demo:ingredients/demo:ingredient" at="index('edit-ingredient-repeat')"/>
                 </xf:action>
             </xf:trigger>

--- a/demos/xml/demo-repeat-xform.xml
+++ b/demos/xml/demo-repeat-xform.xml
@@ -77,7 +77,7 @@
             <xf:input ref="demo:title">
                 <xf:label>Recipe Name:</xf:label>
             </xf:input>
-            <xf:repeat id="ingredients-repeat" nodeset="demo:ingredients/demo:ingredient">
+            <xf:repeat id="edit-ingredient-repeat" nodeset="demo:ingredients/demo:ingredient">
                 <xf:input ref=".">
                     <xf:label>Ingredient:</xf:label>
                 </xf:input>
@@ -88,27 +88,27 @@
             <xf:trigger>
                 <xf:label>Add ingredient after selected item</xf:label>
                 <xf:action ev:event="DOMActivate">
-                    <xf:insert context="." nodeset="demo:ingredients/demo:ingredient" at="index('ingredients-repeat')" position="after" origin="instance('i-new-ingredient')"/>
+                    <xf:insert context="." nodeset="demo:ingredients/demo:ingredient" at="index('edit-ingredient-repeat')" position="after" origin="instance('i-new-ingredient')"/>
                 </xf:action>
             </xf:trigger>
 
             <xf:trigger>
                 <xf:label>Delete selected ingredient</xf:label>
                 <xf:action ev:event="DOMActivate">
-                    <xf:delete context="." nodeset="demo:ingredients/demo:ingredient" at="index('ingredients-repeat')"/>
+                    <xf:delete context="." nodeset="demo:ingredients/demo:ingredient" at="index('edit-ingredient-repeat')"/>
                 </xf:action>
             </xf:trigger>
             
             <xf:trigger>
                 <xf:label>Move selected ingredient Up</xf:label>
                 <!-- xf:action groups a sequence of actions -->
-                <xf:action ev:event="DOMActivate" if="index('ingredients-repeat') != 1">
+                <xf:action ev:event="DOMActivate" if="index('edit-ingredient-repeat') != 1">
                     <!-- insert changes "focus" index to the newly inserted node -->
-                    <xf:insert context="." nodeset="demo:ingredients/demo:ingredient" at="index('ingredients-repeat') - 1" position="before" origin="demo:ingredients/demo:ingredient[index('ingredients-repeat')]"/>
+                    <xf:insert context="." nodeset="demo:ingredients/demo:ingredient" at="index('edit-ingredient-repeat') - 1" position="before" origin="demo:ingredients/demo:ingredient[index('edit-ingredient-repeat')]"/>
                     <!-- push focus back to original node -->
-                    <xf:setindex repeat="ingredients-repeat" index="index('ingredients-repeat') + 2"/>
-                    <xf:setfocus control="ingredients-repeat"/>
-                    <xf:delete context="." nodeset="demo:ingredients/demo:ingredient" at="index('ingredients-repeat')"/>
+                    <xf:setindex repeat="edit-ingredient-repeat" index="index('edit-ingredient-repeat') + 2"/>
+                    <xf:setfocus control="edit-ingredient-repeat"/>
+                    <xf:delete context="." nodeset="demo:ingredients/demo:ingredient" at="index('edit-ingredient-repeat')"/>
                     <xf:rebuild model="m-recipes"/>
                 </xf:action>
             </xf:trigger>
@@ -117,19 +117,19 @@
                 <xf:label>Move selected ingredient Down</xf:label>
                 <!-- xf:action groups a sequence of actions 
                      
-                     tried position() instead of index('ingredients-repeat') but didn't work
+                     tried position() instead of index('edit-ingredient-repeat') but didn't work
                      possibly because focus was on a different row from where 'Down' was clicked
                      -->
-                <xf:action ev:event="DOMActivate" if="index('ingredients-repeat') != count(ingredients/ingredient)">
+                <xf:action ev:event="DOMActivate" if="index('edit-ingredient-repeat') != count(ingredients/ingredient)">
                     <!-- insert changes "focus" index to the newly inserted node 
                      
                      weirdly, this doesn't work properly using the REST URL
                      -->
-                    <xf:insert context="." nodeset="demo:ingredients/demo:ingredient" at="index('ingredients-repeat') + 1" position="after" origin="demo:ingredients/demo:ingredient[index('ingredients-repeat')]"/>
+                    <xf:insert context="." nodeset="demo:ingredients/demo:ingredient" at="index('edit-ingredient-repeat') + 1" position="after" origin="demo:ingredients/demo:ingredient[index('edit-ingredient-repeat')]"/>
                     <!-- push focus back to original node -->
-                    <xf:setindex repeat="ingredients-repeat" index="index('ingredients-repeat') - 2"/>
-                    <xf:setfocus control="ingredients-repeat"/>
-                    <xf:delete context="." nodeset="demo:ingredients/demo:ingredient" at="index('ingredients-repeat')"/>
+                    <xf:setindex repeat="edit-ingredient-repeat" index="index('edit-ingredient-repeat') - 2"/>
+                    <xf:setfocus control="edit-ingredient-repeat"/>
+                    <xf:delete context="." nodeset="demo:ingredients/demo:ingredient" at="index('edit-ingredient-repeat')"/>
                 </xf:action>
             </xf:trigger>
         </xf:group>

--- a/src/saxon-xforms.xsl
+++ b/src/saxon-xforms.xsl
@@ -223,7 +223,7 @@
             </xsl:map>  
         </xsl:variable>
         
-        <xsl:message use-when="$debugMode">[xformsjs-main] RelevantBindings = <xsl:sequence select="serialize($RelevantBindings)"/></xsl:message>
+<!--        <xsl:message use-when="$debugMode">[xformsjs-main] RelevantBindings = <xsl:sequence select="serialize($RelevantBindings)"/></xsl:message>-->
         
 
         <xsl:variable name="CalculationBindings" as="map(xs:string, xs:string)">
@@ -239,7 +239,7 @@
             </xsl:map>  
         </xsl:variable>
         
-        <xsl:message use-when="$debugMode">[xformsjs-main] CalculationBindings = <xsl:sequence select="serialize($CalculationBindings)"/></xsl:message>
+<!--        <xsl:message use-when="$debugMode">[xformsjs-main] CalculationBindings = <xsl:sequence select="serialize($CalculationBindings)"/></xsl:message>-->
         
         
         <!-- copy xform-doc to HTML page -->
@@ -693,7 +693,10 @@
         
         <xsl:call-template name="refreshElementsUsingIndexFunction-JS"/>
         
-        <xsl:sequence select="js:setFocus( xs:string(@id) )"/>
+        <xsl:if test="self::input">
+            <xsl:sequence select="js:setFocus( xs:string(@id) )"/>    
+        </xsl:if>
+        
 
     </xsl:template>
     
@@ -763,7 +766,7 @@
                 <xsl:when test="$base = ''">
                     <xsl:sequence select="$relative"/>
                 </xsl:when>
-                <xsl:when test="$relative = ''">
+                <xsl:when test="$relative = '' or $relative = '.'">
                     <xsl:sequence select="$base"/>
                 </xsl:when>
                 <xsl:otherwise>
@@ -1772,7 +1775,7 @@
         
         
         <xsl:if test=". is $insert-node-location and $position-relative = 'before'">
-            <xsl:message>[insert-node mode] Found! <xsl:value-of select="serialize($insert-node-location)"/></xsl:message>
+<!--            <xsl:message>[insert-node mode] Found! <xsl:value-of select="serialize($insert-node-location)"/></xsl:message>-->
             <xsl:copy-of select="$node-to-insert"/>
         </xsl:if>
         <xsl:copy>
@@ -1797,7 +1800,7 @@
         
         <xsl:choose>
             <xsl:when test=". is $delete-node">
-                <xsl:message>[delete-node mode] Found! <xsl:value-of select="serialize($delete-node)"/></xsl:message>
+<!--                <xsl:message>[delete-node mode] Found! <xsl:value-of select="serialize($delete-node)"/></xsl:message>-->
                 
             <!-- deleting controls from the xform -->
              <!--   <xsl:for-each
@@ -2230,7 +2233,7 @@
         <xd:desc>Template for XForms Action elements nested within others (e.g. xforms:action, xforms:setvalue)</xd:desc>
         <xd:param name="nodeset">XPath identifying instance node(s) affected by the XForms Action element.</xd:param>
     </xd:doc>
-    <xsl:template match="xforms:*[local-name() = $xforms-actions]" mode="xforms-action-map">
+<!--    <xsl:template match="xforms:*[local-name() = $xforms-actions]" mode="xforms-action-map">
         
         <xsl:param name="nodeset" select="''" tunnel="yes"/>        
         
@@ -2239,12 +2242,12 @@
                <xsl:for-each select="current-group()">
                    <xsl:apply-templates select="." mode="#default"/>
                </xsl:for-each>
-           </xsl:variable>
+            </xsl:variable>
            <xsl:sequence select="array{$array}" />
        </xsl:map-entry>
         
         
-    </xsl:template>
+    </xsl:template>-->
     
     
 
@@ -2802,6 +2805,7 @@
     
     -->
     
+    
     <xd:doc scope="component">
         <xd:desc>
             <xd:p>Determine if an XForms element has a reference to the index() function.</xd:p>
@@ -3099,6 +3103,7 @@
             then normalize-space( xs:string($this/@ref) ) 
             else ()"/>
         
+        
         <xsl:variable name="this-binding-ref" as="xs:string?">
             <xsl:choose>
                 <xsl:when test="exists($bindingi)">
@@ -3140,7 +3145,7 @@
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:variable>
-                
+<!--        <xsl:message use-when="$debugMode">[getDataRef] $data-ref = '<xsl:value-of select="$data-ref"/>'</xsl:message>-->
         <xsl:sequence select="$data-ref"/>
         
     </xsl:template>
@@ -3154,6 +3159,8 @@
     </xd:doc>
     <xsl:template name="getReferencedInstanceField">
         <xsl:param name="refi" as="xs:string" required="no" select="''"/>
+        
+<!--        <xsl:message use-when="$debugMode">[getReferencedInstanceField] $refi = '<xsl:value-of select="$refi"/>'</xsl:message>-->
         
         <xsl:variable name="field" as="node()*">
             <xsl:choose>
@@ -3274,6 +3281,7 @@
         </xd:desc>
     </xd:doc>
     <xsl:template name="refreshElementsUsingIndexFunction-JS">
+        <xsl:message use-when="$debugMode">[refreshElementsUsingIndexFunction-JS] START</xsl:message>
         <xsl:variable name="ElementsUsingIndexFunction-keys" select="js:getElementsUsingIndexFunctionKeys()" as="item()*"/>
         
         <xsl:variable name="instance-keys" as="item()*" select="js:getInstanceKeys()"/>
@@ -3362,7 +3370,7 @@
             </xsl:choose>
         </xsl:variable>
         
-        <!--<xsl:message use-when="$debugMode">[applyActions] evaluating action = <xsl:value-of select="serialize($action-map)"/></xsl:message>-->
+<!--        <xsl:message use-when="$debugMode">[applyActions] evaluating action = <xsl:value-of select="serialize($action-map)"/></xsl:message>-->
         
         <xsl:variable name="context" as="node()?">
             <xsl:choose>
@@ -3381,7 +3389,7 @@
         <xsl:variable name="ifExecuted" as="xs:boolean">
             <xsl:choose>
                 <xsl:when test="exists($ifVar) and exists($context)">
-                    <xsl:evaluate xpath="$ifVar" context-item="$context" namespace-context="$context"/>
+                    <xsl:evaluate xpath="xforms:impose($ifVar)" context-item="$context" namespace-context="$context"/>
                 </xsl:when>
                 <xsl:otherwise>
                     <xsl:sequence select="true()" />
@@ -3417,6 +3425,9 @@
                 <xsl:when test="$action-name = 'message'">
                     <xsl:call-template name="action-message"/>
                 </xsl:when>
+                <xsl:when test="$action-name = 'setindex'">
+                    <xsl:call-template name="action-setindex"/>
+                </xsl:when>
                 <xsl:when test="$action-name = 'rebuild'">
                     <xsl:call-template name="xforms-rebuild"/>
                 </xsl:when>
@@ -3425,41 +3436,22 @@
                 </xsl:otherwise>
             </xsl:choose>
             
-            <xsl:for-each select="$xforms-actions">
-                <xsl:if test="map:contains($action-map,.)">
-                    <xsl:call-template name="applyNestedActions">
-                        <xsl:with-param name="action-name" select="." as="xs:string"/>
-                    </xsl:call-template>
-                </xsl:if>
-            </xsl:for-each>
-        </xsl:if>
-        
-    </xsl:template>
-    
-    <xd:doc scope="component">
-        <xd:desc>
-            <xd:p>Handle nested actions, e.g. xforms:action/xforms:setvalue</xd:p>
-        </xd:desc>
-        <xd:param name="action-map">Action map</xd:param>
-        <xd:param name="action-name">Name of action</xd:param>
-    </xd:doc>
-    <xsl:template name="applyNestedActions">
-        <xsl:param name="action-map" required="yes" as="map(*)" tunnel="yes"/>
-        <xsl:param name="action-name" required="yes" as="xs:string"/>
-        
-        <xsl:if test="map:contains($action-map,$action-name)">
-            <xsl:variable name="actionsArray" select="map:get($action-map, $action-name)" as="array(map(*))"/>
-            <xsl:variable name="actions" as="item()*">
-                <xsl:sequence select="array:flatten($actionsArray)"/>
+            
+            <xsl:variable name="nested-actions-array" select="map:get($action-map, 'nested-actions')" as="array(map(*))?"/>
+            <xsl:variable name="nested-actions" as="item()*">
+                <xsl:sequence select="array:flatten($nested-actions-array)"/>
             </xsl:variable>
-            <xsl:for-each select="$actions">
+            <xsl:for-each select="$nested-actions">
                 <xsl:call-template name="applyActions">
                     <xsl:with-param name="action-map" select="." tunnel="yes"/>
                 </xsl:call-template>
             </xsl:for-each>
+            
         </xsl:if>
+        
     </xsl:template>
     
+
     <xd:doc scope="component">
         <xd:desc>
             <xd:p>setAction: create map of an action relevant to $this</xd:p>
@@ -3487,7 +3479,8 @@
         </xsl:variable>
         
         
-<!--        <xsl:message use-when="$debugMode">[setAction] <xsl:value-of select="name($this)"/> ; $nodeset = '<xsl:value-of select="$nodeset"/>'</xsl:message>-->
+<!--        <xsl:message use-when="$debugMode">[setAction] <xsl:value-of select="serialize($this)"/> ; $nodeset = '<xsl:value-of select="$nodeset"/>'; $refi = '<xsl:value-of select="$refi"/>'</xsl:message>-->
+        
         <xsl:map>
             <xsl:map-entry key="'name'" select="local-name()"/>
             
@@ -3536,23 +3529,65 @@
                 <xsl:map-entry key="'@control'" select="string($this/@control)" />
             </xsl:if>
             
+            <xsl:if test="exists($this/@repeat)">
+                <xsl:map-entry key="'@repeat'" select="string($this/@repeat)" />
+            </xsl:if>
+            
+            <xsl:if test="exists($this/@index)">
+                
+                <!-- identify instance field corresponding to this output -->
+                <xsl:variable name="instanceField" as="node()?">
+                    <xsl:call-template name="getReferencedInstanceField">
+                        <xsl:with-param name="refi" select="$refi"/>
+                    </xsl:call-template>
+                </xsl:variable>
+                
+                <xsl:variable name="namespace-context-item" as="element()" select="
+                    if (exists($instanceField))
+                    then (
+                    if ($instanceField[self::text()])
+                    then $instanceField/parent::*
+                    else $instanceField
+                    )
+                    else js:getXForm()"/>
+                
+                <xsl:variable name="index" as="xs:integer">
+                    <xsl:evaluate xpath="xforms:impose($this/@index)" context-item="$instanceField" namespace-context="$namespace-context-item"/>
+                </xsl:variable>
+                
+                <xsl:map-entry key="'@index'" select="$index" />
+            </xsl:if>
+            
             <xsl:if test="exists($this/@origin)">
                 <!-- 
                     get node to insert using getReferencedInstanceField
                 -->
+                <xsl:variable name="origin-context" as="xs:string" select="
+                    if (exists($this/@context)) 
+                    then xforms:resolveXPathStrings($nodeset,$this/@context)
+                    else $nodeset"/>
+                <xsl:variable name="origin-ref" as="xs:string" select="xforms:resolveXPathStrings($origin-context,$this/@origin)"/>
                 <xsl:variable name="origin" as="node()?">
                     <xsl:call-template name="getReferencedInstanceField">
-                        <xsl:with-param name="refi" select="string($this/@origin)"/>
+                        <xsl:with-param name="refi" select="$origin-ref"/>
                     </xsl:call-template>
-<!--                    <TEST>fred</TEST>-->
                 </xsl:variable>
                 
                 <xsl:map-entry key="'@origin'" select="$origin" />
             </xsl:if>
-
-            <xsl:for-each-group select="$this/child::*" group-by="local-name()">
-                <xsl:apply-templates select="." mode="xforms-action-map"/>
-            </xsl:for-each-group>          
+            
+            <!-- need to apply nested actions in order! -->            
+            <xsl:if test="$this/child::*">
+                <xsl:map-entry key="'nested-actions'">
+                    <xsl:variable name="array" as="map(*)*">
+                        <xsl:for-each select="$this/child::*">
+                            <xsl:apply-templates select="." mode="#default"/>
+                        </xsl:for-each>
+                    </xsl:variable>
+                    <xsl:sequence select="array{$array}" />
+                 </xsl:map-entry>
+            </xsl:if>
+            
         </xsl:map>
         
         
@@ -3693,9 +3728,9 @@
                 <xsl:map-entry key="'@includenamespaceprefixes'" select="string($this/@includenamespaceprefixes)" />
             </xsl:if>
             
-            <xsl:for-each-group select="$this/child::*" group-by="local-name()">
+            <!--<xsl:for-each-group select="$this/child::*" group-by="local-name()">
                 <xsl:apply-templates select="." mode="xforms-action-map"/>
-            </xsl:for-each-group>          
+            </xsl:for-each-group> -->         
             
         </xsl:map>
         
@@ -4220,7 +4255,7 @@
         <xsl:variable name="ifExecuted" as="xs:boolean">
             <xsl:choose>
                 <xsl:when test="exists($ifVar)">
-                    <xsl:evaluate xpath="$ifVar" context-item="$delete-node" namespace-context="$delete-node"/>
+                    <xsl:evaluate xpath="xforms:impose($ifVar)" context-item="$delete-node" namespace-context="$delete-node"/>
                 </xsl:when>
                 <xsl:otherwise>
                     <xsl:sequence select="true()" />
@@ -4266,14 +4301,34 @@
     <xsl:template name="action-setfocus">
         <xsl:param name="action-map" required="yes" as="map(*)" tunnel="yes"/>
         
-        <xsl:variable name="control" as="xs:string" select="map:get($action-map,'control')"/>
+        <xsl:variable name="control" as="xs:string" select="map:get($action-map,'@control')"/>
         
         <!-- TO DO: implement remainder of this action -->
     </xsl:template>
     
 
 
-
+    <xd:doc scope="component">
+        <xd:desc>
+            <xd:p>Template for applying setindex action</xd:p>
+        </xd:desc>
+        <xd:param name="action-map">Action map</xd:param>
+    </xd:doc>
+    <xsl:template name="action-setindex">
+        <xsl:param name="action-map" required="yes" as="map(*)" tunnel="yes"/>
+        
+        <xsl:variable name="repeatID" as="xs:string" select="map:get($action-map,'@repeat')"/>
+        <xsl:variable name="new-index" as="xs:integer" select="map:get($action-map,'@index')"/>
+        
+        
+<!--        <xsl:message use-when="$debugMode">[action-setindex] $action-map = <xsl:value-of select="serialize($action-map)"/></xsl:message>-->
+        
+        <xsl:sequence select="js:setRepeatIndex($repeatID,$new-index)"/>
+        
+    </xsl:template>
+    
+    
+    
    
 
     <xd:doc scope="component">

--- a/src/saxon-xforms.xsl
+++ b/src/saxon-xforms.xsl
@@ -189,10 +189,11 @@
                 <xsl:for-each select="$xforms-doci/xforms:xform/xforms:model/xforms:bind">
                     <!-- [exists(@type)] -->
                     <xsl:map-entry
-                        key="
-                            xs:string(if (exists(@id)) 
+                        key="xs:string(
+                            if (exists(@id)) 
                             then @id
-                            else @nodeset)"
+                            else @nodeset
+                            )"
                         select="."/>
                 </xsl:for-each>
             </xsl:map>
@@ -223,7 +224,7 @@
         </xsl:variable>
         
         <xsl:message use-when="$debugMode">[xformsjs-main] RelevantBindings = <xsl:sequence select="serialize($RelevantBindings)"/></xsl:message>
-
+        
 
         <xsl:variable name="CalculationBindings" as="map(xs:string, xs:string)">
             <xsl:map>
@@ -286,6 +287,8 @@
                             var outputs = {};
                             var relevantMap = {};
                             var calculationMap = {};
+                            var repeatIndexMap = {};
+                            var elementsUsingIndexFunction = {};
                             
                             var getCurrentDate = function(){
                                 var today = new Date();
@@ -358,6 +361,10 @@
                            
                             var getInstanceKeys = function() {
                                 return Object.keys(instanceDocs);
+                            }
+                            
+                            var getInstances = function() {
+                                return instanceDocs;
                             }
                             
                             var setPendingUpdates = function(map1) {
@@ -434,12 +441,58 @@
                                 return calculationMap;
                             }
   
+                            
+                            var setRepeatIndex = function(name, value) {
+                                repeatIndexMap[name] = value;
+                            }
+                            
+                            var getRepeatIndex = function(name) {
+                                if ( typeof(repeatIndexMap[name]) != 'undefined' ) {
+                                    return repeatIndexMap[name];
+                                }
+                                else {
+                                    return 0;
+                                }
+                            } 
+                            
+                            var setElementUsingIndexFunction = function(name, value) {
+                                elementsUsingIndexFunction[name] = value;
+                            } 
+                            
+                            var getElementUsingIndexFunction = function(name) {
+                                return elementsUsingIndexFunction[name];
+                            }
+                            
+                            var getElementsUsingIndexFunctionKeys = function() {
+                            return Object.keys(elementsUsingIndexFunction);
+                            }
+                            
+                            
                             var startTime = function(name) {
                                 console.time(name);
                             }
                             
                             var endTime = function(name) {
                                 console.timeEnd(name);
+                            }
+                            
+                            var highlightClicked = function(id) {
+                                var item = document.getElementById(id);
+                                toggleClass(item);
+                            }
+                            
+                            var toggleClass = function(element) {
+                                if (element.className == 'selected') {
+                                    element.classList.remove('selected');
+                                }
+                                else {
+                                    var x = document.getElementsByClassName('selected');
+                                    var i;
+                                    for (i = 0; i &lt; x.length; i++) {
+                                        x[i].classList.remove('selected');
+                                    } 
+                                    element.classList.add('selected');
+                                }
                             }
                             
                         </script>
@@ -588,7 +641,7 @@
     <xd:doc scope="component">
         <xd:desc>Handle incremental change to HTML input</xd:desc>
     </xd:doc>
-    <xsl:template match="input[exists(@class) and xforms:hasClass(@class,'incremental')]" mode="ixsl:onkeyup">
+    <xsl:template match="input[xforms:hasClass(.,'incremental')]" mode="ixsl:onkeyup">
         
         <xsl:call-template name="xforms-value-changed">
             <xsl:with-param name="form-control" select="."/>
@@ -616,10 +669,32 @@
     </xsl:template>
     
     
+    <xd:doc scope="component">
+        <xd:desc>
+            <xd:p>Highlight repeat item when selected</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:template match="div[@data-repeat-item = 'true']//span" mode="ixsl:onclick">
+        <xsl:sequence select="js:highlightClicked( string(@id) )"/>
+                
+        <!-- update repeat index of ancestors (we may have clicked on a repeat item within a repeat item) -->
+        <xsl:for-each select="./ancestor::div[@data-repeat-item = 'true']">
+            <xsl:variable name="repeat-id" as="xs:string" select="./ancestor::div[xforms:hasClass(.,'repeat')][1]/@id"/>
+            <xsl:variable name="item-position" as="xs:integer" select="count(./preceding-sibling::div[@data-repeat-item = 'true']) + 1"/>
+            
+<!--            <xsl:message use-when="$debugMode">[div onclick] Setting repeat index '<xsl:value-of select="$repeat-id"/>' to value '<xsl:value-of select="$item-position"/>'</xsl:message>
+-->            <xsl:sequence select="js:setRepeatIndex($repeat-id,$item-position)"/>                        
+        </xsl:for-each>
+        
+        <xsl:call-template name="refreshElementsUsingIndexFunction-JS"/>
+
+    </xsl:template>
+    
+    
 
     <xd:doc scope="component">
         <xd:desc>
-            <xd:p>Function to get 'if' statemenmt from an action map</xd:p>
+            <xd:p>Function to get 'if' statement from an action map</xd:p>
         </xd:desc>
         <xd:return>Value of map entry for @if (XPath expression)</xd:return>
         <xd:param name="map">Action map</xd:param>
@@ -669,45 +744,47 @@
         <xsl:param name="base" as="xs:string"/>
         <xsl:param name="relative" as="xs:string"/>
         
-        <xsl:choose>
-            <xsl:when test="starts-with($relative,'/')">
-                <xsl:sequence select="$relative"/>
-            </xsl:when>
-            <xsl:when test="starts-with($relative,'instance(')">
-                <xsl:sequence select="$relative"/>
-            </xsl:when>
-            <xsl:when test="$base = ''">
-                <xsl:sequence select="$relative"/>
-            </xsl:when>
-            <xsl:when test="$relative = ''">
-                <xsl:sequence select="$base"/>
-            </xsl:when>
-            <xsl:otherwise>
-                
-                <xsl:variable name="parentCallCount" select="if(contains($relative, '/')) then count(tokenize($relative, '/')[. ='..']) else if(contains($relative, '..')) then 1 else 0"/>
-                <xsl:variable name="slashes"
-                    select="if(contains($base, '/')) then index-of(string-to-codepoints($base), string-to-codepoints('/')) else 0"
-                    as="xs:integer*"/>
-                
-<!--                <xsl:message use-when="$debugMode">resolveXPathString base =<xsl:value-of select="$base"/> 
+        <!-- first get full path -->
+        <xsl:variable name="full-path" as="xs:string">
+            <xsl:choose>
+                <xsl:when test="starts-with($relative,'/')">
+                    <xsl:sequence select="$relative"/>
+                </xsl:when>
+                <xsl:when test="starts-with($relative,'instance(')">
+                    <xsl:sequence select="$relative"/>
+                </xsl:when>
+                <xsl:when test="$base = ''">
+                    <xsl:sequence select="$relative"/>
+                </xsl:when>
+                <xsl:when test="$relative = ''">
+                    <xsl:sequence select="$base"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    
+                    <xsl:variable name="parentCallCount" select="if(contains($relative, '/')) then count(tokenize($relative, '/')[. ='..']) else if(contains($relative, '..')) then 1 else 0"/>
+                    <xsl:variable name="slashes"
+                        select="if(contains($base, '/')) then index-of(string-to-codepoints($base), string-to-codepoints('/')) else 0"
+                        as="xs:integer*"/>
+                    
+                    <!--                <xsl:message use-when="$debugMode">resolveXPathString base =<xsl:value-of select="$base"/> 
                     relative <xsl:value-of select="$relative"/>
                     parentCallCount = <xsl:value-of select="$parentCallCount"/>
                     slashes = <xsl:value-of select="$slashes"/>
                 </xsl:message>
 -->                
-                <xsl:variable name="parentSlash"
-                    as="xs:integer">
-                    <xsl:choose>
-                        <xsl:when test="(count($slashes) >= $parentCallCount) and ($parentCallCount>0)">
-                            <xsl:sequence select="$slashes[last() - ($parentCallCount - 1)]" />
-                        </xsl:when>
-                        <xsl:otherwise>
-                            <xsl:sequence select="$slashes[last()]" />
-                        </xsl:otherwise>
-                    </xsl:choose>
-                </xsl:variable>
-                
-               <!-- <xsl:message use-when="$debugMode">[xforms:resolveXPathStrings] base =<xsl:value-of select="$base"/> 
+                    <xsl:variable name="parentSlash"
+                        as="xs:integer">
+                        <xsl:choose>
+                            <xsl:when test="(count($slashes) >= $parentCallCount) and ($parentCallCount>0)">
+                                <xsl:sequence select="$slashes[last() - ($parentCallCount - 1)]" />
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:sequence select="$slashes[last()]" />
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:variable>
+                    
+                    <!-- <xsl:message use-when="$debugMode">[xforms:resolveXPathStrings] base =<xsl:value-of select="$base"/> 
                     lastSlash = <xsl:value-of select="$parentSlash"/> 
                     relative = <xsl:value-of select="$relative"/> 
                     countparent = <xsl:value-of select="$parentCallCount"/>
@@ -717,21 +794,44 @@
                     </xsl:if>
                     
                 </xsl:message>-->
-                
-                <xsl:choose>
-                    <xsl:when test="$parentCallCount gt 0">
-                        <!-- TODO - need to resolve path. This does not work properly -->
-                        <xsl:sequence
-                            select="concat(substring($base, 1, $parentSlash), replace($relative, '\.\./', ''))"
-                        />
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <xsl:sequence select="concat($base, '/', $relative)"/>
-                    </xsl:otherwise>
-                </xsl:choose>
-                
-            </xsl:otherwise>
-        </xsl:choose>
+                    
+                    <xsl:choose>
+                        <xsl:when test="$parentCallCount gt 0">
+                            <!-- TODO - need to resolve path. This does not work properly -->
+                            <xsl:sequence
+                                select="concat(substring($base, 1, $parentSlash), replace($relative, '\.\./', ''))"
+                            />
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:sequence select="concat($base, '/', $relative)"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                    
+                </xsl:otherwise>
+            </xsl:choose>            
+        </xsl:variable>
+        
+        <!-- then resolve index() into an integer position -->
+        <xsl:variable name="full-path-parsed-components" as="xs:string+">
+            <xsl:analyze-string select="$full-path" regex="(index\(&apos;([^&apos;]+)&apos;\)|/.$)">
+                <xsl:matching-substring>
+                    <xsl:variable name="match" select="regex-group(1)"/>
+                    <xsl:choose>
+                        <xsl:when test="$match = '/.'"/>
+                        <xsl:otherwise>
+                            <xsl:sequence select="xs:string( js:getRepeatIndex( regex-group(2) ) )"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:matching-substring>
+                <xsl:non-matching-substring>
+                    <xsl:sequence select="normalize-space(.)"/>
+                </xsl:non-matching-substring>
+            </xsl:analyze-string>
+        </xsl:variable>
+        
+        <xsl:sequence select="string-join($full-path-parsed-components)"/>
+        
+<!--        <xsl:sequence select="$full-path"/>-->
 
     </xsl:function>
 
@@ -946,11 +1046,19 @@
             <xd:p>Generates HTML output field and registers actions.</xd:p>
         </xd:desc>
         <xd:param name="position">Integer representing position of item (in a repeat list for example).</xd:param>
+        <xd:param name="context-position">String representing position of item in a hierarchy (e.g. in nested repeat)</xd:param>
     </xd:doc>
     <xsl:template match="xforms:output">
         <xsl:param name="position" as="xs:integer" required="no" select="0"/>
-
-        <xsl:variable name="myid" as="xs:string" select="if (exists(@id)) then @id else concat( generate-id(), '-', $position )"/>
+        <xsl:param name="context-position" as="xs:string" required="no" select="''"/>
+        
+        <xsl:variable name="string-position" as="xs:string" select="if ($context-position != '') then $context-position else string($position)"/>
+        
+        <xsl:variable name="myid" as="xs:string" select="if (exists(@id)) then @id else concat( generate-id(), '-', $string-position )"/>
+        
+        <xsl:if test="xforms:usesIndexFunction(.) and not(ancestor::*[xforms:usesIndexFunction(.)])">
+            <xsl:sequence select="js:setElementUsingIndexFunction($myid,.)"/>
+        </xsl:if>
         
          
         <!-- get xforms:bind element relevant to this -->
@@ -1047,11 +1155,19 @@
             <xd:p>Generates HTML input field and registers actions.</xd:p>
         </xd:desc>
         <xd:param name="position">Integer representing position of item (in a repeat list for example).</xd:param>
+        <xd:param name="context-position">String representing position of item in a hierarchy (e.g. in nested repeat)</xd:param>
     </xd:doc>
     <xsl:template match="xforms:input">
         <xsl:param name="position" as="xs:integer" required="no" select="0"/>
+        <xsl:param name="context-position" as="xs:string" required="no" select="''"/>
         
-        <xsl:variable name="myid" as="xs:string" select="if (exists(@id)) then @id else concat( generate-id(), '-', $position )"/>
+        <xsl:variable name="string-position" as="xs:string" select="if ($context-position != '') then $context-position else string($position)"/>
+        
+        <xsl:variable name="myid" as="xs:string" select="if (exists(@id)) then @id else concat( generate-id(), '-', $string-position )"/>
+        
+        <xsl:if test="xforms:usesIndexFunction(.) and not(ancestor::*[xforms:usesIndexFunction(.)])">
+            <xsl:sequence select="js:setElementUsingIndexFunction($myid,.)"/>
+        </xsl:if>
         
         <xsl:variable name="time-id" as="xs:string" select="generate-id()"/>
         <xsl:sequence use-when="$debugTiming" select="js:startTime(concat('XForms-input-', $time-id))" />
@@ -1235,11 +1351,19 @@
             <xd:p>Generates HTML output field and registers actions.</xd:p>
         </xd:desc>
         <xd:param name="position">Integer representing position of item (in a repeat list for example).</xd:param>
+        <xd:param name="context-position">String representing position of item in a hierarchy (e.g. in nested repeat)</xd:param>
     </xd:doc>
     <xsl:template match="xforms:textarea" priority="2">
         <xsl:param name="position" as="xs:integer" required="no" select="0"/>
+        <xsl:param name="context-position" as="xs:string" required="no" select="''"/>
         
-        <xsl:variable name="myid" as="xs:string" select="if (exists(@id)) then @id else concat( generate-id(), '-', $position )"/>
+        <xsl:variable name="string-position" as="xs:string" select="if ($context-position != '') then $context-position else string($position)"/>
+        
+        <xsl:variable name="myid" as="xs:string" select="if (exists(@id)) then @id else concat( generate-id(), '-', $string-position )"/>
+        
+        <xsl:if test="xforms:usesIndexFunction(.) and not(ancestor::*[xforms:usesIndexFunction(.)])">
+            <xsl:sequence select="js:setElementUsingIndexFunction($myid,.)"/>
+        </xsl:if>
         
         <!-- get xforms:bind element relevant to this -->
         <xsl:variable name="bindingi" as="node()?">
@@ -1312,11 +1436,19 @@
             <xd:p>Generates HTML select field and registers actions.</xd:p>
         </xd:desc>
         <xd:param name="position">Integer representing position of item (in a repeat list for example).</xd:param>
+        <xd:param name="context-position">String representing position of item in a hierarchy (e.g. in nested repeat)</xd:param>
     </xd:doc>
     <xsl:template match="xforms:select1 | xforms:select">
         <xsl:param name="position" as="xs:integer" required="no" select="0"/>
+        <xsl:param name="context-position" as="xs:string" required="no" select="''"/>
         
-        <xsl:variable name="myid" as="xs:string" select="if (exists(@id)) then @id else concat( generate-id(), '-', $position )"/>
+        <xsl:variable name="string-position" as="xs:string" select="if ($context-position != '') then $context-position else string($position)"/>
+        
+        <xsl:variable name="myid" as="xs:string" select="if (exists(@id)) then @id else concat( generate-id(), '-', $string-position )"/>
+        
+        <xsl:if test="xforms:usesIndexFunction(.) and not(ancestor::*[xforms:usesIndexFunction(.)])">
+            <xsl:sequence select="js:setElementUsingIndexFunction($myid,.)"/>
+        </xsl:if>
         
         <xsl:variable name="time-id" select="generate-id()"/>
         <xsl:sequence use-when="$debugTiming" select="js:startTime(concat('XForms-select', $time-id))" />
@@ -1465,9 +1597,22 @@
     <xd:doc scope="component">
         <xd:desc>
             <xd:p>Implementation of XForms <a href="https://www.w3.org/TR/xforms11/#ui-group">group element</a></xd:p>
-            <xd:p>Generates an HTML div and passes @ref or @nodeset to descendants.</xd:p></xd:desc>
+            <xd:p>Generates an HTML div and passes @ref or @nodeset to descendants.</xd:p>
+        </xd:desc>
+        <xd:param name="position">Integer representing position of item (in a repeat list for example).</xd:param>
+        <xd:param name="context-position">String representing position of item in a hierarchy (e.g. in nested repeat)</xd:param>
     </xd:doc>
     <xsl:template match="xforms:group">
+        <xsl:param name="position" as="xs:integer" required="no" select="0"/>
+        <xsl:param name="context-position" as="xs:string" required="no" select="''"/>
+        
+        <xsl:variable name="string-position" as="xs:string" select="if ($context-position != '') then $context-position else string($position)"/>
+        
+        <xsl:variable name="myid" as="xs:string" select="if (exists(@id)) then @id else concat( generate-id(), '-', $string-position )"/>
+        
+        <xsl:if test="xforms:usesIndexFunction(.) and not(ancestor::*[xforms:usesIndexFunction(.)])">
+            <xsl:sequence select="js:setElementUsingIndexFunction($myid,.)"/>
+        </xsl:if>
         
         <xsl:variable name="refi" as="xs:string?">
             <xsl:choose>
@@ -1477,12 +1622,12 @@
             </xsl:choose>
         </xsl:variable>
         
+
+
         <div>
+            <xsl:attribute name="id" select="$myid"/>
             <xsl:if test="exists($refi)">
                 <xsl:attribute name="data-group-ref" select="$refi" />
-            </xsl:if>
-            <xsl:if test="exists(@id)">
-                <xsl:attribute name="id" select="@id"/>
             </xsl:if>
             <xsl:apply-templates select="child::*">
                 <xsl:with-param name="nodeset" select="if(exists($refi))then $refi else ''" tunnel="yes"/>
@@ -1498,11 +1643,15 @@
             <xd:p>Generates HTML div and iterates over items within.</xd:p>
         </xd:desc>
         <xd:param name="position">Integer representing position of item (in a repeat list for example).</xd:param>
+        <xd:param name="context-position">String representing position of item in a hierarchy (e.g. in nested repeat)</xd:param>
     </xd:doc>
     <xsl:template match="xforms:repeat">
         <xsl:param name="position" as="xs:integer" required="no" select="0"/>
+        <xsl:param name="context-position" as="xs:string" required="no" select="''"/>
         
-        <xsl:variable name="myid" as="xs:string" select="if (exists(@id)) then @id else concat( generate-id(), '-', $position )"/>
+        <xsl:variable name="string-position" as="xs:string" select="if ($context-position != '') then $context-position else string($position)"/>
+        
+        <xsl:variable name="myid" as="xs:string" select="if (exists(@id)) then @id else concat( generate-id(), '-', $string-position )"/>
         
         <xsl:variable name="time-id" select="generate-id()"/>
         <xsl:sequence use-when="$debugTiming" select="js:startTime(concat('XForms-repeat', $time-id))" />
@@ -1532,7 +1681,7 @@
             <xsl:sequence use-when="$debugTiming" select="js:endTime(concat('XForms-repeat-evaluate', $time-id))" />
         </xsl:variable>
         
-        <xsl:message use-when="$debugMode">
+        <!--<xsl:message use-when="$debugMode">
             <xsl:choose>
                 <xsl:when test="exists($selectedRepeatVar)">
                     [xforms:repeat] ref = <xsl:sequence select="$refi" />
@@ -1540,7 +1689,7 @@
                 </xsl:when>
                 <xsl:otherwise>[xforms:repeat] No repeat found for ref <xsl:sequence select="$refi" /></xsl:otherwise>
             </xsl:choose>
-        </xsl:message>
+        </xsl:message>-->
            
         <xsl:if test="exists($selectedRepeatVar)">
             <div>
@@ -1551,10 +1700,13 @@
                 <xsl:attribute name="id" select="$myid"/>
                 <xsl:variable name="xf-repeat" select="." as="element(xforms:repeat)"/>
                 <xsl:for-each select="$selectedRepeatVar">
+                    <xsl:variable name="string-position" as="xs:string" select="string(position())"/>
+                    <xsl:variable name="new-context-position" as="xs:string" select="if ($context-position != '') then concat($context-position, '.', $string-position) else $string-position"/>
                     <div data-repeat-item="true">
                         <xsl:apply-templates select="$xf-repeat/child::*">
                             <xsl:with-param name="nodeset" select="concat($refi, '[', position(), ']')" tunnel="yes"/>
                             <xsl:with-param name="position" select="position()"/>
+                            <xsl:with-param name="context-position" select="$new-context-position"/>
                         </xsl:apply-templates>
                     </div>
                 </xsl:for-each>
@@ -1656,7 +1808,7 @@
         </xsl:choose>
     </xsl:template>
     
-    <xsl:template match="@data-action" mode="update-ref" priority="2" >
+<!--    <xsl:template match="@data-action" mode="update-ref" priority="2" >
         <xsl:param name="path" as="xs:string" select="''" />
         <xsl:param name="position" select="0" />
         
@@ -1701,7 +1853,7 @@
         </xsl:copy>
         
     </xsl:template> 
-
+-->
  
     <xd:doc scope="component">
         <xd:desc>Handle HTML button click</xd:desc>
@@ -1722,11 +1874,19 @@
             <xd:p>Generates HTML link or button and registers actions.</xd:p>
         </xd:desc>
         <xd:param name="position">Integer representing position of item (in a repeat list for example).</xd:param>
+        <xd:param name="context-position">String representing position of item in a hierarchy (e.g. in nested repeat)</xd:param>
     </xd:doc>
     <xsl:template match="xforms:trigger">
         <xsl:param name="position" as="xs:integer" required="no" select="0"/>
+        <xsl:param name="context-position" as="xs:string" required="no" select="''"/>
         
-        <xsl:variable name="myid" as="xs:string" select="if (exists(@id)) then @id else concat( generate-id(), '-', $position )"/>
+        <xsl:variable name="string-position" as="xs:string" select="if ($context-position != '') then $context-position else string($position)"/>
+        
+        <xsl:variable name="myid" as="xs:string" select="if (exists(@id)) then @id else concat( generate-id(), '-', $string-position )"/>
+        
+        <xsl:if test="xforms:usesIndexFunction(.) and not(ancestor::*[xforms:usesIndexFunction(.)])">
+            <xsl:sequence select="js:setElementUsingIndexFunction($myid,.)"/>
+        </xsl:if>
         
         <!-- get xforms:bind element relevant to this -->
         <xsl:variable name="bindingi" as="node()?">
@@ -1828,7 +1988,7 @@
     
     <!-- mode="xforms-action" REDUNDANT? MD 2018-07-01 -->
 
-    <xsl:template match="xforms:insert" mode="xforms-action">
+<!--    <xsl:template match="xforms:insert" mode="xforms-action">
         <xsl:param name="nodeset" select="''" tunnel="yes"/>
         <insert>
             <xsl:if test="exists(@ref)">
@@ -1932,7 +2092,7 @@
 
     <xsl:template match="xforms:setvalue" mode="xforms-action">
         <xsl:param name="nodeset" select="''" tunnel="yes"/>
-<!--        <xsl:message use-when="$debugMode">setvalue ZZZ= <xsl:value-of select="serialize(.)"/></xsl:message>-->
+<!-\-        <xsl:message use-when="$debugMode">setvalue ZZZ= <xsl:value-of select="serialize(.)"/></xsl:message>-\->
         <setvalue>
             <xsl:if test="exists(@value)">
                 <xsl:attribute name="value">
@@ -2050,7 +2210,7 @@
         </reset>
     </xsl:template>
     
-    
+-->    
     
     <!-- action-to-map -->
     
@@ -2077,7 +2237,7 @@
     
     
 
-    <xsl:function name="xforms:convert-xml-to-jxml" as="node()" exclude-result-prefixes="#all">
+<!--    <xsl:function name="xforms:convert-xml-to-jxml" as="node()" exclude-result-prefixes="#all">
         <xsl:param name="xinstance" as="node()"/>
         <xsl:variable name="rep-xml">
             <xsl:element name="map" namespace="http://www.w3.org/2005/xpath-functions">
@@ -2091,8 +2251,8 @@
     <xsl:template match="*" mode="json-xml">
 
         <xsl:choose>
-            <!-- TODO handle attributes??? -->
-            <!--<xsl:when test="attribute()"></xsl:when>-->
+            <!-\- TODO handle attributes??? -\->
+            <!-\-<xsl:when test="attribute()"></xsl:when>-\->
             <xsl:when test="count(*) > 0">
                 <xsl:for-each-group select="* | @*" group-by="local-name()">
                     <xsl:choose>
@@ -2152,18 +2312,18 @@
         </xsl:choose>
 
     </xsl:template>
-
-
+-->
+<!--
     <xsl:function name="xforms:convert-json-to-xml" as="node()" exclude-result-prefixes="#all">
         <xsl:param name="jinstance" as="xs:string"/>
         <xsl:variable name="rep-xml">
             <xsl:sequence select="json-to-xml($jinstance)"/>
         </xsl:variable>
-        <!-- <xsl:message use-when="$debugMode">TESTING json xml map = <xsl:value-of select="serialize($rep-xml)"/></xsl:message> -->
+        <!-\- <xsl:message use-when="$debugMode">TESTING json xml map = <xsl:value-of select="serialize($rep-xml)"/></xsl:message> -\->
         <xsl:variable name="result">
-            <!--<xsl:element name="document"> -->
+            <!-\-<xsl:element name="document"> -\->
             <xsl:apply-templates select="$rep-xml" mode="jxml-xml"/>
-            <!--  </xsl:element> -->
+            <!-\-  </xsl:element> -\->
         </xsl:variable>
         <xsl:sequence select="$result"/>
     </xsl:function>
@@ -2218,7 +2378,7 @@
 
     </xsl:template>
 
-
+-->
     <!-- Form instance check for updates made -->
 
     <xd:doc scope="component">
@@ -2249,9 +2409,37 @@
         </xsl:variable>
         
         <xsl:copy>
-            <xsl:apply-templates select="*" mode="form-check">
-                <xsl:with-param name="curPath" select="$curPath"/>
-            </xsl:apply-templates>
+            
+            <xsl:for-each-group select="element()" group-by="local-name(.)">                  
+                
+                <xsl:variable name="updatedChildPath" select="concat($curPath, current-grouping-key())"/>
+                <!--<xsl:variable name="repeatableVar"
+                select="ixsl:page()//*[@data-repeatable-context = $updatedPath2]"/>-->
+                
+                <xsl:variable name="dataRefWithFilter"
+                    select="ixsl:page()//*[starts-with(@data-ref, concat($updatedChildPath,'['))]"/>
+                <xsl:choose>
+                    <xsl:when test="count(current-group()) > 1 or exists($dataRefWithFilter)">   
+                        <xsl:for-each select="current-group()">
+                            <xsl:apply-templates select="." mode="form-check">
+                                <xsl:with-param name="curPath" select="$curPath"/>
+                                <xsl:with-param name="position" select="position()"/>
+                            </xsl:apply-templates>
+                        </xsl:for-each>                    
+                    </xsl:when>
+                    
+                    <xsl:otherwise>
+                        <xsl:for-each select="current-group()">
+                            <xsl:apply-templates select="." mode="form-check">
+                                <xsl:with-param name="curPath" select="$curPath"/>
+                            </xsl:apply-templates>
+                        </xsl:for-each>                        
+                    </xsl:otherwise>
+                    
+                </xsl:choose>
+                
+            </xsl:for-each-group>
+            
         </xsl:copy>
     </xsl:template>
     
@@ -2274,10 +2462,10 @@
                 then concat($curPath, name(), '[', $position, ']')
                 else concat($curPath, name())"/>
 
-<!--        <xsl:message use-when="$debugMode">form-check processing node: <xsl:value-of select="local-name()"/></xsl:message>-->
-<!--        <xsl:message use-when="$debugMode">form-check updatedPath: <xsl:value-of select="$updatedPath"/></xsl:message> -->
+<!--        <xsl:message use-when="$debugMode">form-check processing node: <xsl:value-of select="local-name()"/></xsl:message>
+        <xsl:message use-when="$debugMode">form-check updatedPath: <xsl:value-of select="$updatedPath"/></xsl:message> 
         
-        
+-->        
         <xsl:copy>
             <!-- *** Process attributes of context node -->
             <xsl:apply-templates select="attribute()" mode="form-check">
@@ -2286,16 +2474,19 @@
             
             <!-- *** Process text content of context node -->
             <!-- Check for associated/bound form-control with id=$updatedPath  -->
-            <xsl:variable name="associated-form-control"
-                select="ixsl:page()//*[@data-ref = $updatedPath]"/>
+            <xsl:variable name="associated-form-control" as="element()*"
+                select="ixsl:page()//*[self::input or self::select or self::textarea][@data-ref = $updatedPath]"/>
                      
+            <xsl:if test="count($associated-form-control) > 1">
+                <xsl:message>[form-check] More than one form element controls the value of XForm node at <xsl:value-of select="$updatedPath"/>; Saxon-Forms will apply the value of the first</xsl:message>
+            </xsl:if>
             
             <xsl:choose>
                 <xsl:when test="exists($associated-form-control)">
-                    <!--<xsl:message use-when="$debugMode">[form-check mode] Found form control &lt;<xsl:value-of select="name($associated-form-control)"/>&gt; associated with instance item at: <xsl:value-of
+                    <!--<xsl:message use-when="$debugMode">[form-check mode] Found form control &lt;<xsl:value-of select="name($associated-form-control[1])"/>&gt; associated with instance item at: <xsl:value-of
                         select="$updatedPath"/></xsl:message> -->
                     <xsl:value-of>
-                        <xsl:apply-templates select="$associated-form-control" mode="get-field"/>
+                        <xsl:apply-templates select="$associated-form-control[1]" mode="get-field"/>
                     </xsl:value-of>
                 </xsl:when>
                 <xsl:when test="exists($pendingUpdates) and map:contains($pendingUpdates, $updatedPath)">
@@ -2601,6 +2792,53 @@
     -->
     
     <xd:doc scope="component">
+        <xd:desc>
+            <xd:p>Determine if an XForms element has a reference to the index() function.</xd:p>
+            <xd:p>(If so, it will be added to a Javascript variable to support the xforms-recalculate event)</xd:p>
+        </xd:desc>
+        <xd:param name="this">Element to be checked</xd:param>
+    </xd:doc>
+    <xsl:function name="xforms:usesIndexFunction" as="xs:boolean">
+        <xsl:param name="this" as="element()"/>
+        <xsl:variable name="index-function-match" as="xs:string*" >
+            <!-- 
+            \i = "initial name character"
+            \c = "name character"
+            
+            https://www.w3.org/TR/xmlschema11-2/#Name
+            https://www.mulberrytech.com/quickref/regex.pdf
+            
+            -->
+            <xsl:analyze-string select="$this/@ref" regex="\i\c*\(">
+                <xsl:matching-substring>
+                    <xsl:choose>
+                        <xsl:when test="substring-before(.,'(')= 'index'">
+                            <xsl:sequence select="'i'" />
+                        </xsl:when>
+                        <xsl:otherwise/>
+                    </xsl:choose>
+                </xsl:matching-substring>
+                <xsl:non-matching-substring/>
+            </xsl:analyze-string>
+            
+            <xsl:analyze-string select="$this/@nodeset" regex="\i\c*\(">
+                <xsl:matching-substring>
+                    <xsl:choose>
+                        <xsl:when test="substring-before(.,'(')= 'index'">
+                            <xsl:sequence select="'i'" />
+                        </xsl:when>
+                        <xsl:otherwise/>
+                    </xsl:choose>
+                </xsl:matching-substring>
+                <xsl:non-matching-substring/>
+            </xsl:analyze-string>
+        </xsl:variable>
+        
+        <xsl:sequence select="if (exists($index-function-match)) then true() else false()"/>
+        
+    </xsl:function>
+    
+    <xd:doc scope="component">
         <xd:desc>Add all relevant namespace declarations to the xform element, to help with xsl:evaluation</xd:desc>
         <xd:param name="this">Element for which namespaces are needed</xd:param>
     </xd:doc>
@@ -2621,12 +2859,14 @@
     <xd:doc scope="component">
         <xd:desc>Find string in HTML @class attribute.</xd:desc>
         <xd:return>True if $string is one of the values of $class</xd:return>
-        <xd:param name="class">HTML @class attribute (e.g. class="block incremental")</xd:param>
+        <xd:param name="element">HTML element that may have a @class attribute (e.g. class="block incremental")</xd:param>
         <xd:param name="string">String to match in class (e.g. "incremental")</xd:param>
     </xd:doc>
     <xsl:function name="xforms:hasClass" as="xs:boolean">
-        <xsl:param name="class" as="attribute(class)"/>
+        <xsl:param name="element" as="element()"/>
         <xsl:param name="string" as="xs:string"/>
+        
+        <xsl:variable name="class" as="xs:string?" select="$element/@class"/>
         <xsl:variable name="classes" as="xs:string*" select="tokenize($class)"/>
         <xsl:choose>
             <xsl:when test="$string = $classes">
@@ -2848,20 +3088,29 @@
             then normalize-space( xs:string($this/@ref) ) 
             else ()"/>
         
-        <xsl:variable name="data-ref" as="xs:string">
+        <xsl:variable name="this-binding-ref" as="xs:string?">
             <xsl:choose>
                 <xsl:when test="exists($bindingi)">
                     <!-- 
-                    MD 2018-07-01: xforms:bind should not have a @ref element 
-                
-                    https://www.w3.org/TR/xforms11/#structure-bind-element
-                -->
+                        MD 2018-07-01: xforms:bind should not have a @ref element
+                        https://www.w3.org/TR/xforms11/#structure-bind-element
+                    -->
                     <xsl:value-of
                         select="
                         if (exists($bindingi/@nodeset)) 
-                        then $bindingi/@nodeset
-                        else $bindingi/@ref"
+                        then normalize-space( xs:string($bindingi/@nodeset) )
+                        else normalize-space( xs:string($bindingi/@ref) )
+                        "
                     />
+                </xsl:when>
+            </xsl:choose>
+        </xsl:variable>
+        
+        <xsl:variable name="data-ref" as="xs:string">
+            <xsl:choose>
+                <xsl:when test="exists($bindingi)">
+                    
+                    <xsl:sequence select="xforms:resolveXPathStrings('',$this-binding-ref)"/>
                 </xsl:when>
                 <xsl:when test="exists($this-ref)">
                     <xsl:sequence select="xforms:resolveXPathStrings($nodeset,$this-ref)"/>
@@ -2998,6 +3247,43 @@
         
     </xsl:template>
     
+    <xd:doc scope="component">
+        <xd:desc>
+            <xd:p>Update HTML display elements corresponding to XForms elements that use the index() function</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:template name="refreshElementsUsingIndexFunction-JS">
+        <xsl:variable name="ElementsUsingIndexFunction-keys" select="js:getElementsUsingIndexFunctionKeys()" as="item()*"/>
+        
+        <xsl:variable name="instance-keys" as="item()*" select="js:getInstanceKeys()"/>
+        <xsl:variable name="instances" as="map(xs:string, element())">
+            <xsl:map>
+                <xsl:for-each select="$instance-keys">
+                    <xsl:map-entry key="." select="js:getInstance(.)"/>
+                </xsl:for-each>
+            </xsl:map>
+        </xsl:variable>
+                
+        <xsl:for-each select="$ElementsUsingIndexFunction-keys">
+            <xsl:variable name="this-key" as="xs:string" select="."/>
+            <xsl:variable name="this-element" as="element()" select="js:getElementUsingIndexFunction($this-key)"/>
+            <xsl:variable name="this-element-refi" as="xs:string?">
+                <xsl:choose>
+                    <xsl:when test="exists($this-element/@nodeset)"><xsl:sequence select="$this-element/@nodeset" /></xsl:when>
+                    <xsl:when test="exists($this-element/@ref)"><xsl:sequence select="$this-element/@ref" /></xsl:when>
+                    <xsl:otherwise/>
+                </xsl:choose>
+            </xsl:variable>
+            <xsl:result-document href="#{$this-key}" method="ixsl:replace-content">
+                <xsl:apply-templates select="$this-element/*">
+                    <xsl:with-param name="instances" select="$instances" tunnel="yes"/>
+                    <xsl:with-param name="nodeset" select="if(exists($this-element-refi))then $this-element-refi else ''" tunnel="yes"/>
+                </xsl:apply-templates>
+            </xsl:result-document>
+            
+        </xsl:for-each>
+        
+    </xsl:template>
     
     <xd:doc scope="component">
         <xd:desc>
@@ -3416,10 +3702,11 @@
                 </xsl:apply-templates>
             </xsl:variable>
             
-            <xsl:message use-when="$debugMode">[xforms-recalculate] updated instance: <xsl:value-of select="serialize($updatedInstanceXML)"/></xsl:message>
+            <!--<xsl:message use-when="$debugMode">[xforms-recalculate] updated instance: <xsl:value-of select="serialize($updatedInstanceXML)"/></xsl:message>-->
             
             <xsl:sequence select="js:setInstance(.,$updatedInstanceXML)"/>
             <xsl:call-template name="refreshOutputs-JS"/>
+            <xsl:call-template name="refreshElementsUsingIndexFunction-JS"/>
         </xsl:for-each>    
                 
     </xsl:template>

--- a/src/xforms-function-library.xsl
+++ b/src/xforms-function-library.xsl
@@ -74,20 +74,13 @@
     
     <xsl:function name="xforms:index" as="xs:integer">
         <xsl:param name="repeatID" as="xs:string" />
-        
-<!--        <xsl:variable name="repeatIndexMap" select="js:getRepeatIndexMap()" as="map(xs:string,xs:integer)"/>-->
-        
-        
+                
         <!-- call to js:getRepeatIndex doesn't work on first pass for some reason -->
         <xsl:variable name="repeat-index" as="xs:double?" select="js:getRepeatIndex($repeatID)"/>
-        
-<!--        <xsl:variable name="repeat-index" as="xs:integer?" select="map:get($repeatIndexMap,$repeatID)"/>-->
-        
+                
         <!-- assign value '0' if $repeat-index does not exist -->
         <xsl:sequence select="if (exists($repeat-index)) then xs:integer($repeat-index) else 0"/>
         
-        <xsl:message>[xforms:index] Index of '<xsl:value-of select="$repeatID"/>' is '<xsl:value-of select="$repeat-index"/>'</xsl:message>
-                
     </xsl:function>
     
     <xsl:function name="xforms:random" as="xs:double">

--- a/src/xforms-function-library.xsl
+++ b/src/xforms-function-library.xsl
@@ -74,20 +74,20 @@
     
     <xsl:function name="xforms:index" as="xs:integer">
         <xsl:param name="repeatID" as="xs:string" />
-        <xsl:variable name="element" select="ixsl:page()//*[@id = $repeatID]"/>
-        <xsl:choose>
-            <xsl:when test="empty($element)">
-                <!--<xsl:sequence select="xs:integer('NaN')" />-->
-                <xsl:sequence select="0" />
-            </xsl:when>
-            <xsl:when test="exists($element/@data-count)">
-                <xsl:sequence select="xs:integer($element/@data-count)" />
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:sequence select="0" />
-            </xsl:otherwise>
-        </xsl:choose>
         
+<!--        <xsl:variable name="repeatIndexMap" select="js:getRepeatIndexMap()" as="map(xs:string,xs:integer)"/>-->
+        
+        
+        <!-- call to js:getRepeatIndex doesn't work on first pass for some reason -->
+        <xsl:variable name="repeat-index" as="xs:double?" select="js:getRepeatIndex($repeatID)"/>
+        
+<!--        <xsl:variable name="repeat-index" as="xs:integer?" select="map:get($repeatIndexMap,$repeatID)"/>-->
+        
+        <!-- assign value '0' if $repeat-index does not exist -->
+        <xsl:sequence select="if (exists($repeat-index)) then xs:integer($repeat-index) else 0"/>
+        
+        <xsl:message>[xforms:index] Index of '<xsl:value-of select="$repeatID"/>' is '<xsl:value-of select="$repeat-index"/>'</xsl:message>
+                
     </xsl:function>
     
     <xsl:function name="xforms:random" as="xs:double">


### PR DESCRIPTION
Nested repeats are handled. The index of a repeat can be set. A node can be inserted in a repeat at a specified index. The inserted node can be set by the XForm (using @origin).

demos/demo-repeat.html illustrates the functionality.