### PR TITLE
Improved handling of repeats and focus of form controls

### DIFF
--- a/demos/php/Test.php
+++ b/demos/php/Test.php
@@ -1,0 +1,5 @@
+<?php
+	header("Content-Type: text/plain; charset=UTF-8");
+	print_r($_GET);
+
+?>

--- a/demos/php/echo.php
+++ b/demos/php/echo.php
@@ -1,0 +1,28 @@
+<?php
+	header("Content-Type: text/html");
+	header("Access-control: allow <*>");
+	echo "<?xml version=\"1.0\"?>";
+	echo "<html xmlns=\"http://www.w3.org/1999/xhtml\">";
+	echo "<head>";
+	echo "<title>Results from echo.php</title>";
+	echo "</head>";
+	echo "<body>";
+	echo "<h1>Form posted data</h1>";
+	$posteddata = file_get_contents("php://input");
+	$posteddata = str_replace("&", "&amp;", $posteddata);
+	$posteddata = str_replace("<", "&lt;", $posteddata);
+	$posteddata = str_replace(">", "&gt;", $posteddata);
+	echo "<pre>$posteddata</pre>";
+	echo "<h1>Environment variables</h1>";
+	echo "<pre>";
+	$env = $_ENV;
+	ksort($env);
+	foreach($env as $key => $value) {
+		if(substr($key,0,8) == "CONTENT_" || substr($key,0,5) == "HTTP_" || substr($key,0,8) == "REQUEST_" || $key == "QUERY_STRING") {
+			echo "$key=$value\n";
+		}
+	}
+	echo "</pre>";
+	echo "</body>";
+	echo "</html>";
+?>

--- a/demos/xml/demo-repeat-xform.xml
+++ b/demos/xml/demo-repeat-xform.xml
@@ -51,7 +51,7 @@
     <div id="content">
         <h2>Recipe list</h2>
         
-        <xf:repeat id="recipe-repeat" nodeset="instance('all')/demo:recipe" class="repeat">
+        <xf:repeat id="recipe-repeat" nodeset="instance('all')/demo:recipe" class="repeat" startindex="2">
             <xf:output ref="demo:title"/>
             <xf:repeat id="ingredient-repeat" nodeset="demo:ingredients/demo:ingredient" class="repeat">
                 <xf:output ref="text()"/>
@@ -78,7 +78,7 @@
                 <xf:label>Recipe Name:</xf:label>
             </xf:input>
             <xf:repeat id="edit-ingredient-repeat" nodeset="demo:ingredients/demo:ingredient">
-                <xf:input ref=".">
+                <xf:input ref="." id="edit-ingredient-repeat-input">
                     <xf:label>Ingredient:</xf:label>
                 </xf:input>
             </xf:repeat>
@@ -89,6 +89,7 @@
                 <xf:label>Add ingredient after selected item</xf:label>
                 <xf:action ev:event="DOMActivate">
                     <xf:insert context="." nodeset="demo:ingredients/demo:ingredient" at="index('edit-ingredient-repeat')" position="after" origin="instance('i-new-ingredient')"/>
+                    <xf:setfocus control="edit-ingredient-repeat-input"/>
                 </xf:action>
             </xf:trigger>
 
@@ -96,6 +97,7 @@
                 <xf:label>Delete selected ingredient</xf:label>
                 <xf:action ev:event="DOMActivate">
                     <xf:delete context="." nodeset="demo:ingredients/demo:ingredient" at="index('edit-ingredient-repeat')"/>
+                    <xf:setfocus control="edit-ingredient-repeat-input"/>
                 </xf:action>
             </xf:trigger>
             
@@ -107,11 +109,9 @@
                 <xf:action ev:event="DOMActivate" if="index('edit-ingredient-repeat') != 1">
                     <!-- insert changes "focus" index to the newly inserted node -->
                     <xf:insert context="." nodeset="demo:ingredients/demo:ingredient" at="index('edit-ingredient-repeat') - 1" position="before" origin="demo:ingredients/demo:ingredient[index('edit-ingredient-repeat')]"/>
-                    <!-- original node is now at index() + 1 -->
-                    <xf:setindex repeat="edit-ingredient-repeat" index="index('edit-ingredient-repeat') + 1"/>
-<!--                    <xf:setfocus control="edit-ingredient-repeat"/>-->
-                    <xf:delete context="." nodeset="demo:ingredients/demo:ingredient" at="index('edit-ingredient-repeat')"/>
-                    <xf:rebuild model="m-recipes"/>
+                    <!-- original node is now at index() + 2 -->
+                    <xf:delete context="." nodeset="demo:ingredients/demo:ingredient" at="index('edit-ingredient-repeat') + 2"/>
+                    <xf:setfocus control="edit-ingredient-repeat-input"/>
                 </xf:action>
             </xf:trigger>
             
@@ -123,13 +123,13 @@
                      possibly because focus was on a different row from where 'Down' was clicked
                      -->
                 <xf:action ev:event="DOMActivate" if="index('edit-ingredient-repeat') != count(ingredients/ingredient)">
-                    <!-- insert changes "focus" index to the newly inserted node 
-                     
-                     weirdly, this doesn't work properly using the REST URL
-                     -->
+                    <!-- insert changes "focus" index to the newly inserted node -->
                     <xf:insert context="." nodeset="demo:ingredients/demo:ingredient" at="index('edit-ingredient-repeat') + 1" position="after" origin="demo:ingredients/demo:ingredient[index('edit-ingredient-repeat')]"/>
-<!--                    <xf:setfocus control="edit-ingredient-repeat"/>-->
-                    <xf:delete context="." nodeset="demo:ingredients/demo:ingredient" at="index('edit-ingredient-repeat')"/>
+                    <!-- original node is now at index() - 2 -->
+                    <xf:delete context="." nodeset="demo:ingredients/demo:ingredient" at="index('edit-ingredient-repeat') - 2"/>
+                    <!-- copy of original node is now at index() - 1 -->
+                    <xf:setindex repeat="edit-ingredient-repeat" index="index('edit-ingredient-repeat') - 1"/>
+                    <xf:setfocus control="edit-ingredient-repeat-input"/>
                 </xf:action>
             </xf:trigger>
         </xf:group>

--- a/samples/sample3/hello.html
+++ b/samples/sample3/hello.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+       <title>Hello World in XForms</title>
+      <link rel="stylesheet" href="css/style.css" type="text/css" />
+      <script src="../../Saxon-JS-1.1.0/SaxonJS.js"></script>
+
+      <script>
+      window.onload = function() {
+        SaxonJS.transform({
+           "stylesheetLocation":"../../sef/saxon-xforms.sef.xml",
+           "sourceLocation":"xml/hello-xform.xml",
+           "stylesheetParams": {"xforms-file":"xml/hello-xform.xml"}
+           })
+      }     
+      </script>
+   </head>
+
+   <body>
+       <h1 id="title">Hello World in XForms</h1>
+      
+      <div>
+          <p>Type your first name in the input box.</p>
+          <p>If you are running XForms, the output should be displayed in the output area.</p>
+      </div>
+      <div id="xForm"></div>
+    
+
+   </body>
+</html>

--- a/samples/sample3/xml/hello-xform.xml
+++ b/samples/sample3/xml/hello-xform.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xf:xform xmlns:xf="http://www.w3.org/2002/xforms" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+ 
+    <xf:model>
+        <xf:instance id="hello">
+            <data xmlns="">
+                <PersonGivenName>Mark</PersonGivenName>
+                <PetType>pet</PetType>
+                <CatName></CatName>
+            </data>
+        </xf:instance>
+    </xf:model>
+    
+    <xf:input ref="instance('hello')/PersonGivenName" incremental="true" class="hello-input">
+        <xf:label>Please enter your first name: </xf:label>
+        <xf:hint>Also known as your given name</xf:hint>
+    </xf:input>
+
+    
+    <xf:select1 ref="instance('hello')/PetType" incremental="true">
+        <xf:label>Type of pet:</xf:label>
+        <xf:item>
+            <xf:label>[Pet]</xf:label>
+            <xf:value>pet</xf:value> 
+        </xf:item>
+        <xf:item>
+            <xf:label>Cat</xf:label>
+            <xf:value>cat</xf:value> 
+        </xf:item>
+        <xf:item>
+            <xf:label>Dog</xf:label>
+            <xf:value>dog</xf:value> 
+        </xf:item>
+        <xf:item>
+            <xf:label>Tortoise</xf:label>
+            <xf:value>tortoise</xf:value> 
+        </xf:item>
+    </xf:select1>
+        
+    
+ 
+    <xf:input ref="instance('hello')/CatName" class="hello-input">
+        <xf:label>(Non-incremental) Please enter your pet's name: </xf:label>
+        <xf:hint>Or any old string</xf:hint>
+    </xf:input>
+    
+    
+    
+
+    <xf:output value="concat('Hello ', instance('hello')/PersonGivenName  , '. Your ', instance('hello')/PetType, ' is called ', instance('hello')/CatName)" class="block"/>
+    
+
+    
+</xf:xform>

--- a/sef/saxon-xforms.sef.xml
+++ b/sef/saxon-xforms.sef.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns='http://ns.saxonica.com/xslt/export' xmlns:fn='http://www.w3.org/2005/xpath-functions' xmlns:xs='http://www.w3.org/2001/XMLSchema' xmlns:vv='http://saxon.sf.net/generated-variable' xmlns:java-type='http://saxon.sf.net/java-type' when='2020-02-22T22:54:41.392Z' id='0' version='30' packageVersion='1' saxonVersion='9.9.1.5' target='JS' targetVersion='1' relocatable='true' implicit='true'>
+<package xmlns='http://ns.saxonica.com/xslt/export' xmlns:fn='http://www.w3.org/2005/xpath-functions' xmlns:xs='http://www.w3.org/2001/XMLSchema' xmlns:vv='http://saxon.sf.net/generated-variable' xmlns:java-type='http://saxon.sf.net/java-type' when='2020-02-23T16:30:37.976Z' id='0' version='30' packageVersion='1' saxonVersion='9.9.1.5' target='JS' targetVersion='1' relocatable='true' implicit='true'>
  <co id='0' binds='1 2 1 2 3 3 4 5 6 3 7'>
-  <template name='Q{}action-insert' flags='os' line='4553' module='saxon-xforms.xsl' slots='18'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4554'>
+  <template name='Q{}action-insert' flags='os' line='4646' module='saxon-xforms.xsl' slots='20'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4647'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -10,7 +10,7 @@
       </check>
      </treat>
     </param>
-    <param line='4555' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
+    <param line='4648' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
      <empty role='select'/>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|instanceXML'>
       <check card='?' diag='8|0|XTTE0590|instanceXML'>
@@ -18,7 +18,7 @@
       </check>
      </treat>
     </param>
-    <param line='4556' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
+    <param line='4649' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -30,7 +30,7 @@
       </check>
      </treat>
     </param>
-    <let line='4558' var='Q{}ref' as='xs:string' slot='3' eval='16'>
+    <let line='4651' var='Q{}ref' as='xs:string' slot='3' eval='16'>
      <let var='Q{}relative' as='xs:string' slot='4' eval='16'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|1||xforms:resolveXPathStrings'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
@@ -44,22 +44,22 @@
         </cvUntyped>
        </check>
       </treat>
-      <choose line='836'>
+      <choose line='838'>
        <fn name='starts-with'>
         <varRef name='Q{}relative' slot='4'/>
         <str val='/'/>
        </fn>
-       <varRef line='837' name='Q{}relative' slot='4'/>
-       <fn line='839' name='starts-with'>
+       <varRef line='839' name='Q{}relative' slot='4'/>
+       <fn line='841' name='starts-with'>
         <varRef name='Q{}relative' slot='4'/>
         <str val='instance('/>
        </fn>
-       <varRef line='840' name='Q{}relative' slot='4'/>
-       <fn line='4558' name='not'>
+       <varRef line='842' name='Q{}relative' slot='4'/>
+       <fn line='4651' name='not'>
         <varRef name='Q{}nodeset' slot='2'/>
        </fn>
-       <varRef line='843' name='Q{}relative' slot='4'/>
-       <or line='845' op='or'>
+       <varRef line='845' name='Q{}relative' slot='4'/>
+       <or line='847' op='or'>
         <fn name='not'>
          <varRef name='Q{}relative' slot='4'/>
         </fn>
@@ -68,9 +68,9 @@
          <str val='.'/>
         </vc>
        </or>
-       <varRef line='4558' name='Q{}nodeset' slot='2'/>
+       <varRef line='4651' name='Q{}nodeset' slot='2'/>
        <true/>
-       <let line='850' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
+       <let line='852' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
         <choose>
          <fn name='contains'>
           <varRef name='Q{}relative' slot='4'/>
@@ -97,30 +97,30 @@
          <true/>
          <int val='0'/>
         </choose>
-        <let line='853' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
+        <let line='855' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
          <choose>
-          <fn line='4558' name='contains'>
+          <fn line='4651' name='contains'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
           </fn>
           <fn name='index-of'>
            <fn name='string-to-codepoints'>
-            <varRef line='4558' name='Q{}nodeset' slot='2'/>
+            <varRef line='4651' name='Q{}nodeset' slot='2'/>
            </fn>
            <int val='47'/>
           </fn>
           <true/>
           <int val='0'/>
          </choose>
-         <choose line='885'>
+         <choose line='887'>
           <compareToInt op='gt' val='0'>
            <varRef name='Q{}parentCallCount' slot='5'/>
           </compareToInt>
-          <fn line='889' name='concat'>
+          <fn line='891' name='concat'>
            <fn name='substring'>
-            <varRef line='4558' name='Q{}nodeset' slot='2'/>
+            <varRef line='4651' name='Q{}nodeset' slot='2'/>
             <int val='1'/>
-            <choose line='864'>
+            <choose line='866'>
              <and op='and'>
               <vc op='ge' onEmpty='0' comp='CAVC'>
                <fn name='count'>
@@ -132,7 +132,7 @@
                <varRef name='Q{}parentCallCount' slot='5'/>
               </compareToInt>
              </and>
-             <let line='865' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='7' eval='13'>
+             <let line='867' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='7' eval='13'>
               <arith op='-' calc='i-i'>
                <varRef name='Q{}parentCallCount' slot='5'/>
                <int val='1'/>
@@ -148,7 +148,7 @@
               </check>
              </let>
              <true/>
-             <check line='868' card='1' diag='3|0|XTTE0570|parentSlash'>
+             <check line='870' card='1' diag='3|0|XTTE0570|parentSlash'>
               <lastOf>
                <varRef name='Q{}slashes' slot='6'/>
               </lastOf>
@@ -163,17 +163,17 @@
            </fn>
           </fn>
           <true/>
-          <fn line='4558' name='concat'>
+          <fn line='4651' name='concat'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
-           <varRef line='892' name='Q{}relative' slot='4'/>
+           <varRef line='894' name='Q{}relative' slot='4'/>
           </fn>
          </choose>
         </let>
        </let>
       </choose>
      </let>
-     <let line='4559' var='Q{}at' as='xs:string?' slot='8' eval='7'>
+     <let line='4652' var='Q{}at' as='xs:string?' slot='8' eval='7'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|at'>
        <check card='?' diag='3|0|XTTE0570|at'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|at'>
@@ -186,7 +186,7 @@
         </cvUntyped>
        </check>
       </treat>
-      <let line='4560' var='Q{}position' as='xs:string?' slot='9' eval='7'>
+      <let line='4653' var='Q{}position' as='xs:string?' slot='9' eval='7'>
        <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|position'>
         <check card='?' diag='3|0|XTTE0570|position'>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|position'>
@@ -199,7 +199,7 @@
          </cvUntyped>
         </check>
        </treat>
-       <let line='4561' var='Q{}origin-ref' as='xs:string?' slot='10' eval='7'>
+       <let line='4654' var='Q{}origin-ref' as='xs:string?' slot='10' eval='7'>
         <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|origin-ref'>
          <check card='?' diag='3|0|XTTE0570|origin-ref'>
           <cvUntyped to='xs:string' diag='3|0|XTTE0570|origin-ref'>
@@ -212,272 +212,218 @@
           </cvUntyped>
          </check>
         </treat>
-        <let line='4576' var='Q{}instanceXML2' as='element()' slot='11' eval='16'>
-         <choose line='4578'>
-          <and op='and'>
-           <vc op='eq' onEmpty='0' comp='CCC'>
-            <ufCall line='4574' name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='6'>
-             <varRef name='Q{}ref' slot='3'/>
-            </ufCall>
-            <str val='saxon-forms-default'/>
-           </vc>
-           <fn name='exists'>
-            <varRef name='Q{}instanceXML' slot='1'/>
-           </fn>
-          </and>
-          <check line='4579' card='1' diag='3|0|XTTE0570|instanceXML2'>
-           <varRef name='Q{}instanceXML' slot='1'/>
-          </check>
-          <true/>
-          <check line='4582' card='1' diag='3|0|XTTE0570|instanceXML2'>
-           <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='1' eval='6'>
-            <varRef name='Q{}ref' slot='3'/>
-           </ufCall>
-          </check>
-         </choose>
-         <let line='4589' var='Q{}instanceXML-origin' as='element()' slot='12' eval='16'>
-          <choose line='4591'>
+        <let line='4667' var='Q{}instance-id' as='xs:string' slot='11' eval='16'>
+         <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='6'>
+          <varRef name='Q{}ref' slot='3'/>
+         </ufCall>
+         <let line='4669' var='Q{}instanceXML2' as='element()' slot='12' eval='16'>
+          <choose line='4671'>
            <and op='and'>
             <vc op='eq' onEmpty='0' comp='CCC'>
-             <ufCall line='4587' name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='2' eval='16'>
-              <check card='1' diag='0|0||xforms:getInstanceId'>
-               <varRef name='Q{}origin-ref' slot='10'/>
-              </check>
-             </ufCall>
+             <varRef name='Q{}instance-id' slot='11'/>
              <str val='saxon-forms-default'/>
             </vc>
             <fn name='exists'>
              <varRef name='Q{}instanceXML' slot='1'/>
             </fn>
            </and>
-           <check line='4592' card='1' diag='3|0|XTTE0570|instanceXML-origin'>
+           <check line='4672' card='1' diag='3|0|XTTE0570|instanceXML2'>
             <varRef name='Q{}instanceXML' slot='1'/>
            </check>
            <true/>
-           <check line='4595' card='1' diag='3|0|XTTE0570|instanceXML-origin'>
-            <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='3' eval='16'>
-             <check card='1' diag='0|0||xforms:getInstance-JS'>
-              <varRef name='Q{}origin-ref' slot='10'/>
-             </check>
+           <check line='4675' card='1' diag='3|0|XTTE0570|instanceXML2'>
+            <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='6'>
+             <varRef name='Q{}instance-id' slot='11'/>
             </ufCall>
            </check>
           </choose>
-          <let line='4606' var='Q{}origin-node' as='node()?' slot='13' eval='7'>
-           <treat line='4607' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|origin-node'>
-            <check card='?' diag='3|0|XTTE0570|origin-node'>
-             <evaluate dxns=''>
-              <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='4' eval='16'>
-               <check card='1' diag='0|0||xforms:impose'>
-                <varRef name='Q{}origin-ref' slot='10'/>
-               </check>
-              </ufCall>
-              <varRef role='cxt' name='Q{}instanceXML-origin' slot='12'/>
-              <varRef role='nsCxt' name='Q{}instanceXML-origin' slot='12'/>
-              <str role='sa' val='no'/>
-              <map role='options' size='0'/>
-              <map role='wp' size='0'/>
-             </evaluate>
+          <let line='4680' var='Q{}instance-id-origin' as='xs:string' slot='13' eval='16'>
+           <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='2' eval='16'>
+            <check card='1' diag='0|0||xforms:getInstanceId'>
+             <varRef name='Q{}origin-ref' slot='10'/>
             </check>
-           </treat>
-           <let line='4610' var='Q{}insert-node-location' as='node()' slot='14' eval='16'>
-            <treat line='4611' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|insert-node-location'>
-             <check card='1' diag='3|0|XTTE0570|insert-node-location'>
-              <evaluate dxns=''>
-               <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='5' eval='16'>
-                <check card='1' diag='0|0||xforms:impose'>
-                 <choose line='4572'>
-                  <vc op='ne' onEmpty='0' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
-                   <varRef name='Q{}ref' slot='3'/>
-                   <str val=''/>
-                  </vc>
-                  <choose>
-                   <fn name='exists'>
-                    <varRef name='Q{}at' slot='8'/>
-                   </fn>
-                   <fn name='concat'>
-                    <varRef name='Q{}ref' slot='3'/>
-                    <str val='['/>
-                    <varRef name='Q{}at' slot='8'/>
-                    <str val=']'/>
-                   </fn>
-                   <true/>
-                   <varRef name='Q{}ref' slot='3'/>
-                  </choose>
-                 </choose>
-                </check>
-               </ufCall>
-               <varRef role='cxt' name='Q{}instanceXML2' slot='11'/>
-               <varRef role='nsCxt' name='Q{}instanceXML2' slot='11'/>
-               <str role='sa' val='no'/>
-               <map role='options' size='0'/>
-               <map role='wp' size='0'/>
-              </evaluate>
+           </ufCall>
+           <let line='4682' var='Q{}instanceXML-origin' as='element()' slot='14' eval='16'>
+            <choose line='4684'>
+             <and op='and'>
+              <vc op='eq' onEmpty='0' comp='CCC'>
+               <varRef name='Q{}instance-id-origin' slot='13'/>
+               <str val='saxon-forms-default'/>
+              </vc>
+              <fn name='exists'>
+               <varRef name='Q{}instanceXML' slot='1'/>
+              </fn>
+             </and>
+             <check line='4685' card='1' diag='3|0|XTTE0570|instanceXML-origin'>
+              <varRef name='Q{}instanceXML' slot='1'/>
              </check>
-            </treat>
-            <sequence line='4614'>
-             <message>
-              <sequence role='select'>
-               <valueOf>
-                <str val='[action-insert] $insert-node-location = '/>
-               </valueOf>
-               <valueOf>
-                <fn name='serialize'>
-                 <varRef name='Q{}insert-node-location' slot='14'/>
-                </fn>
-               </valueOf>
-              </sequence>
-              <str role='terminate' val='no'/>
-              <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-             </message>
-             <message line='4615'>
-              <sequence role='select'>
-               <valueOf>
-                <str val='[action-insert] $origin-node = '/>
-               </valueOf>
-               <valueOf>
-                <fn name='serialize'>
-                 <varRef name='Q{}origin-node' slot='13'/>
-                </fn>
-               </valueOf>
-              </sequence>
-              <str role='terminate' val='no'/>
-              <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-             </message>
-             <let line='4632' var='Q{}instance-with-insert' as='element()' slot='15' eval='16'>
-              <treat line='4633' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-insert'>
-               <check card='1' diag='3|0|XTTE0570|instance-with-insert'>
-                <applyT mode='Q{}insert-node' bSlot='6'>
-                 <varRef role='select' name='Q{}instanceXML2' slot='11'/>
-                 <withParam name='Q{}insert-node-location' flags='t' as='node()'>
-                  <varRef line='4634' name='Q{}insert-node-location' slot='14'/>
-                 </withParam>
-                 <withParam name='Q{}node-to-insert' flags='t' as='node()?'>
-                  <choose line='4621'>
-                   <fn name='exists'>
-                    <varRef name='Q{}origin-node' slot='13'/>
-                   </fn>
-                   <copyOf line='4622' flags='vc'>
-                    <varRef name='Q{}origin-node' slot='13'/>
-                   </copyOf>
-                   <true/>
-                   <copyOf line='4625' flags='vc'>
-                    <varRef name='Q{}insert-node-location' slot='14'/>
-                   </copyOf>
-                  </choose>
-                 </withParam>
-                 <withParam name='Q{}position-relative' flags='t' as='xs:string?'>
-                  <varRef line='4636' name='Q{}position' slot='9'/>
-                 </withParam>
-                </applyT>
-               </check>
-              </treat>
-              <sequence line='4640'>
-               <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='7' eval='6 6'>
-                <varRef name='Q{}ref' slot='3'/>
-                <varRef name='Q{}instance-with-insert' slot='15'/>
-               </ufCall>
-               <choose line='4644'>
-                <fn name='matches'>
-                 <varRef name='Q{}at' slot='8'/>
-                 <str val='index\s*\('/>
-                 <str val=''/>
-                </fn>
-                <let line='4645' var='Q{}repeat-id' as='xs:string?' slot='16' eval='7'>
-                 <ufCall name='Q{http://www.w3.org/2002/xforms}getRepeatID' tailCall='false' bSlot='8' eval='16'>
-                  <check card='1' diag='0|0||xforms:getRepeatID'>
-                   <varRef name='Q{}at' slot='8'/>
+             <true/>
+             <check line='4688' card='1' diag='3|0|XTTE0570|instanceXML-origin'>
+              <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='3' eval='6'>
+               <varRef name='Q{}instance-id-origin' slot='13'/>
+              </ufCall>
+             </check>
+            </choose>
+            <let line='4700' var='Q{}origin-node' as='node()?' slot='15' eval='7'>
+             <treat line='4701' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|origin-node'>
+              <check card='?' diag='3|0|XTTE0570|origin-node'>
+               <evaluate dxns=''>
+                <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='4' eval='16'>
+                 <check card='1' diag='0|0||xforms:impose'>
+                  <varRef name='Q{}origin-ref' slot='10'/>
+                 </check>
+                </ufCall>
+                <varRef role='cxt' name='Q{}instanceXML-origin' slot='14'/>
+                <varRef role='nsCxt' name='Q{}instanceXML-origin' slot='14'/>
+                <str role='sa' val='no'/>
+                <map role='options' size='0'/>
+                <map role='wp' size='0'/>
+               </evaluate>
+              </check>
+             </treat>
+             <let line='4704' var='Q{}insert-node-location' as='node()' slot='16' eval='16'>
+              <treat line='4705' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|insert-node-location'>
+               <check card='1' diag='3|0|XTTE0570|insert-node-location'>
+                <evaluate dxns=''>
+                 <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='5' eval='16'>
+                  <check card='1' diag='0|0||xforms:impose'>
+                   <choose line='4665'>
+                    <vc op='ne' onEmpty='0' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+                     <varRef name='Q{}ref' slot='3'/>
+                     <str val=''/>
+                    </vc>
+                    <choose>
+                     <fn name='exists'>
+                      <varRef name='Q{}at' slot='8'/>
+                     </fn>
+                     <fn name='concat'>
+                      <varRef name='Q{}ref' slot='3'/>
+                      <str val='['/>
+                      <varRef name='Q{}at' slot='8'/>
+                      <str val=']'/>
+                     </fn>
+                     <true/>
+                     <varRef name='Q{}ref' slot='3'/>
+                    </choose>
+                   </choose>
                   </check>
                  </ufCall>
-                 <let line='4646' var='Q{}at-position' as='xs:integer' slot='17' eval='16'>
-                  <treat line='4647' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|at-position'>
-                   <check card='1' diag='3|0|XTTE0570|at-position'>
-                    <cvUntyped to='xs:integer' diag='3|0|XTTE0570|at-position'>
-                     <data>
-                      <evaluate dxns=''>
-                       <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='9' eval='16'>
-                        <check card='1' diag='0|0||xforms:impose'>
-                         <varRef name='Q{}at' slot='8'/>
-                        </check>
-                       </ufCall>
-                       <empty role='cxt'/>
-                       <str role='sa' val='no'/>
-                       <map role='options' size='0'/>
-                       <map role='wp' size='0'/>
-                      </evaluate>
-                     </data>
-                    </cvUntyped>
-                   </check>
-                  </treat>
-                  <sequence line='4649'>
-                   <message>
-                    <sequence role='select'>
-                     <valueOf>
-                      <str val='[action-insert] $repeat-id = '/>
-                     </valueOf>
-                     <valueOf>
-                      <varRef name='Q{}repeat-id' slot='16'/>
-                     </valueOf>
-                    </sequence>
-                    <str role='terminate' val='no'/>
-                    <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-                   </message>
-                   <message line='4650'>
-                    <sequence role='select'>
-                     <valueOf>
-                      <str val='[action-insert] $at-position evaluated as '/>
-                     </valueOf>
-                     <valueOf>
-                      <convert from='xs:integer' to='xs:string'>
-                       <varRef name='Q{}at-position' slot='17'/>
-                      </convert>
-                     </valueOf>
-                    </sequence>
-                    <str role='terminate' val='no'/>
-                    <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-                   </message>
-                   <choose line='4652'>
+                 <varRef role='cxt' name='Q{}instanceXML2' slot='12'/>
+                 <varRef role='nsCxt' name='Q{}instanceXML2' slot='12'/>
+                 <str role='sa' val='no'/>
+                 <map role='options' size='0'/>
+                 <map role='wp' size='0'/>
+                </evaluate>
+               </check>
+              </treat>
+              <let line='4726' var='Q{}instance-with-insert' as='element()' slot='17' eval='16'>
+               <treat line='4727' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-insert'>
+                <check card='1' diag='3|0|XTTE0570|instance-with-insert'>
+                 <applyT mode='Q{}insert-node' bSlot='6'>
+                  <varRef role='select' name='Q{}instanceXML2' slot='12'/>
+                  <withParam name='Q{}insert-node-location' flags='t' as='node()'>
+                   <varRef line='4728' name='Q{}insert-node-location' slot='16'/>
+                  </withParam>
+                  <withParam name='Q{}node-to-insert' flags='t' as='node()?'>
+                   <choose line='4715'>
                     <fn name='exists'>
-                     <varRef name='Q{}repeat-id' slot='16'/>
+                     <varRef name='Q{}origin-node' slot='15'/>
                     </fn>
-                    <choose line='4654'>
+                    <copyOf line='4716' flags='vc'>
+                     <varRef name='Q{}origin-node' slot='15'/>
+                    </copyOf>
+                    <true/>
+                    <copyOf line='4719' flags='vc'>
+                     <varRef name='Q{}insert-node-location' slot='16'/>
+                    </copyOf>
+                   </choose>
+                  </withParam>
+                  <withParam name='Q{}position-relative' flags='t' as='xs:string?'>
+                   <varRef line='4730' name='Q{}position' slot='9'/>
+                  </withParam>
+                 </applyT>
+                </check>
+               </treat>
+               <sequence line='4736'>
+                <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='7' eval='6 6'>
+                 <varRef name='Q{}ref' slot='3'/>
+                 <varRef name='Q{}instance-with-insert' slot='17'/>
+                </ufCall>
+                <choose line='4740'>
+                 <fn name='matches'>
+                  <varRef name='Q{}at' slot='8'/>
+                  <str val='index\s*\('/>
+                  <str val=''/>
+                 </fn>
+                 <let line='4741' var='Q{}repeat-id' as='xs:string?' slot='18' eval='7'>
+                  <ufCall name='Q{http://www.w3.org/2002/xforms}getRepeatID' tailCall='false' bSlot='8' eval='16'>
+                   <check card='1' diag='0|0||xforms:getRepeatID'>
+                    <varRef name='Q{}at' slot='8'/>
+                   </check>
+                  </ufCall>
+                  <let line='4742' var='Q{}at-position' as='xs:integer' slot='19' eval='16'>
+                   <treat line='4743' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|at-position'>
+                    <check card='1' diag='3|0|XTTE0570|at-position'>
+                     <cvUntyped to='xs:integer' diag='3|0|XTTE0570|at-position'>
+                      <data>
+                       <evaluate dxns=''>
+                        <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='9' eval='16'>
+                         <check card='1' diag='0|0||xforms:impose'>
+                          <varRef name='Q{}at' slot='8'/>
+                         </check>
+                        </ufCall>
+                        <empty role='cxt'/>
+                        <str role='sa' val='no'/>
+                        <map role='options' size='0'/>
+                        <map role='wp' size='0'/>
+                       </evaluate>
+                      </data>
+                     </cvUntyped>
+                    </check>
+                   </treat>
+                   <choose line='4748'>
+                    <fn name='exists'>
+                     <varRef name='Q{}repeat-id' slot='18'/>
+                    </fn>
+                    <choose line='4750'>
                      <vc op='eq' onEmpty='0' comp='CCC'>
                       <varRef name='Q{}position' slot='9'/>
                       <str val='before'/>
                      </vc>
-                     <ifCall line='4655' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                     <ifCall line='4751' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                       <check card='1' diag='0|0||ixsl:call'>
                        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                       </check>
                       <str val='setRepeatIndex'/>
                       <arrayBlock>
-                       <varRef name='Q{}repeat-id' slot='16'/>
-                       <varRef name='Q{}at-position' slot='17'/>
+                       <varRef name='Q{}repeat-id' slot='18'/>
+                       <varRef name='Q{}at-position' slot='19'/>
                       </arrayBlock>
                      </ifCall>
                      <true/>
-                     <ifCall line='4658' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                     <ifCall line='4754' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                       <check card='1' diag='0|0||ixsl:call'>
                        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                       </check>
                       <str val='setRepeatIndex'/>
                       <arrayBlock>
-                       <varRef name='Q{}repeat-id' slot='16'/>
+                       <varRef name='Q{}repeat-id' slot='18'/>
                        <arith op='+' calc='i+i'>
-                        <varRef name='Q{}at-position' slot='17'/>
+                        <varRef name='Q{}at-position' slot='19'/>
                         <int val='1'/>
                        </arith>
                       </arrayBlock>
                      </ifCall>
                     </choose>
                    </choose>
-                  </sequence>
+                  </let>
                  </let>
-                </let>
-               </choose>
-               <callT line='4668' name='Q{}xforms-recalculate' bSlot='10' flags='t'/>
-              </sequence>
+                </choose>
+                <callT line='4764' name='Q{}xforms-recalculate' bSlot='10' flags='t'/>
+               </sequence>
+              </let>
              </let>
-            </sequence>
+            </let>
            </let>
           </let>
          </let>
@@ -490,8 +436,8 @@
   </template>
  </co>
  <co id='8' binds='1 2 3 3 9 5 6 3 7'>
-  <template name='Q{}action-delete' flags='os' line='4681' module='saxon-xforms.xsl' slots='18'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4682'>
+  <template name='Q{}action-delete' flags='os' line='4777' module='saxon-xforms.xsl' slots='19'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4778'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -499,14 +445,14 @@
       </check>
      </treat>
     </param>
-    <param line='4683' name='Q{}instanceXML' slot='1' flags='ti' as='element()'>
+    <param line='4779' name='Q{}instanceXML' slot='1' flags='ti' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|instanceXML'>
       <check card='1' diag='8|0|XTTE0590|instanceXML'>
        <supplied slot='1'/>
       </check>
      </treat>
     </param>
-    <param line='4684' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
+    <param line='4780' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -518,7 +464,7 @@
       </check>
      </treat>
     </param>
-    <let line='4686' var='Q{}ref' as='xs:string' slot='3' eval='16'>
+    <let line='4782' var='Q{}ref' as='xs:string' slot='3' eval='16'>
      <let var='Q{}relative' as='xs:string' slot='4' eval='16'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|1||xforms:resolveXPathStrings'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
@@ -532,22 +478,22 @@
         </cvUntyped>
        </check>
       </treat>
-      <choose line='836'>
+      <choose line='838'>
        <fn name='starts-with'>
         <varRef name='Q{}relative' slot='4'/>
         <str val='/'/>
        </fn>
-       <varRef line='837' name='Q{}relative' slot='4'/>
-       <fn line='839' name='starts-with'>
+       <varRef line='839' name='Q{}relative' slot='4'/>
+       <fn line='841' name='starts-with'>
         <varRef name='Q{}relative' slot='4'/>
         <str val='instance('/>
        </fn>
-       <varRef line='840' name='Q{}relative' slot='4'/>
-       <fn line='4686' name='not'>
+       <varRef line='842' name='Q{}relative' slot='4'/>
+       <fn line='4782' name='not'>
         <varRef name='Q{}nodeset' slot='2'/>
        </fn>
-       <varRef line='843' name='Q{}relative' slot='4'/>
-       <or line='845' op='or'>
+       <varRef line='845' name='Q{}relative' slot='4'/>
+       <or line='847' op='or'>
         <fn name='not'>
          <varRef name='Q{}relative' slot='4'/>
         </fn>
@@ -556,9 +502,9 @@
          <str val='.'/>
         </vc>
        </or>
-       <varRef line='4686' name='Q{}nodeset' slot='2'/>
+       <varRef line='4782' name='Q{}nodeset' slot='2'/>
        <true/>
-       <let line='850' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
+       <let line='852' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
         <choose>
          <fn name='contains'>
           <varRef name='Q{}relative' slot='4'/>
@@ -585,30 +531,30 @@
          <true/>
          <int val='0'/>
         </choose>
-        <let line='853' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
+        <let line='855' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
          <choose>
-          <fn line='4686' name='contains'>
+          <fn line='4782' name='contains'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
           </fn>
           <fn name='index-of'>
            <fn name='string-to-codepoints'>
-            <varRef line='4686' name='Q{}nodeset' slot='2'/>
+            <varRef line='4782' name='Q{}nodeset' slot='2'/>
            </fn>
            <int val='47'/>
           </fn>
           <true/>
           <int val='0'/>
          </choose>
-         <choose line='885'>
+         <choose line='887'>
           <compareToInt op='gt' val='0'>
            <varRef name='Q{}parentCallCount' slot='5'/>
           </compareToInt>
-          <fn line='889' name='concat'>
+          <fn line='891' name='concat'>
            <fn name='substring'>
-            <varRef line='4686' name='Q{}nodeset' slot='2'/>
+            <varRef line='4782' name='Q{}nodeset' slot='2'/>
             <int val='1'/>
-            <choose line='864'>
+            <choose line='866'>
              <and op='and'>
               <vc op='ge' onEmpty='0' comp='CAVC'>
                <fn name='count'>
@@ -620,7 +566,7 @@
                <varRef name='Q{}parentCallCount' slot='5'/>
               </compareToInt>
              </and>
-             <let line='865' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='7' eval='13'>
+             <let line='867' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='7' eval='13'>
               <arith op='-' calc='i-i'>
                <varRef name='Q{}parentCallCount' slot='5'/>
                <int val='1'/>
@@ -636,7 +582,7 @@
               </check>
              </let>
              <true/>
-             <check line='868' card='1' diag='3|0|XTTE0570|parentSlash'>
+             <check line='870' card='1' diag='3|0|XTTE0570|parentSlash'>
               <lastOf>
                <varRef name='Q{}slashes' slot='6'/>
               </lastOf>
@@ -651,17 +597,17 @@
            </fn>
           </fn>
           <true/>
-          <fn line='4686' name='concat'>
+          <fn line='4782' name='concat'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
-           <varRef line='892' name='Q{}relative' slot='4'/>
+           <varRef line='894' name='Q{}relative' slot='4'/>
           </fn>
          </choose>
         </let>
        </let>
       </choose>
      </let>
-     <let line='4687' var='Q{}at' as='xs:string?' slot='8' eval='7'>
+     <let line='4783' var='Q{}at' as='xs:string?' slot='8' eval='7'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|at'>
        <check card='?' diag='3|0|XTTE0570|at'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|at'>
@@ -674,7 +620,7 @@
         </cvUntyped>
        </check>
       </treat>
-      <let line='4697' var='Q{}ref-qualified' as='xs:string' slot='9' eval='16'>
+      <let line='4793' var='Q{}ref-qualified' as='xs:string' slot='9' eval='16'>
        <choose>
         <fn name='exists'>
          <varRef name='Q{}at' slot='8'/>
@@ -688,229 +634,232 @@
         <true/>
         <varRef name='Q{}ref' slot='3'/>
        </choose>
-       <let line='4701' var='Q{}instanceXML2' as='element()' slot='10' eval='16'>
-        <choose line='4703'>
-         <vc op='eq' onEmpty='0' comp='CCC'>
-          <ufCall line='4699' name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='6'>
-           <varRef name='Q{}ref' slot='3'/>
-          </ufCall>
-          <str val='saxon-forms-default'/>
-         </vc>
-         <varRef line='4704' name='Q{}instanceXML' slot='1'/>
-         <true/>
-         <check line='4707' card='1' diag='3|0|XTTE0570|instanceXML2'>
-          <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='1' eval='6'>
-           <varRef name='Q{}ref' slot='3'/>
-          </ufCall>
-         </check>
-        </choose>
-        <let line='4712' var='Q{}ifVar' as='xs:string?' slot='11' eval='7'>
-         <choose line='791'>
-          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
-           <varRef line='4712' name='Q{}action-map' slot='0'/>
-           <str val='@if'/>
-          </ifCall>
-          <treat line='792' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
-           <check card='?' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
-            <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
-             <data>
-              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-               <varRef line='4712' name='Q{}action-map' slot='0'/>
-               <str val='@if'/>
-              </ifCall>
-             </data>
-            </cvUntyped>
-           </check>
-          </treat>
+       <let line='4795' var='Q{}instance-id' as='xs:string' slot='10' eval='16'>
+        <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='6'>
+         <varRef name='Q{}ref' slot='3'/>
+        </ufCall>
+        <let line='4797' var='Q{}instanceXML2' as='element()' slot='11' eval='16'>
+         <choose line='4799'>
+          <vc op='eq' onEmpty='0' comp='CCC'>
+           <varRef name='Q{}instance-id' slot='10'/>
+           <str val='saxon-forms-default'/>
+          </vc>
+          <varRef line='4800' name='Q{}instanceXML' slot='1'/>
+          <true/>
+          <check line='4803' card='1' diag='3|0|XTTE0570|instanceXML2'>
+           <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='6'>
+            <varRef name='Q{}instance-id' slot='10'/>
+           </ufCall>
+          </check>
          </choose>
-         <let line='4715' var='Q{}delete-node' as='node()?' slot='12' eval='7'>
-          <choose line='4717'>
-           <and op='and'>
-            <fn name='exists'>
-             <varRef name='Q{}ref-qualified' slot='9'/>
-            </fn>
-            <vc op='ne' onEmpty='1' comp='CCC'>
-             <varRef name='Q{}ref-qualified' slot='9'/>
-             <str val=''/>
-            </vc>
-           </and>
-           <treat line='4718' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|delete-node'>
-            <check card='?' diag='3|0|XTTE0570|delete-node'>
-             <evaluate dxns=''>
-              <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
-               <check card='1' diag='0|0||xforms:impose'>
-                <varRef name='Q{}ref-qualified' slot='9'/>
-               </check>
-              </ufCall>
-              <varRef role='cxt' name='Q{}instanceXML2' slot='10'/>
-              <varRef role='nsCxt' name='Q{}instanceXML2' slot='10'/>
-              <str role='sa' val='no'/>
-              <map role='options' size='0'/>
-              <map role='wp' size='0'/>
-             </evaluate>
+         <let line='4808' var='Q{}ifVar' as='xs:string?' slot='12' eval='7'>
+          <choose line='793'>
+           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+            <varRef line='4808' name='Q{}action-map' slot='0'/>
+            <str val='@if'/>
+           </ifCall>
+           <treat line='794' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
+            <check card='?' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
+             <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
+              <data>
+               <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                <varRef line='4808' name='Q{}action-map' slot='0'/>
+                <str val='@if'/>
+               </ifCall>
+              </data>
+             </cvUntyped>
             </check>
            </treat>
           </choose>
-          <let line='4723' var='Q{}ifExecuted' as='xs:boolean' slot='13' eval='16'>
-           <choose line='4725'>
-            <fn name='exists'>
-             <varRef name='Q{}ifVar' slot='11'/>
-            </fn>
-            <treat line='4726' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|ifExecuted'>
-             <check card='1' diag='3|0|XTTE0570|ifExecuted'>
-              <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|ifExecuted'>
-               <data>
-                <evaluate dxns=''>
-                 <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='3' eval='16'>
-                  <check card='1' diag='0|0||xforms:impose'>
-                   <varRef name='Q{}ifVar' slot='11'/>
-                  </check>
-                 </ufCall>
-                 <varRef role='cxt' name='Q{}delete-node' slot='12'/>
-                 <check role='nsCxt' card='1' diag='4|0|XTTE3170|xsl:evaluate/namespace-context'>
-                  <varRef name='Q{}delete-node' slot='12'/>
-                 </check>
-                 <str role='sa' val='no'/>
-                 <map role='options' size='0'/>
-                 <map role='wp' size='0'/>
-                </evaluate>
-               </data>
-              </cvUntyped>
+          <let line='4811' var='Q{}delete-node' as='node()?' slot='13' eval='7'>
+           <choose line='4813'>
+            <and op='and'>
+             <fn name='exists'>
+              <varRef name='Q{}ref-qualified' slot='9'/>
+             </fn>
+             <vc op='ne' onEmpty='1' comp='CCC'>
+              <varRef name='Q{}ref-qualified' slot='9'/>
+              <str val=''/>
+             </vc>
+            </and>
+            <treat line='4814' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|delete-node'>
+             <check card='?' diag='3|0|XTTE0570|delete-node'>
+              <evaluate dxns=''>
+               <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
+                <check card='1' diag='0|0||xforms:impose'>
+                 <varRef name='Q{}ref-qualified' slot='9'/>
+                </check>
+               </ufCall>
+               <varRef role='cxt' name='Q{}instanceXML2' slot='11'/>
+               <varRef role='nsCxt' name='Q{}instanceXML2' slot='11'/>
+               <str role='sa' val='no'/>
+               <map role='options' size='0'/>
+               <map role='wp' size='0'/>
+              </evaluate>
              </check>
             </treat>
-            <true/>
-            <true/>
            </choose>
-           <choose line='4734'>
-            <varRef name='Q{}ifExecuted' slot='13'/>
-            <let line='4735' var='Q{}instance-with-delete' as='element()' slot='14' eval='16'>
-             <treat line='4736' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-delete'>
-              <check card='1' diag='3|0|XTTE0570|instance-with-delete'>
-               <applyT mode='Q{}delete-node' bSlot='4'>
-                <varRef role='select' name='Q{}instanceXML2' slot='10'/>
-                <withParam name='Q{}delete-node' flags='t' as='node()?'>
-                 <varRef line='4737' name='Q{}delete-node' slot='12'/>
-                </withParam>
-               </applyT>
+           <let line='4819' var='Q{}ifExecuted' as='xs:boolean' slot='14' eval='16'>
+            <choose line='4821'>
+             <fn name='exists'>
+              <varRef name='Q{}ifVar' slot='12'/>
+             </fn>
+             <treat line='4822' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|ifExecuted'>
+              <check card='1' diag='3|0|XTTE0570|ifExecuted'>
+               <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|ifExecuted'>
+                <data>
+                 <evaluate dxns=''>
+                  <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='3' eval='16'>
+                   <check card='1' diag='0|0||xforms:impose'>
+                    <varRef name='Q{}ifVar' slot='12'/>
+                   </check>
+                  </ufCall>
+                  <varRef role='cxt' name='Q{}delete-node' slot='13'/>
+                  <check role='nsCxt' card='1' diag='4|0|XTTE3170|xsl:evaluate/namespace-context'>
+                   <varRef name='Q{}delete-node' slot='13'/>
+                  </check>
+                  <str role='sa' val='no'/>
+                  <map role='options' size='0'/>
+                  <map role='wp' size='0'/>
+                 </evaluate>
+                </data>
+               </cvUntyped>
               </check>
              </treat>
-             <sequence line='4741'>
-              <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='5' eval='6 6'>
-               <varRef name='Q{}ref' slot='3'/>
-               <varRef name='Q{}instance-with-delete' slot='14'/>
-              </ufCall>
-              <choose line='4744'>
-               <fn name='matches'>
-                <varRef name='Q{}at' slot='8'/>
-                <str val='index\s*\('/>
-                <str val=''/>
-               </fn>
-               <let line='4745' var='Q{}repeat-id' as='xs:string?' slot='15' eval='7'>
-                <ufCall name='Q{http://www.w3.org/2002/xforms}getRepeatID' tailCall='false' bSlot='6' eval='16'>
-                 <check card='1' diag='0|0||xforms:getRepeatID'>
-                  <varRef name='Q{}at' slot='8'/>
-                 </check>
-                </ufCall>
-                <let line='4746' var='Q{}at-position' as='xs:integer' slot='16' eval='16'>
-                 <treat line='4747' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|at-position'>
-                  <check card='1' diag='3|0|XTTE0570|at-position'>
-                   <cvUntyped to='xs:integer' diag='3|0|XTTE0570|at-position'>
-                    <data>
-                     <evaluate dxns=''>
-                      <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='7' eval='16'>
-                       <check card='1' diag='0|0||xforms:impose'>
-                        <varRef name='Q{}at' slot='8'/>
-                       </check>
-                      </ufCall>
-                      <empty role='cxt'/>
-                      <str role='sa' val='no'/>
-                      <map role='options' size='0'/>
-                      <map role='wp' size='0'/>
-                     </evaluate>
-                    </data>
-                   </cvUntyped>
+             <true/>
+             <true/>
+            </choose>
+            <choose line='4830'>
+             <varRef name='Q{}ifExecuted' slot='14'/>
+             <let line='4831' var='Q{}instance-with-delete' as='element()' slot='15' eval='16'>
+              <treat line='4832' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-delete'>
+               <check card='1' diag='3|0|XTTE0570|instance-with-delete'>
+                <applyT mode='Q{}delete-node' bSlot='4'>
+                 <varRef role='select' name='Q{}instanceXML2' slot='11'/>
+                 <withParam name='Q{}delete-node' flags='t' as='node()?'>
+                  <varRef line='4833' name='Q{}delete-node' slot='13'/>
+                 </withParam>
+                </applyT>
+               </check>
+              </treat>
+              <sequence line='4839'>
+               <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='5' eval='6 6'>
+                <varRef name='Q{}ref' slot='3'/>
+                <varRef name='Q{}instance-with-delete' slot='15'/>
+               </ufCall>
+               <choose line='4842'>
+                <fn name='matches'>
+                 <varRef name='Q{}at' slot='8'/>
+                 <str val='index\s*\('/>
+                 <str val=''/>
+                </fn>
+                <let line='4843' var='Q{}repeat-id' as='xs:string?' slot='16' eval='7'>
+                 <ufCall name='Q{http://www.w3.org/2002/xforms}getRepeatID' tailCall='false' bSlot='6' eval='16'>
+                  <check card='1' diag='0|0||xforms:getRepeatID'>
+                   <varRef name='Q{}at' slot='8'/>
                   </check>
-                 </treat>
-                 <choose line='4750'>
-                  <fn name='exists'>
-                   <varRef name='Q{}repeat-id' slot='15'/>
-                  </fn>
-                  <let line='4751' var='Q{}repeat-size' as='xs:double' slot='17' eval='16'>
-                   <check card='1' diag='3|0|XTTE0570|repeat-size'>
-                    <convert from='xs:anyAtomicType' to='xs:double' flags='p' diag='3|0|XTTE0570|repeat-size'>
-                     <cvUntyped to='xs:double' diag='3|0|XTTE0570|repeat-size'>
-                      <data>
-                       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                        <check card='1' diag='0|0||ixsl:call'>
-                         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                 </ufCall>
+                 <let line='4844' var='Q{}at-position' as='xs:integer' slot='17' eval='16'>
+                  <treat line='4845' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|at-position'>
+                   <check card='1' diag='3|0|XTTE0570|at-position'>
+                    <cvUntyped to='xs:integer' diag='3|0|XTTE0570|at-position'>
+                     <data>
+                      <evaluate dxns=''>
+                       <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='7' eval='16'>
+                        <check card='1' diag='0|0||xforms:impose'>
+                         <varRef name='Q{}at' slot='8'/>
                         </check>
-                        <str val='getRepeatSize'/>
-                        <arrayBlock>
-                         <varRef name='Q{}repeat-id' slot='15'/>
-                        </arrayBlock>
-                       </ifCall>
-                      </data>
-                     </cvUntyped>
-                    </convert>
+                       </ufCall>
+                       <empty role='cxt'/>
+                       <str role='sa' val='no'/>
+                       <map role='options' size='0'/>
+                       <map role='wp' size='0'/>
+                      </evaluate>
+                     </data>
+                    </cvUntyped>
                    </check>
-                   <sequence line='4753'>
-                    <message>
-                     <sequence role='select'>
-                      <valueOf>
-                       <str val='[action-delete] Size of repeat &#39;'/>
-                      </valueOf>
-                      <valueOf>
-                       <varRef name='Q{}repeat-id' slot='15'/>
-                      </valueOf>
-                      <valueOf>
-                       <str val='&#39; is '/>
-                      </valueOf>
-                      <valueOf>
-                       <convert from='xs:double' to='xs:string'>
-                        <varRef name='Q{}repeat-size' slot='17'/>
-                       </convert>
-                      </valueOf>
-                      <valueOf>
-                       <str val=', index is '/>
-                      </valueOf>
-                      <valueOf>
-                       <convert from='xs:integer' to='xs:string'>
-                        <varRef name='Q{}at-position' slot='16'/>
-                       </convert>
-                      </valueOf>
-                     </sequence>
-                     <str role='terminate' val='no'/>
-                     <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-                    </message>
-                    <choose line='4756'>
-                     <vc op='eq' onEmpty='0' comp='CAVC'>
-                      <varRef name='Q{}at-position' slot='16'/>
-                      <varRef name='Q{}repeat-size' slot='17'/>
-                     </vc>
-                     <ifCall line='4758' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                      <check card='1' diag='0|0||ixsl:call'>
-                       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-                      </check>
-                      <str val='setRepeatIndex'/>
-                      <arrayBlock>
-                       <varRef name='Q{}repeat-id' slot='15'/>
-                       <arith op='-' calc='d-d'>
-                        <varRef name='Q{}repeat-size' slot='17'/>
-                        <dbl val='1'/>
-                       </arith>
-                      </arrayBlock>
-                     </ifCall>
-                    </choose>
-                   </sequence>
-                  </let>
-                 </choose>
+                  </treat>
+                  <choose line='4848'>
+                   <fn name='exists'>
+                    <varRef name='Q{}repeat-id' slot='16'/>
+                   </fn>
+                   <let line='4849' var='Q{}repeat-size' as='xs:double' slot='18' eval='16'>
+                    <check card='1' diag='3|0|XTTE0570|repeat-size'>
+                     <convert from='xs:anyAtomicType' to='xs:double' flags='p' diag='3|0|XTTE0570|repeat-size'>
+                      <cvUntyped to='xs:double' diag='3|0|XTTE0570|repeat-size'>
+                       <data>
+                        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                         <check card='1' diag='0|0||ixsl:call'>
+                          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                         </check>
+                         <str val='getRepeatSize'/>
+                         <arrayBlock>
+                          <varRef name='Q{}repeat-id' slot='16'/>
+                         </arrayBlock>
+                        </ifCall>
+                       </data>
+                      </cvUntyped>
+                     </convert>
+                    </check>
+                    <sequence line='4851'>
+                     <message>
+                      <sequence role='select'>
+                       <valueOf>
+                        <str val='[action-delete] Size of repeat &#39;'/>
+                       </valueOf>
+                       <valueOf>
+                        <varRef name='Q{}repeat-id' slot='16'/>
+                       </valueOf>
+                       <valueOf>
+                        <str val='&#39; is '/>
+                       </valueOf>
+                       <valueOf>
+                        <convert from='xs:double' to='xs:string'>
+                         <varRef name='Q{}repeat-size' slot='18'/>
+                        </convert>
+                       </valueOf>
+                       <valueOf>
+                        <str val=', index is '/>
+                       </valueOf>
+                       <valueOf>
+                        <convert from='xs:integer' to='xs:string'>
+                         <varRef name='Q{}at-position' slot='17'/>
+                        </convert>
+                       </valueOf>
+                      </sequence>
+                      <str role='terminate' val='no'/>
+                      <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+                     </message>
+                     <choose line='4854'>
+                      <vc op='eq' onEmpty='0' comp='CAVC'>
+                       <varRef name='Q{}at-position' slot='17'/>
+                       <varRef name='Q{}repeat-size' slot='18'/>
+                      </vc>
+                      <ifCall line='4856' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                       <check card='1' diag='0|0||ixsl:call'>
+                        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                       </check>
+                       <str val='setRepeatIndex'/>
+                       <arrayBlock>
+                        <varRef name='Q{}repeat-id' slot='16'/>
+                        <arith op='-' calc='d-d'>
+                         <varRef name='Q{}repeat-size' slot='18'/>
+                         <dbl val='1'/>
+                        </arith>
+                       </arrayBlock>
+                      </ifCall>
+                     </choose>
+                    </sequence>
+                   </let>
+                  </choose>
+                 </let>
                 </let>
-               </let>
-              </choose>
-              <callT line='4767' name='Q{}xforms-recalculate' bSlot='8' flags='t'/>
-             </sequence>
-            </let>
-           </choose>
+               </choose>
+               <callT line='4865' name='Q{}xforms-recalculate' bSlot='8' flags='t'/>
+              </sequence>
+             </let>
+            </choose>
+           </let>
           </let>
          </let>
         </let>
@@ -922,8 +871,8 @@
   </template>
  </co>
  <co id='10' binds='11'>
-  <template name='Q{}action-send' flags='os' line='4812' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4813'>
+  <template name='Q{}action-send' flags='os' line='4910' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4911'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -931,9 +880,9 @@
       </check>
      </treat>
     </param>
-    <callT line='4819' name='Q{}xforms-submit' bSlot='0' flags='t'>
+    <callT line='4917' name='Q{}xforms-submit' bSlot='0' flags='t'>
      <withParam name='Q{}submission' flags='c' as='xs:string'>
-      <treat line='4817' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|submission'>
+      <treat line='4915' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|submission'>
        <check card='1' diag='3|0|XTTE0570|submission'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|submission'>
          <data>
@@ -951,10 +900,10 @@
   </template>
  </co>
  <co id='12' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}usesIndexFunction' line='2989' module='saxon-xforms.xsl' eval='8' flags='pU' as='xs:boolean' slots='1'>
+  <function name='Q{http://www.w3.org/2002/xforms}usesIndexFunction' line='2962' module='saxon-xforms.xsl' eval='8' flags='pU' as='xs:boolean' slots='1'>
    <arg name='Q{}this' as='element()'/>
-   <fn role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3025' name='exists'>
-    <sequence line='3000'>
+   <fn role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2998' name='exists'>
+    <sequence line='2973'>
      <analyzeString>
       <cvUntyped role='select' to='xs:string'>
        <data>
@@ -966,7 +915,7 @@
       </cvUntyped>
       <str role='regex' val='\i\c*\('/>
       <str role='flags' val=''/>
-      <choose role='matching' line='3003'>
+      <choose role='matching' line='2976'>
        <vc op='eq' onEmpty='0' comp='CCC'>
         <fn name='substring-before'>
          <dot type='xs:string'/>
@@ -978,7 +927,7 @@
       </choose>
       <empty role='nonMatching'/>
      </analyzeString>
-     <analyzeString line='3012'>
+     <analyzeString line='2985'>
       <cvUntyped role='select' to='xs:string'>
        <data>
         <slash simple='1'>
@@ -989,7 +938,7 @@
       </cvUntyped>
       <str role='regex' val='\i\c*\('/>
       <str role='flags' val=''/>
-      <choose role='matching' line='3015'>
+      <choose role='matching' line='2988'>
        <vc op='eq' onEmpty='0' comp='CCC'>
         <fn name='substring-before'>
          <dot type='xs:string'/>
@@ -1007,18 +956,18 @@
  </co>
  <co id='13' binds='14 13 14 15 13 13 15'>
   <mode name='Q{}form-check' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='27' rank='0' minImp='0' slots='12' flags='s' line='2612' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='27' rank='0' minImp='0' slots='12' flags='s' line='2621' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2613'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2622'>
      <param name='Q{}curPath' slot='0'>
       <str role='select' val=''/>
       <supplied role='conversion' slot='0'/>
      </param>
-     <param line='2614' name='Q{}position' slot='1'>
+     <param line='2623' name='Q{}position' slot='1'>
       <int role='select' val='0'/>
       <supplied role='conversion' slot='1'/>
      </param>
-     <param line='2615' name='Q{}pendingUpdates' slot='2' flags='t' as='map(xs:string, xs:string)?'>
+     <param line='2624' name='Q{}pendingUpdates' slot='2' flags='t' as='map(xs:string, xs:string)?'>
       <empty role='select'/>
       <treat role='conversion' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|pendingUpdates'>
        <check card='?' diag='8|0|XTTE0590|pendingUpdates'>
@@ -1026,7 +975,7 @@
        </check>
       </treat>
      </param>
-     <param line='2616' name='Q{}updated-node' slot='3' flags='t' as='node()?'>
+     <param line='2625' name='Q{}updated-node' slot='3' flags='t' as='node()?'>
       <empty role='select'/>
       <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|updated-node'>
        <check card='?' diag='8|0|XTTE0590|updated-node'>
@@ -1034,7 +983,7 @@
        </check>
       </treat>
      </param>
-     <param line='2617' name='Q{}value' slot='4' flags='t' as='xs:string?'>
+     <param line='2626' name='Q{}value' slot='4' flags='t' as='xs:string?'>
       <empty role='select'/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|value'>
        <check card='?' diag='8|0|XTTE0590|value'>
@@ -1046,7 +995,7 @@
        </check>
       </treat>
      </param>
-     <let line='2638' var='Q{}updatedPath' as='xs:string' slot='5' eval='16'>
+     <let line='2647' var='Q{}updatedPath' as='xs:string' slot='5' eval='16'>
       <choose>
        <gc op='&gt;' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
         <data>
@@ -1077,7 +1026,7 @@
         </fn>
        </fn>
       </choose>
-      <sequence line='2644'>
+      <sequence line='2653'>
        <message>
         <sequence role='select'>
          <valueOf>
@@ -1091,7 +1040,7 @@
         <str role='terminate' val='no'/>
         <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
        </message>
-       <forEach line='2645'>
+       <forEach line='2654'>
         <filter flags='b'>
          <slash simple='1'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
@@ -1111,7 +1060,7 @@
           </fn>
          </or>
         </filter>
-        <sequence line='2646'>
+        <sequence line='2655'>
          <message>
           <sequence role='select'>
            <valueOf>
@@ -1131,7 +1080,7 @@
           <str role='terminate' val='no'/>
           <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
          </message>
-         <message line='2647'>
+         <message line='2656'>
           <sequence role='select'>
            <valueOf>
             <str val='[form-check] resolved @data-ref = &#39;'/>
@@ -1152,18 +1101,18 @@
          </message>
         </sequence>
        </forEach>
-       <copy line='2652' flags='cin'>
+       <copy line='2661' flags='cin'>
         <sequence role='content'>
          <applyT mode='Q{}form-check' bSlot='1'>
           <axis role='select' name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
           <withParam name='Q{}curPath' as='xs:string'>
-           <fn line='2653' name='concat'>
+           <fn line='2662' name='concat'>
             <varRef name='Q{}updatedPath' slot='5'/>
             <str val='/'/>
            </fn>
           </withParam>
          </applyT>
-         <let line='2659' var='Q{}associated-form-control' as='element()*' slot='6' eval='8'>
+         <let line='2668' var='Q{}associated-form-control' as='element()*' slot='6' eval='8'>
           <filter flags='b'>
            <filter flags='b'>
             <slash simple='1'>
@@ -1195,14 +1144,14 @@
             <varRef name='Q{}updatedPath' slot='5'/>
            </vc>
           </filter>
-          <sequence line='2661'>
+          <sequence line='2670'>
            <choose>
             <fn name='exists'>
              <tail start='2'>
               <varRef name='Q{}associated-form-control' slot='6'/>
              </tail>
             </fn>
-            <message line='2662'>
+            <message line='2671'>
              <sequence role='select'>
               <valueOf>
                <str val='[form-check] More than one form element controls the value of XForm node at '/>
@@ -1218,12 +1167,12 @@
              <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
             </message>
            </choose>
-           <choose line='2666'>
+           <choose line='2675'>
             <is op='is'>
              <varRef name='Q{}updated-node' slot='3'/>
              <dot type='element()'/>
             </is>
-            <sequence line='2667'>
+            <sequence line='2676'>
              <message>
               <valueOf role='select'>
                <str val='&#xA;                        [form-check] Matched node!!&#xA;                    '/>
@@ -1231,14 +1180,14 @@
               <str role='terminate' val='no'/>
               <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
              </message>
-             <valueOf line='2670' flags='l'>
+             <valueOf line='2679' flags='l'>
               <varRef name='Q{}value' slot='4'/>
              </valueOf>
             </sequence>
-            <fn line='2672' name='exists'>
+            <fn line='2681' name='exists'>
              <varRef name='Q{}associated-form-control' slot='6'/>
             </fn>
-            <valueOf line='2676' flags='l'>
+            <valueOf line='2685' flags='l'>
              <fn name='string-join'>
               <convert from='xs:anyAtomicType' to='xs:string'>
                <data>
@@ -1254,7 +1203,7 @@
               <str val=''/>
              </fn>
             </valueOf>
-            <and line='2679' op='and'>
+            <and line='2688' op='and'>
              <fn name='exists'>
               <varRef name='Q{}pendingUpdates' slot='2'/>
              </fn>
@@ -1265,7 +1214,7 @@
               <varRef name='Q{}updatedPath' slot='5'/>
              </ifCall>
             </and>
-            <valueOf line='2687' flags='l'>
+            <valueOf line='2696' flags='l'>
              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
               <check card='1' diag='0|0||map:get'>
                <varRef name='Q{}pendingUpdates' slot='2'/>
@@ -1274,7 +1223,7 @@
              </ifCall>
             </valueOf>
             <true/>
-            <valueOf line='2696' flags='l'>
+            <valueOf line='2705' flags='l'>
              <fn name='normalize-space'>
               <fn name='string-join'>
                <data>
@@ -1285,13 +1234,13 @@
              </fn>
             </valueOf>
            </choose>
-           <forEachGroup line='2701' algorithm='by'>
+           <forEachGroup line='2710' algorithm='by'>
             <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
             <fn role='key' name='local-name'>
              <dot type='element()'/>
             </fn>
             <str role='collation' val='http://www.w3.org/2005/xpath-functions/collation/codepoint'/>
-            <let role='content' line='2703' var='Q{}updatedChildPath' as='xs:string' slot='7' eval='8'>
+            <let role='content' line='2712' var='Q{}updatedChildPath' as='xs:string' slot='7' eval='8'>
              <fn name='concat'>
               <varRef name='Q{}updatedPath' slot='5'/>
               <str val='/'/>
@@ -1299,7 +1248,7 @@
                <currentGroupingKey/>
               </check>
              </fn>
-             <let line='2708' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='8' eval='13'>
+             <let line='2717' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='8' eval='13'>
               <fn name='concat'>
                <varRef name='Q{}updatedChildPath' slot='7'/>
                <str val='['/>
@@ -1317,7 +1266,7 @@
                  <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='8'/>
                 </fn>
                </filter>
-               <choose line='2711'>
+               <choose line='2720'>
                 <or op='or'>
                  <fn name='exists'>
                   <tail start='2'>
@@ -1328,36 +1277,36 @@
                   <varRef name='Q{}dataRefWithFilter' slot='9'/>
                  </fn>
                 </or>
-                <let line='2714' var='Q{http://saxon.sf.net/generated-variable}v1' as='xs:string' slot='10' eval='13'>
-                 <fn name='concat'>
-                  <varRef name='Q{}updatedPath' slot='5'/>
-                  <str val='/'/>
-                 </fn>
-                 <forEach line='2712'>
-                  <currentGroup/>
-                  <applyT line='2713' mode='Q{}form-check' bSlot='4'>
-                   <dot role='select'/>
-                   <withParam name='Q{}curPath' as='xs:string'>
-                    <varRef line='2714' name='Q{http://saxon.sf.net/generated-variable}v1' slot='10'/>
-                   </withParam>
-                   <withParam name='Q{}position' as='xs:integer'>
-                    <fn line='2715' name='position'/>
-                   </withParam>
-                  </applyT>
-                 </forEach>
-                </let>
-                <true/>
-                <let line='2723' var='Q{http://saxon.sf.net/generated-variable}v2' as='xs:string' slot='11' eval='13'>
+                <let line='2723' var='Q{http://saxon.sf.net/generated-variable}v1' as='xs:string' slot='10' eval='13'>
                  <fn name='concat'>
                   <varRef name='Q{}updatedPath' slot='5'/>
                   <str val='/'/>
                  </fn>
                  <forEach line='2721'>
                   <currentGroup/>
-                  <applyT line='2722' mode='Q{}form-check' bSlot='5'>
+                  <applyT line='2722' mode='Q{}form-check' bSlot='4'>
                    <dot role='select'/>
                    <withParam name='Q{}curPath' as='xs:string'>
-                    <varRef line='2723' name='Q{http://saxon.sf.net/generated-variable}v2' slot='11'/>
+                    <varRef line='2723' name='Q{http://saxon.sf.net/generated-variable}v1' slot='10'/>
+                   </withParam>
+                   <withParam name='Q{}position' as='xs:integer'>
+                    <fn line='2724' name='position'/>
+                   </withParam>
+                  </applyT>
+                 </forEach>
+                </let>
+                <true/>
+                <let line='2732' var='Q{http://saxon.sf.net/generated-variable}v2' as='xs:string' slot='11' eval='13'>
+                 <fn name='concat'>
+                  <varRef name='Q{}updatedPath' slot='5'/>
+                  <str val='/'/>
+                 </fn>
+                 <forEach line='2730'>
+                  <currentGroup/>
+                  <applyT line='2731' mode='Q{}form-check' bSlot='5'>
+                   <dot role='select'/>
+                   <withParam name='Q{}curPath' as='xs:string'>
+                    <varRef line='2732' name='Q{http://saxon.sf.net/generated-variable}v2' slot='11'/>
                    </withParam>
                   </applyT>
                  </forEach>
@@ -1375,14 +1324,14 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='-0.5' seq='30' rank='0' minImp='0' slots='4' flags='s' line='2861' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='30' rank='0' minImp='0' slots='4' flags='s' line='2807' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2862'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2808'>
      <param name='Q{}curPath' slot='0'>
       <str role='select' val=''/>
       <supplied role='conversion' slot='0'/>
      </param>
-     <param line='2863' name='Q{}pendingUpdates' slot='1' flags='t' as='map(xs:string, xs:string)?'>
+     <param line='2809' name='Q{}pendingUpdates' slot='1' flags='t' as='map(xs:string, xs:string)?'>
       <empty role='select'/>
       <treat role='conversion' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|pendingUpdates'>
        <check card='?' diag='8|0|XTTE0590|pendingUpdates'>
@@ -1390,7 +1339,7 @@
        </check>
       </treat>
      </param>
-     <let line='2864' var='Q{}updatedPath' as='xs:string' slot='2' eval='8'>
+     <let line='2810' var='Q{}updatedPath' as='xs:string' slot='2' eval='8'>
       <fn name='concat'>
        <atomSing card='?' diag='0|0||fn:concat'>
         <varRef name='Q{}curPath' slot='0'/>
@@ -1400,7 +1349,7 @@
         <dot type='attribute()'/>
        </fn>
       </fn>
-      <let line='2873' var='Q{}associated-form-control' as='element()*' slot='3' eval='8'>
+      <let line='2819' var='Q{}associated-form-control' as='element()*' slot='3' eval='8'>
        <filter flags='b'>
         <slash simple='1'>
          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
@@ -1413,15 +1362,15 @@
          <varRef name='Q{}updatedPath' slot='2'/>
         </vc>
        </filter>
-       <choose line='2876'>
+       <choose line='2822'>
         <fn name='exists'>
          <varRef name='Q{}associated-form-control' slot='3'/>
         </fn>
-        <compAtt line='2879'>
+        <compAtt line='2825'>
          <fn role='name' name='local-name'>
           <dot type='attribute()'/>
          </fn>
-         <fn role='select' line='2880' name='string-join'>
+         <fn role='select' line='2826' name='string-join'>
           <convert from='xs:anyAtomicType' to='xs:string'>
            <data>
             <mergeAdj>
@@ -1434,7 +1383,7 @@
           <str val=''/>
          </fn>
         </compAtt>
-        <and line='2883' op='and'>
+        <and line='2829' op='and'>
          <fn name='exists'>
           <varRef name='Q{}pendingUpdates' slot='1'/>
          </fn>
@@ -1445,11 +1394,11 @@
           <varRef name='Q{}updatedPath' slot='2'/>
          </ifCall>
         </and>
-        <compAtt line='2884'>
+        <compAtt line='2830'>
          <fn role='name' name='local-name'>
           <dot type='attribute()'/>
          </fn>
-         <ifCall role='select' line='2885' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+         <ifCall role='select' line='2831' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
           <check card='1' diag='0|0||map:get'>
            <varRef name='Q{}pendingUpdates' slot='1'/>
           </check>
@@ -1457,7 +1406,7 @@
          </ifCall>
         </compAtt>
         <true/>
-        <forEach line='2889'>
+        <forEach line='2835'>
          <dot type='attribute()'/>
          <copyOf flags='vsc'>
           <dot type='attribute()'/>
@@ -1472,9 +1421,9 @@
  </co>
  <co id='16' binds='13 13'>
   <mode name='Q{}form-check-initial' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='26' rank='0' minImp='0' slots='6' flags='s' line='2550' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='26' rank='0' minImp='0' slots='6' flags='s' line='2559' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2551'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2560'>
      <param name='Q{}instance-id' slot='0' as='xs:string'>
       <str role='select' val='saxon-forms-default'/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|instance-id'>
@@ -1487,7 +1436,7 @@
        </check>
       </treat>
      </param>
-     <param line='2552' name='Q{}pendingUpdates' slot='1' flags='t' as='map(xs:string, xs:string)?'>
+     <param line='2561' name='Q{}pendingUpdates' slot='1' flags='t' as='map(xs:string, xs:string)?'>
       <empty role='select'/>
       <treat role='conversion' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|pendingUpdates'>
        <check card='?' diag='8|0|XTTE0590|pendingUpdates'>
@@ -1495,15 +1444,15 @@
        </check>
       </treat>
      </param>
-     <let line='2558' var='Q{}curPath' as='xs:string' slot='2' eval='16'>
-      <choose line='2560'>
+     <let line='2567' var='Q{}curPath' as='xs:string' slot='2' eval='16'>
+      <choose line='2569'>
        <vc op='eq' onEmpty='0' comp='CCC'>
         <varRef name='Q{}instance-id' slot='0'/>
         <str val='saxon-forms-default'/>
        </vc>
        <str val=''/>
        <true/>
-       <cvUntyped line='2564' to='xs:string' diag='3|0|XTTE0570|curPath'>
+       <cvUntyped line='2573' to='xs:string' diag='3|0|XTTE0570|curPath'>
         <cast as='xs:untypedAtomic' emptiable='0'>
          <fn name='concat'>
           <str val='instance(&#39;'/>
@@ -1513,21 +1462,21 @@
         </cast>
        </cvUntyped>
       </choose>
-      <copy line='2571' flags='cin'>
+      <copy line='2580' flags='cin'>
        <forEachGroup role='content' algorithm='by'>
         <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
         <fn role='key' name='local-name'>
          <dot type='element()'/>
         </fn>
         <str role='collation' val='http://www.w3.org/2005/xpath-functions/collation/codepoint'/>
-        <let role='content' line='2573' var='Q{}updatedChildPath' as='xs:string' slot='3' eval='8'>
+        <let role='content' line='2582' var='Q{}updatedChildPath' as='xs:string' slot='3' eval='8'>
          <fn name='concat'>
           <varRef name='Q{}curPath' slot='2'/>
           <check card='?' diag='0|1||fn:concat'>
            <currentGroupingKey/>
           </check>
          </fn>
-         <let line='2578' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='4' eval='13'>
+         <let line='2587' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='4' eval='13'>
           <fn name='concat'>
            <varRef name='Q{}updatedChildPath' slot='3'/>
            <str val='['/>
@@ -1545,7 +1494,7 @@
              <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='4'/>
             </fn>
            </filter>
-           <choose line='2580'>
+           <choose line='2589'>
             <or op='or'>
              <fn name='exists'>
               <tail start='2'>
@@ -1556,25 +1505,25 @@
               <varRef name='Q{}dataRefWithFilter' slot='5'/>
              </fn>
             </or>
-            <forEach line='2581'>
+            <forEach line='2590'>
              <currentGroup/>
-             <applyT line='2582' mode='Q{}form-check' bSlot='0'>
+             <applyT line='2591' mode='Q{}form-check' bSlot='0'>
               <dot role='select'/>
               <withParam name='Q{}curPath' as='xs:string'>
-               <varRef line='2583' name='Q{}curPath' slot='2'/>
+               <varRef line='2592' name='Q{}curPath' slot='2'/>
               </withParam>
               <withParam name='Q{}position' as='xs:integer'>
-               <fn line='2584' name='position'/>
+               <fn line='2593' name='position'/>
               </withParam>
              </applyT>
             </forEach>
             <true/>
-            <forEach line='2590'>
+            <forEach line='2599'>
              <currentGroup/>
-             <applyT line='2591' mode='Q{}form-check' bSlot='1'>
+             <applyT line='2600' mode='Q{}form-check' bSlot='1'>
               <dot role='select'/>
               <withParam name='Q{}curPath' as='xs:string'>
-               <varRef line='2592' name='Q{}curPath' slot='2'/>
+               <varRef line='2601' name='Q{}curPath' slot='2'/>
               </withParam>
              </applyT>
             </forEach>
@@ -1590,9 +1539,9 @@
   </mode>
  </co>
  <co id='6' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}getRepeatID' line='764' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
+  <function name='Q{http://www.w3.org/2002/xforms}getRepeatID' line='766' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
    <arg name='Q{}string-to-parse' as='xs:string'/>
-   <treat role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='767' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getRepeatID#1'>
+   <treat role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='769' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getRepeatID#1'>
     <check card='?' diag='5|0|XTTE0780|xforms:getRepeatID#1'>
      <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getRepeatID#1'>
       <data>
@@ -1600,10 +1549,10 @@
         <varRef role='select' name='Q{}string-to-parse' slot='0'/>
         <str role='regex' val='^.*index\s*\(\s*&#39;([^&#39;]+)&#39;\s*\).*$'/>
         <str role='flags' val=''/>
-        <fn role='matching' line='769' name='regex-group'>
+        <fn role='matching' line='771' name='regex-group'>
          <int val='1'/>
         </fn>
-        <message role='nonMatching' line='772'>
+        <message role='nonMatching' line='774'>
          <sequence role='select'>
           <valueOf>
            <str val='[xforms:getRepeatID] No repeat identifiable from value &#39;'/>
@@ -1626,8 +1575,8 @@
   </function>
  </co>
  <co id='17' binds=''>
-  <template name='Q{}action-reset' flags='os' line='4859' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4860'>
+  <template name='Q{}action-reset' flags='os' line='4957' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4958'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -1635,7 +1584,7 @@
       </check>
      </treat>
     </param>
-    <message line='4862'>
+    <message line='4960'>
      <valueOf role='select'>
       <str val='[action-reset] Reset triggered!'/>
      </valueOf>
@@ -1645,17 +1594,9 @@
    </sequence>
   </template>
  </co>
- <co id='18' binds='19'>
-  <globalVariable name='Q{http://saxon.sf.net/generated-variable}gg99297450' type='element()*' line='4232' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='function test(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};if (test(val)) {return val;} else {throw SaxonJS.XError(&#39;Conversion failed&#39;, &#39;XTTE0590&#39;);}' jsCardCheck='function c() {return true;};'>
-   <slash ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4232' simple='1'>
-    <gVarRef name='Q{}xforms-doc' bSlot='0'/>
-    <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-   </slash>
-  </globalVariable>
- </co>
- <co id='20' binds='2 3 15 16 1 5 21 7 22'>
-  <template name='Q{}xforms-value-changed' flags='os' line='4157' module='saxon-xforms.xsl' slots='8'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4158'>
+ <co id='18' binds='1 2 3 15 19 5 20 7 21'>
+  <template name='Q{}xforms-value-changed' flags='os' line='4171' module='saxon-xforms.xsl' slots='9'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4172'>
     <param name='Q{}form-control' slot='0' flags='i' as='node()'>
      <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|form-control'>
       <check card='1' diag='8|0|XTTE0590|form-control'>
@@ -1663,199 +1604,184 @@
       </check>
      </treat>
     </param>
-    <let line='4160' var='Q{}refi' as='attribute(Q{}data-ref)?' slot='1' eval='8'>
+    <let line='4174' var='Q{}refi' as='attribute(Q{}data-ref)?' slot='1' eval='8'>
      <slash simple='1'>
       <varRef name='Q{}form-control' slot='0'/>
       <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
      </slash>
-     <let line='4164' var='Q{}actions' as='item()?' slot='2' eval='8'>
-      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-       <check card='1' diag='0|0||ixsl:call'>
-        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+     <let line='4177' var='Q{}instance-id' as='xs:string' slot='2' eval='16'>
+      <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='16'>
+       <check card='1' diag='0|0||xforms:getInstanceId'>
+        <cvUntyped to='xs:string'>
+         <data>
+          <varRef name='Q{}refi' slot='1'/>
+         </data>
+        </cvUntyped>
        </check>
-       <str val='getAction'/>
-       <arrayBlock>
-        <fn name='string'>
-         <slash simple='1'>
-          <varRef name='Q{}form-control' slot='0'/>
-          <axis name='attribute' nodeTest='attribute(Q{}data-action)' jsTest='return item.name===&#39;data-action&#39;'/>
-         </slash>
-        </fn>
-       </arrayBlock>
-      </ifCall>
-      <let line='4167' var='Q{}instanceXML' as='element()' slot='3' eval='16'>
-       <check card='1' diag='3|0|XTTE0570|instanceXML'>
-        <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='0' eval='16'>
-         <check card='1' diag='0|0||xforms:getInstance-JS'>
-          <cvUntyped to='xs:string'>
-           <data>
-            <varRef name='Q{}refi' slot='1'/>
-           </data>
-          </cvUntyped>
-         </check>
-        </ufCall>
-       </check>
-       <let line='4175' var='Q{}updatedNode' as='node()' slot='4' eval='16'>
-        <treat line='4176' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|updatedNode'>
-         <check card='1' diag='3|0|XTTE0570|updatedNode'>
-          <evaluate dxns=''>
-           <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='1' eval='16'>
-            <check card='1' diag='0|0||xforms:impose'>
-             <cvUntyped to='xs:string'>
-              <data>
-               <varRef name='Q{}refi' slot='1'/>
-              </data>
-             </cvUntyped>
-            </check>
-           </ufCall>
-           <varRef role='cxt' name='Q{}instanceXML' slot='3'/>
-           <varRef role='nsCxt' name='Q{}instanceXML' slot='3'/>
-           <str role='sa' val='no'/>
-           <map role='options' size='0'/>
-           <map role='wp' size='0'/>
-          </evaluate>
-         </check>
-        </treat>
-        <let line='4178' var='Q{}new-value' as='xs:string' slot='5' eval='16'>
-         <treat line='4179' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-value'>
-          <check card='1' diag='3|0|XTTE0570|new-value'>
-           <cvUntyped to='xs:string' diag='3|0|XTTE0570|new-value'>
-            <data>
-             <applyT mode='Q{}get-field' bSlot='2'>
-              <varRef role='select' name='Q{}form-control' slot='0'/>
-             </applyT>
-            </data>
-           </cvUntyped>
+      </ufCall>
+      <let line='4178' var='Q{}actions' as='item()?' slot='3' eval='8'>
+       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <check card='1' diag='0|0||ixsl:call'>
+         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+        </check>
+        <str val='getAction'/>
+        <arrayBlock>
+         <fn name='string'>
+          <slash simple='1'>
+           <varRef name='Q{}form-control' slot='0'/>
+           <axis name='attribute' nodeTest='attribute(Q{}data-action)' jsTest='return item.name===&#39;data-action&#39;'/>
+          </slash>
+         </fn>
+        </arrayBlock>
+       </ifCall>
+       <let line='4189' var='Q{}instanceXML' as='element()' slot='4' eval='16'>
+        <check card='1' diag='3|0|XTTE0570|instanceXML'>
+         <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='6'>
+          <varRef name='Q{}instance-id' slot='2'/>
+         </ufCall>
+        </check>
+        <let line='4190' var='Q{}updatedNode' as='node()' slot='5' eval='16'>
+         <treat line='4191' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|updatedNode'>
+          <check card='1' diag='3|0|XTTE0570|updatedNode'>
+           <evaluate dxns=''>
+            <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
+             <check card='1' diag='0|0||xforms:impose'>
+              <cvUntyped to='xs:string'>
+               <data>
+                <varRef name='Q{}refi' slot='1'/>
+               </data>
+              </cvUntyped>
+             </check>
+            </ufCall>
+            <varRef role='cxt' name='Q{}instanceXML' slot='4'/>
+            <varRef role='nsCxt' name='Q{}instanceXML' slot='4'/>
+            <str role='sa' val='no'/>
+            <map role='options' size='0'/>
+            <map role='wp' size='0'/>
+           </evaluate>
           </check>
          </treat>
-         <let line='4181' var='Q{}updatedInstanceXML' as='element()' slot='6' eval='16'>
-          <treat line='4182' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
-           <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
-            <applyT mode='Q{}form-check-initial' bSlot='3'>
-             <varRef role='select' name='Q{}instanceXML' slot='3'/>
-             <withParam name='Q{}instance-id' as='xs:string'>
-              <ufCall line='4163' name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='4' eval='16'>
-               <check card='1' diag='0|0||xforms:getInstanceId'>
-                <cvUntyped to='xs:string'>
-                 <data>
-                  <varRef name='Q{}refi' slot='1'/>
-                 </data>
-                </cvUntyped>
-               </check>
-              </ufCall>
-             </withParam>
-             <withParam name='Q{}updated-node' flags='t' as='node()'>
-              <varRef line='4184' name='Q{}updatedNode' slot='4'/>
-             </withParam>
-             <withParam name='Q{}value' flags='t' as='xs:string'>
-              <varRef line='4185' name='Q{}new-value' slot='5'/>
-             </withParam>
-            </applyT>
+         <let line='4193' var='Q{}new-value' as='xs:string' slot='6' eval='16'>
+          <treat line='4194' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-value'>
+           <check card='1' diag='3|0|XTTE0570|new-value'>
+            <cvUntyped to='xs:string' diag='3|0|XTTE0570|new-value'>
+             <data>
+              <applyT mode='Q{}get-field' bSlot='3'>
+               <varRef role='select' name='Q{}form-control' slot='0'/>
+              </applyT>
+             </data>
+            </cvUntyped>
            </check>
           </treat>
-          <sequence line='4189'>
-           <message>
-            <sequence role='select'>
-             <valueOf>
-              <str val='[xforms-value-changed] Updated XML: '/>
-             </valueOf>
-             <fn name='serialize'>
-              <varRef name='Q{}updatedInstanceXML' slot='6'/>
-             </fn>
-            </sequence>
-            <str role='terminate' val='no'/>
-            <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-           </message>
-           <ufCall line='4192' name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='5' eval='16 6'>
-            <check card='1' diag='0|0||xforms:setInstance-JS'>
-             <cvUntyped to='xs:string'>
-              <data>
-               <varRef name='Q{}refi' slot='1'/>
-              </data>
-             </cvUntyped>
+          <let line='4196' var='Q{}updatedInstanceXML' as='element()' slot='7' eval='16'>
+           <treat line='4197' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+            <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
+             <applyT mode='Q{}recalculate' bSlot='4'>
+              <varRef role='select' name='Q{}instanceXML' slot='4'/>
+              <withParam name='Q{}instance-id' as='xs:string'>
+               <varRef line='4198' name='Q{}instance-id' slot='2'/>
+              </withParam>
+              <withParam name='Q{}updated-nodes' flags='t' as='node()'>
+               <varRef line='4199' name='Q{}updatedNode' slot='5'/>
+              </withParam>
+              <withParam name='Q{}updated-values' flags='t' as='xs:string'>
+               <varRef line='4200' name='Q{}new-value' slot='6'/>
+              </withParam>
+             </applyT>
             </check>
-            <varRef name='Q{}updatedInstanceXML' slot='6'/>
-           </ufCall>
-           <ifCall line='4199' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-            <check card='1' diag='0|0||ixsl:call'>
-             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-            </check>
-            <str val='setPendingUpdates'/>
-            <arrayBlock>
-             <treat line='4196' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||pendingInstanceUpdates'>
-              <map size='0'/>
-             </treat>
-            </arrayBlock>
-           </ifCall>
-           <ifCall line='4200' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-            <check card='1' diag='0|0||ixsl:call'>
-             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-            </check>
-            <str val='setUpdates'/>
-            <arrayBlock>
-             <treat line='4197' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||instanceUpdates'>
-              <map size='0'/>
-             </treat>
-            </arrayBlock>
-           </ifCall>
-           <forEach line='4202'>
-            <varRef name='Q{}actions' slot='2'/>
-            <let line='4203' var='Q{}action-map' as='item()' slot='7' eval='16'>
-             <dot/>
-             <choose line='4205'>
-              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
-               <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:contains'>
-                <varRef name='Q{}action-map' slot='7'/>
-               </treat>
-               <str val='@event'/>
-              </ifCall>
-              <choose line='4206'>
-               <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
-                <data>
-                 <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                  <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:get'>
-                   <varRef name='Q{}action-map' slot='7'/>
-                  </treat>
-                  <str val='@event'/>
-                 </ifCall>
-                </data>
-                <str val='xforms-value-changed'/>
-               </gc>
-               <callT line='4208' name='Q{}applyActions' bSlot='6'>
-                <withParam name='Q{}action-map' flags='t' as='item()'>
-                 <varRef line='4209' name='Q{}action-map' slot='7'/>
-                </withParam>
-                <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                 <check line='4210' card='1' diag='8|0|XTTE0590|nodeset'>
-                  <cvUntyped to='xs:string' diag='8|0|XTTE0590|nodeset'>
-                   <data>
-                    <varRef name='Q{}refi' slot='1'/>
-                   </data>
-                  </cvUntyped>
-                 </check>
-                </withParam>
-                <withParam name='Q{}instanceXML' flags='t' as='element()'>
-                 <varRef line='4211' name='Q{}updatedInstanceXML' slot='6'/>
-                </withParam>
-               </callT>
+           </treat>
+           <sequence line='4207'>
+            <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='5' eval='16 6'>
+             <check card='1' diag='0|0||xforms:setInstance-JS'>
+              <cvUntyped to='xs:string'>
+               <data>
+                <varRef name='Q{}refi' slot='1'/>
+               </data>
+              </cvUntyped>
+             </check>
+             <varRef name='Q{}updatedInstanceXML' slot='7'/>
+            </ufCall>
+            <ifCall line='4214' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+             <check card='1' diag='0|0||ixsl:call'>
+              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+             </check>
+             <str val='setPendingUpdates'/>
+             <arrayBlock>
+              <treat line='4211' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||pendingInstanceUpdates'>
+               <map size='0'/>
+              </treat>
+             </arrayBlock>
+            </ifCall>
+            <ifCall line='4215' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+             <check card='1' diag='0|0||ixsl:call'>
+              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+             </check>
+             <str val='setUpdates'/>
+             <arrayBlock>
+              <treat line='4212' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||instanceUpdates'>
+               <map size='0'/>
+              </treat>
+             </arrayBlock>
+            </ifCall>
+            <forEach line='4217'>
+             <varRef name='Q{}actions' slot='3'/>
+             <let line='4218' var='Q{}action-map' as='item()' slot='8' eval='16'>
+              <dot/>
+              <choose line='4220'>
+               <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+                <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:contains'>
+                 <varRef name='Q{}action-map' slot='8'/>
+                </treat>
+                <str val='@event'/>
+               </ifCall>
+               <choose line='4221'>
+                <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+                 <data>
+                  <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                   <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:get'>
+                    <varRef name='Q{}action-map' slot='8'/>
+                   </treat>
+                   <str val='@event'/>
+                  </ifCall>
+                 </data>
+                 <str val='xforms-value-changed'/>
+                </gc>
+                <callT line='4223' name='Q{}applyActions' bSlot='6'>
+                 <withParam name='Q{}action-map' flags='t' as='item()'>
+                  <varRef line='4224' name='Q{}action-map' slot='8'/>
+                 </withParam>
+                 <withParam name='Q{}nodeset' flags='t' as='xs:string'>
+                  <check line='4225' card='1' diag='8|0|XTTE0590|nodeset'>
+                   <cvUntyped to='xs:string' diag='8|0|XTTE0590|nodeset'>
+                    <data>
+                     <varRef name='Q{}refi' slot='1'/>
+                    </data>
+                   </cvUntyped>
+                  </check>
+                 </withParam>
+                 <withParam name='Q{}instanceXML' flags='t' as='element()'>
+                  <varRef line='4226' name='Q{}updatedInstanceXML' slot='7'/>
+                 </withParam>
+                </callT>
+               </choose>
               </choose>
-             </choose>
-            </let>
-           </forEach>
-           <callT line='4217' name='Q{}xforms-recalculate' bSlot='7'/>
-           <ufCall line='4219' name='Q{http://www.w3.org/2002/xforms}checkRelevantFields' tailCall='false' bSlot='8' eval='16'>
-            <check card='1' diag='0|0||xforms:checkRelevantFields'>
-             <cvUntyped to='xs:string'>
-              <data>
-               <slash line='4161' simple='1'>
-                <varRef name='Q{}form-control' slot='0'/>
-                <axis name='attribute' nodeTest='attribute(Q{}data-element)' jsTest='return item.name===&#39;data-element&#39;'/>
-               </slash>
-              </data>
-             </cvUntyped>
-            </check>
-           </ufCall>
-          </sequence>
+             </let>
+            </forEach>
+            <callT line='4232' name='Q{}xforms-recalculate' bSlot='7'/>
+            <ufCall line='4234' name='Q{http://www.w3.org/2002/xforms}checkRelevantFields' tailCall='false' bSlot='8' eval='16'>
+             <check card='1' diag='0|0||xforms:checkRelevantFields'>
+              <cvUntyped to='xs:string'>
+               <data>
+                <slash line='4175' simple='1'>
+                 <varRef name='Q{}form-control' slot='0'/>
+                 <axis name='attribute' nodeTest='attribute(Q{}data-element)' jsTest='return item.name===&#39;data-element&#39;'/>
+                </slash>
+               </data>
+              </cvUntyped>
+             </check>
+            </ufCall>
+           </sequence>
+          </let>
          </let>
         </let>
        </let>
@@ -1865,9 +1791,9 @@
    </sequence>
   </template>
  </co>
- <co id='23' binds='24 25 3 25'>
-  <template name='Q{}getReferencedInstanceField' flags='os' line='3437' module='saxon-xforms.xsl' slots='5'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3438'>
+ <co id='22' binds='23 24 3 24'>
+  <template name='Q{}getReferencedInstanceField' flags='os' line='3417' module='saxon-xforms.xsl' slots='5'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3418'>
     <param name='Q{}refi' slot='0' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|refi'>
@@ -1880,17 +1806,17 @@
       </check>
      </treat>
     </param>
-    <let line='3442' var='Q{}field' as='node()*' slot='1' eval='8'>
-     <choose line='3444'>
+    <let line='3422' var='Q{}field' as='node()*' slot='1' eval='8'>
+     <choose line='3424'>
       <varRef name='Q{}refi' slot='0'/>
-      <let line='3445' var='Q{}instance-map' as='map(xs:string, xs:string)' slot='2' eval='16'>
+      <let line='3425' var='Q{}instance-map' as='map(xs:string, xs:string)' slot='2' eval='16'>
        <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='0' eval='6'>
         <varRef name='Q{}refi' slot='0'/>
        </ufCall>
-       <let line='3452' var='Q{}this-instance' as='element()?' slot='3' eval='9'>
-        <callT line='3453' name='Q{}getInstance' bSlot='1'>
+       <let line='3432' var='Q{}this-instance' as='element()?' slot='3' eval='9'>
+        <callT line='3433' name='Q{}getInstance' bSlot='1'>
          <withParam name='Q{}instance-id' flags='c' as='xs:string'>
-          <check line='3454' card='1' diag='8|0|XTTE0590|instance-id'>
+          <check line='3434' card='1' diag='8|0|XTTE0590|instance-id'>
            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
             <varRef name='Q{}instance-map' slot='2'/>
             <str val='instance-id'/>
@@ -1898,9 +1824,9 @@
           </check>
          </withParam>
         </callT>
-        <treat line='3462' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|field'>
+        <treat line='3442' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|field'>
          <evaluate dxns=''>
-          <ufCall role='xpath' line='3458' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
+          <ufCall role='xpath' line='3438' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
            <check card='1' diag='0|0||xforms:impose'>
             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
              <varRef name='Q{}instance-map' slot='2'/>
@@ -1920,23 +1846,23 @@
        </let>
       </let>
       <true/>
-      <let line='3467' var='Q{}default-instance' as='element()?' slot='4' eval='9'>
-       <callT line='3468' name='Q{}getInstance' bSlot='3'>
+      <let line='3447' var='Q{}default-instance' as='element()?' slot='4' eval='9'>
+       <callT line='3448' name='Q{}getInstance' bSlot='3'>
         <withParam name='Q{}instance-id' flags='c' as='xs:string'>
          <str val='saxon-forms-default'/>
         </withParam>
        </callT>
-       <varRef line='3472' name='Q{}default-instance' slot='4'/>
+       <varRef line='3452' name='Q{}default-instance' slot='4'/>
       </let>
      </choose>
-     <varRef line='3477' name='Q{}field' slot='1'/>
+     <varRef line='3457' name='Q{}field' slot='1'/>
     </let>
    </sequence>
   </template>
  </co>
- <co id='26' binds=''>
-  <template name='Q{}action-message' flags='os' line='4779' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4780'>
+ <co id='25' binds=''>
+  <template name='Q{}action-message' flags='os' line='4877' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4878'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -1944,13 +1870,13 @@
       </check>
      </treat>
     </param>
-    <message line='4784'>
+    <message line='4882'>
      <sequence role='select'>
       <valueOf>
        <str val='[action-message] Message reads "'/>
       </valueOf>
       <valueOf>
-       <treat line='4782' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|message-value'>
+       <treat line='4880' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|message-value'>
         <check card='1' diag='3|0|XTTE0570|message-value'>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|message-value'>
           <data>
@@ -1973,26 +1899,26 @@
    </sequence>
   </template>
  </co>
- <co id='27' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}resolveXPathStrings' line='829' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:string' slots='5'>
+ <co id='26' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}resolveXPathStrings' line='831' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:string' slots='5'>
    <arg name='Q{}base' as='xs:string'/>
    <arg name='Q{}relative' as='xs:string'/>
-   <choose role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='836'>
+   <choose role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='838'>
     <fn name='starts-with'>
      <varRef name='Q{}relative' slot='1'/>
      <str val='/'/>
     </fn>
-    <varRef line='837' name='Q{}relative' slot='1'/>
-    <fn line='839' name='starts-with'>
+    <varRef line='839' name='Q{}relative' slot='1'/>
+    <fn line='841' name='starts-with'>
      <varRef name='Q{}relative' slot='1'/>
      <str val='instance('/>
     </fn>
-    <varRef line='840' name='Q{}relative' slot='1'/>
-    <fn line='842' name='not'>
+    <varRef line='842' name='Q{}relative' slot='1'/>
+    <fn line='844' name='not'>
      <varRef name='Q{}base' slot='0'/>
     </fn>
-    <varRef line='843' name='Q{}relative' slot='1'/>
-    <or line='845' op='or'>
+    <varRef line='845' name='Q{}relative' slot='1'/>
+    <or line='847' op='or'>
      <fn name='not'>
       <varRef name='Q{}relative' slot='1'/>
      </fn>
@@ -2001,9 +1927,9 @@
       <str val='.'/>
      </vc>
     </or>
-    <varRef line='846' name='Q{}base' slot='0'/>
+    <varRef line='848' name='Q{}base' slot='0'/>
     <true/>
-    <let line='850' var='Q{}parentCallCount' as='xs:integer' slot='2' eval='16'>
+    <let line='852' var='Q{}parentCallCount' as='xs:integer' slot='2' eval='16'>
      <choose>
       <fn name='contains'>
        <varRef name='Q{}relative' slot='1'/>
@@ -2030,7 +1956,7 @@
       <true/>
       <int val='0'/>
      </choose>
-     <let line='853' var='Q{}slashes' as='xs:integer*' slot='3' eval='4'>
+     <let line='855' var='Q{}slashes' as='xs:integer*' slot='3' eval='4'>
       <choose>
        <fn name='contains'>
         <varRef name='Q{}base' slot='0'/>
@@ -2045,15 +1971,15 @@
        <true/>
        <int val='0'/>
       </choose>
-      <choose line='885'>
+      <choose line='887'>
        <compareToInt op='gt' val='0'>
         <varRef name='Q{}parentCallCount' slot='2'/>
        </compareToInt>
-       <fn line='889' name='concat'>
+       <fn line='891' name='concat'>
         <fn name='substring'>
          <varRef name='Q{}base' slot='0'/>
          <int val='1'/>
-         <choose line='864'>
+         <choose line='866'>
           <and op='and'>
            <vc op='ge' onEmpty='0' comp='CAVC'>
             <fn name='count'>
@@ -2065,7 +1991,7 @@
             <varRef name='Q{}parentCallCount' slot='2'/>
            </compareToInt>
           </and>
-          <let line='865' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='4' eval='13'>
+          <let line='867' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='4' eval='13'>
            <arith op='-' calc='i-i'>
             <varRef name='Q{}parentCallCount' slot='2'/>
             <int val='1'/>
@@ -2081,7 +2007,7 @@
            </check>
           </let>
           <true/>
-          <check line='868' card='1' diag='3|0|XTTE0570|parentSlash'>
+          <check line='870' card='1' diag='3|0|XTTE0570|parentSlash'>
            <lastOf>
             <varRef name='Q{}slashes' slot='3'/>
            </lastOf>
@@ -2096,7 +2022,7 @@
         </fn>
        </fn>
        <true/>
-       <fn line='892' name='concat'>
+       <fn line='894' name='concat'>
         <varRef name='Q{}base' slot='0'/>
         <str val='/'/>
         <varRef name='Q{}relative' slot='1'/>
@@ -2107,7 +2033,7 @@
    </choose>
   </function>
  </co>
- <co id='28' binds=''>
+ <co id='27' binds=''>
   <function name='Q{http://saxonica.com/ns/forms-local}current-date' line='118' module='xforms-function-library.xsl' eval='16' flags='pU' as='xs:string' slots='0'>
    <treat role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='119' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|today'>
     <check card='1' diag='3|0|XTTE0570|today'>
@@ -2126,7 +2052,7 @@
    </treat>
   </function>
  </co>
- <co id='14' binds='29'>
+ <co id='14' binds='28'>
   <function name='Q{http://www.w3.org/2002/xforms}resolve-index' line='72' module='xforms-function-library.xsl' eval='8' flags='pU' as='xs:string' slots='2'>
    <arg name='Q{}input' as='xs:string'/>
    <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='74' var='Q{}parts' as='xs:string*' slot='1' eval='8'>
@@ -2149,9 +2075,9 @@
    </let>
   </function>
  </co>
- <co id='30' binds='3'>
-  <template name='Q{}action-setindex' flags='os' line='4832' module='saxon-xforms.xsl' slots='2'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4833'>
+ <co id='29' binds='3'>
+  <template name='Q{}action-setindex' flags='os' line='4930' module='saxon-xforms.xsl' slots='2'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4931'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -2159,14 +2085,14 @@
       </check>
      </treat>
     </param>
-    <let line='4839' var='Q{}new-index' as='xs:integer' slot='1' eval='16'>
-     <treat line='4840' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|new-index'>
+    <let line='4937' var='Q{}new-index' as='xs:integer' slot='1' eval='16'>
+     <treat line='4938' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|new-index'>
       <check card='1' diag='3|0|XTTE0570|new-index'>
        <cvUntyped to='xs:integer' diag='3|0|XTTE0570|new-index'>
         <data>
          <evaluate dxns=''>
           <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='0' eval='16'>
-           <treat line='4836' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-index-ref'>
+           <treat line='4934' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-index-ref'>
             <check card='1' diag='3|0|XTTE0570|new-index-ref'>
              <cvUntyped to='xs:string' diag='3|0|XTTE0570|new-index-ref'>
               <data>
@@ -2188,7 +2114,7 @@
        </cvUntyped>
       </check>
      </treat>
-     <sequence line='4843'>
+     <sequence line='4941'>
       <message>
        <sequence role='select'>
         <valueOf>
@@ -2203,13 +2129,13 @@
        <str role='terminate' val='no'/>
        <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
       </message>
-      <ifCall line='4845' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+      <ifCall line='4943' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
        </check>
        <str val='setRepeatIndex'/>
        <arrayBlock>
-        <treat line='4835' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|repeatID'>
+        <treat line='4933' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|repeatID'>
          <check card='1' diag='3|0|XTTE0570|repeatID'>
           <cvUntyped to='xs:string' diag='3|0|XTTE0570|repeatID'>
            <data>
@@ -2229,9 +2155,9 @@
    </sequence>
   </template>
  </co>
- <co id='31' binds='32'>
-  <template name='Q{}action-setfocus' flags='os' line='4794' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4795'>
+ <co id='30' binds='31'>
+  <template name='Q{}action-setfocus' flags='os' line='4892' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4893'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -2239,9 +2165,9 @@
       </check>
      </treat>
     </param>
-    <callT line='4799' name='Q{}xforms-focus' bSlot='0' flags='t'>
+    <callT line='4897' name='Q{}xforms-focus' bSlot='0' flags='t'>
      <withParam name='Q{}control' flags='c' as='xs:string'>
-      <treat line='4797' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|control'>
+      <treat line='4895' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|control'>
        <check card='1' diag='3|0|XTTE0570|control'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|control'>
          <data>
@@ -2258,9 +2184,9 @@
    </sequence>
   </template>
  </co>
- <co id='33' binds='1 3 3 34 16 2 5 35'>
-  <template name='Q{}action-setvalue' flags='os' line='4465' module='saxon-xforms.xsl' slots='14'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4466'>
+ <co id='32' binds='1 3 3 33 16 34 5 35'>
+  <template name='Q{}action-setvalue' flags='os' line='4558' module='saxon-xforms.xsl' slots='14'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4559'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -2268,7 +2194,7 @@
       </check>
      </treat>
     </param>
-    <param line='4467' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
+    <param line='4560' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
      <empty role='select'/>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|instanceXML'>
       <check card='?' diag='8|0|XTTE0590|instanceXML'>
@@ -2276,7 +2202,7 @@
       </check>
      </treat>
     </param>
-    <param line='4468' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
+    <param line='4561' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -2288,7 +2214,7 @@
       </check>
      </treat>
     </param>
-    <let line='4472' var='Q{}refz' as='xs:string' slot='3' eval='16'>
+    <let line='4565' var='Q{}refz' as='xs:string' slot='3' eval='16'>
      <let var='Q{}relative' as='xs:string' slot='4' eval='16'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|1||xforms:resolveXPathStrings'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
@@ -2302,22 +2228,22 @@
         </cvUntyped>
        </check>
       </treat>
-      <choose line='836'>
+      <choose line='838'>
        <fn name='starts-with'>
         <varRef name='Q{}relative' slot='4'/>
         <str val='/'/>
        </fn>
-       <varRef line='837' name='Q{}relative' slot='4'/>
-       <fn line='839' name='starts-with'>
+       <varRef line='839' name='Q{}relative' slot='4'/>
+       <fn line='841' name='starts-with'>
         <varRef name='Q{}relative' slot='4'/>
         <str val='instance('/>
        </fn>
-       <varRef line='840' name='Q{}relative' slot='4'/>
-       <fn line='4472' name='not'>
+       <varRef line='842' name='Q{}relative' slot='4'/>
+       <fn line='4565' name='not'>
         <varRef name='Q{}nodeset' slot='2'/>
        </fn>
-       <varRef line='843' name='Q{}relative' slot='4'/>
-       <or line='845' op='or'>
+       <varRef line='845' name='Q{}relative' slot='4'/>
+       <or line='847' op='or'>
         <fn name='not'>
          <varRef name='Q{}relative' slot='4'/>
         </fn>
@@ -2326,9 +2252,9 @@
          <str val='.'/>
         </vc>
        </or>
-       <varRef line='4472' name='Q{}nodeset' slot='2'/>
+       <varRef line='4565' name='Q{}nodeset' slot='2'/>
        <true/>
-       <let line='850' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
+       <let line='852' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
         <choose>
          <fn name='contains'>
           <varRef name='Q{}relative' slot='4'/>
@@ -2355,30 +2281,30 @@
          <true/>
          <int val='0'/>
         </choose>
-        <let line='853' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
+        <let line='855' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
          <choose>
-          <fn line='4472' name='contains'>
+          <fn line='4565' name='contains'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
           </fn>
           <fn name='index-of'>
            <fn name='string-to-codepoints'>
-            <varRef line='4472' name='Q{}nodeset' slot='2'/>
+            <varRef line='4565' name='Q{}nodeset' slot='2'/>
            </fn>
            <int val='47'/>
           </fn>
           <true/>
           <int val='0'/>
          </choose>
-         <choose line='885'>
+         <choose line='887'>
           <compareToInt op='gt' val='0'>
            <varRef name='Q{}parentCallCount' slot='5'/>
           </compareToInt>
-          <fn line='889' name='concat'>
+          <fn line='891' name='concat'>
            <fn name='substring'>
-            <varRef line='4472' name='Q{}nodeset' slot='2'/>
+            <varRef line='4565' name='Q{}nodeset' slot='2'/>
             <int val='1'/>
-            <choose line='864'>
+            <choose line='866'>
              <and op='and'>
               <vc op='ge' onEmpty='0' comp='CAVC'>
                <fn name='count'>
@@ -2390,7 +2316,7 @@
                <varRef name='Q{}parentCallCount' slot='5'/>
               </compareToInt>
              </and>
-             <let line='865' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='7' eval='13'>
+             <let line='867' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='7' eval='13'>
               <arith op='-' calc='i-i'>
                <varRef name='Q{}parentCallCount' slot='5'/>
                <int val='1'/>
@@ -2406,7 +2332,7 @@
               </check>
              </let>
              <true/>
-             <check line='868' card='1' diag='3|0|XTTE0570|parentSlash'>
+             <check line='870' card='1' diag='3|0|XTTE0570|parentSlash'>
               <lastOf>
                <varRef name='Q{}slashes' slot='6'/>
               </lastOf>
@@ -2421,29 +2347,29 @@
            </fn>
           </fn>
           <true/>
-          <fn line='4472' name='concat'>
+          <fn line='4565' name='concat'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
-           <varRef line='892' name='Q{}relative' slot='4'/>
+           <varRef line='894' name='Q{}relative' slot='4'/>
           </fn>
          </choose>
         </let>
        </let>
       </choose>
      </let>
-     <let line='4474' var='Q{}instance-id' as='xs:string' slot='8' eval='16'>
+     <let line='4567' var='Q{}instance-id' as='xs:string' slot='8' eval='16'>
       <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='6'>
        <varRef name='Q{}refz' slot='3'/>
       </ufCall>
-      <let line='4487' var='Q{}valuez' as='document-node()' slot='9' eval='16'>
-       <doc line='4489' validation='preserve'>
+      <let line='4580' var='Q{}valuez' as='document-node()' slot='9' eval='16'>
+       <doc line='4582' validation='preserve'>
         <choose>
          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
           <varRef name='Q{}action-map' slot='0'/>
           <str val='@value'/>
          </ifCall>
-         <let line='4490' var='Q{}contexti' as='node()' slot='10' eval='8'>
-          <evaluate line='4491' as='node()' dxns=''>
+         <let line='4583' var='Q{}contexti' as='node()' slot='10' eval='8'>
+          <evaluate line='4584' as='node()' dxns=''>
            <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='1' eval='6'>
             <varRef name='Q{}nodeset' slot='2'/>
            </ufCall>
@@ -2455,7 +2381,7 @@
            <map role='options' size='0'/>
            <map role='wp' size='0'/>
           </evaluate>
-          <evaluate line='4494' dxns=''>
+          <evaluate line='4587' dxns=''>
            <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
             <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:impose'>
              <check card='1' diag='0|0||xforms:impose'>
@@ -2477,13 +2403,13 @@
            <map role='wp' size='0'/>
           </evaluate>
          </let>
-         <ifCall line='4497' name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+         <ifCall line='4590' name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
           <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:contains'>
            <dot flags='a'/>
           </treat>
           <str val='value'/>
          </ifCall>
-         <ifCall line='4498' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+         <ifCall line='4591' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
           <varRef name='Q{}action-map' slot='0'/>
           <str val='value'/>
          </ifCall>
@@ -2491,8 +2417,8 @@
          <str val=''/>
         </choose>
        </doc>
-       <sequence line='4508'>
-        <let line='4510' var='Q{}associated-form-control' as='element()?' slot='11' eval='7'>
+       <sequence line='4601'>
+        <let line='4603' var='Q{}associated-form-control' as='element()?' slot='11' eval='7'>
          <check card='?' diag='3|0|XTTE0570|associated-form-control'>
           <filter flags='b'>
            <slash simple='1'>
@@ -2507,22 +2433,22 @@
            </vc>
           </filter>
          </check>
-         <choose line='4512'>
+         <choose line='4605'>
           <fn name='exists'>
            <varRef name='Q{}associated-form-control' slot='11'/>
           </fn>
-          <sequence line='4513'>
+          <sequence line='4606'>
            <applyT mode='Q{}set-field' bSlot='3'>
             <varRef role='select' name='Q{}associated-form-control' slot='11'/>
             <withParam name='Q{}value' flags='t' as='xs:string'>
-             <cast line='4514' as='xs:string' emptiable='0'>
+             <cast line='4607' as='xs:string' emptiable='0'>
               <data>
                <varRef name='Q{}valuez' slot='9'/>
               </data>
              </cast>
             </withParam>
            </applyT>
-           <ifCall line='4516' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+           <ifCall line='4609' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
             <check card='1' diag='0|0||ixsl:call'>
              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
             </check>
@@ -2551,7 +2477,7 @@
            </ifCall>
           </sequence>
           <true/>
-          <ifCall line='4519' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+          <ifCall line='4612' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
            <check card='1' diag='0|0||ixsl:call'>
             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
            </check>
@@ -2580,12 +2506,12 @@
           </ifCall>
          </choose>
         </let>
-        <choose line='4525'>
+        <choose line='4618'>
          <vc op='ne' onEmpty='1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
           <varRef name='Q{}refz' slot='3'/>
           <str val=''/>
          </vc>
-         <let line='4527' var='Q{}pendingUpdates' as='map(xs:string, xs:string)?' slot='12' eval='7'>
+         <let line='4620' var='Q{}pendingUpdates' as='map(xs:string, xs:string)?' slot='12' eval='7'>
           <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|pendingUpdates'>
            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
             <check card='1' diag='0|0||ixsl:call'>
@@ -2595,11 +2521,11 @@
             <array size='0'/>
            </ifCall>
           </treat>
-          <let line='4529' var='Q{}updatedInstanceXML' as='element()' slot='13' eval='16'>
-           <treat line='4530' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+          <let line='4622' var='Q{}updatedInstanceXML' as='element()' slot='13' eval='16'>
+           <treat line='4623' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
             <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
              <applyT mode='Q{}form-check-initial' bSlot='4'>
-              <choose role='select' line='4478'>
+              <choose role='select' line='4571'>
                <and op='and'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <varRef name='Q{}instance-id' slot='8'/>
@@ -2609,31 +2535,31 @@
                  <varRef name='Q{}instanceXML' slot='1'/>
                 </fn>
                </and>
-               <check line='4479' card='1' diag='3|0|XTTE0570|instanceXML2'>
+               <check line='4572' card='1' diag='3|0|XTTE0570|instanceXML2'>
                 <varRef name='Q{}instanceXML' slot='1'/>
                </check>
                <true/>
-               <check line='4482' card='1' diag='3|0|XTTE0570|instanceXML2'>
+               <check line='4575' card='1' diag='3|0|XTTE0570|instanceXML2'>
                 <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='5' eval='6'>
                  <varRef name='Q{}refz' slot='3'/>
                 </ufCall>
                </check>
               </choose>
               <withParam name='Q{}instance-id' as='xs:string'>
-               <varRef line='4531' name='Q{}instance-id' slot='8'/>
+               <varRef line='4624' name='Q{}instance-id' slot='8'/>
               </withParam>
               <withParam name='Q{}pendingUpdates' flags='t' as='map(xs:string, xs:string)?'>
-               <varRef line='4532' name='Q{}pendingUpdates' slot='12'/>
+               <varRef line='4625' name='Q{}pendingUpdates' slot='12'/>
               </withParam>
              </applyT>
             </check>
            </treat>
-           <sequence line='4537'>
+           <sequence line='4630'>
             <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='6' eval='6 6'>
              <varRef name='Q{}refz' slot='3'/>
              <varRef name='Q{}updatedInstanceXML' slot='13'/>
             </ufCall>
-            <callT line='4538' name='Q{}refreshOutputs-JS' bSlot='7' flags='t'/>
+            <callT line='4631' name='Q{}refreshOutputs-JS' bSlot='7' flags='t'/>
            </sequence>
           </let>
          </let>
@@ -2646,13 +2572,13 @@
   </template>
  </co>
  <co id='36' binds=''>
-  <globalVariable name='Q{}default-submission-id' type='xs:string' line='76' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
+  <globalVariable name='Q{}default-submission-id' type='xs:string' line='78' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
    <str val='saxon-forms-default-submission'/>
   </globalVariable>
  </co>
- <co id='21' binds='1 2 3 3 33 0 8 30 31 37 7 17 10 26 21'>
-  <template name='Q{}applyActions' flags='os' line='3689' module='saxon-xforms.xsl' slots='12'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3690'>
+ <co id='20' binds='1 34 3 3 32 0 8 29 30 37 7 17 10 25 20'>
+  <template name='Q{}applyActions' flags='os' line='3669' module='saxon-xforms.xsl' slots='12'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3670'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -2660,7 +2586,7 @@
       </check>
      </treat>
     </param>
-    <param line='3691' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
+    <param line='3671' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
      <empty role='select'/>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|instanceXML'>
       <check card='?' diag='8|0|XTTE0590|instanceXML'>
@@ -2668,7 +2594,7 @@
       </check>
      </treat>
     </param>
-    <param line='3692' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
+    <param line='3672' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -2680,7 +2606,7 @@
       </check>
      </treat>
     </param>
-    <let line='3694' var='Q{}ref' as='xs:string?' slot='3' eval='7'>
+    <let line='3674' var='Q{}ref' as='xs:string?' slot='3' eval='7'>
      <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|ref'>
       <check card='?' diag='3|0|XTTE0570|ref'>
        <cvUntyped to='xs:string' diag='3|0|XTTE0570|ref'>
@@ -2693,7 +2619,7 @@
        </cvUntyped>
       </check>
      </treat>
-     <let line='3695' var='Q{}at' as='xs:string?' slot='4' eval='7'>
+     <let line='3675' var='Q{}at' as='xs:string?' slot='4' eval='7'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|at'>
        <check card='?' diag='3|0|XTTE0570|at'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|at'>
@@ -2706,7 +2632,7 @@
         </cvUntyped>
        </check>
       </treat>
-      <let line='3707' var='Q{}ref-qualified' as='xs:string?' slot='5' eval='7'>
+      <let line='3687' var='Q{}ref-qualified' as='xs:string?' slot='5' eval='7'>
        <choose>
         <and op='and'>
          <fn name='exists'>
@@ -2728,14 +2654,14 @@
          <varRef name='Q{}ref' slot='3'/>
         </choose>
        </choose>
-       <let line='3709' var='Q{}instance-id' as='xs:string' slot='6' eval='16'>
+       <let line='3689' var='Q{}instance-id' as='xs:string' slot='6' eval='16'>
         <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='16'>
          <check card='1' diag='0|0||xforms:getInstanceId'>
           <varRef name='Q{}ref' slot='3'/>
          </check>
         </ufCall>
-        <let line='3711' var='Q{}instanceXML2' as='element()?' slot='7' eval='7'>
-         <choose line='3713'>
+        <let line='3691' var='Q{}instanceXML2' as='element()?' slot='7' eval='7'>
+         <choose line='3693'>
           <and op='and'>
            <vc op='eq' onEmpty='0' comp='CCC'>
             <varRef name='Q{}instance-id' slot='6'/>
@@ -2745,18 +2671,18 @@
             <varRef name='Q{}instanceXML' slot='1'/>
            </fn>
           </and>
-          <varRef line='3714' name='Q{}instanceXML' slot='1'/>
-          <fn line='3716' name='exists'>
+          <varRef line='3694' name='Q{}instanceXML' slot='1'/>
+          <fn line='3696' name='exists'>
            <varRef name='Q{}ref-qualified' slot='5'/>
           </fn>
-          <ufCall line='3717' name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='1' eval='16'>
+          <ufCall line='3697' name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='1' eval='16'>
            <check card='1' diag='0|0||xforms:getInstance-JS'>
             <varRef name='Q{}ref-qualified' slot='5'/>
            </check>
           </ufCall>
          </choose>
-         <let line='3725' var='Q{}context' as='node()?' slot='8' eval='7'>
-          <choose line='3727'>
+         <let line='3705' var='Q{}context' as='node()?' slot='8' eval='7'>
+          <choose line='3707'>
            <and op='and'>
             <and op='and'>
              <fn name='exists'>
@@ -2771,7 +2697,7 @@
              <varRef name='Q{}instanceXML2' slot='7'/>
             </fn>
            </and>
-           <treat line='3728' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|context'>
+           <treat line='3708' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|context'>
             <check card='?' diag='3|0|XTTE0570|context'>
              <evaluate dxns=''>
               <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
@@ -2790,18 +2716,18 @@
             </check>
            </treat>
           </choose>
-          <let line='3735' var='Q{}ifVar' as='xs:string?' slot='9' eval='7'>
-           <choose line='791'>
+          <let line='3715' var='Q{}ifVar' as='xs:string?' slot='9' eval='7'>
+           <choose line='793'>
             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
-             <varRef line='3735' name='Q{}action-map' slot='0'/>
+             <varRef line='3715' name='Q{}action-map' slot='0'/>
              <str val='@if'/>
             </ifCall>
-            <treat line='792' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
+            <treat line='794' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
              <check card='?' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
               <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
                <data>
                 <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                 <varRef line='3735' name='Q{}action-map' slot='0'/>
+                 <varRef line='3715' name='Q{}action-map' slot='0'/>
                  <str val='@if'/>
                 </ifCall>
                </data>
@@ -2809,8 +2735,8 @@
              </check>
             </treat>
            </choose>
-           <let line='3739' var='Q{}ifExecuted' as='xs:boolean' slot='10' eval='16'>
-            <choose line='3741'>
+           <let line='3719' var='Q{}ifExecuted' as='xs:boolean' slot='10' eval='16'>
+            <choose line='3721'>
              <and op='and'>
               <fn name='exists'>
                <varRef name='Q{}ifVar' slot='9'/>
@@ -2819,7 +2745,7 @@
                <varRef name='Q{}context' slot='8'/>
               </fn>
              </and>
-             <treat line='3742' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|ifExecuted'>
+             <treat line='3722' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|ifExecuted'>
               <check card='1' diag='3|0|XTTE0570|ifExecuted'>
                <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|ifExecuted'>
                 <data>
@@ -2831,7 +2757,7 @@
                   </ufCall>
                   <varRef role='cxt' name='Q{}context' slot='8'/>
                   <check role='nsCxt' card='1' diag='4|0|XTTE3170|xsl:evaluate/namespace-context'>
-                   <varRef name='Q{}context' slot='8'/>
+                   <varRef name='Q{}instanceXML2' slot='7'/>
                   </check>
                   <str role='sa' val='no'/>
                   <map role='options' size='0'/>
@@ -2844,9 +2770,9 @@
              <true/>
              <true/>
             </choose>
-            <choose line='3752'>
+            <choose line='3732'>
              <varRef name='Q{}ifExecuted' slot='10'/>
-             <let line='3753' var='Q{}action-name' as='xs:string' slot='11' eval='16'>
+             <let line='3733' var='Q{}action-name' as='xs:string' slot='11' eval='16'>
               <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|action-name'>
                <check card='1' diag='3|0|XTTE0570|action-name'>
                 <cvUntyped to='xs:string' diag='3|0|XTTE0570|action-name'>
@@ -2859,98 +2785,98 @@
                 </cvUntyped>
                </check>
               </treat>
-              <sequence line='3756'>
+              <sequence line='3736'>
                <choose>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <varRef name='Q{}action-name' slot='11'/>
                  <str val='action'/>
                 </vc>
                 <empty/>
-                <vc line='3759' op='eq' onEmpty='0' comp='CCC'>
+                <vc line='3739' op='eq' onEmpty='0' comp='CCC'>
                  <varRef name='Q{}action-name' slot='11'/>
                  <str val='setvalue'/>
                 </vc>
-                <callT line='3760' name='Q{}action-setvalue' bSlot='4'>
+                <callT line='3740' name='Q{}action-setvalue' bSlot='4'>
                  <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                  <check line='3761' card='1' diag='8|0|XTTE0590|nodeset'>
+                  <check line='3741' card='1' diag='8|0|XTTE0590|nodeset'>
                    <varRef name='Q{}ref' slot='3'/>
                   </check>
                  </withParam>
                  <withParam name='Q{}instanceXML' flags='t' as='element()'>
-                  <check line='3762' card='1' diag='8|0|XTTE0590|instanceXML'>
+                  <check line='3742' card='1' diag='8|0|XTTE0590|instanceXML'>
                    <varRef name='Q{}instanceXML2' slot='7'/>
                   </check>
                  </withParam>
                 </callT>
-                <vc line='3765' op='eq' onEmpty='0' comp='CCC'>
+                <vc line='3745' op='eq' onEmpty='0' comp='CCC'>
                  <varRef name='Q{}action-name' slot='11'/>
                  <str val='insert'/>
                 </vc>
-                <callT line='3766' name='Q{}action-insert' bSlot='5'>
+                <callT line='3746' name='Q{}action-insert' bSlot='5'>
                  <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                  <check line='3767' card='1' diag='8|0|XTTE0590|nodeset'>
+                  <check line='3747' card='1' diag='8|0|XTTE0590|nodeset'>
                    <varRef name='Q{}ref-qualified' slot='5'/>
                   </check>
                  </withParam>
                  <withParam name='Q{}instanceXML' flags='t' as='element()'>
-                  <check line='3768' card='1' diag='8|0|XTTE0590|instanceXML'>
+                  <check line='3748' card='1' diag='8|0|XTTE0590|instanceXML'>
                    <varRef name='Q{}instanceXML2' slot='7'/>
                   </check>
                  </withParam>
                 </callT>
-                <vc line='3771' op='eq' onEmpty='0' comp='CCC'>
+                <vc line='3751' op='eq' onEmpty='0' comp='CCC'>
                  <varRef name='Q{}action-name' slot='11'/>
                  <str val='delete'/>
                 </vc>
-                <callT line='3772' name='Q{}action-delete' bSlot='6'>
+                <callT line='3752' name='Q{}action-delete' bSlot='6'>
                  <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                  <check line='3773' card='1' diag='8|0|XTTE0590|nodeset'>
+                  <check line='3753' card='1' diag='8|0|XTTE0590|nodeset'>
                    <varRef name='Q{}ref-qualified' slot='5'/>
                   </check>
                  </withParam>
                  <withParam name='Q{}instanceXML' flags='t' as='element()'>
-                  <check line='3774' card='1' diag='8|0|XTTE0590|instanceXML'>
+                  <check line='3754' card='1' diag='8|0|XTTE0590|instanceXML'>
                    <varRef name='Q{}instanceXML2' slot='7'/>
                   </check>
                  </withParam>
                 </callT>
-                <vc line='3777' op='eq' onEmpty='0' comp='CCC'>
+                <vc line='3757' op='eq' onEmpty='0' comp='CCC'>
                  <varRef name='Q{}action-name' slot='11'/>
                  <str val='setindex'/>
                 </vc>
-                <callT line='3778' name='Q{}action-setindex' bSlot='7'/>
-                <vc line='3783' op='eq' onEmpty='0' comp='CCC'>
+                <callT line='3758' name='Q{}action-setindex' bSlot='7'/>
+                <vc line='3763' op='eq' onEmpty='0' comp='CCC'>
                  <varRef name='Q{}action-name' slot='11'/>
                  <str val='setfocus'/>
                 </vc>
-                <callT line='3784' name='Q{}action-setfocus' bSlot='8'/>
-                <vc line='3789' op='eq' onEmpty='0' comp='CCC'>
+                <callT line='3764' name='Q{}action-setfocus' bSlot='8'/>
+                <vc line='3769' op='eq' onEmpty='0' comp='CCC'>
                  <varRef name='Q{}action-name' slot='11'/>
                  <str val='rebuild'/>
                 </vc>
-                <callT line='3790' name='Q{}xforms-rebuild' bSlot='9'/>
-                <vc line='3792' op='eq' onEmpty='0' comp='CCC'>
+                <callT line='3770' name='Q{}xforms-rebuild' bSlot='9'/>
+                <vc line='3772' op='eq' onEmpty='0' comp='CCC'>
                  <varRef name='Q{}action-name' slot='11'/>
                  <str val='recalculate'/>
                 </vc>
-                <callT line='3793' name='Q{}xforms-recalculate' bSlot='10'/>
-                <vc line='3801' op='eq' onEmpty='0' comp='CCC'>
+                <callT line='3773' name='Q{}xforms-recalculate' bSlot='10'/>
+                <vc line='3781' op='eq' onEmpty='0' comp='CCC'>
                  <varRef name='Q{}action-name' slot='11'/>
                  <str val='reset'/>
                 </vc>
-                <callT line='3802' name='Q{}action-reset' bSlot='11'/>
-                <vc line='3807' op='eq' onEmpty='0' comp='CCC'>
+                <callT line='3782' name='Q{}action-reset' bSlot='11'/>
+                <vc line='3787' op='eq' onEmpty='0' comp='CCC'>
                  <varRef name='Q{}action-name' slot='11'/>
                  <str val='send'/>
                 </vc>
-                <callT line='3808' name='Q{}action-send' bSlot='12'/>
-                <vc line='3810' op='eq' onEmpty='0' comp='CCC'>
+                <callT line='3788' name='Q{}action-send' bSlot='12'/>
+                <vc line='3790' op='eq' onEmpty='0' comp='CCC'>
                  <varRef name='Q{}action-name' slot='11'/>
                  <str val='message'/>
                 </vc>
-                <callT line='3811' name='Q{}action-message' bSlot='13'/>
+                <callT line='3791' name='Q{}action-message' bSlot='13'/>
                 <true/>
-                <message line='3814'>
+                <message line='3794'>
                  <sequence role='select'>
                   <valueOf>
                    <str val='[applyActions] action &#39;'/>
@@ -2966,8 +2892,8 @@
                  <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
                 </message>
                </choose>
-               <forEach line='3823'>
-                <ifCall line='3819' name='Q{http://www.w3.org/2005/xpath-functions/array}flatten' type='item()*'>
+               <forEach line='3803'>
+                <ifCall line='3799' name='Q{http://www.w3.org/2005/xpath-functions/array}flatten' type='item()*'>
                  <treat as='array(map(*))' jsTest='function v(item) {return SaxonJS.U.isMap(item)};function c(n) {return n==1;};return SaxonJS.U.isArray(item) &amp;&amp; SaxonJS.U.ForArray(item.value).every(function(seq){return c(seq.length) &amp;&amp; SaxonJS.U.ForArray(seq).every(v)});' diag='3|0|XTTE0570|nested-actions-array'>
                   <check card='?' diag='3|0|XTTE0570|nested-actions-array'>
                    <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
@@ -2977,9 +2903,9 @@
                   </check>
                  </treat>
                 </ifCall>
-                <callT line='3824' name='Q{}applyActions' bSlot='14'>
+                <callT line='3804' name='Q{}applyActions' bSlot='14'>
                  <withParam name='Q{}action-map' flags='t' as='item()'>
-                  <dot line='3825'/>
+                  <dot line='3805'/>
                  </withParam>
                 </callT>
                </forEach>
@@ -2999,9 +2925,9 @@
  </co>
  <co id='4' binds='4'>
   <mode name='Q{}insert-node' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='21' rank='0' minImp='0' slots='3' flags='s' line='1915' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='21' rank='0' minImp='0' slots='3' flags='s' line='1922' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1916'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1923'>
      <param name='Q{}insert-node-location' slot='0' flags='ti' as='node()'>
       <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|insert-node-location'>
        <check card='1' diag='8|0|XTTE0590|insert-node-location'>
@@ -3009,14 +2935,14 @@
        </check>
       </treat>
      </param>
-     <param line='1917' name='Q{}node-to-insert' slot='1' flags='ti' as='node()'>
+     <param line='1924' name='Q{}node-to-insert' slot='1' flags='ti' as='node()'>
       <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|node-to-insert'>
        <check card='1' diag='8|0|XTTE0590|node-to-insert'>
         <supplied slot='1'/>
        </check>
       </treat>
      </param>
-     <param line='1918' name='Q{}position-relative' slot='2' flags='t' as='xs:string?'>
+     <param line='1925' name='Q{}position-relative' slot='2' flags='t' as='xs:string?'>
       <str role='select' val='after'/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|position-relative'>
        <check card='?' diag='8|0|XTTE0590|position-relative'>
@@ -3028,7 +2954,7 @@
        </check>
       </treat>
      </param>
-     <choose line='1921'>
+     <choose line='1928'>
       <and op='and'>
        <is op='is'>
         <dot type='element()'/>
@@ -3039,21 +2965,21 @@
         <str val='before'/>
        </vc>
       </and>
-      <copyOf line='1923' flags='vc'>
+      <copyOf line='1930' flags='vc'>
        <varRef name='Q{}node-to-insert' slot='1'/>
       </copyOf>
      </choose>
-     <copy line='1926' flags='cin'>
+     <copy line='1933' flags='cin'>
       <sequence role='content'>
        <copyOf flags='vc'>
         <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
        </copyOf>
-       <applyT line='1927' mode='Q{}insert-node' bSlot='0'>
+       <applyT line='1934' mode='Q{}insert-node' bSlot='0'>
         <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
        </applyT>
       </sequence>
      </copy>
-     <choose line='1929'>
+     <choose line='1936'>
       <and op='and'>
        <is op='is'>
         <dot type='element()'/>
@@ -3064,7 +2990,7 @@
         <str val='after'/>
        </vc>
       </and>
-      <copyOf line='1930' flags='vc'>
+      <copyOf line='1937' flags='vc'>
        <varRef name='Q{}node-to-insert' slot='1'/>
       </copyOf>
      </choose>
@@ -3073,10 +2999,10 @@
   </mode>
  </co>
  <co id='38' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}hasClass' line='3067' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:boolean' slots='2'>
+  <function name='Q{http://www.w3.org/2002/xforms}hasClass' line='3040' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:boolean' slots='2'>
    <arg name='Q{}element' as='element()'/>
    <arg name='Q{}string' as='xs:string'/>
-   <gc role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3071' op='=' card='N:1' comp='CCC'>
+   <gc role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3044' op='=' card='N:1' comp='CCC'>
     <fn name='tokenize'>
      <cvUntyped to='xs:string' diag='3|0|XTTE0570|class'>
       <data>
@@ -3087,24 +3013,24 @@
       </data>
      </cvUntyped>
     </fn>
-    <varRef line='3074' name='Q{}string' slot='1'/>
+    <varRef line='3047' name='Q{}string' slot='1'/>
    </gc>
   </function>
  </co>
  <co id='39' binds=''>
-  <globalParam name='Q{}xforms-instance-id' type='item()*' line='63' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return val;' jsCardCheck='function c() {return true;};'>
+  <globalParam name='Q{}xforms-instance-id' type='item()*' line='65' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return val;' jsCardCheck='function c() {return true;};'>
    <str val='xforms-jinstance'/>
   </globalParam>
  </co>
  <co id='40' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}getIfStatement' line='788' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
+  <function name='Q{http://www.w3.org/2002/xforms}getIfStatement' line='790' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
    <arg name='Q{}map' as='map(*)'/>
-   <choose role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='791'>
+   <choose role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='793'>
     <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
      <varRef name='Q{}map' slot='0'/>
      <str val='@if'/>
     </ifCall>
-    <treat line='792' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
+    <treat line='794' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
      <check card='?' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
       <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
        <data>
@@ -3120,17 +3046,17 @@
   </function>
  </co>
  <co id='41' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}getClass' line='3088' module='saxon-xforms.xsl' eval='7' flags='pU' as='attribute(Q{}class)?' slots='3'>
+  <function name='Q{http://www.w3.org/2002/xforms}getClass' line='3061' module='saxon-xforms.xsl' eval='7' flags='pU' as='attribute(Q{}class)?' slots='3'>
    <arg name='Q{}element' as='element()'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3091' var='Q{}class' as='xs:string?' slot='1' eval='7'>
-    <choose line='3092'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3064' var='Q{}class' as='xs:string?' slot='1' eval='7'>
+    <choose line='3065'>
      <fn name='exists'>
       <slash simple='1'>
        <varRef name='Q{}element' slot='0'/>
        <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
       </slash>
      </fn>
-     <cvUntyped line='3093' to='xs:string' diag='3|0|XTTE0570|class'>
+     <cvUntyped line='3066' to='xs:string' diag='3|0|XTTE0570|class'>
       <cast as='xs:untypedAtomic' emptiable='0'>
        <fn name='string'>
         <convert from='xs:untypedAtomic' to='xs:string'>
@@ -3145,15 +3071,15 @@
       </cast>
      </cvUntyped>
     </choose>
-    <let line='3096' var='Q{}class-mod' as='xs:string?' slot='2' eval='7'>
-     <choose line='3098'>
+    <let line='3069' var='Q{}class-mod' as='xs:string?' slot='2' eval='7'>
+     <choose line='3071'>
       <fn name='exists'>
        <slash simple='1'>
         <varRef name='Q{}element' slot='0'/>
         <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
        </slash>
       </fn>
-      <cvUntyped line='3099' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+      <cvUntyped line='3072' to='xs:string' diag='3|0|XTTE0570|class-mod'>
        <cast as='xs:untypedAtomic' emptiable='0'>
         <fn name='string-join'>
          <sequence>
@@ -3165,13 +3091,13 @@
        </cast>
       </cvUntyped>
       <true/>
-      <varRef line='3102' name='Q{}class' slot='1'/>
+      <varRef line='3075' name='Q{}class' slot='1'/>
      </choose>
-     <choose line='3106'>
+     <choose line='3079'>
       <fn name='exists'>
        <varRef name='Q{}class-mod' slot='2'/>
       </fn>
-      <treat line='3107' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+      <treat line='3080' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
        <att name='class'>
         <varRef name='Q{}class-mod' slot='2'/>
        </att>
@@ -3181,9 +3107,9 @@
    </let>
   </function>
  </co>
- <co id='42' binds='43 24 44 19 45'>
-  <template name='Q{}refreshRepeats-JS' flags='os' line='3565' module='saxon-xforms.xsl' slots='8'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3567'>
+ <co id='42' binds='2 23 43 44 45'>
+  <template name='Q{}refreshRepeats-JS' flags='os' line='3545' module='saxon-xforms.xsl' slots='8'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3547'>
     <message>
      <valueOf role='select'>
       <str val='[refreshRepeats-JS] START refreshRepeats'/>
@@ -3191,7 +3117,7 @@
      <str role='terminate' val='no'/>
      <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
     </message>
-    <let line='3570' var='Q{}repeat-keys' as='item()?' slot='0' eval='8'>
+    <let line='3550' var='Q{}repeat-keys' as='item()?' slot='0' eval='8'>
      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
       <check card='1' diag='0|0||ixsl:call'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -3199,9 +3125,9 @@
       <str val='getRepeatKeys'/>
       <array size='0'/>
      </ifCall>
-     <forEach line='3572'>
+     <forEach line='3552'>
       <varRef name='Q{}repeat-keys' slot='0'/>
-      <let line='3573' var='Q{}this-key' as='xs:string' slot='1' eval='16'>
+      <let line='3553' var='Q{}this-key' as='xs:string' slot='1' eval='16'>
        <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|this-key'>
         <check card='1' diag='3|0|XTTE0570|this-key'>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|this-key'>
@@ -3211,7 +3137,7 @@
          </cvUntyped>
         </check>
        </treat>
-       <let line='3574' var='Q{}this-repeat-nodeset' as='xs:string' slot='2' eval='16'>
+       <let line='3554' var='Q{}this-repeat-nodeset' as='xs:string' slot='2' eval='16'>
         <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|this-repeat-nodeset'>
          <check card='1' diag='3|0|XTTE0570|this-repeat-nodeset'>
           <cvUntyped to='xs:string' diag='3|0|XTTE0570|this-repeat-nodeset'>
@@ -3229,7 +3155,7 @@
           </cvUntyped>
          </check>
         </treat>
-        <sequence line='3576'>
+        <sequence line='3556'>
          <message>
           <sequence role='select'>
            <valueOf>
@@ -3243,9 +3169,9 @@
           <str role='terminate' val='no'/>
           <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
          </message>
-         <let line='3587' var='Q{}contexti' as='element()?' slot='3' eval='7'>
-          <ufCall line='3588' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='0' eval='16'>
-           <check line='3580' card='1' diag='3|0|XTTE0570|this-instance-id'>
+         <let line='3567' var='Q{}contexti' as='element()?' slot='3' eval='7'>
+          <ufCall line='3568' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='0' eval='16'>
+           <check line='3560' card='1' diag='3|0|XTTE0570|this-instance-id'>
             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
              <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='1' eval='6'>
               <varRef name='Q{}this-repeat-nodeset' slot='2'/>
@@ -3254,7 +3180,7 @@
             </ifCall>
            </check>
           </ufCall>
-          <let line='3595' var='Q{}namespace-context-item' as='element()' slot='4' eval='16'>
+          <let line='3575' var='Q{}namespace-context-item' as='element()' slot='4' eval='16'>
            <choose>
             <fn name='exists'>
              <varRef name='Q{}contexti' slot='3'/>
@@ -3275,7 +3201,7 @@
              </check>
             </treat>
            </choose>
-           <let line='3597' var='Q{}page-element' as='element()?' slot='5' eval='7'>
+           <let line='3577' var='Q{}page-element' as='element()?' slot='5' eval='7'>
             <check card='?' diag='3|0|XTTE0570|page-element'>
              <filter flags='b'>
               <slash simple='1'>
@@ -3290,11 +3216,11 @@
               </vc>
              </filter>
             </check>
-            <choose line='3600'>
+            <choose line='3580'>
              <fn name='exists'>
               <varRef name='Q{}page-element' slot='5'/>
              </fn>
-             <let line='3601' var='Q{}instance-keys' as='item()?' slot='6' eval='8'>
+             <let line='3581' var='Q{}instance-keys' as='item()?' slot='6' eval='8'>
               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                <check card='1' diag='0|0||ixsl:call'>
                 <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -3302,12 +3228,12 @@
                <str val='getInstanceKeys'/>
                <array size='0'/>
               </ifCall>
-              <let line='3602' var='Q{}instances' as='map(xs:string, element())' slot='7' eval='16'>
-               <treat line='3604' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances'>
+              <let line='3582' var='Q{}instances' as='map(xs:string, element())' slot='7' eval='16'>
+               <treat line='3584' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances'>
                 <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
                  <forEach>
                   <varRef name='Q{}instance-keys' slot='6'/>
-                  <ifCall line='3605' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                  <ifCall line='3585' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                    <atomSing diag='0|0||map:entry'>
                     <dot/>
                    </atomSing>
@@ -3330,12 +3256,12 @@
                  </map>
                 </ifCall>
                </treat>
-               <resultDoc line='3609' global='#&#xA;#Sat Feb 22 22:54:41 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sat Feb 22 22:54:41 GMT 2020&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xA;'>
+               <resultDoc line='3589' global='#&#xA;#Sun Feb 23 16:30:37 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sun Feb 23 16:30:37 GMT 2020&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xA;'>
                 <fn role='href' name='concat'>
                  <str val='#'/>
                  <varRef name='Q{}this-key' slot='1'/>
                 </fn>
-                <applyT role='content' line='3610' bSlot='2'>
+                <applyT role='content' line='3590' bSlot='2'>
                  <filter role='select' flags='b'>
                   <slash simple='1'>
                    <gVarRef name='Q{}xforms-doc' bSlot='3'/>
@@ -3356,7 +3282,7 @@
                   <true/>
                  </withParam>
                  <withParam name='Q{}instances' flags='t' as='map(xs:string, element())'>
-                  <varRef line='3611' name='Q{}instances' slot='7'/>
+                  <varRef line='3591' name='Q{}instances' slot='7'/>
                  </withParam>
                 </applyT>
                </resultDoc>
@@ -3374,9 +3300,9 @@
    </sequence>
   </template>
  </co>
- <co id='35' binds='3 43 24 24'>
-  <template name='Q{}refreshOutputs-JS' flags='os' line='3486' module='saxon-xforms.xsl' slots='8'>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3493' var='Q{}output-keys' as='item()?' slot='0' eval='8'>
+ <co id='35' binds='3 2 23 23'>
+  <template name='Q{}refreshOutputs-JS' flags='os' line='3466' module='saxon-xforms.xsl' slots='8'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3473' var='Q{}output-keys' as='item()?' slot='0' eval='8'>
     <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
      <check card='1' diag='0|0||ixsl:call'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -3384,9 +3310,9 @@
      <str val='getOutputKeys'/>
      <array size='0'/>
     </ifCall>
-    <forEach line='3495'>
+    <forEach line='3475'>
      <varRef name='Q{}output-keys' slot='0'/>
-     <let line='3496' var='Q{}this-key' as='xs:string' slot='1' eval='16'>
+     <let line='3476' var='Q{}this-key' as='xs:string' slot='1' eval='16'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|this-key'>
        <check card='1' diag='3|0|XTTE0570|this-key'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|this-key'>
@@ -3396,7 +3322,7 @@
         </cvUntyped>
        </check>
       </treat>
-      <let line='3497' var='Q{}this-output' as='map(*)' slot='2' eval='16'>
+      <let line='3477' var='Q{}this-output' as='map(*)' slot='2' eval='16'>
        <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|this-output'>
         <check card='1' diag='3|0|XTTE0570|this-output'>
          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
@@ -3410,7 +3336,7 @@
          </ifCall>
         </check>
        </treat>
-       <sequence line='3499'>
+       <sequence line='3479'>
         <message>
          <sequence role='select'>
           <valueOf>
@@ -3424,14 +3350,14 @@
          <str role='terminate' val='no'/>
          <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
         </message>
-        <let line='3516' var='Q{}xpath-mod' as='xs:string' slot='3' eval='16'>
+        <let line='3496' var='Q{}xpath-mod' as='xs:string' slot='3' eval='16'>
          <ufCall name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='0' eval='16'>
-          <choose line='3504'>
+          <choose line='3484'>
            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
             <varRef name='Q{}this-output' slot='2'/>
             <str val='@value'/>
            </ifCall>
-           <treat line='3505' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|xpath'>
+           <treat line='3485' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|xpath'>
             <check card='1' diag='3|0|XTTE0570|xpath'>
              <cvUntyped to='xs:string' diag='3|0|XTTE0570|xpath'>
               <data>
@@ -3443,11 +3369,11 @@
              </cvUntyped>
             </check>
            </treat>
-           <ifCall line='3507' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+           <ifCall line='3487' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
             <varRef name='Q{}this-output' slot='2'/>
             <str val='@ref'/>
            </ifCall>
-           <treat line='3508' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|xpath'>
+           <treat line='3488' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|xpath'>
             <check card='1' diag='3|0|XTTE0570|xpath'>
              <cvUntyped to='xs:string' diag='3|0|XTTE0570|xpath'>
               <data>
@@ -3463,7 +3389,7 @@
            <str val=''/>
           </choose>
          </ufCall>
-         <sequence line='3518'>
+         <sequence line='3498'>
           <message>
            <sequence role='select'>
             <valueOf>
@@ -3477,21 +3403,21 @@
            <str role='terminate' val='no'/>
            <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
           </message>
-          <let line='3534' var='Q{}contexti' as='element()?' slot='4' eval='7'>
-           <ufCall line='3535' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='16'>
-            <check line='3522' card='1' diag='3|0|XTTE0570|this-instance-id'>
+          <let line='3514' var='Q{}contexti' as='element()?' slot='4' eval='7'>
+           <ufCall line='3515' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='16'>
+            <check line='3502' card='1' diag='3|0|XTTE0570|this-instance-id'>
              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
               <choose>
                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
                 <varRef name='Q{}this-output' slot='2'/>
                 <str val='@ref'/>
                </ifCall>
-               <ufCall line='3524' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='2' eval='16'>
+               <ufCall line='3504' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='2' eval='16'>
                 <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:getInstanceMap'>
                  <check card='1' diag='0|0||xforms:getInstanceMap'>
                   <cvUntyped to='xs:string'>
                    <data>
-                    <ifCall line='3523' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                    <ifCall line='3503' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
                      <varRef name='Q{}this-output' slot='2'/>
                      <str val='@ref'/>
                     </ifCall>
@@ -3501,7 +3427,7 @@
                 </treat>
                </ufCall>
                <true/>
-               <ufCall line='3527' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='3' eval='0'>
+               <ufCall line='3507' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='3' eval='0'>
                 <str val='saxon-forms-default'/>
                </ufCall>
               </choose>
@@ -3509,7 +3435,7 @@
              </ifCall>
             </check>
            </ufCall>
-           <let line='3542' var='Q{}namespace-context-item' as='element()' slot='5' eval='16'>
+           <let line='3522' var='Q{}namespace-context-item' as='element()' slot='5' eval='16'>
             <choose>
              <fn name='exists'>
               <varRef name='Q{}contexti' slot='4'/>
@@ -3530,8 +3456,8 @@
               </check>
              </treat>
             </choose>
-            <let line='3544' var='Q{}value' as='xs:string?' slot='6' eval='7'>
-             <treat line='3545' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|value'>
+            <let line='3524' var='Q{}value' as='xs:string?' slot='6' eval='7'>
+             <treat line='3525' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|value'>
               <check card='?' diag='3|0|XTTE0570|value'>
                <cvUntyped to='xs:string' diag='3|0|XTTE0570|value'>
                 <data>
@@ -3547,7 +3473,7 @@
                </cvUntyped>
               </check>
              </treat>
-             <let line='3548' var='Q{}associated-form-control' as='element()?' slot='7' eval='7'>
+             <let line='3528' var='Q{}associated-form-control' as='element()?' slot='7' eval='7'>
               <check card='?' diag='3|0|XTTE0570|associated-form-control'>
                <filter flags='b'>
                 <slash simple='1'>
@@ -3562,16 +3488,16 @@
                 </vc>
                </filter>
               </check>
-              <choose line='3551'>
+              <choose line='3531'>
                <fn name='exists'>
                 <varRef name='Q{}associated-form-control' slot='7'/>
                </fn>
-               <resultDoc line='3552' global='#&#xA;#Sat Feb 22 22:54:41 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sat Feb 22 22:54:41 GMT 2020&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xA;'>
+               <resultDoc line='3532' global='#&#xA;#Sun Feb 23 16:30:38 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sun Feb 23 16:30:38 GMT 2020&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xA;'>
                 <fn role='href' name='concat'>
                  <str val='#'/>
                  <varRef name='Q{}this-key' slot='1'/>
                 </fn>
-                <valueOf role='content' line='3553'>
+                <valueOf role='content' line='3533'>
                  <varRef name='Q{}value' slot='6'/>
                 </valueOf>
                </resultDoc>
@@ -3589,9 +3515,9 @@
    </let>
   </template>
  </co>
- <co id='32' binds='18'>
-  <template name='Q{}xforms-focus' flags='os' line='4230' module='saxon-xforms.xsl' slots='5'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4231'>
+ <co id='31' binds='46'>
+  <template name='Q{}xforms-focus' flags='os' line='4245' module='saxon-xforms.xsl' slots='5'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4246'>
     <param name='Q{}control' slot='0' flags='i' as='xs:string'>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|control'>
       <check card='1' diag='8|0|XTTE0590|control'>
@@ -3603,10 +3529,10 @@
       </check>
      </treat>
     </param>
-    <let line='4232' var='Q{}xforms-control' as='element()' slot='1' eval='16'>
+    <let line='4247' var='Q{}xforms-control' as='element()' slot='1' eval='16'>
      <check card='1' diag='3|0|XTTE0570|xforms-control'>
       <filter flags='b'>
-       <gVarRef name='Q{http://saxon.sf.net/generated-variable}gg99297450' bSlot='0'/>
+       <gVarRef name='Q{http://saxon.sf.net/generated-variable}gg1399833911' bSlot='0'/>
        <vc op='eq' onEmpty='0' comp='CCC'>
         <cast as='xs:string' emptiable='1'>
          <attVal name='Q{}id' chk='0'/>
@@ -3615,19 +3541,19 @@
        </vc>
       </filter>
      </check>
-     <choose line='4237'>
+     <choose line='4252'>
       <fn name='exists'>
        <slash simple='1'>
         <varRef name='Q{}xforms-control' slot='1'/>
         <axis name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
        </slash>
       </fn>
-      <let line='4241' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='2' eval='13'>
+      <let line='4256' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='2' eval='13'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
        </check>
-       <let line='4238' var='Q{}context-indexes' as='xs:double*' slot='3' eval='8'>
-        <convert line='4239' from='xs:anyAtomicType' to='xs:double' flags='p' diag='3|0|XTTE0570|context-indexes'>
+       <let line='4253' var='Q{}context-indexes' as='xs:double*' slot='3' eval='8'>
+        <convert line='4254' from='xs:anyAtomicType' to='xs:double' flags='p' diag='3|0|XTTE0570|context-indexes'>
          <cvUntyped to='xs:double' diag='3|0|XTTE0570|context-indexes'>
           <data>
            <forEach>
@@ -3638,7 +3564,7 @@
                <axis name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
               </fn>
              </slash>
-             <sortKey line='4240' comp='DESC|NC11'>
+             <sortKey line='4255' comp='DESC|NC11'>
               <fn role='select' name='position'/>
               <str role='order' val='descending'/>
               <str role='dataType' val='number'/>
@@ -3648,7 +3574,7 @@
               <str role='collation' val='http://www.w3.org/2005/xpath-functions/collation/codepoint'/>
              </sortKey>
             </sort>
-            <ifCall line='4241' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+            <ifCall line='4256' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
              <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='2'/>
              <str val='getRepeatIndex'/>
              <arrayBlock>
@@ -3661,12 +3587,12 @@
           </data>
          </cvUntyped>
         </convert>
-        <let line='4245' var='Q{}control-index' as='xs:string' slot='4' eval='8'>
+        <let line='4260' var='Q{}control-index' as='xs:string' slot='4' eval='8'>
          <fn name='string-join'>
           <varRef name='Q{}context-indexes' slot='3'/>
           <str val='.'/>
          </fn>
-         <sequence line='4246'>
+         <sequence line='4261'>
           <message>
            <sequence role='select'>
             <valueOf>
@@ -3684,7 +3610,7 @@
            <str role='terminate' val='no'/>
            <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
           </message>
-          <ifCall line='4247' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+          <ifCall line='4262' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
            <check card='1' diag='0|0||ixsl:call'>
             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
            </check>
@@ -3702,7 +3628,7 @@
        </let>
       </let>
       <true/>
-      <ifCall line='4250' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+      <ifCall line='4265' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
        </check>
@@ -3716,10 +3642,10 @@
    </sequence>
   </template>
  </co>
- <co id='22' binds='2'>
-  <function name='Q{http://www.w3.org/2002/xforms}checkRelevantFields' line='631' module='saxon-xforms.xsl' eval='8' flags='pU' as='item()*' slots='13'>
+ <co id='21' binds='34'>
+  <function name='Q{http://www.w3.org/2002/xforms}checkRelevantFields' line='633' module='saxon-xforms.xsl' eval='8' flags='pU' as='item()*' slots='13'>
    <arg name='Q{}refElement' as='xs:string'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='634' var='Q{}pendingUpdatesi' as='map(xs:string, xs:string)?' slot='1' eval='7'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='636' var='Q{}pendingUpdatesi' as='map(xs:string, xs:string)?' slot='1' eval='7'>
     <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|pendingUpdatesi'>
      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
       <check card='1' diag='0|0||ixsl:call'>
@@ -3729,7 +3655,7 @@
       <array size='0'/>
      </ifCall>
     </treat>
-    <let line='637' var='Q{}updatesi' as='map(xs:string, xs:string)?' slot='2' eval='7'>
+    <let line='639' var='Q{}updatesi' as='map(xs:string, xs:string)?' slot='2' eval='7'>
      <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|updatesi'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
@@ -3739,7 +3665,7 @@
        <array size='0'/>
       </ifCall>
      </treat>
-     <let line='640' var='Q{}relevantMap' as='map(xs:string, xs:string)' slot='3' eval='16'>
+     <let line='642' var='Q{}relevantMap' as='map(xs:string, xs:string)' slot='3' eval='16'>
       <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|relevantMap'>
        <check card='1' diag='3|0|XTTE0570|relevantMap'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
@@ -3751,16 +3677,16 @@
         </ifCall>
        </check>
       </treat>
-      <let line='641' var='Q{}mapKeys' as='xs:anyAtomicType*' slot='4' eval='4'>
+      <let line='643' var='Q{}mapKeys' as='xs:anyAtomicType*' slot='4' eval='4'>
        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
         <varRef name='Q{}relevantMap' slot='3'/>
        </ifCall>
-       <sequence line='671'>
+       <sequence line='673'>
         <forEach>
-         <sequence line='644'>
+         <sequence line='646'>
           <forEach>
            <varRef name='Q{}mapKeys' slot='4'/>
-           <choose line='645'>
+           <choose line='647'>
             <fn name='matches'>
              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
               <varRef name='Q{}relevantMap' slot='3'/>
@@ -3769,10 +3695,10 @@
              <varRef name='Q{}refElement' slot='0'/>
              <str val=''/>
             </fn>
-            <dot line='646' type='xs:anyAtomicType'/>
+            <dot line='648' type='xs:anyAtomicType'/>
            </choose>
           </forEach>
-          <forEach line='635'>
+          <forEach line='637'>
            <choose>
             <fn name='exists'>
              <varRef name='Q{}pendingUpdatesi' slot='1'/>
@@ -3783,7 +3709,7 @@
              </check>
             </ifCall>
            </choose>
-           <let line='652' var='Q{}keyi' as='xs:string?' slot='5' eval='7'>
+           <let line='654' var='Q{}keyi' as='xs:string?' slot='5' eval='7'>
             <lastOf>
              <fn name='tokenize'>
               <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||fn:tokenize'>
@@ -3795,13 +3721,13 @@
               <str val=''/>
              </fn>
             </lastOf>
-            <let line='654' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='6' eval='13'>
+            <let line='656' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='6' eval='13'>
              <check card='1' diag='0|1||fn:matches'>
               <varRef name='Q{}keyi' slot='5'/>
              </check>
-             <forEach line='653'>
+             <forEach line='655'>
               <varRef name='Q{}mapKeys' slot='4'/>
-              <choose line='654'>
+              <choose line='656'>
                <fn name='matches'>
                 <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
                  <varRef name='Q{}relevantMap' slot='3'/>
@@ -3810,13 +3736,13 @@
                 <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='6'/>
                 <str val=''/>
                </fn>
-               <dot line='655' type='xs:anyAtomicType'/>
+               <dot line='657' type='xs:anyAtomicType'/>
               </choose>
              </forEach>
             </let>
            </let>
           </forEach>
-          <forEach line='638'>
+          <forEach line='640'>
            <choose>
             <fn name='exists'>
              <varRef name='Q{}updatesi' slot='2'/>
@@ -3827,7 +3753,7 @@
              </check>
             </ifCall>
            </choose>
-           <let line='661' var='Q{}keyi' as='xs:string?' slot='7' eval='7'>
+           <let line='663' var='Q{}keyi' as='xs:string?' slot='7' eval='7'>
             <lastOf>
              <fn name='tokenize'>
               <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||fn:tokenize'>
@@ -3839,13 +3765,13 @@
               <str val=''/>
              </fn>
             </lastOf>
-            <let line='663' var='Q{http://saxon.sf.net/generated-variable}v1' as='xs:string' slot='8' eval='13'>
+            <let line='665' var='Q{http://saxon.sf.net/generated-variable}v1' as='xs:string' slot='8' eval='13'>
              <check card='1' diag='0|1||fn:matches'>
               <varRef name='Q{}keyi' slot='7'/>
              </check>
-             <forEach line='662'>
+             <forEach line='664'>
               <varRef name='Q{}mapKeys' slot='4'/>
-              <choose line='663'>
+              <choose line='665'>
                <fn name='matches'>
                 <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
                  <varRef name='Q{}relevantMap' slot='3'/>
@@ -3854,16 +3780,16 @@
                 <varRef name='Q{http://saxon.sf.net/generated-variable}v1' slot='8'/>
                 <str val=''/>
                </fn>
-               <dot line='664' type='xs:anyAtomicType'/>
+               <dot line='666' type='xs:anyAtomicType'/>
               </choose>
              </forEach>
             </let>
            </let>
           </forEach>
          </sequence>
-         <let line='672' var='Q{}keyi' as='xs:anyAtomicType' slot='9' eval='16'>
+         <let line='674' var='Q{}keyi' as='xs:anyAtomicType' slot='9' eval='16'>
           <dot type='xs:anyAtomicType'/>
-          <let line='673' var='Q{}context' as='element()*' slot='10' eval='8'>
+          <let line='675' var='Q{}context' as='element()*' slot='10' eval='8'>
            <filter flags='b'>
             <slash simple='1'>
              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
@@ -3874,7 +3800,7 @@
              <varRef name='Q{}keyi' slot='9'/>
             </gc>
            </filter>
-           <let line='674' var='Q{}updatedInstanceXML4' as='element()?' slot='11' eval='7'>
+           <let line='676' var='Q{}updatedInstanceXML4' as='element()?' slot='11' eval='7'>
             <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='0' eval='16'>
              <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:getInstance-JS'>
               <cvUntyped to='xs:string'>
@@ -3882,8 +3808,8 @@
               </cvUntyped>
              </treat>
             </ufCall>
-            <let line='676' var='Q{}relevantCheck' as='xs:boolean' slot='12' eval='16'>
-             <treat line='677' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantCheck'>
+            <let line='678' var='Q{}relevantCheck' as='xs:boolean' slot='12' eval='16'>
+             <treat line='679' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantCheck'>
               <check card='1' diag='3|0|XTTE0570|relevantCheck'>
                <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|relevantCheck'>
                 <data>
@@ -3908,9 +3834,9 @@
                </cvUntyped>
               </check>
              </treat>
-             <choose line='680'>
+             <choose line='682'>
               <varRef name='Q{}relevantCheck' slot='12'/>
-              <ifCall line='683' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+              <ifCall line='685' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
                <str val='style.display'/>
                <str val='inline'/>
                <check card='1' diag='0|2||ixsl:set-property'>
@@ -3923,14 +3849,14 @@
                  <docOrder intra='1'>
                   <slash simple='2'>
                    <varRef name='Q{}context' slot='10'/>
-                   <axis name='parent' nodeTest='(element()|document-node())' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11||item.nodeType===1);'/>
+                   <axis name='parent' nodeTest='(document-node()|element())' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11||item.nodeType===1);'/>
                   </slash>
                  </docOrder>
                 </conditionalSort>
                </check>
               </ifCall>
               <true/>
-              <ifCall line='686' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+              <ifCall line='688' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
                <str val='style.display'/>
                <str val='none'/>
                <check card='1' diag='0|2||ixsl:set-property'>
@@ -3943,7 +3869,7 @@
                  <docOrder intra='1'>
                   <slash simple='2'>
                    <varRef name='Q{}context' slot='10'/>
-                   <axis name='parent' nodeTest='(element()|document-node())' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11||item.nodeType===1);'/>
+                   <axis name='parent' nodeTest='(document-node()|element())' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11||item.nodeType===1);'/>
                   </slash>
                  </docOrder>
                 </conditionalSort>
@@ -3955,14 +3881,14 @@
           </let>
          </let>
         </forEach>
-        <ifCall line='691' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='693' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
          <str val='clearPendingUpdates'/>
          <array size='0'/>
         </ifCall>
-        <ifCall line='692' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='694' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -3976,12 +3902,12 @@
    </let>
   </function>
  </co>
- <co id='46' binds=''>
-  <globalParam name='Q{}xform-html-id' type='xs:string' line='67' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
+ <co id='47' binds=''>
+  <globalParam name='Q{}xform-html-id' type='xs:string' line='69' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
    <str val='xForm'/>
   </globalParam>
  </co>
- <co id='47' binds=''>
+ <co id='48' binds=''>
   <function name='Q{http://www.w3.org/2002/xforms}random' line='108' module='xforms-function-library.xsl' eval='16' flags='pU' as='xs:double' slots='0'>
    <check role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='109' card='1' diag='3|0|XTTE0570|randomNumber'>
     <convert from='xs:anyAtomicType' to='xs:double' flags='p' diag='3|0|XTTE0570|randomNumber'>
@@ -4000,84 +3926,202 @@
    </check>
   </function>
  </co>
- <co id='7' binds='2 48 2 35 42 49'>
-  <template name='Q{}xforms-recalculate' flags='os' line='4125' module='saxon-xforms.xsl' slots='3'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4126'>
-    <message>
-     <valueOf role='select'>
-      <str val='[xforms-recalculate] START'/>
-     </valueOf>
-     <str role='terminate' val='no'/>
-     <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-    </message>
-    <let line='4127' var='Q{}instance-keys' as='item()?' slot='0' eval='8'>
-     <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-      <check card='1' diag='0|0||ixsl:call'>
-       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-      </check>
-      <str val='getInstanceKeys'/>
-      <array size='0'/>
-     </ifCall>
-     <forEach line='4128'>
-      <varRef name='Q{}instance-keys' slot='0'/>
-      <let line='4129' var='Q{}refz' as='xs:string' slot='1' eval='8'>
-       <fn name='concat'>
-        <str val='instance(&#39;'/>
-        <atomSing card='?' diag='0|1||fn:concat'>
-         <dot/>
-        </atomSing>
-        <str val='&#39;)/'/>
-       </fn>
-       <sequence line='4130'>
-        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
-         <atomSing diag='0|0||map:entry'>
-          <dot/>
-         </atomSing>
-         <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='0' eval='6'>
-          <varRef name='Q{}refz' slot='1'/>
-         </ufCall>
-        </ifCall>
-        <let line='4133' var='Q{}updatedInstanceXML' as='element()' slot='2' eval='16'>
-         <treat line='4134' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
-          <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
-           <applyT mode='Q{}binding-calculation-initial' bSlot='1'>
-            <check role='select' line='4132' card='1' diag='3|0|XTTE0570|instanceXML'>
-             <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='2' eval='6'>
-              <varRef name='Q{}refz' slot='1'/>
-             </ufCall>
-            </check>
-            <withParam name='Q{}instance-id' as='item()'>
-             <dot line='4135'/>
-            </withParam>
-           </applyT>
+ <co id='7' binds='1 2 3 3 19 35 42 49'>
+  <template name='Q{}xforms-recalculate' flags='os' line='4105' module='saxon-xforms.xsl' slots='11'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4152' var='Q{http://saxon.sf.net/generated-variable}v1' as='item()' slot='0' eval='13'>
+    <check card='1' diag='0|0||ixsl:call'>
+     <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+    </check>
+    <sequence line='4106'>
+     <message>
+      <valueOf role='select'>
+       <str val='[xforms-recalculate] START'/>
+      </valueOf>
+      <str role='terminate' val='no'/>
+      <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+     </message>
+     <let line='4107' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
+      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+       <check card='1' diag='0|0||ixsl:call'>
+        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+       </check>
+       <str val='getInstanceKeys'/>
+       <array size='0'/>
+      </ifCall>
+      <let line='4108' var='Q{}calculationMap' as='map(xs:string, xs:string)' slot='2' eval='16'>
+       <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|calculationMap'>
+        <check card='1' diag='3|0|XTTE0570|calculationMap'>
+         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+          <check card='1' diag='0|0||ixsl:call'>
+           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
           </check>
-         </treat>
-         <sequence line='4141'>
-          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-           <check card='1' diag='0|0||ixsl:call'>
-            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-           </check>
-           <str val='setInstance'/>
-           <arrayBlock>
-            <dot/>
-            <varRef name='Q{}updatedInstanceXML' slot='2'/>
-           </arrayBlock>
+          <str val='getCalculationMap'/>
+          <array size='0'/>
+         </ifCall>
+        </check>
+       </treat>
+       <let line='4110' var='Q{}instances-with-calculations' as='map(xs:string, map(*)*)' slot='3' eval='16'>
+        <treat line='4112' as='map(xs:string, map(*)*)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isMap(item)};function c() {return true;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances-with-calculations'>
+         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+          <forEachGroup algorithm='by'>
+           <ifCall role='select' name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
+            <varRef name='Q{}calculationMap' slot='2'/>
+           </ifCall>
+           <ufCall role='key' name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='16'>
+            <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:getInstanceId'>
+             <cvUntyped to='xs:string'>
+              <dot type='xs:anyAtomicType'/>
+             </cvUntyped>
+            </treat>
+           </ufCall>
+           <str role='collation' val='http://www.w3.org/2005/xpath-functions/collation/codepoint'/>
+           <ifCall role='content' line='4113' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+            <check card='1' diag='0|0||map:entry'>
+             <currentGroupingKey/>
+            </check>
+            <currentGroup/>
+           </ifCall>
+          </forEachGroup>
+          <map size='2'>
+           <str val='duplicates'/>
+           <str val='reject'/>
+           <str val='duplicates-error-code'/>
+           <str val='XTDE3365'/>
+          </map>
+         </ifCall>
+        </treat>
+        <sequence line='4118'>
+         <forEach>
+          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
+           <varRef name='Q{}instances-with-calculations' slot='3'/>
           </ifCall>
-          <callT line='4142' name='Q{}refreshOutputs-JS' bSlot='3'/>
-          <callT line='4143' name='Q{}refreshRepeats-JS' bSlot='4'/>
-          <callT line='4144' name='Q{}refreshElementsUsingIndexFunction-JS' bSlot='5' flags='t'/>
-         </sequence>
-        </let>
-       </sequence>
+          <let line='4119' var='Q{}instanceXML' as='element()' slot='4' eval='16'>
+           <check card='1' diag='3|0|XTTE0570|instanceXML'>
+            <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='16'>
+             <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:instance'>
+              <cvUntyped to='xs:string'>
+               <dot type='xs:anyAtomicType'/>
+              </cvUntyped>
+             </treat>
+            </ufCall>
+           </check>
+           <let line='4121' var='Q{}calculations' as='map(xs:string, xs:string)*' slot='5' eval='4'>
+            <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|calculations'>
+             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+              <varRef name='Q{}instances-with-calculations' slot='3'/>
+              <dot type='xs:anyAtomicType'/>
+             </ifCall>
+            </treat>
+            <let line='4135' var='Q{http://saxon.sf.net/generated-variable}v0' as='map(xs:string, xs:string)' slot='6' eval='13'>
+             <check card='1' diag='0|0||map:get'>
+              <varRef name='Q{}calculations' slot='5'/>
+             </check>
+             <let line='4124' var='Q{}calculated-nodes' as='node()*' slot='7' eval='8'>
+              <treat line='4125' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|calculated-nodes'>
+               <forEach>
+                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
+                 <check card='1' diag='0|0||map:keys'>
+                  <varRef name='Q{}calculations' slot='5'/>
+                 </check>
+                </ifCall>
+                <evaluate line='4126' dxns=''>
+                 <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
+                  <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:impose'>
+                   <cvUntyped to='xs:string'>
+                    <dot type='xs:anyAtomicType'/>
+                   </cvUntyped>
+                  </treat>
+                 </ufCall>
+                 <varRef role='cxt' name='Q{}instanceXML' slot='4'/>
+                 <varRef role='nsCxt' name='Q{}instanceXML' slot='4'/>
+                 <str role='sa' val='no'/>
+                 <map role='options' size='0'/>
+                 <map role='wp' size='0'/>
+                </evaluate>
+               </forEach>
+              </treat>
+              <let line='4131' var='Q{}calculated-values' as='xs:string*' slot='8' eval='8'>
+               <forEach line='4132'>
+                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
+                 <check card='1' diag='0|0||map:keys'>
+                  <varRef name='Q{}calculations' slot='5'/>
+                 </check>
+                </ifCall>
+                <let line='4134' var='Q{}value' as='xs:string?' slot='9' eval='7'>
+                 <treat line='4135' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|value'>
+                  <check card='?' diag='3|0|XTTE0570|value'>
+                   <cvUntyped to='xs:string' diag='3|0|XTTE0570|value'>
+                    <data>
+                     <evaluate dxns=''>
+                      <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='3' eval='16'>
+                       <check card='1' diag='0|0||xforms:impose'>
+                        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                         <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='6'/>
+                         <dot type='xs:anyAtomicType'/>
+                        </ifCall>
+                       </check>
+                      </ufCall>
+                      <varRef role='cxt' name='Q{}instanceXML' slot='4'/>
+                      <varRef role='nsCxt' name='Q{}instanceXML' slot='4'/>
+                      <str role='sa' val='no'/>
+                      <map role='options' size='0'/>
+                      <map role='wp' size='0'/>
+                     </evaluate>
+                    </data>
+                   </cvUntyped>
+                  </check>
+                 </treat>
+                 <first line='4141'>
+                  <sequence>
+                   <varRef name='Q{}value' slot='9'/>
+                   <str val=''/>
+                  </sequence>
+                 </first>
+                </let>
+               </forEach>
+               <let line='4145' var='Q{}updatedInstanceXML' as='element()' slot='10' eval='16'>
+                <treat line='4146' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+                 <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
+                  <applyT mode='Q{}recalculate' bSlot='4'>
+                   <varRef role='select' name='Q{}instanceXML' slot='4'/>
+                   <withParam name='Q{}updated-nodes' as='node()*'>
+                    <varRef line='4147' name='Q{}calculated-nodes' slot='7'/>
+                   </withParam>
+                   <withParam name='Q{}updated-values' as='xs:string*'>
+                    <varRef line='4148' name='Q{}calculated-values' slot='8'/>
+                   </withParam>
+                  </applyT>
+                 </check>
+                </treat>
+                <ifCall line='4152' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <varRef name='Q{http://saxon.sf.net/generated-variable}v1' slot='0'/>
+                 <str val='setInstance'/>
+                 <arrayBlock>
+                  <dot type='xs:anyAtomicType'/>
+                  <varRef name='Q{}updatedInstanceXML' slot='10'/>
+                 </arrayBlock>
+                </ifCall>
+               </let>
+              </let>
+             </let>
+            </let>
+           </let>
+          </let>
+         </forEach>
+         <callT line='4156' name='Q{}refreshOutputs-JS' bSlot='5'/>
+         <callT line='4157' name='Q{}refreshRepeats-JS' bSlot='6'/>
+         <callT line='4158' name='Q{}refreshElementsUsingIndexFunction-JS' bSlot='7' flags='t'/>
+        </sequence>
+       </let>
       </let>
-     </forEach>
-    </let>
-   </sequence>
+     </let>
+    </sequence>
+   </let>
   </template>
  </co>
- <co id='19' binds='50 50 50'>
-  <globalVariable name='Q{}xforms-doc' type='document-node()?' line='71' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='function test(item) {return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);};if (test(val)) {return val;} else {throw SaxonJS.XError(&#39;Conversion failed&#39;, &#39;XTTE0590&#39;);}' jsCardCheck='function c(n) {return n&lt;=1;};'>
-   <choose ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='71'>
+ <co id='44' binds='50 50 50'>
+  <globalVariable name='Q{}xforms-doc' type='document-node()?' line='73' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='function test(item) {return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);};if (test(val)) {return val;} else {throw SaxonJS.XError(&#39;Conversion failed&#39;, &#39;XTTE0590&#39;);}' jsCardCheck='function c(n) {return n&lt;=1;};'>
+   <choose ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='73'>
     <and op='and'>
      <fn name='exists'>
       <gVarRef name='Q{}xforms-file' bSlot='0'/>
@@ -4093,23 +4137,23 @@
   </globalVariable>
  </co>
  <co id='50' binds=''>
-  <globalParam name='Q{}xforms-file' type='xs:string?' line='69' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n&lt;=1;};'>
+  <globalParam name='Q{}xforms-file' type='xs:string?' line='71' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n&lt;=1;};'>
    <empty/>
   </globalParam>
  </co>
  <co id='51' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}addNamespaceDeclarations' line='3033' module='saxon-xforms.xsl' eval='16' flags='pU' as='element()' slots='1'>
+  <function name='Q{http://www.w3.org/2002/xforms}addNamespaceDeclarations' line='3006' module='saxon-xforms.xsl' eval='16' flags='pU' as='element()' slots='1'>
    <arg name='Q{}this' as='element()'/>
-   <compElem role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3035'>
+   <compElem role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3008'>
     <fn role='name' name='name'>
      <varRef name='Q{}this' slot='0'/>
     </fn>
-    <sequence role='content' line='3036'>
+    <sequence role='content' line='3009'>
      <namespace flags='l'>
       <str role='name' val='xforms'/>
       <str role='select' val='http://www.w3.org/2002/xforms'/>
      </namespace>
-     <forEach line='3037'>
+     <forEach line='3010'>
       <filter flags='b'>
        <filter flags='b'>
         <slash simple='1'>
@@ -4148,21 +4192,21 @@
         </gc>
        </fn>
       </filter>
-      <namespace line='3040' flags='l'>
-       <fn role='name' line='3039' name='substring-before'>
+      <namespace line='3013' flags='l'>
+       <fn role='name' line='3012' name='substring-before'>
         <fn name='name'>
          <dot type='element()'/>
         </fn>
         <str val=':'/>
        </fn>
        <convert role='select' from='xs:anyURI' to='xs:string'>
-        <fn line='3038' name='namespace-uri'>
+        <fn line='3011' name='namespace-uri'>
          <dot type='element()'/>
         </fn>
        </convert>
       </namespace>
      </forEach>
-     <copyOf line='3042' flags='vc'>
+     <copyOf line='3015' flags='vc'>
       <sequence>
        <slash simple='1'>
         <varRef name='Q{}this' slot='0'/>
@@ -4178,9 +4222,9 @@
    </compElem>
   </function>
  </co>
- <co id='11' binds='2 43 16 52 3 53 21'>
-  <template name='Q{}xforms-submit' flags='os' line='4263' module='saxon-xforms.xsl' slots='17'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4264'>
+ <co id='11' binds='2 1 3 15 19 52 3 53 20'>
+  <template name='Q{}xforms-submit' flags='os' line='4278' module='saxon-xforms.xsl' slots='20'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4279'>
     <param name='Q{}submission' slot='0' flags='i' as='xs:string'>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|submission'>
       <check card='1' diag='8|0|XTTE0590|submission'>
@@ -4192,7 +4236,7 @@
       </check>
      </treat>
     </param>
-    <let line='4266' var='Q{}submission-map' as='map(*)' slot='1' eval='16'>
+    <let line='4281' var='Q{}submission-map' as='map(*)' slot='1' eval='16'>
      <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|submission-map'>
       <check card='1' diag='3|0|XTTE0570|submission-map'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
@@ -4206,7 +4250,7 @@
        </ifCall>
       </check>
      </treat>
-     <let line='4267' var='Q{}actions' as='map(*)?' slot='2' eval='7'>
+     <let line='4282' var='Q{}actions' as='map(*)?' slot='2' eval='7'>
       <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
         <check card='1' diag='0|0||ixsl:call'>
@@ -4218,324 +4262,279 @@
         </arrayBlock>
        </ifCall>
       </treat>
-      <sequence line='4269'>
-       <message>
-        <sequence role='select'>
-         <valueOf>
-          <str val='[xforms-submit] Submitting: '/>
-         </valueOf>
-         <valueOf>
-          <fn name='serialize'>
-           <varRef name='Q{}submission-map' slot='1'/>
-          </fn>
-         </valueOf>
-        </sequence>
-        <str role='terminate' val='no'/>
-        <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-       </message>
-       <let line='4271' var='Q{}refi' as='xs:string?' slot='3' eval='7'>
-        <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
-         <check card='?' diag='3|0|XTTE0570|refi'>
-          <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
-           <data>
-            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-             <varRef name='Q{}submission-map' slot='1'/>
-             <str val='@ref'/>
-            </ifCall>
-           </data>
-          </cvUntyped>
+      <let line='4286' var='Q{}refi' as='xs:string?' slot='3' eval='7'>
+       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <check card='?' diag='3|0|XTTE0570|refi'>
+         <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
+          <data>
+           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+            <varRef name='Q{}submission-map' slot='1'/>
+            <str val='@ref'/>
+           </ifCall>
+          </data>
+         </cvUntyped>
+        </check>
+       </treat>
+       <let line='4288' var='Q{}instance-id' as='xs:string' slot='4' eval='16'>
+        <choose line='4290'>
+         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+          <varRef name='Q{}submission-map' slot='1'/>
+          <str val='@instance'/>
+         </ifCall>
+         <treat line='4291' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|instance-id'>
+          <check card='1' diag='3|0|XTTE0570|instance-id'>
+           <cvUntyped to='xs:string' diag='3|0|XTTE0570|instance-id'>
+            <data>
+             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+              <varRef name='Q{}submission-map' slot='1'/>
+              <str val='@instance'/>
+             </ifCall>
+            </data>
+           </cvUntyped>
+          </check>
+         </treat>
+         <true/>
+         <str val='saxon-forms-default'/>
+        </choose>
+        <let line='4312' var='Q{}instanceXML' as='element()' slot='5' eval='16'>
+         <check card='1' diag='3|0|XTTE0570|instanceXML'>
+          <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='0' eval='6'>
+           <varRef name='Q{}instance-id' slot='4'/>
+          </ufCall>
          </check>
-        </treat>
-        <let line='4273' var='Q{}instance-id' as='xs:string' slot='4' eval='16'>
-         <choose line='4275'>
-          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-           <varRef name='Q{}submission-map' slot='1'/>
-           <str val='@instance'/>
-          </ifCall>
-          <treat line='4276' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|instance-id'>
-           <check card='1' diag='3|0|XTTE0570|instance-id'>
-            <cvUntyped to='xs:string' diag='3|0|XTTE0570|instance-id'>
-             <data>
-              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-               <varRef name='Q{}submission-map' slot='1'/>
-               <str val='@instance'/>
-              </ifCall>
-             </data>
-            </cvUntyped>
-           </check>
-          </treat>
-          <true/>
-          <str val='saxon-forms-default'/>
-         </choose>
-         <let line='4287' var='Q{}instanceXML' as='element()' slot='5' eval='16'>
-          <choose>
-           <varRef name='Q{}refi' slot='3'/>
-           <check card='1' diag='3|0|XTTE0570|instanceXML'>
-            <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='0' eval='16'>
-             <check card='1' diag='0|0||xforms:getInstance-JS'>
-              <varRef name='Q{}refi' slot='3'/>
-             </check>
-            </ufCall>
-           </check>
-           <true/>
-           <check card='1' diag='3|0|XTTE0570|instanceXML'>
-            <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='6'>
-             <varRef name='Q{}instance-id' slot='4'/>
-            </ufCall>
-           </check>
-          </choose>
-          <let line='4289' var='Q{}updatedInstanceXML' as='element()' slot='6' eval='16'>
-           <treat line='4290' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
-            <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
-             <applyT mode='Q{}form-check-initial' bSlot='2'>
-              <varRef role='select' name='Q{}instanceXML' slot='5'/>
-              <withParam name='Q{}instance-id' as='xs:string'>
-               <varRef line='4291' name='Q{}instance-id' slot='4'/>
-              </withParam>
-             </applyT>
-            </check>
-           </treat>
-           <let line='4297' var='Q{}required-fieldsi' as='element()*' slot='7' eval='8'>
+         <let line='4313' var='Q{}data-fields' as='element()*' slot='6' eval='8'>
+          <filter flags='b'>
+           <filter flags='b'>
             <filter flags='b'>
              <slash simple='1'>
               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
               <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
              </slash>
-             <fn name='exists'>
-              <axis name='attribute' nodeTest='attribute(Q{}data-required)' jsTest='return item.name===&#39;data-required&#39;'/>
-             </fn>
-            </filter>
-            <let line='4299' var='Q{}required-fields-check' as='element()*' slot='8' eval='3'>
-             <ufCall name='Q{http://www.w3.org/2002/xforms}check-required-fields' tailCall='false' bSlot='3' eval='6'>
-              <varRef name='Q{}updatedInstanceXML' slot='6'/>
-             </ufCall>
-             <sequence line='4301'>
-              <message>
-               <sequence role='select'>
-                <valueOf>
-                 <str val='[xforms-submit] Submitting instance XML: '/>
-                </valueOf>
-                <valueOf>
-                 <fn name='serialize'>
-                  <varRef name='Q{}instanceXML' slot='5'/>
-                 </fn>
-                </valueOf>
-               </sequence>
-               <str role='terminate' val='no'/>
-               <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-              </message>
-              <message line='4302'>
-               <sequence role='select'>
-                <valueOf>
-                 <str val='[xforms-submit] Updated instance XML: '/>
-                </valueOf>
-                <valueOf>
-                 <fn name='serialize'>
-                  <varRef name='Q{}updatedInstanceXML' slot='6'/>
-                 </fn>
-                </valueOf>
-               </sequence>
-               <str role='terminate' val='no'/>
-               <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-              </message>
-              <choose line='4305'>
-               <fn name='empty'>
-                <varRef name='Q{}required-fields-check' slot='8'/>
+             <or op='or'>
+              <or op='or'>
+               <fn name='exists'>
+                <axis name='self' nodeTest='element(Q{}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
                </fn>
-               <let line='4306' var='Q{}requestBodyXML' as='element()' slot='9' eval='16'>
-                <choose line='4308'>
-                 <varRef name='Q{}refi' slot='3'/>
-                 <treat line='4309' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|requestBodyXML'>
-                  <check card='1' diag='3|0|XTTE0570|requestBodyXML'>
-                   <evaluate dxns=''>
-                    <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='4' eval='16'>
-                     <check card='1' diag='0|0||xforms:impose'>
-                      <varRef name='Q{}refi' slot='3'/>
-                     </check>
-                    </ufCall>
-                    <varRef role='cxt' name='Q{}instanceXML' slot='5'/>
-                    <varRef role='nsCxt' name='Q{}instanceXML' slot='5'/>
-                    <str role='sa' val='no'/>
-                    <map role='options' size='0'/>
-                    <map role='wp' size='0'/>
-                   </evaluate>
-                  </check>
-                 </treat>
-                 <true/>
-                 <varRef line='4312' name='Q{}instanceXML' slot='5'/>
-                </choose>
-                <let line='4326' var='Q{}method' as='xs:string' slot='10' eval='16'>
-                 <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|method'>
-                  <check card='1' diag='3|0|XTTE0570|method'>
-                   <cvUntyped to='xs:string' diag='3|0|XTTE0570|method'>
-                    <data>
-                     <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                      <varRef name='Q{}submission-map' slot='1'/>
-                      <str val='@method'/>
-                     </ifCall>
-                    </data>
-                   </cvUntyped>
-                  </check>
-                 </treat>
-                 <let line='4328' var='Q{}serialization' as='xs:string?' slot='11' eval='7'>
-                  <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|serialization'>
-                   <check card='?' diag='3|0|XTTE0570|serialization'>
-                    <cvUntyped to='xs:string' diag='3|0|XTTE0570|serialization'>
+               <fn name='exists'>
+                <axis name='self' nodeTest='element(Q{}select)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;select&#39;;'/>
+               </fn>
+              </or>
+              <fn name='exists'>
+               <axis name='self' nodeTest='element(Q{}textarea)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;textarea&#39;;'/>
+              </fn>
+             </or>
+            </filter>
+            <fn name='exists'>
+             <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
+            </fn>
+           </filter>
+           <vc op='eq' onEmpty='0' comp='CCC'>
+            <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='1' eval='16'>
+             <check card='1' diag='0|0||xforms:getInstanceId'>
+              <cvUntyped to='xs:string'>
+               <attVal name='Q{}data-ref' chk='0'/>
+              </cvUntyped>
+             </check>
+            </ufCall>
+            <varRef name='Q{}instance-id' slot='4'/>
+           </vc>
+          </filter>
+          <let line='4316' var='Q{}calculated-nodes' as='node()*' slot='7' eval='8'>
+           <treat line='4317' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|calculated-nodes'>
+            <forEach>
+             <varRef name='Q{}data-fields' slot='6'/>
+             <evaluate line='4318' dxns=''>
+              <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
+               <fn name='string'>
+                <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
+               </fn>
+              </ufCall>
+              <varRef role='cxt' name='Q{}instanceXML' slot='5'/>
+              <varRef role='nsCxt' name='Q{}instanceXML' slot='5'/>
+              <str role='sa' val='no'/>
+              <map role='options' size='0'/>
+              <map role='wp' size='0'/>
+             </evaluate>
+            </forEach>
+           </treat>
+           <let line='4323' var='Q{}calculated-values' as='xs:string*' slot='8' eval='3'>
+            <forEach line='4324'>
+             <varRef name='Q{}data-fields' slot='6'/>
+             <let line='4326' var='Q{}value' as='xs:string' slot='9' eval='8'>
+              <cvUntyped line='4328' to='xs:string' diag='3|0|XTTE0570|value'>
+               <cast as='xs:untypedAtomic' emptiable='0'>
+                <fn name='string-join'>
+                 <convert from='xs:anyAtomicType' to='xs:string'>
+                  <data>
+                   <mergeAdj>
+                    <applyT mode='Q{}get-field' bSlot='3'>
+                     <dot role='select' type='element()'/>
+                    </applyT>
+                   </mergeAdj>
+                  </data>
+                 </convert>
+                 <str val=''/>
+                </fn>
+               </cast>
+              </cvUntyped>
+              <first line='4335'>
+               <sequence>
+                <varRef name='Q{}value' slot='9'/>
+                <str val=''/>
+               </sequence>
+              </first>
+             </let>
+            </forEach>
+            <let line='4339' var='Q{}updatedInstanceXML' as='element()' slot='10' eval='16'>
+             <treat line='4340' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+              <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
+               <applyT mode='Q{}recalculate' bSlot='4'>
+                <varRef role='select' name='Q{}instanceXML' slot='5'/>
+                <withParam name='Q{}updated-nodes' as='node()*'>
+                 <varRef line='4341' name='Q{}calculated-nodes' slot='7'/>
+                </withParam>
+                <withParam name='Q{}updated-values' as='xs:string*'>
+                 <varRef line='4342' name='Q{}calculated-values' slot='8'/>
+                </withParam>
+               </applyT>
+              </check>
+             </treat>
+             <let line='4347' var='Q{}required-fieldsi' as='element()*' slot='11' eval='8'>
+              <filter flags='b'>
+               <slash simple='1'>
+                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
+                <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+               </slash>
+               <fn name='exists'>
+                <axis name='attribute' nodeTest='attribute(Q{}data-required)' jsTest='return item.name===&#39;data-required&#39;'/>
+               </fn>
+              </filter>
+              <let line='4349' var='Q{}required-fields-check' as='element()*' slot='12' eval='3'>
+               <ufCall name='Q{http://www.w3.org/2002/xforms}check-required-fields' tailCall='false' bSlot='5' eval='6'>
+                <varRef name='Q{}updatedInstanceXML' slot='10'/>
+               </ufCall>
+               <choose line='4355'>
+                <fn name='empty'>
+                 <varRef name='Q{}required-fields-check' slot='12'/>
+                </fn>
+                <let line='4356' var='Q{}requestBodyXML' as='node()' slot='13' eval='16'>
+                 <choose line='4358'>
+                  <varRef name='Q{}refi' slot='3'/>
+                  <treat line='4359' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|requestBodyXML'>
+                   <check card='1' diag='3|0|XTTE0570|requestBodyXML'>
+                    <evaluate dxns=''>
+                     <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='6' eval='16'>
+                      <check card='1' diag='0|0||xforms:impose'>
+                       <varRef name='Q{}refi' slot='3'/>
+                      </check>
+                     </ufCall>
+                     <varRef role='cxt' name='Q{}instanceXML' slot='5'/>
+                     <varRef role='nsCxt' name='Q{}instanceXML' slot='5'/>
+                     <str role='sa' val='no'/>
+                     <map role='options' size='0'/>
+                     <map role='wp' size='0'/>
+                    </evaluate>
+                   </check>
+                  </treat>
+                  <true/>
+                  <varRef line='4362' name='Q{}instanceXML' slot='5'/>
+                 </choose>
+                 <let line='4385' var='Q{}method' as='xs:string' slot='14' eval='16'>
+                  <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|method'>
+                   <check card='1' diag='3|0|XTTE0570|method'>
+                    <cvUntyped to='xs:string' diag='3|0|XTTE0570|method'>
                      <data>
                       <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
                        <varRef name='Q{}submission-map' slot='1'/>
-                       <str val='@serialization'/>
+                       <str val='@method'/>
                       </ifCall>
                      </data>
                     </cvUntyped>
                    </check>
                   </treat>
-                  <let line='4330' var='Q{}query-parameters' as='xs:string?' slot='12' eval='7'>
-                   <choose line='4331'>
-                    <and op='and'>
-                     <fn name='exists'>
-                      <varRef name='Q{}serialization' slot='11'/>
+                  <let line='4387' var='Q{}serialization' as='xs:string?' slot='15' eval='7'>
+                   <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|serialization'>
+                    <check card='?' diag='3|0|XTTE0570|serialization'>
+                     <cvUntyped to='xs:string' diag='3|0|XTTE0570|serialization'>
+                      <data>
+                       <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                        <varRef name='Q{}submission-map' slot='1'/>
+                        <str val='@serialization'/>
+                       </ifCall>
+                      </data>
+                     </cvUntyped>
+                    </check>
+                   </treat>
+                   <let line='4389' var='Q{}query-parameters' as='xs:string?' slot='16' eval='7'>
+                    <choose line='4390'>
+                     <and op='and'>
+                      <fn name='exists'>
+                       <varRef name='Q{}serialization' slot='15'/>
+                      </fn>
+                      <vc op='eq' onEmpty='0' comp='CCC'>
+                       <varRef name='Q{}serialization' slot='15'/>
+                       <str val='application/x-www-form-urlencoded'/>
+                      </vc>
+                     </and>
+                     <fn line='4401' name='string-join'>
+                      <forEach line='4392'>
+                       <slash simple='1'>
+                        <varRef name='Q{}requestBodyXML' slot='13'/>
+                        <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+                       </slash>
+                       <let line='4393' var='Q{}query-part' as='xs:string' slot='17' eval='8'>
+                        <fn name='concat'>
+                         <fn name='name'>
+                          <dot type='element()'/>
+                         </fn>
+                         <str val='='/>
+                         <fn name='string'>
+                          <dot type='element()'/>
+                         </fn>
+                        </fn>
+                        <sequence line='4394'>
+                         <varRef name='Q{}query-part' slot='17'/>
+                         <message line='4395'>
+                          <sequence role='select'>
+                           <valueOf>
+                            <str val='[xforms-submit] Query part: '/>
+                           </valueOf>
+                           <valueOf>
+                            <varRef name='Q{}query-part' slot='17'/>
+                           </valueOf>
+                          </sequence>
+                          <str role='terminate' val='no'/>
+                          <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+                         </message>
+                        </sequence>
+                       </let>
+                      </forEach>
+                      <str val='&amp;'/>
                      </fn>
-                     <vc op='eq' onEmpty='0' comp='CCC'>
-                      <varRef name='Q{}serialization' slot='11'/>
-                      <str val='application/x-www-form-urlencoded'/>
-                     </vc>
-                    </and>
-                    <fn line='4342' name='string-join'>
-                     <forEach line='4333'>
-                      <slash simple='1'>
-                       <varRef name='Q{}requestBodyXML' slot='9'/>
-                       <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-                      </slash>
-                      <let line='4334' var='Q{}query-part' as='xs:string' slot='13' eval='8'>
-                       <fn name='concat'>
-                        <fn name='name'>
-                         <dot type='element()'/>
-                        </fn>
-                        <str val='='/>
-                        <fn name='string'>
-                         <dot type='element()'/>
-                        </fn>
-                       </fn>
-                       <sequence line='4335'>
-                        <varRef name='Q{}query-part' slot='13'/>
-                        <message line='4336'>
-                         <sequence role='select'>
-                          <valueOf>
-                           <str val='[xforms-submit] Query part: '/>
-                          </valueOf>
-                          <valueOf>
-                           <varRef name='Q{}query-part' slot='13'/>
-                          </valueOf>
-                         </sequence>
-                         <str role='terminate' val='no'/>
-                         <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-                        </message>
-                       </sequence>
-                      </let>
-                     </forEach>
-                     <str val='&amp;'/>
-                    </fn>
-                   </choose>
-                   <let line='4346' var='Q{}href-base' as='xs:string' slot='14' eval='16'>
-                    <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|href-base'>
-                     <check card='1' diag='3|0|XTTE0570|href-base'>
-                      <cvUntyped to='xs:string' diag='3|0|XTTE0570|href-base'>
-                       <data>
-                        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                         <varRef name='Q{}submission-map' slot='1'/>
-                         <str val='@resource'/>
-                        </ifCall>
-                       </data>
-                      </cvUntyped>
-                     </check>
-                    </treat>
-                    <let line='4362' var='Q{}HTTPrequest' as='map(xs:string, item())' slot='15' eval='8'>
-                     <ifCall line='4364' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
-                      <sequence>
-                       <choose>
-                        <vc op='ne' onEmpty='1' comp='CCC'>
-                         <fn name='upper-case'>
-                          <varRef name='Q{}method' slot='10'/>
-                         </fn>
-                         <str val='GET'/>
-                        </vc>
-                        <ifCall line='4365' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
-                         <str val='body'/>
-                         <doc line='4321' validation='preserve'>
-                          <doc flags='l'>
-                           <varRef line='4322' name='Q{}requestBodyXML' slot='9'/>
-                          </doc>
-                         </doc>
-                        </ifCall>
-                       </choose>
-                       <ifCall line='4367' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
-                        <str val='method'/>
-                        <varRef name='Q{}method' slot='10'/>
-                       </ifCall>
-                       <ifCall line='4368' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
-                        <str val='href'/>
-                        <choose line='4350'>
-                         <fn name='exists'>
-                          <varRef name='Q{}query-parameters' slot='12'/>
-                         </fn>
-                         <fn line='4351' name='concat'>
-                          <varRef name='Q{}href-base' slot='14'/>
-                          <str val='?'/>
-                          <varRef name='Q{}query-parameters' slot='12'/>
-                         </fn>
-                         <true/>
-                         <varRef line='4354' name='Q{}href-base' slot='14'/>
-                        </choose>
-                       </ifCall>
-                       <ifCall line='4369' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
-                        <str val='media-type'/>
-                        <treat line='4359' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|mediatype'>
-                         <check card='1' diag='3|0|XTTE0570|mediatype'>
-                          <cvUntyped to='xs:string' diag='3|0|XTTE0570|mediatype'>
-                           <data>
-                            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                             <varRef name='Q{}submission-map' slot='1'/>
-                             <str val='@mediatype'/>
-                            </ifCall>
-                           </data>
-                          </cvUntyped>
-                         </check>
-                        </treat>
-                       </ifCall>
-                      </sequence>
-                      <map size='2'>
-                       <str val='duplicates'/>
-                       <str val='reject'/>
-                       <str val='duplicates-error-code'/>
-                       <str val='XTDE3365'/>
-                      </map>
-                     </ifCall>
-                     <sequence line='4373'>
-                      <message>
-                       <sequence role='select'>
-                        <valueOf>
-                         <str val='[xforms-submit] Sending HTTP request &#39;'/>
-                        </valueOf>
-                        <fn name='serialize'>
-                         <varRef name='Q{}HTTPrequest' slot='15'/>
-                        </fn>
-                        <valueOf flags='S'>
-                         <str val='&#39;'/>
-                        </valueOf>
-                       </sequence>
-                       <str role='terminate' val='no'/>
-                       <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-                      </message>
-                      <ifCall line='4379' name='Q{http://saxonica.com/ns/interactiveXSLT}schedule-action' type='item()*'>
+                    </choose>
+                    <let line='4405' var='Q{}href-base' as='xs:string' slot='18' eval='16'>
+                     <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|href-base'>
+                      <check card='1' diag='3|0|XTTE0570|href-base'>
+                       <cvUntyped to='xs:string' diag='3|0|XTTE0570|href-base'>
+                        <data>
+                         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                          <varRef name='Q{}submission-map' slot='1'/>
+                          <str val='@resource'/>
+                         </ifCall>
+                        </data>
+                       </cvUntyped>
+                      </check>
+                     </treat>
+                     <sequence line='4446'>
+                      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}schedule-action' type='item()*'>
                        <int val='0'/>
                        <empty/>
-                       <callT name='Q{}HTTPsubmit' bSlot='5'>
+                       <callT name='Q{}HTTPsubmit' bSlot='7'>
                         <withParam name='Q{}instance-id' flags='c' as='xs:string'>
-                         <varRef line='4380' name='Q{}instance-id' slot='4'/>
+                         <varRef line='4447' name='Q{}instance-id' slot='4'/>
                         </withParam>
                         <withParam name='Q{}targetref' flags='c' as='xs:string?'>
-                         <treat line='4381' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|targetref'>
+                         <treat line='4448' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|targetref'>
                           <check card='?' diag='8|0|XTTE0590|targetref'>
                            <cvUntyped to='xs:string' diag='8|0|XTTE0590|targetref'>
                             <data>
@@ -4549,7 +4548,7 @@
                          </treat>
                         </withParam>
                         <withParam name='Q{}replace' flags='c' as='xs:string?'>
-                         <treat line='4382' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|replace'>
+                         <treat line='4449' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|replace'>
                           <check card='?' diag='8|0|XTTE0590|replace'>
                            <cvUntyped to='xs:string' diag='8|0|XTTE0590|replace'>
                             <data>
@@ -4563,38 +4562,95 @@
                          </treat>
                         </withParam>
                        </callT>
-                       <varRef line='4376' name='Q{}HTTPrequest' slot='15'/>
+                       <ifCall line='4423' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+                        <sequence>
+                         <choose>
+                          <vc op='ne' onEmpty='1' comp='CCC'>
+                           <fn name='upper-case'>
+                            <varRef name='Q{}method' slot='14'/>
+                           </fn>
+                           <str val='GET'/>
+                          </vc>
+                          <ifCall line='4432' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                           <str val='body'/>
+                           <doc line='4381'>
+                            <varRef line='4382' name='Q{}requestBodyXML' slot='13'/>
+                           </doc>
+                          </ifCall>
+                         </choose>
+                         <ifCall line='4434' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                          <str val='method'/>
+                          <varRef name='Q{}method' slot='14'/>
+                         </ifCall>
+                         <ifCall line='4435' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                          <str val='href'/>
+                          <choose line='4409'>
+                           <fn name='exists'>
+                            <varRef name='Q{}query-parameters' slot='16'/>
+                           </fn>
+                           <fn line='4410' name='concat'>
+                            <varRef name='Q{}href-base' slot='18'/>
+                            <str val='?'/>
+                            <varRef name='Q{}query-parameters' slot='16'/>
+                           </fn>
+                           <true/>
+                           <varRef line='4413' name='Q{}href-base' slot='18'/>
+                          </choose>
+                         </ifCall>
+                         <ifCall line='4436' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                          <str val='media-type'/>
+                          <treat line='4418' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|mediatype'>
+                           <check card='1' diag='3|0|XTTE0570|mediatype'>
+                            <cvUntyped to='xs:string' diag='3|0|XTTE0570|mediatype'>
+                             <data>
+                              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                               <varRef name='Q{}submission-map' slot='1'/>
+                               <str val='@mediatype'/>
+                              </ifCall>
+                             </data>
+                            </cvUntyped>
+                           </check>
+                          </treat>
+                         </ifCall>
+                        </sequence>
+                        <map size='2'>
+                         <str val='duplicates'/>
+                         <str val='reject'/>
+                         <str val='duplicates-error-code'/>
+                         <str val='XTDE3365'/>
+                        </map>
+                       </ifCall>
                       </ifCall>
-                      <forEach line='4386'>
+                      <forEach line='4453'>
                        <varRef name='Q{}actions' slot='2'/>
-                       <let line='4387' var='Q{}action-map' as='map(*)' slot='16' eval='16'>
+                       <let line='4454' var='Q{}action-map' as='map(*)' slot='19' eval='16'>
                         <dot type='map(*)'/>
-                        <choose line='4390'>
+                        <choose line='4457'>
                          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
-                          <varRef name='Q{}action-map' slot='16'/>
+                          <varRef name='Q{}action-map' slot='19'/>
                           <str val='@event'/>
                          </ifCall>
-                         <choose line='4391'>
+                         <choose line='4458'>
                           <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
                            <data>
                             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                             <varRef name='Q{}action-map' slot='16'/>
+                             <varRef name='Q{}action-map' slot='19'/>
                              <str val='@event'/>
                             </ifCall>
                            </data>
                            <str val='xforms-submit-done'/>
                           </gc>
-                          <callT line='4392' name='Q{}applyActions' bSlot='6' flags='t'>
+                          <callT line='4459' name='Q{}applyActions' bSlot='8' flags='t'>
                            <withParam name='Q{}action-map' flags='t' as='item()'>
-                            <varRef line='4393' name='Q{}action-map' slot='16'/>
+                            <varRef line='4460' name='Q{}action-map' slot='19'/>
                            </withParam>
                            <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                            <check line='4394' card='1' diag='8|0|XTTE0590|nodeset'>
+                            <check line='4461' card='1' diag='8|0|XTTE0590|nodeset'>
                              <varRef name='Q{}refi' slot='3'/>
                             </check>
                            </withParam>
                            <withParam name='Q{}instanceXML' flags='t' as='element()'>
-                            <varRef line='4395' name='Q{}instanceXML' slot='5'/>
+                            <varRef line='4462' name='Q{}instanceXML' slot='5'/>
                            </withParam>
                           </callT>
                          </choose>
@@ -4607,52 +4663,52 @@
                   </let>
                  </let>
                 </let>
-               </let>
-               <true/>
-               <ifCall line='4408' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                <check card='1' diag='0|0||ixsl:call'>
-                 <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-                </check>
-                <str val='alert'/>
-                <arrayBlock>
-                 <fn name='serialize'>
-                  <doc line='4403' flags='t' validation='preserve'>
-                   <forEach>
-                    <varRef name='Q{}required-fields-check' slot='8'/>
-                    <valueOf line='4405' flags='l'>
-                     <fn name='concat'>
-                      <str val='Value error see: '/>
-                      <fn name='serialize'>
-                       <slash line='4404' simple='1'>
-                        <dot type='element()'/>
-                        <axis line='4405' name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
-                       </slash>
+                <true/>
+                <ifCall line='4475' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <check card='1' diag='0|0||ixsl:call'>
+                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                 </check>
+                 <str val='alert'/>
+                 <arrayBlock>
+                  <fn name='serialize'>
+                   <doc line='4470' flags='t' validation='preserve'>
+                    <forEach>
+                     <varRef name='Q{}required-fields-check' slot='12'/>
+                     <valueOf line='4472' flags='l'>
+                      <fn name='concat'>
+                       <str val='Value error see: '/>
+                       <fn name='serialize'>
+                        <slash line='4471' simple='1'>
+                         <dot type='element()'/>
+                         <axis line='4472' name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
+                        </slash>
+                       </fn>
+                       <str val='&#xA;'/>
                       </fn>
-                      <str val='&#xA;'/>
-                     </fn>
-                    </valueOf>
-                   </forEach>
-                  </doc>
-                 </fn>
-                </arrayBlock>
-               </ifCall>
-              </choose>
-             </sequence>
+                     </valueOf>
+                    </forEach>
+                   </doc>
+                  </fn>
+                 </arrayBlock>
+                </ifCall>
+               </choose>
+              </let>
+             </let>
             </let>
            </let>
           </let>
          </let>
         </let>
        </let>
-      </sequence>
+      </let>
      </let>
     </let>
    </sequence>
   </template>
  </co>
- <co id='37' binds='2 54 50'>
-  <template name='Q{}xforms-rebuild' flags='os' line='4100' module='saxon-xforms.xsl' slots='2'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4101'>
+ <co id='37' binds='34 54 50'>
+  <template name='Q{}xforms-rebuild' flags='os' line='4080' module='saxon-xforms.xsl' slots='2'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4081'>
     <message>
      <valueOf role='select'>
       <str val='[xforms-rebuild] START'/>
@@ -4660,8 +4716,8 @@
      <str role='terminate' val='no'/>
      <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
     </message>
-    <let line='4102' var='Q{}instanceDocs' as='map(xs:anyAtomicType, element()?)' slot='0' eval='8'>
-     <let line='4103' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
+    <let line='4082' var='Q{}instanceDocs' as='map(xs:anyAtomicType, element()?)' slot='0' eval='8'>
+     <let line='4083' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -4669,15 +4725,15 @@
        <str val='getInstanceKeys'/>
        <array size='0'/>
       </ifCall>
-      <ifCall line='4105' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+      <ifCall line='4085' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
        <forEach>
         <varRef name='Q{}instance-keys' slot='1'/>
-        <ifCall line='4107' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+        <ifCall line='4087' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
          <atomSing diag='0|0||map:entry'>
           <dot/>
          </atomSing>
          <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='0' eval='16'>
-          <fn line='4106' name='concat'>
+          <fn line='4086' name='concat'>
            <str val='instance(&#39;'/>
            <atomSing card='?' diag='0|1||fn:concat'>
             <dot/>
@@ -4695,41 +4751,41 @@
        </map>
       </ifCall>
      </let>
-     <callT line='4112' name='Q{}xformsjs-main' bSlot='1' flags='t'>
+     <callT line='4092' name='Q{}xformsjs-main' bSlot='1' flags='t'>
       <withParam name='Q{}xforms-file' flags='c' as='xs:string?'>
-       <gVarRef line='4113' name='Q{}xforms-file' bSlot='2'/>
+       <gVarRef line='4093' name='Q{}xforms-file' bSlot='2'/>
       </withParam>
       <withParam name='Q{}instance-docs' flags='c' as='map(*)'>
-       <varRef line='4114' name='Q{}instanceDocs' slot='0'/>
+       <varRef line='4094' name='Q{}instanceDocs' slot='0'/>
       </withParam>
      </callT>
     </let>
    </sequence>
   </template>
  </co>
- <co id='34' binds=''>
+ <co id='33' binds=''>
   <mode name='Q{}set-field' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.25' seq='37' rank='0' minImp='0' slots='1' flags='s' line='2967' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='37' rank='0' minImp='0' slots='1' flags='s' line='2940' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:textarea' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;textarea&#39;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2968'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2941'>
      <param name='Q{}value' slot='0' flags='t'>
       <str role='select' val=''/>
       <supplied role='conversion' slot='0'/>
      </param>
-     <ifCall line='2970' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+     <ifCall line='2943' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
       <dot type='*:textarea'/>
       <str val='value'/>
      </ifCall>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='-0.25' seq='36' rank='0' minImp='0' slots='1' flags='s' line='2959' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='36' rank='0' minImp='0' slots='1' flags='s' line='2926' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:select' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;select&#39;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2960'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2927'>
      <param name='Q{}value' slot='0' flags='t'>
       <str role='select' val=''/>
       <supplied role='conversion' slot='0'/>
      </param>
-     <forEach line='2962'>
+     <forEach line='2929'>
       <filter flags='b'>
        <axis name='child' nodeTest='element(Q{}option)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;option&#39;;'/>
        <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
@@ -4739,7 +4795,7 @@
         <attVal name='Q{}value' chk='0'/>
        </gc>
       </filter>
-      <ifCall line='2963' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+      <ifCall line='2930' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
        <str val='selected'/>
        <true/>
        <dot type='element(Q{}option)'/>
@@ -4747,61 +4803,58 @@
      </forEach>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='-0.25' seq='35' rank='0' minImp='0' slots='1' flags='s' line='2938' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='35' rank='0' minImp='0' slots='1' flags='s' line='2905' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:input' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;input&#39;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2939'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2906'>
      <param name='Q{}value' slot='0' flags='t'>
       <str role='select' val=''/>
       <supplied role='conversion' slot='0'/>
      </param>
-     <forEach line='2942'>
-      <dot type='*:input'/>
-      <choose line='2944'>
-       <and op='and'>
-        <fn name='exists'>
-         <axis name='attribute' nodeTest='attribute(Q{}type)' jsTest='return item.name===&#39;type&#39;'/>
-        </fn>
-        <vc op='eq' onEmpty='0' comp='CCC'>
-         <cast as='xs:string' emptiable='1'>
-          <attVal name='Q{}type' chk='0'/>
-         </cast>
-         <str val='checkbox'/>
-        </vc>
-       </and>
-       <ifCall line='2945' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
-        <str val='checked'/>
-        <choose>
-         <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
-          <data>
-           <varRef name='Q{}value' slot='0'/>
-          </data>
-          <str val='true'/>
-         </gc>
-         <check card='?' diag='0|1||ixsl:set-property'>
+     <choose line='2910'>
+      <and op='and'>
+       <fn name='exists'>
+        <axis name='attribute' nodeTest='attribute(Q{}type)' jsTest='return item.name===&#39;type&#39;'/>
+       </fn>
+       <vc op='eq' onEmpty='0' comp='CCC'>
+        <cast as='xs:string' emptiable='1'>
+         <attVal name='Q{}type' chk='0'/>
+        </cast>
+        <str val='checkbox'/>
+       </vc>
+      </and>
+      <ifCall line='2911' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+       <str val='checked'/>
+       <choose>
+        <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+         <data>
           <varRef name='Q{}value' slot='0'/>
-         </check>
-         <true/>
-         <str val=''/>
-        </choose>
-        <dot type='*:input'/>
-       </ifCall>
-       <true/>
-       <ifCall line='2948' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
-        <str val='value'/>
+         </data>
+         <str val='true'/>
+        </gc>
         <check card='?' diag='0|1||ixsl:set-property'>
          <varRef name='Q{}value' slot='0'/>
         </check>
-        <dot type='*:input'/>
-       </ifCall>
-      </choose>
-     </forEach>
+        <true/>
+        <str val=''/>
+       </choose>
+       <dot type='*:input'/>
+      </ifCall>
+      <true/>
+      <ifCall line='2914' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+       <str val='value'/>
+       <check card='?' diag='0|1||ixsl:set-property'>
+        <varRef name='Q{}value' slot='0'/>
+       </check>
+       <dot type='*:input'/>
+      </ifCall>
+     </choose>
     </sequence>
    </templateRule>
   </mode>
  </co>
- <co id='49' binds='44'>
-  <template name='Q{}refreshElementsUsingIndexFunction-JS' flags='os' line='3629' module='saxon-xforms.xsl' slots='6'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3630'>
+ <co id='49' binds='43'>
+  <template name='Q{}refreshElementsUsingIndexFunction-JS' flags='os' line='3609' module='saxon-xforms.xsl' slots='6'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3610'>
     <message>
      <valueOf role='select'>
       <str val='[refreshElementsUsingIndexFunction-JS] START'/>
@@ -4809,7 +4862,7 @@
      <str role='terminate' val='no'/>
      <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
     </message>
-    <let line='3631' var='Q{}ElementsUsingIndexFunction-keys' as='item()?' slot='0' eval='8'>
+    <let line='3611' var='Q{}ElementsUsingIndexFunction-keys' as='item()?' slot='0' eval='8'>
      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
       <check card='1' diag='0|0||ixsl:call'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -4817,7 +4870,7 @@
       <str val='getElementsUsingIndexFunctionKeys'/>
       <array size='0'/>
      </ifCall>
-     <let line='3633' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
+     <let line='3613' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -4825,12 +4878,12 @@
        <str val='getInstanceKeys'/>
        <array size='0'/>
       </ifCall>
-      <let line='3634' var='Q{}instances' as='map(xs:string, element())' slot='2' eval='16'>
-       <treat line='3636' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances'>
+      <let line='3614' var='Q{}instances' as='map(xs:string, element())' slot='2' eval='16'>
+       <treat line='3616' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances'>
         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
          <forEach>
           <varRef name='Q{}instance-keys' slot='1'/>
-          <ifCall line='3637' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <ifCall line='3617' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
            <atomSing diag='0|0||map:entry'>
             <dot/>
            </atomSing>
@@ -4853,9 +4906,9 @@
          </map>
         </ifCall>
        </treat>
-       <forEach line='3643'>
+       <forEach line='3623'>
         <varRef name='Q{}ElementsUsingIndexFunction-keys' slot='0'/>
-        <let line='3644' var='Q{}this-key' as='xs:string' slot='3' eval='16'>
+        <let line='3624' var='Q{}this-key' as='xs:string' slot='3' eval='16'>
          <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|this-key'>
           <check card='1' diag='3|0|XTTE0570|this-key'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|this-key'>
@@ -4865,7 +4918,7 @@
            </cvUntyped>
           </check>
          </treat>
-         <sequence line='3646'>
+         <sequence line='3626'>
           <message>
            <sequence role='select'>
             <valueOf>
@@ -4879,7 +4932,7 @@
            <str role='terminate' val='no'/>
            <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
           </message>
-          <let line='3648' var='Q{}this-element' as='element()' slot='4' eval='16'>
+          <let line='3628' var='Q{}this-element' as='element()' slot='4' eval='16'>
            <treat as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|this-element'>
             <check card='1' diag='3|0|XTTE0570|this-element'>
              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
@@ -4893,8 +4946,8 @@
              </ifCall>
             </check>
            </treat>
-           <let line='3649' var='Q{}this-element-refi' as='xs:string?' slot='5' eval='7'>
-            <choose line='3651'>
+           <let line='3629' var='Q{}this-element-refi' as='xs:string?' slot='5' eval='7'>
+            <choose line='3631'>
              <fn name='exists'>
               <slash simple='1'>
                <varRef name='Q{}this-element' slot='4'/>
@@ -4909,13 +4962,13 @@
                </slash>
               </data>
              </cvUntyped>
-             <fn line='3652' name='exists'>
+             <fn line='3632' name='exists'>
               <slash simple='1'>
                <varRef name='Q{}this-element' slot='4'/>
                <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
               </slash>
              </fn>
-             <cvUntyped line='3652' to='xs:string' diag='3|0|XTTE0570|this-element-refi'>
+             <cvUntyped line='3632' to='xs:string' diag='3|0|XTTE0570|this-element-refi'>
               <data>
                <slash simple='1'>
                 <varRef name='Q{}this-element' slot='4'/>
@@ -4924,12 +4977,12 @@
               </data>
              </cvUntyped>
             </choose>
-            <resultDoc line='3656' global='#&#xA;#Sat Feb 22 22:54:41 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sat Feb 22 22:54:41 GMT 2020&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xA;'>
+            <resultDoc line='3636' global='#&#xA;#Sun Feb 23 16:30:38 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sun Feb 23 16:30:38 GMT 2020&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xA;'>
              <fn role='href' name='concat'>
               <str val='#'/>
               <varRef name='Q{}this-key' slot='3'/>
              </fn>
-             <applyT role='content' line='3657' bSlot='0'>
+             <applyT role='content' line='3637' bSlot='0'>
               <slash role='select' simple='1'>
                <varRef name='Q{}this-element' slot='4'/>
                <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
@@ -4938,10 +4991,10 @@
                <true/>
               </withParam>
               <withParam name='Q{}instances' flags='t' as='map(xs:string, element())'>
-               <varRef line='3658' name='Q{}instances' slot='2'/>
+               <varRef line='3638' name='Q{}instances' slot='2'/>
               </withParam>
               <withParam name='Q{}nodeset' flags='t' as='xs:string?'>
-               <choose line='3659'>
+               <choose line='3639'>
                 <fn name='exists'>
                  <varRef name='Q{}this-element-refi' slot='5'/>
                 </fn>
@@ -4964,7 +5017,7 @@
   </template>
  </co>
  <co id='55' binds=''>
-  <globalVariable name='Q{}xforms-actions' type='xs:string+' line='95' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n&gt;=1;};'>
+  <globalVariable name='Q{}xforms-actions' type='xs:string+' line='97' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n&gt;=1;};'>
    <literal count='15'>
     <str val='setvalue'/>
     <str val='insert'/>
@@ -4992,197 +5045,12 @@
    </compareToInt>
   </function>
  </co>
- <co id='57' binds='57 3 57 57'>
-  <mode name='Q{}binding-calculation' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='29' rank='0' minImp='0' slots='9' flags='s' line='2776' module='saxon-xforms.xsl'>
-    <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2777'>
-     <param name='Q{}curPath' slot='0'>
-      <str role='select' val=''/>
-      <supplied role='conversion' slot='0'/>
-     </param>
-     <param line='2778' name='Q{}position' slot='1'>
-      <int role='select' val='0'/>
-      <supplied role='conversion' slot='1'/>
-     </param>
-     <param line='2779' name='Q{}calculationMap' slot='2' flags='ti' as='map(xs:string, xs:string)'>
-      <treat role='conversion' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|calculationMap'>
-       <check card='1' diag='8|0|XTTE0590|calculationMap'>
-        <supplied slot='2'/>
-       </check>
-      </treat>
-     </param>
-     <let line='2785' var='Q{}updatedPath' as='xs:string' slot='3' eval='16'>
-      <choose>
-       <gc op='&gt;' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
-        <data>
-         <varRef name='Q{}position' slot='1'/>
-        </data>
-        <int val='0'/>
-       </gc>
-       <fn name='concat'>
-        <atomSing card='?' diag='0|0||fn:concat'>
-         <varRef name='Q{}curPath' slot='0'/>
-        </atomSing>
-        <fn name='name'>
-         <dot type='element()'/>
-        </fn>
-        <str val='['/>
-        <atomSing card='?' diag='0|3||fn:concat'>
-         <varRef name='Q{}position' slot='1'/>
-        </atomSing>
-        <str val=']'/>
-       </fn>
-       <true/>
-       <fn name='concat'>
-        <atomSing card='?' diag='0|0||fn:concat'>
-         <varRef name='Q{}curPath' slot='0'/>
-        </atomSing>
-        <fn name='name'>
-         <dot type='element()'/>
-        </fn>
-       </fn>
-      </choose>
-      <copy line='2790' flags='cin'>
-       <sequence role='content'>
-        <applyT mode='Q{}binding-calculation' bSlot='0'>
-         <axis role='select' name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
-         <withParam name='Q{}curPath' as='xs:string'>
-          <fn line='2791' name='concat'>
-           <varRef name='Q{}updatedPath' slot='3'/>
-           <str val='/'/>
-          </fn>
-         </withParam>
-        </applyT>
-        <choose line='2800'>
-         <fn name='exists'>
-          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-           <varRef name='Q{}calculationMap' slot='2'/>
-           <varRef name='Q{}updatedPath' slot='3'/>
-          </ifCall>
-         </fn>
-         <evaluate line='2804' dxns=''>
-          <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='1' eval='16'>
-           <check line='2802' card='1' diag='3|0|XTTE0570|calculationXPath'>
-            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-             <varRef name='Q{}calculationMap' slot='2'/>
-             <varRef name='Q{}updatedPath' slot='3'/>
-            </ifCall>
-           </check>
-          </ufCall>
-          <dot role='cxt' type='element()'/>
-          <dot role='nsCxt' type='element()'/>
-          <str role='sa' val='no'/>
-          <map role='options' size='0'/>
-          <map role='wp' size='0'/>
-         </evaluate>
-         <true/>
-         <valueOf line='2814' flags='l'>
-          <fn name='normalize-space'>
-           <fn name='string-join'>
-            <data>
-             <axis name='child' nodeTest='text()' jsTest='return item.nodeType===3;'/>
-            </data>
-            <str val=''/>
-           </fn>
-          </fn>
-         </valueOf>
-        </choose>
-        <forEachGroup line='2819' algorithm='by'>
-         <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-         <fn role='key' name='local-name'>
-          <dot type='element()'/>
-         </fn>
-         <str role='collation' val='http://www.w3.org/2005/xpath-functions/collation/codepoint'/>
-         <let role='content' line='2821' var='Q{}updatedChildPath' as='xs:string' slot='4' eval='8'>
-          <fn name='concat'>
-           <varRef name='Q{}updatedPath' slot='3'/>
-           <str val='/'/>
-           <check card='?' diag='0|2||fn:concat'>
-            <currentGroupingKey/>
-           </check>
-          </fn>
-          <let line='2826' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='5' eval='13'>
-           <fn name='concat'>
-            <varRef name='Q{}updatedChildPath' slot='4'/>
-            <str val='['/>
-           </fn>
-           <let var='Q{}dataRefWithFilter' as='element()*' slot='6' eval='8'>
-            <filter flags='b'>
-             <slash simple='1'>
-              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
-              <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-             </slash>
-             <fn name='starts-with'>
-              <cvUntyped to='xs:string'>
-               <attVal name='Q{}data-ref' chk='0'/>
-              </cvUntyped>
-              <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='5'/>
-             </fn>
-            </filter>
-            <choose line='2829'>
-             <or op='or'>
-              <fn name='exists'>
-               <tail start='2'>
-                <currentGroup/>
-               </tail>
-              </fn>
-              <fn name='exists'>
-               <varRef name='Q{}dataRefWithFilter' slot='6'/>
-              </fn>
-             </or>
-             <let line='2832' var='Q{http://saxon.sf.net/generated-variable}v1' as='xs:string' slot='7' eval='13'>
-              <fn name='concat'>
-               <varRef name='Q{}updatedPath' slot='3'/>
-               <str val='/'/>
-              </fn>
-              <forEach line='2830'>
-               <currentGroup/>
-               <applyT line='2831' mode='Q{}binding-calculation' bSlot='2'>
-                <dot role='select'/>
-                <withParam name='Q{}curPath' as='xs:string'>
-                 <varRef line='2832' name='Q{http://saxon.sf.net/generated-variable}v1' slot='7'/>
-                </withParam>
-                <withParam name='Q{}position' as='xs:integer'>
-                 <fn line='2833' name='position'/>
-                </withParam>
-               </applyT>
-              </forEach>
-             </let>
-             <true/>
-             <let line='2841' var='Q{http://saxon.sf.net/generated-variable}v2' as='xs:string' slot='8' eval='13'>
-              <fn name='concat'>
-               <varRef name='Q{}updatedPath' slot='3'/>
-               <str val='/'/>
-              </fn>
-              <forEach line='2839'>
-               <currentGroup/>
-               <applyT line='2840' mode='Q{}binding-calculation' bSlot='3'>
-                <dot role='select'/>
-                <withParam name='Q{}curPath' as='xs:string'>
-                 <varRef line='2841' name='Q{http://saxon.sf.net/generated-variable}v2' slot='8'/>
-                </withParam>
-               </applyT>
-              </forEach>
-             </let>
-            </choose>
-           </let>
-          </let>
-         </let>
-        </forEachGroup>
-       </sequence>
-      </copy>
-     </let>
-    </sequence>
-   </templateRule>
-  </mode>
- </co>
- <co id='58' binds=''>
-  <globalParam name='Q{}xforms-cache-id' type='item()*' line='64' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return val;' jsCardCheck='function c() {return true;};'>
+ <co id='57' binds=''>
+  <globalParam name='Q{}xforms-cache-id' type='item()*' line='66' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return val;' jsCardCheck='function c() {return true;};'>
    <str val='xforms-cache'/>
   </globalParam>
  </co>
- <co id='3' binds='59'>
+ <co id='3' binds='58'>
   <function name='Q{http://www.w3.org/2002/xforms}impose' line='22' module='xforms-function-library.xsl' eval='8' flags='pU' as='xs:string' slots='3'>
    <arg name='Q{}input' as='xs:string'/>
    <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='36' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:anyAtomicType*' slot='1' eval='4'>
@@ -5233,7 +5101,7 @@
    </let>
   </function>
  </co>
- <co id='59' binds=''>
+ <co id='58' binds=''>
   <globalVariable name='Q{}xform-functions' type='item()+' line='20' module='xforms-function-library.xsl' visibility='PRIVATE' jsAcceptor='return val;' jsCardCheck='function c(n) {return n&gt;=1;};'>
    <sequence ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='20'>
     <literal count='5'>
@@ -5253,9 +5121,9 @@
   </globalVariable>
  </co>
  <co id='52' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}check-required-fields' line='935' module='saxon-xforms.xsl' eval='8' flags='pU' as='item()*' slots='3'>
+  <function name='Q{http://www.w3.org/2002/xforms}check-required-fields' line='937' module='saxon-xforms.xsl' eval='8' flags='pU' as='item()*' slots='3'>
    <arg name='Q{}instanceXML' as='element()'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='938' var='Q{}required-fieldsi' as='element()*' slot='1' eval='8'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='940' var='Q{}required-fieldsi' as='element()*' slot='1' eval='8'>
     <filter flags='b'>
      <slash simple='1'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
@@ -5265,10 +5133,10 @@
       <axis name='attribute' nodeTest='attribute(Q{}data-required)' jsTest='return item.name===&#39;data-required&#39;'/>
      </fn>
     </filter>
-    <forEach line='940'>
+    <forEach line='942'>
      <varRef name='Q{}required-fieldsi' slot='1'/>
-     <let line='942' var='Q{}resulti' as='document-node()' slot='2' eval='16'>
-      <doc line='945' validation='preserve'>
+     <let line='944' var='Q{}resulti' as='document-node()' slot='2' eval='16'>
+      <doc line='947' validation='preserve'>
        <evaluate dxns=''>
         <fn role='xpath' name='concat'>
          <str val='boolean(normalize-space('/>
@@ -5286,7 +5154,7 @@
         <map role='wp' size='0'/>
        </evaluate>
       </doc>
-      <choose line='951'>
+      <choose line='953'>
        <vc op='eq' onEmpty='0' comp='CCC'>
         <cast as='xs:string' emptiable='0'>
          <data>
@@ -5302,15 +5170,15 @@
    </let>
   </function>
  </co>
- <co id='60' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}logToPage' line='3050' module='saxon-xforms.xsl' eval='7' flags='pU' as='empty-sequence()' slots='1'>
+ <co id='59' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}logToPage' line='3023' module='saxon-xforms.xsl' eval='7' flags='pU' as='empty-sequence()' slots='1'>
    <arg name='Q{}message' as='xs:string'/>
    <check role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='-1' card='°' diag='5|0|XTTE0780|xforms:logToPage#1'>
     <error message='Call to xsl:result-document while in temporary output state' code='XTDE1480' isTypeErr='1'/>
    </check>
   </function>
  </co>
- <co id='29' binds=''>
+ <co id='28' binds=''>
   <function name='Q{http://www.w3.org/2002/xforms}index' line='97' module='xforms-function-library.xsl' eval='16' flags='pU' as='xs:integer' slots='2'>
    <arg name='Q{}repeatID' as='xs:string'/>
    <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='101' var='Q{}repeat-index' as='xs:double?' slot='1' eval='7'>
@@ -5348,9 +5216,9 @@
  </co>
  <co id='9' binds='9'>
   <mode name='Q{}delete-node' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='22' rank='0' minImp='0' slots='1' flags='s' line='1942' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='22' rank='0' minImp='0' slots='1' flags='s' line='1949' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1943'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1950'>
      <param name='Q{}delete-node' slot='0' flags='ti' as='node()'>
       <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|delete-node'>
        <check card='1' diag='8|0|XTTE0590|delete-node'>
@@ -5358,19 +5226,19 @@
        </check>
       </treat>
      </param>
-     <choose line='1946'>
+     <choose line='1953'>
       <is op='is'>
        <dot type='element()'/>
        <varRef name='Q{}delete-node' slot='0'/>
       </is>
       <empty/>
       <true/>
-      <copy line='1960' flags='cin'>
+      <copy line='1967' flags='cin'>
        <sequence role='content'>
         <copyOf flags='vc'>
          <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
         </copyOf>
-        <applyT line='1961' mode='Q{}delete-node' bSlot='0'>
+        <applyT line='1968' mode='Q{}delete-node' bSlot='0'>
          <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
         </applyT>
        </sequence>
@@ -5382,16 +5250,16 @@
  </co>
  <co id='15' binds=''>
   <mode name='Q{}get-field' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.25' seq='34' rank='0' minImp='0' slots='0' flags='s' line='2931' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='34' rank='0' minImp='0' slots='0' flags='s' line='2892' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:textarea' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;textarea&#39;'/>
-    <ifCall role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2934' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+    <ifCall role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2895' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
      <dot type='*:textarea'/>
      <str val='value'/>
     </ifCall>
    </templateRule>
-   <templateRule prec='0' prio='-0.25' seq='33' rank='0' minImp='0' slots='0' flags='s' line='2926' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='33' rank='0' minImp='0' slots='0' flags='s' line='2882' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:select' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;select&#39;'/>
-    <ifCall role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2928' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+    <ifCall role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2884' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
      <check card='?' diag='0|0||ixsl:get'>
       <filter flags='b'>
        <axis name='child' nodeTest='element(Q{}option)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;option&#39;;'/>
@@ -5409,9 +5277,9 @@
      <str val='value'/>
     </ifCall>
    </templateRule>
-   <templateRule prec='0' prio='-0.25' seq='32' rank='0' minImp='0' slots='0' flags='s' line='2912' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='32' rank='0' minImp='0' slots='0' flags='s' line='2863' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:input' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;input&#39;'/>
-    <choose role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2916'>
+    <choose role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2867'>
      <and op='and'>
       <fn name='exists'>
        <axis name='attribute' nodeTest='attribute(Q{}type)' jsTest='return item.name===&#39;type&#39;'/>
@@ -5423,12 +5291,12 @@
        <str val='checkbox'/>
       </vc>
      </and>
-     <ifCall line='2917' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+     <ifCall line='2868' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
       <dot type='*:input'/>
       <str val='checked'/>
      </ifCall>
      <true/>
-     <ifCall line='2920' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+     <ifCall line='2871' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
       <dot type='*:input'/>
       <str val='value'/>
      </ifCall>
@@ -5436,23 +5304,23 @@
    </templateRule>
   </mode>
  </co>
- <co id='44' binds='54 46 61 62 63 23 64 44 44 62 63 23 44 44 44 62 63 23 3 3 44 44 44 44 62 63 23 3 64 44 62 63 23 64 62 63 64 44 44'>
+ <co id='43' binds='54 47 60 61 62 22 63 43 43 61 62 22 43 43 43 61 62 22 3 3 43 43 43 43 61 62 22 3 63 43 61 62 22 63 61 62 63 43 43'>
   <mode onNo='TC' flags='dW' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='7' rank='0' minImp='0' slots='0' flags='s' line='1089' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='7' rank='0' minImp='0' slots='0' flags='s' line='1096' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='document-node()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);'/>
-    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1090' name='Q{}xformsjs-main' bSlot='0' flags='t'>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1097' name='Q{}xformsjs-main' bSlot='0' flags='t'>
      <withParam name='Q{}xforms-doc' flags='c' as='document-node()'>
-      <dot line='1091' type='document-node()'/>
+      <dot line='1098' type='document-node()'/>
      </withParam>
      <withParam name='Q{}xFormsId' flags='c' as='xs:string'>
-      <gVarRef line='1092' name='Q{}xform-html-id' bSlot='1'/>
+      <gVarRef line='1099' name='Q{}xform-html-id' bSlot='1'/>
      </withParam>
     </callT>
    </templateRule>
-   <templateRule prec='0' prio='0.5' seq='25' part='1' rank='2' minImp='0' slots='1' flags='s' line='2117' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.5' seq='25' part='1' rank='2' minImp='0' slots='1' flags='s' line='2124' module='saxon-xforms.xsl'>
     <p.withPredicate role='match'>
      <p.nodeTest test='Q{http://www.w3.org/2002/xforms}*' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.uri===&#39;http://www.w3.org/2002/xforms&#39;'/>
-     <gc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2117' op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+     <gc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2124' op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
       <literal count='15'>
        <str val='setvalue'/>
        <str val='insert'/>
@@ -5475,22 +5343,22 @@
       </fn>
      </gc>
     </p.withPredicate>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2123' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2124' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2132' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2133' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
       <check card='1' diag='3|0|XTTE0570|action-map'>
        <callT name='Q{}setAction' bSlot='2'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2125' type='element()'/>
+         <dot line='2134' type='element()'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <varRef line='2138' name='Q{}action-map' slot='0'/>
+     <varRef line='2147' name='Q{}action-map' slot='0'/>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='13' part='1' rank='1' minImp='0' slots='12' flags='s' line='1538' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='13' part='1' rank='1' minImp='0' slots='12' flags='s' line='1545' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}select)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;select&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1539'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1546'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -5503,7 +5371,7 @@
        </check>
       </treat>
      </param>
-     <param line='1540' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1547' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -5515,7 +5383,7 @@
        </check>
       </treat>
      </param>
-     <let line='1544' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='1551' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -5531,7 +5399,7 @@
          <dot type='element()'/>
         </fn>
         <str val='-'/>
-        <choose line='1542'>
+        <choose line='1549'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -5541,13 +5409,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1546'>
+      <sequence line='1553'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element()' slot='3' eval='16'>
           <dot type='element()'/>
-          <fn line='3025' name='exists'>
-           <sequence line='3000'>
+          <fn line='2998' name='exists'>
+           <sequence line='2973'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -5559,7 +5427,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='3003'>
+             <choose role='matching' line='2976'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -5571,7 +5439,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='3012'>
+            <analyzeString line='2985'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -5582,7 +5450,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='3015'>
+             <choose role='matching' line='2988'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -5605,8 +5473,8 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='3025' name='exists'>
-             <sequence line='3000'>
+            <fn line='2998' name='exists'>
+             <sequence line='2973'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
@@ -5618,7 +5486,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='3003'>
+               <choose role='matching' line='2976'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -5630,7 +5498,7 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
-              <analyzeString line='3012'>
+              <analyzeString line='2985'>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
@@ -5641,7 +5509,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='3015'>
+               <choose role='matching' line='2988'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -5659,7 +5527,7 @@
           </filter>
          </fn>
         </and>
-        <ifCall line='1547' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1554' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -5670,60 +5538,60 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1554' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='1555' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='1561' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1562' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
           <callT name='Q{}getBinding' bSlot='3'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='1556' type='element()'/>
+            <dot line='1563' type='element()'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='1561' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='1562' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='1568' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1569' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
              <callT name='Q{}getDataRef' bSlot='4'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='1563' type='element()'/>
+               <dot line='1570' type='element()'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='1564' name='Q{}bindingi' slot='5'/>
+               <varRef line='1571' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='1569' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
-          <treat line='1570' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+         <let line='1576' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
+          <treat line='1577' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
            <check card='?' diag='3|0|XTTE0570|instanceField'>
             <callT name='Q{}getReferencedInstanceField' bSlot='5'>
              <withParam name='Q{}refi' flags='c' as='xs:string'>
-              <varRef line='1571' name='Q{}refi' slot='6'/>
+              <varRef line='1578' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </check>
           </treat>
-          <let line='1576' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
-           <treat line='1577' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+          <let line='1583' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
+           <treat line='1584' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
             <callT name='Q{}setActions' bSlot='6'>
              <withParam name='Q{}this' flags='c' as='element()'>
-              <dot line='1578' type='element()'/>
+              <dot line='1585' type='element()'/>
              </withParam>
              <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-              <varRef line='1579' name='Q{}refi' slot='6'/>
+              <varRef line='1586' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </treat>
-           <sequence line='1583'>
+           <sequence line='1590'>
             <choose>
              <fn name='exists'>
               <varRef name='Q{}actions' slot='8'/>
              </fn>
-             <ifCall line='1584' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+             <ifCall line='1591' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
               <check card='1' diag='0|0||ixsl:call'>
                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
               </check>
@@ -5734,27 +5602,27 @@
               </arrayBlock>
              </ifCall>
             </choose>
-            <elem line='1601' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+            <elem line='1608' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
              <sequence>
               <att name='class' flags='l'>
                <str val='xforms-select'/>
               </att>
-              <applyT line='1602' bSlot='7'>
+              <applyT line='1609' bSlot='7'>
                <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
               </applyT>
-              <elem line='1604' name='select' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-               <sequence line='1605'>
+              <elem line='1611' name='select' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+               <sequence line='1612'>
                 <let var='Q{}element' as='element()' slot='9' eval='16'>
                  <dot type='element()'/>
-                 <let line='3091' var='Q{}class' as='xs:string?' slot='10' eval='7'>
-                  <choose line='3092'>
+                 <let line='3064' var='Q{}class' as='xs:string?' slot='10' eval='7'>
+                  <choose line='3065'>
                    <fn name='exists'>
                     <slash simple='1'>
                      <varRef name='Q{}element' slot='9'/>
                      <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
                     </slash>
                    </fn>
-                   <cvUntyped line='3093' to='xs:string' diag='3|0|XTTE0570|class'>
+                   <cvUntyped line='3066' to='xs:string' diag='3|0|XTTE0570|class'>
                     <cast as='xs:untypedAtomic' emptiable='0'>
                      <fn name='string'>
                       <convert from='xs:untypedAtomic' to='xs:string'>
@@ -5769,15 +5637,15 @@
                     </cast>
                    </cvUntyped>
                   </choose>
-                  <let line='3096' var='Q{}class-mod' as='xs:string?' slot='11' eval='7'>
-                   <choose line='3098'>
+                  <let line='3069' var='Q{}class-mod' as='xs:string?' slot='11' eval='7'>
+                   <choose line='3071'>
                     <fn name='exists'>
                      <slash simple='1'>
                       <varRef name='Q{}element' slot='9'/>
                       <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
                      </slash>
                     </fn>
-                    <cvUntyped line='3099' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                    <cvUntyped line='3072' to='xs:string' diag='3|0|XTTE0570|class-mod'>
                      <cast as='xs:untypedAtomic' emptiable='0'>
                       <fn name='string-join'>
                        <sequence>
@@ -5789,13 +5657,13 @@
                      </cast>
                     </cvUntyped>
                     <true/>
-                    <varRef line='3102' name='Q{}class' slot='10'/>
+                    <varRef line='3075' name='Q{}class' slot='10'/>
                    </choose>
-                   <choose line='3106'>
+                   <choose line='3079'>
                     <fn name='exists'>
                      <varRef name='Q{}class-mod' slot='11'/>
                     </fn>
-                    <treat line='3107' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                    <treat line='3080' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
                      <att name='class' flags='l'>
                       <varRef name='Q{}class-mod' slot='11'/>
                      </att>
@@ -5804,7 +5672,7 @@
                   </let>
                  </let>
                 </let>
-                <copyOf line='1606' flags='vc'>
+                <copyOf line='1613' flags='vc'>
                  <except op='except'>
                   <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
                   <docOrder intra='1'>
@@ -5816,11 +5684,11 @@
                   </docOrder>
                  </except>
                 </copyOf>
-                <att line='1608' name='data-ref' flags='l'>
+                <att line='1615' name='data-ref' flags='l'>
                  <varRef name='Q{}refi' slot='6'/>
                 </att>
-                <att line='1609' name='data-element' flags='l'>
-                 <lastOf line='1599'>
+                <att line='1616' name='data-element' flags='l'>
+                 <lastOf line='1606'>
                   <fn name='tokenize'>
                    <varRef name='Q{}refi' slot='6'/>
                    <str val='/'/>
@@ -5828,7 +5696,7 @@
                   </fn>
                  </lastOf>
                 </att>
-                <choose line='1611'>
+                <choose line='1618'>
                  <and op='and'>
                   <fn name='exists'>
                    <varRef name='Q{}bindingi' slot='5'/>
@@ -5840,7 +5708,7 @@
                    </slash>
                   </fn>
                  </and>
-                 <att line='1612' name='data-constraint' flags='l'>
+                 <att line='1619' name='data-constraint' flags='l'>
                   <convert from='xs:untypedAtomic' to='xs:string'>
                    <data>
                     <slash simple='1'>
@@ -5851,19 +5719,19 @@
                   </convert>
                  </att>
                 </choose>
-                <choose line='1615'>
+                <choose line='1622'>
                  <vc op='eq' onEmpty='0' comp='CCC'>
                   <fn name='local-name'>
                    <dot type='element()'/>
                   </fn>
                   <str val='select'/>
                  </vc>
-                 <sequence line='1616'>
+                 <sequence line='1623'>
                   <att name='multiple' flags='l'>
                    <str val='true'/>
                   </att>
-                  <att line='1617' name='size' flags='l'>
-                   <convert line='1618' from='xs:integer' to='xs:string'>
+                  <att line='1624' name='size' flags='l'>
+                   <convert line='1625' from='xs:integer' to='xs:string'>
                     <fn name='count'>
                      <axis name='descendant' nodeTest='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
                     </fn>
@@ -5871,22 +5739,22 @@
                   </att>
                  </sequence>
                 </choose>
-                <choose line='1621'>
+                <choose line='1628'>
                  <fn name='exists'>
                   <varRef name='Q{}actions' slot='8'/>
                  </fn>
-                 <att line='1622' name='data-action' flags='l'>
+                 <att line='1629' name='data-action' flags='l'>
                   <varRef name='Q{}myid' slot='2'/>
                  </att>
                 </choose>
-                <applyT line='1625' bSlot='8'>
+                <applyT line='1632' bSlot='8'>
                  <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
                  <withParam name='Q{}selectedValue' as='xs:string'>
-                  <choose line='1590'>
+                  <choose line='1597'>
                    <fn name='exists'>
                     <varRef name='Q{}instanceField' slot='7'/>
                    </fn>
-                   <cvUntyped line='1591' to='xs:string' diag='3|0|XTTE0570|selectedValue'>
+                   <cvUntyped line='1598' to='xs:string' diag='3|0|XTTE0570|selectedValue'>
                     <cast as='xs:untypedAtomic' emptiable='0'>
                      <fn name='string'>
                       <convert from='xs:anyAtomicType' to='xs:string'>
@@ -5915,24 +5783,24 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='25' rank='1' minImp='0' slots='1' flags='s' line='2117' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='25' rank='1' minImp='0' slots='1' flags='s' line='2124' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}action)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;action&#39;;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2123' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2124' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2132' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2133' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
       <check card='1' diag='3|0|XTTE0570|action-map'>
        <callT name='Q{}setAction' bSlot='2'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2125' type='element()'/>
+         <dot line='2134' type='element()'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <varRef line='2138' name='Q{}action-map' slot='0'/>
+     <varRef line='2147' name='Q{}action-map' slot='0'/>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='19' rank='1' minImp='0' slots='15' flags='s' line='1746' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='19' rank='1' minImp='0' slots='15' flags='s' line='1753' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1747'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1754'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -5945,7 +5813,7 @@
        </check>
       </treat>
      </param>
-     <param line='1748' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1755' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -5957,7 +5825,7 @@
        </check>
       </treat>
      </param>
-     <param line='1749' name='Q{}recalculate' slot='2' as='xs:boolean'>
+     <param line='1756' name='Q{}recalculate' slot='2' as='xs:boolean'>
       <false role='select'/>
       <treat role='conversion' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='8|0|XTTE0590|recalculate'>
        <check card='1' diag='8|0|XTTE0590|recalculate'>
@@ -5969,7 +5837,7 @@
        </check>
       </treat>
      </param>
-     <param line='1750' name='Q{}refreshRepeats' slot='3' as='xs:boolean'>
+     <param line='1757' name='Q{}refreshRepeats' slot='3' as='xs:boolean'>
       <false role='select'/>
       <treat role='conversion' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='8|0|XTTE0590|refreshRepeats'>
        <check card='1' diag='8|0|XTTE0590|refreshRepeats'>
@@ -5981,7 +5849,7 @@
        </check>
       </treat>
      </param>
-     <let line='1754' var='Q{}myid' as='xs:string' slot='4' eval='16'>
+     <let line='1761' var='Q{}myid' as='xs:string' slot='4' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -5997,7 +5865,7 @@
          <dot type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
         </fn>
         <str val='-'/>
-        <choose line='1752'>
+        <choose line='1759'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -6007,27 +5875,27 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1761'>
+      <sequence line='1768'>
        <choose>
         <fn name='not'>
          <varRef name='Q{}recalculate' slot='2'/>
         </fn>
-        <ifCall line='1777' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1784' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
          <str val='setRepeatIndex'/>
          <arrayBlock>
           <varRef name='Q{}myid' slot='4'/>
-          <choose line='1764'>
+          <choose line='1771'>
            <fn name='empty'>
             <axis name='attribute' nodeTest='attribute(Q{}startindex)' jsTest='return item.name===&#39;startindex&#39;'/>
            </fn>
            <dbl val='1'/>
-           <castable line='1767' as='xs:double' emptiable='0'>
+           <castable line='1774' as='xs:double' emptiable='0'>
             <axis name='attribute' nodeTest='attribute(Q{}startindex)' jsTest='return item.name===&#39;startindex&#39;'/>
            </castable>
-           <cvUntyped line='1768' to='xs:double' diag='3|0|XTTE0570|this-index'>
+           <cvUntyped line='1775' to='xs:double' diag='3|0|XTTE0570|this-index'>
             <convert from='xs:double' to='xs:untypedAtomic'>
              <fn name='number'>
               <attVal name='Q{}startindex' chk='0'/>
@@ -6035,99 +5903,72 @@
             </convert>
            </cvUntyped>
            <true/>
-           <check line='1771' card='1' diag='3|0|XTTE0570|this-index'>
-            <sequence>
-             <convert from='xs:anyAtomicType' to='xs:double' flags='p' diag='3|0|XTTE0570|this-index'>
-              <cvUntyped to='xs:double' diag='3|0|XTTE0570|this-index'>
-               <data>
-                <message>
-                 <sequence role='select'>
-                  <valueOf>
-                   <str val='[xforms:repeat] value of @startindex (&#39;'/>
-                  </valueOf>
-                  <valueOf>
-                   <convert from='xs:untypedAtomic' to='xs:string'>
-                    <attVal name='Q{}startindex' chk='0'/>
-                   </convert>
-                  </valueOf>
-                  <valueOf>
-                   <str val='&#39;) is not a number. Setting the index to &#39;1&#39;'/>
-                  </valueOf>
-                 </sequence>
-                 <str role='terminate' val='no'/>
-                 <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-                </message>
-               </data>
-              </cvUntyped>
-             </convert>
-             <dbl val='1'/>
-            </sequence>
-           </check>
+           <dbl val='1'/>
           </choose>
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1784' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='1785' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='1791' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1792' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
           <callT name='Q{}getBinding' bSlot='9'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='1786' type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
+            <dot line='1793' type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='1791' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='1792' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='1798' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1799' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
              <callT name='Q{}getDataRef' bSlot='10'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='1793' type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
+               <dot line='1800' type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='1794' name='Q{}bindingi' slot='5'/>
+               <varRef line='1801' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='1800' var='Q{}selectedRepeatVar' as='element()*' slot='7' eval='8'>
-          <treat line='1802' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|selectedRepeatVar'>
+         <let line='1807' var='Q{}selectedRepeatVar' as='element()*' slot='7' eval='8'>
+          <treat line='1809' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|selectedRepeatVar'>
            <callT name='Q{}getReferencedInstanceField' bSlot='11'>
             <withParam name='Q{}refi' flags='c' as='xs:string'>
-             <varRef line='1803' name='Q{}refi' slot='6'/>
+             <varRef line='1810' name='Q{}refi' slot='6'/>
             </withParam>
            </callT>
           </treat>
-          <let line='1818' var='Q{}repeat-items' as='element(Q{}div, Q{http://www.w3.org/2001/XMLSchema}untyped)*' slot='8' eval='3'>
-           <let line='1819' var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}repeat)' slot='9' eval='16'>
+          <let line='1825' var='Q{}repeat-items' as='element(Q{}div, Q{http://www.w3.org/2001/XMLSchema}untyped)*' slot='8' eval='3'>
+           <let line='1826' var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}repeat)' slot='9' eval='16'>
             <dot type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
-            <let line='1824' var='Q{http://saxon.sf.net/generated-variable}v0' as='element()*' slot='10' eval='4'>
+            <let line='1831' var='Q{http://saxon.sf.net/generated-variable}v0' as='element()*' slot='10' eval='4'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='9'/>
               <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
              </slash>
-             <forEach line='1820'>
+             <forEach line='1827'>
               <varRef name='Q{}selectedRepeatVar' slot='7'/>
-              <let line='1821' var='Q{}string-position' as='xs:string' slot='11' eval='8'>
+              <let line='1828' var='Q{}string-position' as='xs:string' slot='11' eval='8'>
                <fn name='string'>
                 <fn name='position'/>
                </fn>
-               <elem line='1823' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+               <elem line='1830' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
                 <sequence>
                  <att name='data-repeat-item' flags='l'>
                   <str val='true'/>
                  </att>
-                 <applyT line='1824' bSlot='12'>
+                 <applyT line='1831' bSlot='12'>
                   <varRef role='select' name='Q{http://saxon.sf.net/generated-variable}v0' slot='10'/>
                   <withParam name='Q{}position' as='xs:integer'>
-                   <fn line='1826' name='position'/>
+                   <fn line='1833' name='position'/>
                   </withParam>
                   <withParam name='Q{}context-position' as='xs:string'>
-                   <choose line='1822'>
+                   <choose line='1829'>
                     <varRef name='Q{}context-position' slot='1'/>
                     <fn name='concat'>
                      <varRef name='Q{}context-position' slot='1'/>
@@ -6139,7 +5980,7 @@
                    </choose>
                   </withParam>
                   <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                   <fn line='1825' name='concat'>
+                   <fn line='1832' name='concat'>
                     <varRef name='Q{}refi' slot='6'/>
                     <str val='['/>
                     <fn name='position'/>
@@ -6153,24 +5994,24 @@
              </forEach>
             </let>
            </let>
-           <sequence line='1835'>
+           <sequence line='1842'>
             <choose>
              <varRef name='Q{}refreshRepeats' slot='3'/>
-             <varRef line='1836' name='Q{}repeat-items' slot='8'/>
+             <varRef line='1843' name='Q{}repeat-items' slot='8'/>
              <true/>
-             <elem line='1839' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-              <sequence line='1840'>
+             <elem line='1846' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+              <sequence line='1847'>
                <let var='Q{}element' as='element(Q{http://www.w3.org/2002/xforms}repeat)' slot='12' eval='16'>
                 <dot type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
-                <let line='3091' var='Q{}class' as='xs:string?' slot='13' eval='7'>
-                 <choose line='3092'>
+                <let line='3064' var='Q{}class' as='xs:string?' slot='13' eval='7'>
+                 <choose line='3065'>
                   <fn name='exists'>
                    <slash simple='1'>
                     <varRef name='Q{}element' slot='12'/>
                     <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
                    </slash>
                   </fn>
-                  <cvUntyped line='3093' to='xs:string' diag='3|0|XTTE0570|class'>
+                  <cvUntyped line='3066' to='xs:string' diag='3|0|XTTE0570|class'>
                    <cast as='xs:untypedAtomic' emptiable='0'>
                     <fn name='string'>
                      <convert from='xs:untypedAtomic' to='xs:string'>
@@ -6185,15 +6026,15 @@
                    </cast>
                   </cvUntyped>
                  </choose>
-                 <let line='3096' var='Q{}class-mod' as='xs:string?' slot='14' eval='7'>
-                  <choose line='3098'>
+                 <let line='3069' var='Q{}class-mod' as='xs:string?' slot='14' eval='7'>
+                  <choose line='3071'>
                    <fn name='exists'>
                     <slash simple='1'>
                      <varRef name='Q{}element' slot='12'/>
                      <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
                     </slash>
                    </fn>
-                   <cvUntyped line='3099' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                   <cvUntyped line='3072' to='xs:string' diag='3|0|XTTE0570|class-mod'>
                     <cast as='xs:untypedAtomic' emptiable='0'>
                      <fn name='string-join'>
                       <sequence>
@@ -6205,13 +6046,13 @@
                     </cast>
                    </cvUntyped>
                    <true/>
-                   <varRef line='3102' name='Q{}class' slot='13'/>
+                   <varRef line='3075' name='Q{}class' slot='13'/>
                   </choose>
-                  <choose line='3106'>
+                  <choose line='3079'>
                    <fn name='exists'>
                     <varRef name='Q{}class-mod' slot='14'/>
                    </fn>
-                   <treat line='3107' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                   <treat line='3080' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
                     <att name='class' flags='l'>
                      <varRef name='Q{}class-mod' slot='14'/>
                     </att>
@@ -6220,24 +6061,24 @@
                  </let>
                 </let>
                </let>
-               <att line='1842' name='data-repeatable-context' flags='l'>
+               <att line='1849' name='data-repeatable-context' flags='l'>
                 <varRef name='Q{}refi' slot='6'/>
                </att>
-               <att line='1843' name='data-count' flags='l'>
+               <att line='1850' name='data-count' flags='l'>
                 <convert from='xs:integer' to='xs:string'>
                  <fn name='count'>
                   <varRef name='Q{}selectedRepeatVar' slot='7'/>
                  </fn>
                 </convert>
                </att>
-               <att line='1844' name='id' flags='l'>
+               <att line='1851' name='id' flags='l'>
                 <varRef name='Q{}myid' slot='4'/>
                </att>
-               <varRef line='1846' name='Q{}repeat-items' slot='8'/>
+               <varRef line='1853' name='Q{}repeat-items' slot='8'/>
               </sequence>
              </elem>
             </choose>
-            <choose line='1854'>
+            <choose line='1861'>
              <and op='and'>
               <fn name='not'>
                <varRef name='Q{}recalculate' slot='2'/>
@@ -6249,30 +6090,18 @@
                </slash>
               </fn>
              </and>
-             <sequence line='1856'>
-              <message>
-               <fn role='select' name='concat'>
-                <str val='[xforms:repeat] Registering repeat with ID '/>
-                <varRef name='Q{}myid' slot='4'/>
-                <str val=' and parsed nodeset '/>
-                <varRef name='Q{}refi' slot='6'/>
-               </fn>
-               <str role='terminate' val='no'/>
-               <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-              </message>
-              <ifCall line='1858' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-               <check card='1' diag='0|0||ixsl:call'>
-                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-               </check>
-               <str val='addRepeat'/>
-               <arrayBlock>
-                <varRef name='Q{}myid' slot='4'/>
-                <varRef name='Q{}refi' slot='6'/>
-               </arrayBlock>
-              </ifCall>
-             </sequence>
+             <ifCall line='1865' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+              <check card='1' diag='0|0||ixsl:call'>
+               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+              </check>
+              <str val='addRepeat'/>
+              <arrayBlock>
+               <varRef name='Q{}myid' slot='4'/>
+               <varRef name='Q{}refi' slot='6'/>
+              </arrayBlock>
+             </ifCall>
             </choose>
-            <ifCall line='1862' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+            <ifCall line='1869' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
              <check card='1' diag='0|0||ixsl:call'>
               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
              </check>
@@ -6293,9 +6122,9 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='18' rank='1' minImp='0' slots='6' flags='s' line='1702' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='18' rank='1' minImp='0' slots='6' flags='s' line='1709' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}group)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;group&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1703'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1710'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -6308,7 +6137,7 @@
        </check>
       </treat>
      </param>
-     <param line='1704' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1711' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -6320,7 +6149,7 @@
        </check>
       </treat>
      </param>
-     <let line='1708' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='1715' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -6336,7 +6165,7 @@
          <dot type='element(Q{http://www.w3.org/2002/xforms}group)'/>
         </fn>
         <str val='-'/>
-        <choose line='1706'>
+        <choose line='1713'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -6346,13 +6175,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1710'>
+      <sequence line='1717'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}group)' slot='3' eval='16'>
           <dot type='element(Q{http://www.w3.org/2002/xforms}group)'/>
-          <fn line='3025' name='exists'>
-           <sequence line='3000'>
+          <fn line='2998' name='exists'>
+           <sequence line='2973'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -6364,7 +6193,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='3003'>
+             <choose role='matching' line='2976'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -6376,7 +6205,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='3012'>
+            <analyzeString line='2985'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -6387,7 +6216,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='3015'>
+             <choose role='matching' line='2988'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -6410,8 +6239,8 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='3025' name='exists'>
-             <sequence line='3000'>
+            <fn line='2998' name='exists'>
+             <sequence line='2973'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
@@ -6423,7 +6252,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='3003'>
+               <choose role='matching' line='2976'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -6435,7 +6264,7 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
-              <analyzeString line='3012'>
+              <analyzeString line='2985'>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
@@ -6446,7 +6275,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='3015'>
+               <choose role='matching' line='2988'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -6464,7 +6293,7 @@
           </filter>
          </fn>
         </and>
-        <ifCall line='1711' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1718' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -6475,38 +6304,38 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1714' var='Q{}refi' as='xs:string?' slot='5' eval='7'>
-        <choose line='1716'>
+       <let line='1721' var='Q{}refi' as='xs:string?' slot='5' eval='7'>
+        <choose line='1723'>
          <fn name='exists'>
           <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
          </fn>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
           <attVal name='Q{}nodeset' chk='0'/>
          </cvUntyped>
-         <fn line='1717' name='exists'>
+         <fn line='1724' name='exists'>
           <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
          </fn>
-         <cvUntyped line='1717' to='xs:string' diag='3|0|XTTE0570|refi'>
+         <cvUntyped line='1724' to='xs:string' diag='3|0|XTTE0570|refi'>
           <attVal name='Q{}ref' chk='0'/>
          </cvUntyped>
         </choose>
-        <elem line='1723' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-         <sequence line='1724'>
+        <elem line='1730' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+         <sequence line='1731'>
           <att name='id' flags='l'>
            <varRef name='Q{}myid' slot='2'/>
           </att>
-          <choose line='1725'>
+          <choose line='1732'>
            <fn name='exists'>
             <varRef name='Q{}refi' slot='5'/>
            </fn>
-           <att line='1726' name='data-group-ref' flags='l'>
+           <att line='1733' name='data-group-ref' flags='l'>
             <varRef name='Q{}refi' slot='5'/>
            </att>
           </choose>
-          <applyT line='1728' bSlot='13'>
+          <applyT line='1735' bSlot='13'>
            <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
            <withParam name='Q{}nodeset' flags='t' as='xs:string?'>
-            <choose line='1729'>
+            <choose line='1736'>
              <fn name='exists'>
               <varRef name='Q{}refi' slot='5'/>
              </fn>
@@ -6523,15 +6352,15 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='8' rank='1' minImp='0' slots='0' flags='s' line='1106' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='8' rank='1' minImp='0' slots='0' flags='s' line='1113' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/1999/xhtml}html)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/1999/xhtml&#39;&amp;&amp;q.local===&#39;html&#39;;'/>
-    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1107' name='html' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-     <sequence line='1108'>
+    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1114' name='html' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+     <sequence line='1115'>
       <copyOf flags='vc'>
        <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
       </copyOf>
-      <elem line='1109' name='head' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-       <sequence line='1110'>
+      <elem line='1116' name='head' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+       <sequence line='1117'>
         <copyOf flags='vc'>
          <union op='|'>
           <slash simple='2'>
@@ -6544,7 +6373,7 @@
           </slash>
          </union>
         </copyOf>
-        <elem line='1111' name='meta' nsuri='' flags='l'>
+        <elem line='1118' name='meta' nsuri='' flags='l'>
          <sequence>
           <att name='http-equiv' flags='l'>
            <str val='Content-Type'/>
@@ -6554,7 +6383,7 @@
           </att>
          </sequence>
         </elem>
-        <forEach line='1113'>
+        <forEach line='1120'>
          <union op='|'>
           <filter flags='b'>
            <slash simple='2'>
@@ -6581,19 +6410,19 @@
            </vc>
           </filter>
          </union>
-         <elem line='1114' name='meta' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-          <copyOf line='1115' flags='vc'>
+         <elem line='1121' name='meta' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+          <copyOf line='1122' flags='vc'>
            <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
           </copyOf>
          </elem>
         </forEach>
-        <copyOf line='1120' flags='vc'>
+        <copyOf line='1127' flags='vc'>
          <axis name='child' nodeTest='element(Q{}script)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;script&#39;;'/>
         </copyOf>
        </sequence>
       </elem>
-      <elem line='1122' name='body' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-       <applyT line='1123' bSlot='14'>
+      <elem line='1129' name='body' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+       <applyT line='1130' bSlot='14'>
         <slash role='select' simple='2'>
          <axis name='child' nodeTest='element(Q{}body)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;body&#39;;'/>
          <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
@@ -6603,9 +6432,9 @@
      </sequence>
     </elem>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='9' rank='1' minImp='0' slots='15' flags='s' line='1138' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='9' rank='1' minImp='0' slots='15' flags='s' line='1145' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}output)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;output&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1139'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1146'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -6618,7 +6447,7 @@
        </check>
       </treat>
      </param>
-     <param line='1140' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1147' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -6630,7 +6459,7 @@
        </check>
       </treat>
      </param>
-     <let line='1144' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='1151' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -6646,7 +6475,7 @@
          <dot type='element(Q{http://www.w3.org/2002/xforms}output)'/>
         </fn>
         <str val='-'/>
-        <choose line='1142'>
+        <choose line='1149'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -6656,13 +6485,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1146'>
+      <sequence line='1153'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}output)' slot='3' eval='16'>
           <dot type='element(Q{http://www.w3.org/2002/xforms}output)'/>
-          <fn line='3025' name='exists'>
-           <sequence line='3000'>
+          <fn line='2998' name='exists'>
+           <sequence line='2973'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -6674,7 +6503,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='3003'>
+             <choose role='matching' line='2976'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -6686,7 +6515,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='3012'>
+            <analyzeString line='2985'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -6697,7 +6526,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='3015'>
+             <choose role='matching' line='2988'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -6720,8 +6549,8 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='3025' name='exists'>
-             <sequence line='3000'>
+            <fn line='2998' name='exists'>
+             <sequence line='2973'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
@@ -6733,7 +6562,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='3003'>
+               <choose role='matching' line='2976'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -6745,7 +6574,7 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
-              <analyzeString line='3012'>
+              <analyzeString line='2985'>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
@@ -6756,7 +6585,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='3015'>
+               <choose role='matching' line='2988'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -6774,7 +6603,7 @@
           </filter>
          </fn>
         </and>
-        <ifCall line='1147' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1154' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -6785,44 +6614,44 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1152' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='1153' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='1159' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1160' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
           <callT name='Q{}getBinding' bSlot='15'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='1154' type='element(Q{http://www.w3.org/2002/xforms}output)'/>
+            <dot line='1161' type='element(Q{http://www.w3.org/2002/xforms}output)'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='1159' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='1160' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='1166' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1167' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
              <callT name='Q{}getDataRef' bSlot='16'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='1161' type='element(Q{http://www.w3.org/2002/xforms}output)'/>
+               <dot line='1168' type='element(Q{http://www.w3.org/2002/xforms}output)'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='1162' name='Q{}bindingi' slot='5'/>
+               <varRef line='1169' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='1167' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
-          <treat line='1168' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+         <let line='1174' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
+          <treat line='1175' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
            <check card='?' diag='3|0|XTTE0570|instanceField'>
             <callT name='Q{}getReferencedInstanceField' bSlot='17'>
              <withParam name='Q{}refi' flags='c' as='xs:string'>
-              <varRef line='1169' name='Q{}refi' slot='6'/>
+              <varRef line='1176' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </check>
           </treat>
-          <let line='1180' var='Q{}namespace-context-item' as='element()' slot='8' eval='16'>
+          <let line='1187' var='Q{}namespace-context-item' as='element()' slot='8' eval='16'>
            <choose>
             <fn name='exists'>
              <varRef name='Q{}instanceField' slot='7'/>
@@ -6857,16 +6686,16 @@
                <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
               </slash>
              </check>
-             <compElem line='3035'>
+             <compElem line='3008'>
               <fn role='name' name='name'>
                <varRef name='Q{}this' slot='9'/>
               </fn>
-              <sequence role='content' line='3036'>
+              <sequence role='content' line='3009'>
                <namespace flags='l'>
                 <str role='name' val='xforms'/>
                 <str role='select' val='http://www.w3.org/2002/xforms'/>
                </namespace>
-               <forEach line='3037'>
+               <forEach line='3010'>
                 <filter flags='b'>
                  <filter flags='b'>
                   <slash simple='1'>
@@ -6905,21 +6734,21 @@
                   </gc>
                  </fn>
                 </filter>
-                <namespace line='3040' flags='l'>
-                 <fn role='name' line='3039' name='substring-before'>
+                <namespace line='3013' flags='l'>
+                 <fn role='name' line='3012' name='substring-before'>
                   <fn name='name'>
                    <dot type='element()'/>
                   </fn>
                   <str val=':'/>
                  </fn>
                  <convert role='select' from='xs:anyURI' to='xs:string'>
-                  <fn line='3038' name='namespace-uri'>
+                  <fn line='3011' name='namespace-uri'>
                    <dot type='element()'/>
                   </fn>
                  </convert>
                 </namespace>
                </forEach>
-               <copyOf line='3042' flags='vc'>
+               <copyOf line='3015' flags='vc'>
                 <sequence>
                  <slash simple='1'>
                   <varRef name='Q{}this' slot='9'/>
@@ -6935,12 +6764,12 @@
              </compElem>
             </let>
            </choose>
-           <let line='1182' var='Q{}valueExecuted' as='xs:string' slot='10' eval='16'>
-            <choose line='1184'>
+           <let line='1189' var='Q{}valueExecuted' as='xs:string' slot='10' eval='16'>
+            <choose line='1191'>
              <fn name='exists'>
               <axis name='attribute' nodeTest='attribute(Q{}value)' jsTest='return item.name===&#39;value&#39;'/>
              </fn>
-             <evaluate line='1185' as='xs:string' dxns=''>
+             <evaluate line='1192' as='xs:string' dxns=''>
               <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='18' eval='16'>
                <check card='1' diag='0|0||xforms:impose'>
                 <cvUntyped to='xs:string'>
@@ -6955,7 +6784,7 @@
               <map role='wp' size='0'/>
              </evaluate>
              <true/>
-             <cvUntyped line='1188' to='xs:string' diag='3|0|XTTE0570|valueExecuted'>
+             <cvUntyped line='1195' to='xs:string' diag='3|0|XTTE0570|valueExecuted'>
               <cast as='xs:untypedAtomic' emptiable='0'>
                <fn name='string'>
                 <convert from='xs:anyAtomicType' to='xs:string'>
@@ -6967,8 +6796,8 @@
               </cast>
              </cvUntyped>
             </choose>
-            <let line='1194' var='Q{}relevantVar' as='xs:boolean' slot='11' eval='16'>
-             <choose line='1196'>
+            <let line='1201' var='Q{}relevantVar' as='xs:boolean' slot='11' eval='16'>
+             <choose line='1203'>
               <and op='and'>
                <and op='and'>
                 <fn name='exists'>
@@ -6985,7 +6814,7 @@
                 <varRef name='Q{}instanceField' slot='7'/>
                </fn>
               </and>
-              <treat line='1197' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantVar'>
+              <treat line='1204' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantVar'>
                <check card='1' diag='3|0|XTTE0570|relevantVar'>
                 <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|relevantVar'>
                  <data>
@@ -7015,20 +6844,20 @@
               <true/>
               <true/>
              </choose>
-             <sequence line='1208'>
+             <sequence line='1215'>
               <elem name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-               <sequence line='1209'>
+               <sequence line='1216'>
                 <let var='Q{}element' as='element(Q{http://www.w3.org/2002/xforms}output)' slot='12' eval='16'>
                  <dot type='element(Q{http://www.w3.org/2002/xforms}output)'/>
-                 <let line='3091' var='Q{}class' as='xs:string?' slot='13' eval='7'>
-                  <choose line='3092'>
+                 <let line='3064' var='Q{}class' as='xs:string?' slot='13' eval='7'>
+                  <choose line='3065'>
                    <fn name='exists'>
                     <slash simple='1'>
                      <varRef name='Q{}element' slot='12'/>
                      <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
                     </slash>
                    </fn>
-                   <cvUntyped line='3093' to='xs:string' diag='3|0|XTTE0570|class'>
+                   <cvUntyped line='3066' to='xs:string' diag='3|0|XTTE0570|class'>
                     <cast as='xs:untypedAtomic' emptiable='0'>
                      <fn name='string'>
                       <convert from='xs:untypedAtomic' to='xs:string'>
@@ -7043,15 +6872,15 @@
                     </cast>
                    </cvUntyped>
                   </choose>
-                  <let line='3096' var='Q{}class-mod' as='xs:string?' slot='14' eval='7'>
-                   <choose line='3098'>
+                  <let line='3069' var='Q{}class-mod' as='xs:string?' slot='14' eval='7'>
+                   <choose line='3071'>
                     <fn name='exists'>
                      <slash simple='1'>
                       <varRef name='Q{}element' slot='12'/>
                       <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
                      </slash>
                     </fn>
-                    <cvUntyped line='3099' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                    <cvUntyped line='3072' to='xs:string' diag='3|0|XTTE0570|class-mod'>
                      <cast as='xs:untypedAtomic' emptiable='0'>
                       <fn name='string-join'>
                        <sequence>
@@ -7063,13 +6892,13 @@
                      </cast>
                     </cvUntyped>
                     <true/>
-                    <varRef line='3102' name='Q{}class' slot='13'/>
+                    <varRef line='3075' name='Q{}class' slot='13'/>
                    </choose>
-                   <choose line='3106'>
+                   <choose line='3079'>
                     <fn name='exists'>
                      <varRef name='Q{}class-mod' slot='14'/>
                     </fn>
-                    <treat line='3107' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                    <treat line='3080' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
                      <att name='class' flags='l'>
                       <varRef name='Q{}class-mod' slot='14'/>
                      </att>
@@ -7078,15 +6907,15 @@
                   </let>
                  </let>
                 </let>
-                <applyT line='1211' bSlot='20'>
+                <applyT line='1218' bSlot='20'>
                  <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
                 </applyT>
-                <elem line='1213' name='span' nsuri='' flags='l'>
-                 <sequence line='1214'>
+                <elem line='1220' name='span' nsuri='' flags='l'>
+                 <sequence line='1221'>
                   <att name='id' flags='l'>
                    <varRef name='Q{}myid' slot='2'/>
                   </att>
-                  <att line='1215' name='style' flags='l'>
+                  <att line='1222' name='style' flags='l'>
                    <choose>
                     <varRef name='Q{}relevantVar' slot='11'/>
                     <str val='display:inline'/>
@@ -7094,68 +6923,58 @@
                     <str val='display:none'/>
                    </choose>
                   </att>
-                  <att line='1216' name='data-ref' flags='l'>
+                  <att line='1223' name='data-ref' flags='l'>
                    <varRef name='Q{}refi' slot='6'/>
                   </att>
-                  <varRef line='1218' name='Q{}valueExecuted' slot='10'/>
+                  <varRef line='1225' name='Q{}valueExecuted' slot='10'/>
                  </sequence>
                 </elem>
                </sequence>
               </elem>
-              <choose line='1223'>
+              <choose line='1230'>
                <fn name='empty'>
                 <slash simple='1'>
                  <dot type='element(Q{http://www.w3.org/2002/xforms}output)'/>
                  <axis name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
                 </slash>
                </fn>
-               <sequence line='1240'>
-                <message>
-                 <fn role='select' name='concat'>
-                  <str val='[xforms:output] Registering output with ID '/>
-                  <varRef name='Q{}myid' slot='2'/>
-                 </fn>
-                 <str role='terminate' val='no'/>
-                 <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-                </message>
-                <ifCall line='1242' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                 <check card='1' diag='0|0||ixsl:call'>
-                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-                 </check>
-                 <str val='addOutput'/>
-                 <arrayBlock>
-                  <varRef name='Q{}myid' slot='2'/>
-                  <ifCall line='1226' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
-                   <sequence>
-                    <choose>
+               <ifCall line='1249' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                <check card='1' diag='0|0||ixsl:call'>
+                 <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                </check>
+                <str val='addOutput'/>
+                <arrayBlock>
+                 <varRef name='Q{}myid' slot='2'/>
+                 <ifCall line='1233' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+                  <sequence>
+                   <choose>
+                    <varRef name='Q{}refi' slot='6'/>
+                    <ifCall line='1234' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                     <str val='@ref'/>
                      <varRef name='Q{}refi' slot='6'/>
-                     <ifCall line='1227' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
-                      <str val='@ref'/>
-                      <varRef name='Q{}refi' slot='6'/>
-                     </ifCall>
-                    </choose>
-                    <choose line='1230'>
-                     <fn name='exists'>
-                      <axis name='attribute' nodeTest='attribute(Q{}value)' jsTest='return item.name===&#39;value&#39;'/>
-                     </fn>
-                     <ifCall line='1231' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
-                      <str val='@value'/>
-                      <cast as='xs:string' emptiable='1'>
-                       <attVal name='Q{}value' chk='0'/>
-                      </cast>
-                     </ifCall>
-                    </choose>
-                   </sequence>
-                   <map size='2'>
-                    <str val='duplicates'/>
-                    <str val='reject'/>
-                    <str val='duplicates-error-code'/>
-                    <str val='XTDE3365'/>
-                   </map>
-                  </ifCall>
-                 </arrayBlock>
-                </ifCall>
-               </sequence>
+                    </ifCall>
+                   </choose>
+                   <choose line='1237'>
+                    <fn name='exists'>
+                     <axis name='attribute' nodeTest='attribute(Q{}value)' jsTest='return item.name===&#39;value&#39;'/>
+                    </fn>
+                    <ifCall line='1238' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                     <str val='@value'/>
+                     <cast as='xs:string' emptiable='1'>
+                      <attVal name='Q{}value' chk='0'/>
+                     </cast>
+                    </ifCall>
+                   </choose>
+                  </sequence>
+                  <map size='2'>
+                   <str val='duplicates'/>
+                   <str val='reject'/>
+                   <str val='duplicates-error-code'/>
+                   <str val='XTDE3365'/>
+                  </map>
+                 </ifCall>
+                </arrayBlock>
+               </ifCall>
               </choose>
              </sequence>
             </let>
@@ -7168,34 +6987,34 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='5' rank='1' minImp='0' slots='0' flags='s' line='1070' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='5' rank='1' minImp='0' slots='0' flags='s' line='1077' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
-    <applyT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1071' flags='t' bSlot='21'>
+    <applyT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1078' flags='t' bSlot='21'>
      <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
     </applyT>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='25' part='3' rank='1' minImp='0' slots='1' flags='s' line='2117' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='25' part='3' rank='1' minImp='0' slots='1' flags='s' line='2124' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}hide)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;hide&#39;;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2123' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2124' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2132' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2133' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
       <check card='1' diag='3|0|XTTE0570|action-map'>
        <callT name='Q{}setAction' bSlot='2'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2125' type='element()'/>
+         <dot line='2134' type='element()'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <varRef line='2138' name='Q{}action-map' slot='0'/>
+     <varRef line='2147' name='Q{}action-map' slot='0'/>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='12' rank='1' minImp='0' slots='0' flags='s' line='1527' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='12' rank='1' minImp='0' slots='0' flags='s' line='1534' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}hint)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;hint&#39;;'/>
     <empty role='action'/>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='20' rank='1' minImp='0' slots='2' flags='s' line='1875' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='20' rank='1' minImp='0' slots='2' flags='s' line='1882' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}submit)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;submit&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1876'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1883'>
      <param name='Q{}submissions' slot='0' flags='t' as='map(xs:string, map(*))'>
       <map role='select' size='0'/>
       <treat role='conversion' as='map(xs:string, map(*))' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isMap(item)};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|submissions'>
@@ -7204,46 +7023,31 @@
        </check>
       </treat>
      </param>
-     <message line='1878'>
-      <sequence role='select'>
-       <valueOf>
-        <str val='[xforms:submit] Generating form control for submission ID &#39;'/>
-       </valueOf>
-       <fn name='string'>
-        <axis name='attribute' nodeTest='attribute(Q{}submission)' jsTest='return item.name===&#39;submission&#39;'/>
-       </fn>
-       <valueOf flags='S'>
-        <str val='&#39;'/>
-       </valueOf>
-      </sequence>
-      <str role='terminate' val='no'/>
-      <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-     </message>
-     <let line='1882' var='Q{}innerbody' as='document-node()' slot='1' eval='16'>
-      <doc line='1883' validation='preserve'>
+     <let line='1889' var='Q{}innerbody' as='document-node()' slot='1' eval='16'>
+      <doc line='1890' validation='preserve'>
        <applyT bSlot='22'>
         <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
        </applyT>
       </doc>
-      <choose line='1887'>
+      <choose line='1894'>
        <vc op='eq' onEmpty='0' comp='CCC'>
         <cast as='xs:string' emptiable='1'>
          <attVal name='Q{}appearance' chk='0'/>
         </cast>
         <str val='minimal'/>
        </vc>
-       <elem line='1888' name='a' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-        <copyOf line='1889' flags='vc'>
+       <elem line='1895' name='a' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+        <copyOf line='1896' flags='vc'>
          <varRef name='Q{}innerbody' slot='1'/>
         </copyOf>
        </elem>
        <true/>
-       <elem line='1893' name='button' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+       <elem line='1900' name='button' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
         <sequence>
          <att name='type' flags='l'>
           <str val='button'/>
          </att>
-         <copyOf line='1894' flags='vc'>
+         <copyOf line='1901' flags='vc'>
           <filter flags='b'>
            <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
            <vc op='ne' onEmpty='0' comp='CCC'>
@@ -7254,7 +7058,7 @@
            </vc>
           </filter>
          </copyOf>
-         <choose line='1895'>
+         <choose line='1902'>
           <and op='and'>
            <fn name='exists'>
             <axis name='attribute' nodeTest='attribute(Q{}submission)' jsTest='return item.name===&#39;submission&#39;'/>
@@ -7266,22 +7070,13 @@
             </atomSing>
            </ifCall>
           </and>
-          <sequence line='1896'>
-           <message>
-            <valueOf role='select'>
-             <str val='[xforms:submit] Submission found'/>
-            </valueOf>
-            <str role='terminate' val='no'/>
-            <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-           </message>
-           <att line='1897' name='data-submit' flags='l'>
-            <convert from='xs:untypedAtomic' to='xs:string'>
-             <attVal name='Q{}submission' chk='0'/>
-            </convert>
-           </att>
-          </sequence>
+          <att line='1904' name='data-submit' flags='l'>
+           <convert from='xs:untypedAtomic' to='xs:string'>
+            <attVal name='Q{}submission' chk='0'/>
+           </convert>
+          </att>
          </choose>
-         <copyOf line='1899' flags='vc'>
+         <copyOf line='1906' flags='vc'>
           <varRef name='Q{}innerbody' slot='1'/>
          </copyOf>
         </sequence>
@@ -7290,15 +7085,15 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='8' part='1' rank='1' minImp='0' slots='0' flags='s' line='1106' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='8' part='1' rank='1' minImp='0' slots='0' flags='s' line='1113' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{}html)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;html&#39;;'/>
-    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1107' name='html' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-     <sequence line='1108'>
+    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1114' name='html' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+     <sequence line='1115'>
       <copyOf flags='vc'>
        <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
       </copyOf>
-      <elem line='1109' name='head' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-       <sequence line='1110'>
+      <elem line='1116' name='head' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+       <sequence line='1117'>
         <copyOf flags='vc'>
          <union op='|'>
           <slash simple='2'>
@@ -7311,7 +7106,7 @@
           </slash>
          </union>
         </copyOf>
-        <elem line='1111' name='meta' nsuri='' flags='l'>
+        <elem line='1118' name='meta' nsuri='' flags='l'>
          <sequence>
           <att name='http-equiv' flags='l'>
            <str val='Content-Type'/>
@@ -7321,7 +7116,7 @@
           </att>
          </sequence>
         </elem>
-        <forEach line='1113'>
+        <forEach line='1120'>
          <union op='|'>
           <filter flags='b'>
            <slash simple='2'>
@@ -7348,19 +7143,19 @@
            </vc>
           </filter>
          </union>
-         <elem line='1114' name='meta' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-          <copyOf line='1115' flags='vc'>
+         <elem line='1121' name='meta' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+          <copyOf line='1122' flags='vc'>
            <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
           </copyOf>
          </elem>
         </forEach>
-        <copyOf line='1120' flags='vc'>
+        <copyOf line='1127' flags='vc'>
          <axis name='child' nodeTest='element(Q{}script)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;script&#39;;'/>
         </copyOf>
        </sequence>
       </elem>
-      <elem line='1122' name='body' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-       <applyT line='1123' bSlot='14'>
+      <elem line='1129' name='body' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+       <applyT line='1130' bSlot='14'>
         <slash role='select' simple='2'>
          <axis name='child' nodeTest='element(Q{}body)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;body&#39;;'/>
          <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
@@ -7370,9 +7165,9 @@
      </sequence>
     </elem>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='13' rank='1' minImp='0' slots='12' flags='s' line='1538' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='13' rank='1' minImp='0' slots='12' flags='s' line='1545' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}select1)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;select1&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1539'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1546'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -7385,7 +7180,7 @@
        </check>
       </treat>
      </param>
-     <param line='1540' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1547' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -7397,7 +7192,7 @@
        </check>
       </treat>
      </param>
-     <let line='1544' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='1551' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -7413,7 +7208,7 @@
          <dot type='element()'/>
         </fn>
         <str val='-'/>
-        <choose line='1542'>
+        <choose line='1549'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -7423,13 +7218,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1546'>
+      <sequence line='1553'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element()' slot='3' eval='16'>
           <dot type='element()'/>
-          <fn line='3025' name='exists'>
-           <sequence line='3000'>
+          <fn line='2998' name='exists'>
+           <sequence line='2973'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -7441,7 +7236,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='3003'>
+             <choose role='matching' line='2976'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -7453,7 +7248,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='3012'>
+            <analyzeString line='2985'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -7464,7 +7259,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='3015'>
+             <choose role='matching' line='2988'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -7487,8 +7282,8 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='3025' name='exists'>
-             <sequence line='3000'>
+            <fn line='2998' name='exists'>
+             <sequence line='2973'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
@@ -7500,7 +7295,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='3003'>
+               <choose role='matching' line='2976'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -7512,7 +7307,7 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
-              <analyzeString line='3012'>
+              <analyzeString line='2985'>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
@@ -7523,7 +7318,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='3015'>
+               <choose role='matching' line='2988'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -7541,7 +7336,7 @@
           </filter>
          </fn>
         </and>
-        <ifCall line='1547' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1554' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -7552,60 +7347,60 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1554' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='1555' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='1561' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1562' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
           <callT name='Q{}getBinding' bSlot='3'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='1556' type='element()'/>
+            <dot line='1563' type='element()'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='1561' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='1562' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='1568' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1569' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
              <callT name='Q{}getDataRef' bSlot='4'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='1563' type='element()'/>
+               <dot line='1570' type='element()'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='1564' name='Q{}bindingi' slot='5'/>
+               <varRef line='1571' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='1569' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
-          <treat line='1570' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+         <let line='1576' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
+          <treat line='1577' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
            <check card='?' diag='3|0|XTTE0570|instanceField'>
             <callT name='Q{}getReferencedInstanceField' bSlot='5'>
              <withParam name='Q{}refi' flags='c' as='xs:string'>
-              <varRef line='1571' name='Q{}refi' slot='6'/>
+              <varRef line='1578' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </check>
           </treat>
-          <let line='1576' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
-           <treat line='1577' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+          <let line='1583' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
+           <treat line='1584' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
             <callT name='Q{}setActions' bSlot='6'>
              <withParam name='Q{}this' flags='c' as='element()'>
-              <dot line='1578' type='element()'/>
+              <dot line='1585' type='element()'/>
              </withParam>
              <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-              <varRef line='1579' name='Q{}refi' slot='6'/>
+              <varRef line='1586' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </treat>
-           <sequence line='1583'>
+           <sequence line='1590'>
             <choose>
              <fn name='exists'>
               <varRef name='Q{}actions' slot='8'/>
              </fn>
-             <ifCall line='1584' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+             <ifCall line='1591' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
               <check card='1' diag='0|0||ixsl:call'>
                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
               </check>
@@ -7616,27 +7411,27 @@
               </arrayBlock>
              </ifCall>
             </choose>
-            <elem line='1601' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+            <elem line='1608' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
              <sequence>
               <att name='class' flags='l'>
                <str val='xforms-select'/>
               </att>
-              <applyT line='1602' bSlot='7'>
+              <applyT line='1609' bSlot='7'>
                <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
               </applyT>
-              <elem line='1604' name='select' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-               <sequence line='1605'>
+              <elem line='1611' name='select' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+               <sequence line='1612'>
                 <let var='Q{}element' as='element()' slot='9' eval='16'>
                  <dot type='element()'/>
-                 <let line='3091' var='Q{}class' as='xs:string?' slot='10' eval='7'>
-                  <choose line='3092'>
+                 <let line='3064' var='Q{}class' as='xs:string?' slot='10' eval='7'>
+                  <choose line='3065'>
                    <fn name='exists'>
                     <slash simple='1'>
                      <varRef name='Q{}element' slot='9'/>
                      <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
                     </slash>
                    </fn>
-                   <cvUntyped line='3093' to='xs:string' diag='3|0|XTTE0570|class'>
+                   <cvUntyped line='3066' to='xs:string' diag='3|0|XTTE0570|class'>
                     <cast as='xs:untypedAtomic' emptiable='0'>
                      <fn name='string'>
                       <convert from='xs:untypedAtomic' to='xs:string'>
@@ -7651,15 +7446,15 @@
                     </cast>
                    </cvUntyped>
                   </choose>
-                  <let line='3096' var='Q{}class-mod' as='xs:string?' slot='11' eval='7'>
-                   <choose line='3098'>
+                  <let line='3069' var='Q{}class-mod' as='xs:string?' slot='11' eval='7'>
+                   <choose line='3071'>
                     <fn name='exists'>
                      <slash simple='1'>
                       <varRef name='Q{}element' slot='9'/>
                       <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
                      </slash>
                     </fn>
-                    <cvUntyped line='3099' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                    <cvUntyped line='3072' to='xs:string' diag='3|0|XTTE0570|class-mod'>
                      <cast as='xs:untypedAtomic' emptiable='0'>
                       <fn name='string-join'>
                        <sequence>
@@ -7671,13 +7466,13 @@
                      </cast>
                     </cvUntyped>
                     <true/>
-                    <varRef line='3102' name='Q{}class' slot='10'/>
+                    <varRef line='3075' name='Q{}class' slot='10'/>
                    </choose>
-                   <choose line='3106'>
+                   <choose line='3079'>
                     <fn name='exists'>
                      <varRef name='Q{}class-mod' slot='11'/>
                     </fn>
-                    <treat line='3107' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                    <treat line='3080' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
                      <att name='class' flags='l'>
                       <varRef name='Q{}class-mod' slot='11'/>
                      </att>
@@ -7686,7 +7481,7 @@
                   </let>
                  </let>
                 </let>
-                <copyOf line='1606' flags='vc'>
+                <copyOf line='1613' flags='vc'>
                  <except op='except'>
                   <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
                   <docOrder intra='1'>
@@ -7698,11 +7493,11 @@
                   </docOrder>
                  </except>
                 </copyOf>
-                <att line='1608' name='data-ref' flags='l'>
+                <att line='1615' name='data-ref' flags='l'>
                  <varRef name='Q{}refi' slot='6'/>
                 </att>
-                <att line='1609' name='data-element' flags='l'>
-                 <lastOf line='1599'>
+                <att line='1616' name='data-element' flags='l'>
+                 <lastOf line='1606'>
                   <fn name='tokenize'>
                    <varRef name='Q{}refi' slot='6'/>
                    <str val='/'/>
@@ -7710,7 +7505,7 @@
                   </fn>
                  </lastOf>
                 </att>
-                <choose line='1611'>
+                <choose line='1618'>
                  <and op='and'>
                   <fn name='exists'>
                    <varRef name='Q{}bindingi' slot='5'/>
@@ -7722,7 +7517,7 @@
                    </slash>
                   </fn>
                  </and>
-                 <att line='1612' name='data-constraint' flags='l'>
+                 <att line='1619' name='data-constraint' flags='l'>
                   <convert from='xs:untypedAtomic' to='xs:string'>
                    <data>
                     <slash simple='1'>
@@ -7733,19 +7528,19 @@
                   </convert>
                  </att>
                 </choose>
-                <choose line='1615'>
+                <choose line='1622'>
                  <vc op='eq' onEmpty='0' comp='CCC'>
                   <fn name='local-name'>
                    <dot type='element()'/>
                   </fn>
                   <str val='select'/>
                  </vc>
-                 <sequence line='1616'>
+                 <sequence line='1623'>
                   <att name='multiple' flags='l'>
                    <str val='true'/>
                   </att>
-                  <att line='1617' name='size' flags='l'>
-                   <convert line='1618' from='xs:integer' to='xs:string'>
+                  <att line='1624' name='size' flags='l'>
+                   <convert line='1625' from='xs:integer' to='xs:string'>
                     <fn name='count'>
                      <axis name='descendant' nodeTest='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
                     </fn>
@@ -7753,22 +7548,22 @@
                   </att>
                  </sequence>
                 </choose>
-                <choose line='1621'>
+                <choose line='1628'>
                  <fn name='exists'>
                   <varRef name='Q{}actions' slot='8'/>
                  </fn>
-                 <att line='1622' name='data-action' flags='l'>
+                 <att line='1629' name='data-action' flags='l'>
                   <varRef name='Q{}myid' slot='2'/>
                  </att>
                 </choose>
-                <applyT line='1625' bSlot='8'>
+                <applyT line='1632' bSlot='8'>
                  <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
                  <withParam name='Q{}selectedValue' as='xs:string'>
-                  <choose line='1590'>
+                  <choose line='1597'>
                    <fn name='exists'>
                     <varRef name='Q{}instanceField' slot='7'/>
                    </fn>
-                   <cvUntyped line='1591' to='xs:string' diag='3|0|XTTE0570|selectedValue'>
+                   <cvUntyped line='1598' to='xs:string' diag='3|0|XTTE0570|selectedValue'>
                     <cast as='xs:untypedAtomic' emptiable='0'>
                      <fn name='string'>
                       <convert from='xs:anyAtomicType' to='xs:string'>
@@ -7797,14 +7592,14 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='16' rank='1' minImp='0' slots='0' flags='s' line='1663' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='16' rank='1' minImp='0' slots='0' flags='s' line='1670' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
-    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1664' name='label' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-     <choose line='1666'>
+    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1671' name='label' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+     <choose line='1673'>
       <fn name='exists'>
        <axis name='child' nodeTest='( element() | text() | comment() | processing-instruction() )' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);'/>
       </fn>
-      <applyT line='1667' bSlot='23'>
+      <applyT line='1674' bSlot='23'>
        <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
       </applyT>
       <true/>
@@ -7814,39 +7609,39 @@
      </choose>
     </elem>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='25' part='5' rank='1' minImp='0' slots='1' flags='s' line='2117' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='25' part='5' rank='1' minImp='0' slots='1' flags='s' line='2124' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}unload)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;unload&#39;;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2123' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2124' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2132' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2133' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
       <check card='1' diag='3|0|XTTE0570|action-map'>
        <callT name='Q{}setAction' bSlot='2'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2125' type='element()'/>
+         <dot line='2134' type='element()'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <varRef line='2138' name='Q{}action-map' slot='0'/>
+     <varRef line='2147' name='Q{}action-map' slot='0'/>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='25' part='2' rank='1' minImp='0' slots='1' flags='s' line='2117' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='25' part='2' rank='1' minImp='0' slots='1' flags='s' line='2124' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}show)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;show&#39;;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2123' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2124' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2132' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2133' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
       <check card='1' diag='3|0|XTTE0570|action-map'>
        <callT name='Q{}setAction' bSlot='2'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2125' type='element()'/>
+         <dot line='2134' type='element()'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <varRef line='2138' name='Q{}action-map' slot='0'/>
+     <varRef line='2147' name='Q{}action-map' slot='0'/>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='10' rank='1' minImp='0' slots='17' flags='s' line='1256' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='10' rank='1' minImp='0' slots='17' flags='s' line='1263' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1257'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1264'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -7859,7 +7654,7 @@
        </check>
       </treat>
      </param>
-     <param line='1258' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1265' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -7871,7 +7666,7 @@
        </check>
       </treat>
      </param>
-     <let line='1260' var='Q{}string-position' as='xs:string' slot='2' eval='16'>
+     <let line='1267' var='Q{}string-position' as='xs:string' slot='2' eval='16'>
       <choose>
        <varRef name='Q{}context-position' slot='1'/>
        <varRef name='Q{}context-position' slot='1'/>
@@ -7880,7 +7675,7 @@
         <varRef name='Q{}position' slot='0'/>
        </fn>
       </choose>
-      <let line='1262' var='Q{}myid' as='xs:string' slot='3' eval='16'>
+      <let line='1269' var='Q{}myid' as='xs:string' slot='3' eval='16'>
        <choose>
         <fn name='exists'>
          <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -7899,13 +7694,13 @@
          <varRef name='Q{}string-position' slot='2'/>
         </fn>
        </choose>
-       <sequence line='1264'>
+       <sequence line='1271'>
         <choose>
          <and op='and'>
           <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}input)' slot='4' eval='16'>
            <dot type='element(Q{http://www.w3.org/2002/xforms}input)'/>
-           <fn line='3025' name='exists'>
-            <sequence line='3000'>
+           <fn line='2998' name='exists'>
+            <sequence line='2973'>
              <analyzeString>
               <cvUntyped role='select' to='xs:string'>
                <data>
@@ -7917,7 +7712,7 @@
               </cvUntyped>
               <str role='regex' val='\i\c*\('/>
               <str role='flags' val=''/>
-              <choose role='matching' line='3003'>
+              <choose role='matching' line='2976'>
                <vc op='eq' onEmpty='0' comp='CCC'>
                 <fn name='substring-before'>
                  <dot type='xs:string'/>
@@ -7929,7 +7724,7 @@
               </choose>
               <empty role='nonMatching'/>
              </analyzeString>
-             <analyzeString line='3012'>
+             <analyzeString line='2985'>
               <cvUntyped role='select' to='xs:string'>
                <data>
                 <slash simple='1'>
@@ -7940,7 +7735,7 @@
               </cvUntyped>
               <str role='regex' val='\i\c*\('/>
               <str role='flags' val=''/>
-              <choose role='matching' line='3015'>
+              <choose role='matching' line='2988'>
                <vc op='eq' onEmpty='0' comp='CCC'>
                 <fn name='substring-before'>
                  <dot type='xs:string'/>
@@ -7963,8 +7758,8 @@
             </slash>
             <let var='Q{}this' as='element()' slot='5' eval='16'>
              <dot type='element()'/>
-             <fn line='3025' name='exists'>
-              <sequence line='3000'>
+             <fn line='2998' name='exists'>
+              <sequence line='2973'>
                <analyzeString>
                 <cvUntyped role='select' to='xs:string'>
                  <data>
@@ -7976,7 +7771,7 @@
                 </cvUntyped>
                 <str role='regex' val='\i\c*\('/>
                 <str role='flags' val=''/>
-                <choose role='matching' line='3003'>
+                <choose role='matching' line='2976'>
                  <vc op='eq' onEmpty='0' comp='CCC'>
                   <fn name='substring-before'>
                    <dot type='xs:string'/>
@@ -7988,7 +7783,7 @@
                 </choose>
                 <empty role='nonMatching'/>
                </analyzeString>
-               <analyzeString line='3012'>
+               <analyzeString line='2985'>
                 <cvUntyped role='select' to='xs:string'>
                  <data>
                   <slash simple='1'>
@@ -7999,7 +7794,7 @@
                 </cvUntyped>
                 <str role='regex' val='\i\c*\('/>
                 <str role='flags' val=''/>
-                <choose role='matching' line='3015'>
+                <choose role='matching' line='2988'>
                  <vc op='eq' onEmpty='0' comp='CCC'>
                   <fn name='substring-before'>
                    <dot type='xs:string'/>
@@ -8017,7 +7812,7 @@
            </filter>
           </fn>
          </and>
-         <ifCall line='1265' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+         <ifCall line='1272' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
           <check card='1' diag='0|0||ixsl:call'>
            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
           </check>
@@ -8028,45 +7823,45 @@
           </arrayBlock>
          </ifCall>
         </choose>
-        <let line='1273' var='Q{}bindingi' as='node()?' slot='6' eval='7'>
-         <treat line='1274' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+        <let line='1280' var='Q{}bindingi' as='node()?' slot='6' eval='7'>
+         <treat line='1281' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
           <check card='?' diag='3|0|XTTE0570|bindingi'>
            <callT name='Q{}getBinding' bSlot='24'>
             <withParam name='Q{}this' flags='c' as='element()'>
-             <dot line='1275' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
+             <dot line='1282' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
             </withParam>
            </callT>
           </check>
          </treat>
-         <let line='1283' var='Q{}refi' as='xs:string' slot='7' eval='16'>
-          <treat line='1284' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+         <let line='1290' var='Q{}refi' as='xs:string' slot='7' eval='16'>
+          <treat line='1291' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
            <check card='1' diag='3|0|XTTE0570|refi'>
             <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
              <data>
               <callT name='Q{}getDataRef' bSlot='25'>
                <withParam name='Q{}this' flags='c' as='element()'>
-                <dot line='1285' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
+                <dot line='1292' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
                </withParam>
                <withParam name='Q{}bindingi' flags='c' as='node()?'>
-                <varRef line='1286' name='Q{}bindingi' slot='6'/>
+                <varRef line='1293' name='Q{}bindingi' slot='6'/>
                </withParam>
               </callT>
              </data>
             </cvUntyped>
            </check>
           </treat>
-          <let line='1293' var='Q{}instanceField' as='node()?' slot='8' eval='7'>
-           <treat line='1294' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+          <let line='1300' var='Q{}instanceField' as='node()?' slot='8' eval='7'>
+           <treat line='1301' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
             <check card='?' diag='3|0|XTTE0570|instanceField'>
              <callT name='Q{}getReferencedInstanceField' bSlot='26'>
               <withParam name='Q{}refi' flags='c' as='xs:string'>
-               <varRef line='1295' name='Q{}refi' slot='7'/>
+               <varRef line='1302' name='Q{}refi' slot='7'/>
               </withParam>
              </callT>
             </check>
            </treat>
-           <let line='1309' var='Q{}relevantVar' as='xs:boolean' slot='9' eval='16'>
-            <choose line='1311'>
+           <let line='1316' var='Q{}relevantVar' as='xs:boolean' slot='9' eval='16'>
+            <choose line='1318'>
              <and op='and'>
               <and op='and'>
                <fn name='exists'>
@@ -8083,7 +7878,7 @@
                <varRef name='Q{}instanceField' slot='8'/>
               </fn>
              </and>
-             <treat line='1312' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantVar'>
+             <treat line='1319' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantVar'>
               <check card='1' diag='3|0|XTTE0570|relevantVar'>
                <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|relevantVar'>
                 <data>
@@ -8101,7 +7896,7 @@
                    </check>
                   </ufCall>
                   <varRef role='cxt' name='Q{}instanceField' slot='8'/>
-                  <choose role='nsCxt' line='1304'>
+                  <choose role='nsCxt' line='1311'>
                    <fn name='exists'>
                     <varRef name='Q{}instanceField' slot='8'/>
                    </fn>
@@ -8118,16 +7913,16 @@
                       <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
                      </slash>
                     </check>
-                    <compElem line='3035'>
+                    <compElem line='3008'>
                      <fn role='name' name='name'>
                       <varRef name='Q{}this' slot='10'/>
                      </fn>
-                     <sequence role='content' line='3036'>
+                     <sequence role='content' line='3009'>
                       <namespace flags='l'>
                        <str role='name' val='xforms'/>
                        <str role='select' val='http://www.w3.org/2002/xforms'/>
                       </namespace>
-                      <forEach line='3037'>
+                      <forEach line='3010'>
                        <filter flags='b'>
                         <filter flags='b'>
                          <slash simple='1'>
@@ -8166,21 +7961,21 @@
                          </gc>
                         </fn>
                        </filter>
-                       <namespace line='3040' flags='l'>
-                        <fn role='name' line='3039' name='substring-before'>
+                       <namespace line='3013' flags='l'>
+                        <fn role='name' line='3012' name='substring-before'>
                          <fn name='name'>
                           <dot type='element()'/>
                          </fn>
                          <str val=':'/>
                         </fn>
                         <convert role='select' from='xs:anyURI' to='xs:string'>
-                         <fn line='3038' name='namespace-uri'>
+                         <fn line='3011' name='namespace-uri'>
                           <dot type='element()'/>
                          </fn>
                         </convert>
                        </namespace>
                       </forEach>
-                      <copyOf line='3042' flags='vc'>
+                      <copyOf line='3015' flags='vc'>
                        <sequence>
                         <slash simple='1'>
                          <varRef name='Q{}this' slot='10'/>
@@ -8207,23 +8002,23 @@
              <true/>
              <true/>
             </choose>
-            <let line='1322' var='Q{}actions' as='map(*)*' slot='11' eval='8'>
-             <treat line='1323' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+            <let line='1329' var='Q{}actions' as='map(*)*' slot='11' eval='8'>
+             <treat line='1330' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
               <callT name='Q{}setActions' bSlot='28'>
                <withParam name='Q{}this' flags='c' as='element()'>
-                <dot line='1324' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
+                <dot line='1331' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
                </withParam>
                <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                <varRef line='1325' name='Q{}refi' slot='7'/>
+                <varRef line='1332' name='Q{}refi' slot='7'/>
                </withParam>
               </callT>
              </treat>
-             <sequence line='1330'>
+             <sequence line='1337'>
               <choose>
                <fn name='exists'>
                 <varRef name='Q{}actions' slot='11'/>
                </fn>
-               <ifCall line='1331' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+               <ifCall line='1338' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                 <check card='1' diag='0|0||ixsl:call'>
                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                 </check>
@@ -8234,12 +8029,12 @@
                 </arrayBlock>
                </ifCall>
               </choose>
-              <elem line='1336' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+              <elem line='1343' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
                <sequence>
                 <att name='class' flags='l'>
                  <str val='xforms-input'/>
                 </att>
-                <att line='1337' name='style' flags='l'>
+                <att line='1344' name='style' flags='l'>
                  <choose>
                   <varRef name='Q{}relevantVar' slot='9'/>
                   <str val='display:block'/>
@@ -8247,27 +8042,27 @@
                   <str val='display:none'/>
                  </choose>
                 </att>
-                <applyT line='1339' bSlot='29'>
+                <applyT line='1346' bSlot='29'>
                  <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
                 </applyT>
-                <let line='1341' var='Q{}hints' as='text()*' slot='12' eval='4'>
+                <let line='1348' var='Q{}hints' as='text()*' slot='12' eval='4'>
                  <slash simple='2'>
                   <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}hint)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;hint&#39;;'/>
                   <axis name='child' nodeTest='text()' jsTest='return item.nodeType===3;'/>
                  </slash>
-                 <elem line='1345' name='input' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-                  <sequence line='1346'>
+                 <elem line='1352' name='input' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+                  <sequence line='1353'>
                    <let var='Q{}element' as='element(Q{http://www.w3.org/2002/xforms}input)' slot='13' eval='16'>
                     <dot type='element(Q{http://www.w3.org/2002/xforms}input)'/>
-                    <let line='3091' var='Q{}class' as='xs:string?' slot='14' eval='7'>
-                     <choose line='3092'>
+                    <let line='3064' var='Q{}class' as='xs:string?' slot='14' eval='7'>
+                     <choose line='3065'>
                       <fn name='exists'>
                        <slash simple='1'>
                         <varRef name='Q{}element' slot='13'/>
                         <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
                        </slash>
                       </fn>
-                      <cvUntyped line='3093' to='xs:string' diag='3|0|XTTE0570|class'>
+                      <cvUntyped line='3066' to='xs:string' diag='3|0|XTTE0570|class'>
                        <cast as='xs:untypedAtomic' emptiable='0'>
                         <fn name='string'>
                          <convert from='xs:untypedAtomic' to='xs:string'>
@@ -8282,15 +8077,15 @@
                        </cast>
                       </cvUntyped>
                      </choose>
-                     <let line='3096' var='Q{}class-mod' as='xs:string?' slot='15' eval='7'>
-                      <choose line='3098'>
+                     <let line='3069' var='Q{}class-mod' as='xs:string?' slot='15' eval='7'>
+                      <choose line='3071'>
                        <fn name='exists'>
                         <slash simple='1'>
                          <varRef name='Q{}element' slot='13'/>
                          <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
                         </slash>
                        </fn>
-                       <cvUntyped line='3099' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                       <cvUntyped line='3072' to='xs:string' diag='3|0|XTTE0570|class-mod'>
                         <cast as='xs:untypedAtomic' emptiable='0'>
                          <fn name='string-join'>
                           <sequence>
@@ -8302,13 +8097,13 @@
                         </cast>
                        </cvUntyped>
                        <true/>
-                       <varRef line='3102' name='Q{}class' slot='14'/>
+                       <varRef line='3075' name='Q{}class' slot='14'/>
                       </choose>
-                      <choose line='3106'>
+                      <choose line='3079'>
                        <fn name='exists'>
                         <varRef name='Q{}class-mod' slot='15'/>
                        </fn>
-                       <treat line='3107' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                       <treat line='3080' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
                         <att name='class' flags='l'>
                          <varRef name='Q{}class-mod' slot='15'/>
                         </att>
@@ -8317,14 +8112,14 @@
                      </let>
                     </let>
                    </let>
-                   <att line='1347' name='id' flags='l'>
+                   <att line='1354' name='id' flags='l'>
                     <varRef name='Q{}myid' slot='3'/>
                    </att>
-                   <att line='1349' name='data-ref' flags='l'>
+                   <att line='1356' name='data-ref' flags='l'>
                     <varRef name='Q{}refi' slot='7'/>
                    </att>
-                   <att line='1350' name='data-element' flags='l'>
-                    <lastOf line='1343'>
+                   <att line='1357' name='data-element' flags='l'>
+                    <lastOf line='1350'>
                      <fn name='tokenize'>
                       <varRef name='Q{}refi' slot='7'/>
                       <str val='/'/>
@@ -8332,7 +8127,7 @@
                      </fn>
                     </lastOf>
                    </att>
-                   <choose line='1352'>
+                   <choose line='1359'>
                     <and op='and'>
                      <fn name='exists'>
                       <varRef name='Q{}bindingi' slot='6'/>
@@ -8344,7 +8139,7 @@
                       </slash>
                      </fn>
                     </and>
-                    <att line='1353' name='data-required' flags='l'>
+                    <att line='1360' name='data-required' flags='l'>
                      <convert from='xs:untypedAtomic' to='xs:string'>
                       <data>
                        <slash simple='1'>
@@ -8355,7 +8150,7 @@
                      </convert>
                     </att>
                    </choose>
-                   <choose line='1355'>
+                   <choose line='1362'>
                     <and op='and'>
                      <fn name='exists'>
                       <varRef name='Q{}bindingi' slot='6'/>
@@ -8367,7 +8162,7 @@
                       </slash>
                      </fn>
                     </and>
-                    <att line='1356' name='data-constraint' flags='l'>
+                    <att line='1363' name='data-constraint' flags='l'>
                      <convert from='xs:untypedAtomic' to='xs:string'>
                       <data>
                        <slash simple='1'>
@@ -8378,15 +8173,15 @@
                      </convert>
                     </att>
                    </choose>
-                   <choose line='1358'>
+                   <choose line='1365'>
                     <fn name='exists'>
                      <varRef name='Q{}actions' slot='11'/>
                     </fn>
-                    <att line='1359' name='data-action' flags='l'>
+                    <att line='1366' name='data-action' flags='l'>
                      <varRef name='Q{}myid' slot='3'/>
                     </att>
                    </choose>
-                   <choose line='1362'>
+                   <choose line='1369'>
                     <and op='and'>
                      <fn name='exists'>
                       <varRef name='Q{}bindingi' slot='6'/>
@@ -8398,7 +8193,7 @@
                       </slash>
                      </fn>
                     </and>
-                    <att line='1363' name='data-relevant' flags='l'>
+                    <att line='1370' name='data-relevant' flags='l'>
                      <convert from='xs:untypedAtomic' to='xs:string'>
                       <data>
                        <slash simple='1'>
@@ -8409,12 +8204,12 @@
                      </convert>
                     </att>
                    </choose>
-                   <let line='1366' var='Q{}input-value' as='xs:string' slot='16' eval='16'>
-                    <choose line='1368'>
+                   <let line='1373' var='Q{}input-value' as='xs:string' slot='16' eval='16'>
+                    <choose line='1375'>
                      <fn name='exists'>
                       <varRef name='Q{}instanceField' slot='8'/>
                      </fn>
-                     <cvUntyped line='1369' to='xs:string' diag='3|0|XTTE0570|input-value'>
+                     <cvUntyped line='1376' to='xs:string' diag='3|0|XTTE0570|input-value'>
                       <cast as='xs:untypedAtomic' emptiable='0'>
                        <fn name='string'>
                         <convert from='xs:anyAtomicType' to='xs:string'>
@@ -8428,7 +8223,7 @@
                      <true/>
                      <str val=''/>
                     </choose>
-                    <sequence line='1383'>
+                    <sequence line='1390'>
                      <choose>
                       <choose>
                        <fn name='exists'>
@@ -8448,18 +8243,18 @@
                        <true/>
                        <false/>
                       </choose>
-                      <sequence line='1384'>
+                      <sequence line='1391'>
                        <att name='data-type' flags='l'>
                         <str val='date'/>
                        </att>
-                       <att line='1386' name='type' flags='l'>
+                       <att line='1393' name='type' flags='l'>
                         <str val='date'/>
                        </att>
-                       <att line='1388' name='value' flags='l'>
+                       <att line='1395' name='value' flags='l'>
                         <varRef name='Q{}input-value' slot='16'/>
                        </att>
                       </sequence>
-                      <choose line='1395'>
+                      <choose line='1402'>
                        <fn name='exists'>
                         <varRef name='Q{}bindingi' slot='6'/>
                        </fn>
@@ -8477,18 +8272,18 @@
                        <true/>
                        <false/>
                       </choose>
-                      <sequence line='1396'>
+                      <sequence line='1403'>
                        <att name='data-type' flags='l'>
                         <str val='time'/>
                        </att>
-                       <att line='1398' name='type' flags='l'>
+                       <att line='1405' name='type' flags='l'>
                         <str val='time'/>
                        </att>
-                       <att line='1401' name='value' flags='l'>
+                       <att line='1408' name='value' flags='l'>
                         <varRef name='Q{}input-value' slot='16'/>
                        </att>
                       </sequence>
-                      <choose line='1408'>
+                      <choose line='1415'>
                        <fn name='exists'>
                         <varRef name='Q{}bindingi' slot='6'/>
                        </fn>
@@ -8506,48 +8301,48 @@
                        <true/>
                        <false/>
                       </choose>
-                      <sequence line='1409'>
+                      <sequence line='1416'>
                        <att name='data-type' flags='l'>
                         <str val='checkbox'/>
                        </att>
-                       <att line='1411' name='type' flags='l'>
+                       <att line='1418' name='type' flags='l'>
                         <str val='checkbox'/>
                        </att>
-                       <choose line='1416'>
+                       <choose line='1423'>
                         <fn name='exists'>
                          <varRef name='Q{}instanceField' slot='8'/>
                         </fn>
-                        <choose line='1417'>
+                        <choose line='1424'>
                          <and op='and'>
                           <varRef name='Q{}input-value' slot='16'/>
                           <cast as='xs:boolean' emptiable='0'>
                            <varRef name='Q{}input-value' slot='16'/>
                           </cast>
                          </and>
-                         <att line='1418' name='checked' flags='l'>
+                         <att line='1425' name='checked' flags='l'>
                           <varRef name='Q{}input-value' slot='16'/>
                          </att>
                         </choose>
                        </choose>
                       </sequence>
                       <true/>
-                      <sequence line='1424'>
+                      <sequence line='1431'>
                        <choose>
                         <varRef name='Q{}relevantVar' slot='9'/>
-                        <att line='1425' name='type' flags='l'>
+                        <att line='1432' name='type' flags='l'>
                          <str val='text'/>
                         </att>
                        </choose>
-                       <att line='1427' name='value' flags='l'>
+                       <att line='1434' name='value' flags='l'>
                         <varRef name='Q{}input-value' slot='16'/>
                        </att>
                       </sequence>
                      </choose>
-                     <choose line='1431'>
+                     <choose line='1438'>
                       <fn name='exists'>
                        <varRef name='Q{}hints' slot='12'/>
                       </fn>
-                      <att line='1432' name='title' flags='l'>
+                      <att line='1439' name='title' flags='l'>
                        <fn name='string-join'>
                         <convert from='xs:untypedAtomic' to='xs:string'>
                          <data>
@@ -8560,11 +8355,11 @@
                        </fn>
                       </att>
                      </choose>
-                     <choose line='1434'>
+                     <choose line='1441'>
                       <fn name='exists'>
                        <axis name='attribute' nodeTest='attribute(Q{}size)' jsTest='return item.name===&#39;size&#39;'/>
                       </fn>
-                      <att line='1435' name='size' flags='l'>
+                      <att line='1442' name='size' flags='l'>
                        <convert from='xs:untypedAtomic' to='xs:string'>
                         <attVal name='Q{}size' chk='0'/>
                        </convert>
@@ -8588,9 +8383,9 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='2.0' seq='11' rank='3' minImp='0' slots='10' flags='s' line='1453' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='2.0' seq='11' rank='3' minImp='0' slots='10' flags='s' line='1460' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}textarea)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;textarea&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1454'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1461'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -8603,7 +8398,7 @@
        </check>
       </treat>
      </param>
-     <param line='1455' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1462' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -8615,7 +8410,7 @@
        </check>
       </treat>
      </param>
-     <let line='1459' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='1466' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -8631,7 +8426,7 @@
          <dot type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
         </fn>
         <str val='-'/>
-        <choose line='1457'>
+        <choose line='1464'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -8641,13 +8436,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1461'>
+      <sequence line='1468'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}textarea)' slot='3' eval='16'>
           <dot type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
-          <fn line='3025' name='exists'>
-           <sequence line='3000'>
+          <fn line='2998' name='exists'>
+           <sequence line='2973'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -8659,7 +8454,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='3003'>
+             <choose role='matching' line='2976'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -8671,7 +8466,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='3012'>
+            <analyzeString line='2985'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -8682,7 +8477,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='3015'>
+             <choose role='matching' line='2988'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -8705,8 +8500,8 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='3025' name='exists'>
-             <sequence line='3000'>
+            <fn line='2998' name='exists'>
+             <sequence line='2973'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
@@ -8718,7 +8513,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='3003'>
+               <choose role='matching' line='2976'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -8730,7 +8525,7 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
-              <analyzeString line='3012'>
+              <analyzeString line='2985'>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
@@ -8741,7 +8536,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='3015'>
+               <choose role='matching' line='2988'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -8759,7 +8554,7 @@
           </filter>
          </fn>
         </and>
-        <ifCall line='1462' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1469' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -8770,60 +8565,60 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1466' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='1467' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='1473' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1474' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
           <callT name='Q{}getBinding' bSlot='30'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='1468' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
+            <dot line='1475' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='1473' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='1474' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='1480' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1481' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
              <callT name='Q{}getDataRef' bSlot='31'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='1475' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
+               <dot line='1482' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='1476' name='Q{}bindingi' slot='5'/>
+               <varRef line='1483' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='1481' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
-          <treat line='1482' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+         <let line='1488' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
+          <treat line='1489' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
            <check card='?' diag='3|0|XTTE0570|instanceField'>
             <callT name='Q{}getReferencedInstanceField' bSlot='32'>
              <withParam name='Q{}refi' flags='c' as='xs:string'>
-              <varRef line='1483' name='Q{}refi' slot='6'/>
+              <varRef line='1490' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </check>
           </treat>
-          <let line='1488' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
-           <treat line='1489' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+          <let line='1495' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
+           <treat line='1496' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
             <callT name='Q{}setActions' bSlot='33'>
              <withParam name='Q{}this' flags='c' as='element()'>
-              <dot line='1490' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
+              <dot line='1497' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
              </withParam>
              <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-              <varRef line='1491' name='Q{}refi' slot='6'/>
+              <varRef line='1498' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </treat>
-           <sequence line='1495'>
+           <sequence line='1502'>
             <choose>
              <fn name='exists'>
               <varRef name='Q{}actions' slot='8'/>
              </fn>
-             <ifCall line='1496' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+             <ifCall line='1503' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
               <check card='1' diag='0|0||ixsl:call'>
                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
               </check>
@@ -8834,13 +8629,13 @@
               </arrayBlock>
              </ifCall>
             </choose>
-            <let line='1501' var='Q{}hints' as='text()*' slot='9' eval='4'>
+            <let line='1508' var='Q{}hints' as='text()*' slot='9' eval='4'>
              <slash simple='2'>
               <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}hint)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;hint&#39;;'/>
               <axis name='child' nodeTest='text()' jsTest='return item.nodeType===3;'/>
              </slash>
-             <elem line='1503' name='textarea' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-              <sequence line='1504'>
+             <elem line='1510' name='textarea' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+              <sequence line='1511'>
                <copyOf flags='vc'>
                 <filter flags='b'>
                  <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
@@ -8852,8 +8647,8 @@
                  </vc>
                 </filter>
                </copyOf>
-               <att line='1505' name='data-element' flags='l'>
-                <lastOf line='1499'>
+               <att line='1512' name='data-element' flags='l'>
+                <lastOf line='1506'>
                  <fn name='tokenize'>
                   <varRef name='Q{}refi' slot='6'/>
                   <str val='/'/>
@@ -8861,14 +8656,14 @@
                  </fn>
                 </lastOf>
                </att>
-               <att line='1506' name='data-ref' flags='l'>
+               <att line='1513' name='data-ref' flags='l'>
                 <varRef name='Q{}refi' slot='6'/>
                </att>
-               <choose line='1508'>
+               <choose line='1515'>
                 <fn name='exists'>
                  <varRef name='Q{}instanceField' slot='7'/>
                 </fn>
-                <valueOf line='1509' flags='l'>
+                <valueOf line='1516' flags='l'>
                  <convert from='xs:anyAtomicType' to='xs:string'>
                   <data>
                    <varRef name='Q{}instanceField' slot='7'/>
@@ -8876,7 +8671,7 @@
                  </convert>
                 </valueOf>
                 <true/>
-                <sequence line='1511'>
+                <sequence line='1518'>
                  <valueOf flags='Sl'>
                   <str val=''/>
                  </valueOf>
@@ -8885,11 +8680,11 @@
                  </valueOf>
                 </sequence>
                </choose>
-               <choose line='1514'>
+               <choose line='1521'>
                 <fn name='exists'>
                  <varRef name='Q{}hints' slot='9'/>
                 </fn>
-                <att line='1515' name='title' flags='l'>
+                <att line='1522' name='title' flags='l'>
                  <fn name='string-join'>
                   <convert from='xs:untypedAtomic' to='xs:string'>
                    <data>
@@ -8914,9 +8709,9 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='24' rank='1' minImp='0' slots='9' flags='s' line='2035' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='24' rank='1' minImp='0' slots='9' flags='s' line='2042' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}trigger)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;trigger&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2036'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2043'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -8929,7 +8724,7 @@
        </check>
       </treat>
      </param>
-     <param line='2037' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='2044' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -8941,7 +8736,7 @@
        </check>
       </treat>
      </param>
-     <let line='2041' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='2048' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -8957,7 +8752,7 @@
          <dot type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
         </fn>
         <str val='-'/>
-        <choose line='2039'>
+        <choose line='2046'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -8967,13 +8762,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='2043'>
+      <sequence line='2050'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}trigger)' slot='3' eval='16'>
           <dot type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
-          <fn line='3025' name='exists'>
-           <sequence line='3000'>
+          <fn line='2998' name='exists'>
+           <sequence line='2973'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -8985,7 +8780,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='3003'>
+             <choose role='matching' line='2976'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -8997,7 +8792,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='3012'>
+            <analyzeString line='2985'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -9008,7 +8803,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='3015'>
+             <choose role='matching' line='2988'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -9031,8 +8826,8 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='3025' name='exists'>
-             <sequence line='3000'>
+            <fn line='2998' name='exists'>
+             <sequence line='2973'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
@@ -9044,7 +8839,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='3003'>
+               <choose role='matching' line='2976'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -9056,7 +8851,7 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
-              <analyzeString line='3012'>
+              <analyzeString line='2985'>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
@@ -9067,7 +8862,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='3015'>
+               <choose role='matching' line='2988'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -9085,7 +8880,7 @@
           </filter>
          </fn>
         </and>
-        <ifCall line='2044' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='2051' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -9096,50 +8891,50 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='2048' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='2049' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='2055' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='2056' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
           <callT name='Q{}getBinding' bSlot='34'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='2050' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
+            <dot line='2057' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='2055' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='2056' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='2062' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='2063' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
              <callT name='Q{}getDataRef' bSlot='35'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='2057' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
+               <dot line='2064' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='2058' name='Q{}bindingi' slot='5'/>
+               <varRef line='2065' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='2065' var='Q{}actions' as='map(*)*' slot='7' eval='8'>
-          <treat line='2066' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+         <let line='2072' var='Q{}actions' as='map(*)*' slot='7' eval='8'>
+          <treat line='2073' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
            <callT name='Q{}setActions' bSlot='36'>
             <withParam name='Q{}this' flags='c' as='element()'>
-             <dot line='2067' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
+             <dot line='2074' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
             </withParam>
             <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-             <varRef line='2068' name='Q{}refi' slot='6'/>
+             <varRef line='2075' name='Q{}refi' slot='6'/>
             </withParam>
            </callT>
           </treat>
-          <sequence line='2072'>
+          <sequence line='2079'>
            <choose>
             <fn name='exists'>
              <varRef name='Q{}actions' slot='7'/>
             </fn>
-            <ifCall line='2073' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+            <ifCall line='2080' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
              <check card='1' diag='0|0||ixsl:call'>
               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
              </check>
@@ -9150,28 +8945,28 @@
              </arrayBlock>
             </ifCall>
            </choose>
-           <let line='2076' var='Q{}innerbody' as='document-node()' slot='8' eval='16'>
-            <doc line='2078' validation='preserve'>
+           <let line='2083' var='Q{}innerbody' as='document-node()' slot='8' eval='16'>
+            <doc line='2085' validation='preserve'>
              <choose>
               <fn name='exists'>
                <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
               </fn>
-              <applyT line='2079' bSlot='37'>
+              <applyT line='2086' bSlot='37'>
                <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
               </applyT>
               <true/>
-              <valueOf line='2081' flags='l'>
+              <valueOf line='2088' flags='l'>
                <str val=' '/>
               </valueOf>
              </choose>
             </doc>
-            <elem line='2085' name='span' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+            <elem line='2092' name='span' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
              <sequence>
               <att name='style' flags='l'>
                <str val='display:&#39;inline&#39;'/>
               </att>
-              <compElem line='2096' flags='l'>
-               <choose role='name' line='2088'>
+              <compElem line='2103' flags='l'>
+               <choose role='name' line='2095'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <cast as='xs:string' emptiable='1'>
                   <attVal name='Q{}appearance' chk='0'/>
@@ -9182,7 +8977,7 @@
                 <true/>
                 <str val='button'/>
                </choose>
-               <sequence role='content' line='2097'>
+               <sequence role='content' line='2104'>
                 <choose>
                  <vc op='eq' onEmpty='0' comp='CCC'>
                   <cast as='xs:string' emptiable='1'>
@@ -9190,17 +8985,17 @@
                   </cast>
                   <str val='minimal'/>
                  </vc>
-                 <att line='2098' name='type' flags='l'>
+                 <att line='2105' name='type' flags='l'>
                   <str val='button'/>
                  </att>
                 </choose>
-                <att line='2101' name='data-ref' flags='l'>
+                <att line='2108' name='data-ref' flags='l'>
                  <varRef name='Q{}refi' slot='6'/>
                 </att>
-                <att line='2102' name='data-action' flags='l'>
+                <att line='2109' name='data-action' flags='l'>
                  <varRef name='Q{}myid' slot='2'/>
                 </att>
-                <copyOf line='2103' flags='vc'>
+                <copyOf line='2110' flags='vc'>
                  <varRef name='Q{}innerbody' slot='8'/>
                 </copyOf>
                </sequence>
@@ -9216,13 +9011,13 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='6' rank='1' minImp='0' slots='0' flags='s' line='1080' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='6' rank='1' minImp='0' slots='0' flags='s' line='1087' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
     <empty role='action'/>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='17' rank='1' minImp='0' slots='1' flags='s' line='1681' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='17' rank='1' minImp='0' slots='1' flags='s' line='1688' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1682'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1689'>
      <param name='Q{}selectedValue' slot='0' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|selectedValue'>
@@ -9235,7 +9030,7 @@
        </check>
       </treat>
      </param>
-     <elem line='1684' name='option' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+     <elem line='1691' name='option' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
       <sequence>
        <att name='value' flags='l'>
         <fn name='string-join'>
@@ -9247,7 +9042,7 @@
          <str val=' '/>
         </fn>
        </att>
-       <choose line='1685'>
+       <choose line='1692'>
         <vc op='eq' onEmpty='0' comp='CCC'>
          <varRef name='Q{}selectedValue' slot='0'/>
          <cast as='xs:string' emptiable='1'>
@@ -9259,11 +9054,11 @@
           </atomSing>
          </cast>
         </vc>
-        <att line='1686' name='selected' flags='l'>
+        <att line='1693' name='selected' flags='l'>
          <varRef name='Q{}selectedValue' slot='0'/>
         </att>
        </choose>
-       <valueOf line='1689' flags='l'>
+       <valueOf line='1696' flags='l'>
         <fn name='string-join'>
          <convert from='xs:untypedAtomic' to='xs:string'>
           <data>
@@ -9277,24 +9072,24 @@
      </elem>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='25' part='4' rank='1' minImp='0' slots='1' flags='s' line='2117' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='25' part='4' rank='1' minImp='0' slots='1' flags='s' line='2124' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}script)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;script&#39;;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2123' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2124' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2132' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2133' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
       <check card='1' diag='3|0|XTTE0570|action-map'>
        <callT name='Q{}setAction' bSlot='2'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2125' type='element()'/>
+         <dot line='2134' type='element()'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <varRef line='2138' name='Q{}action-map' slot='0'/>
+     <varRef line='2147' name='Q{}action-map' slot='0'/>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='-0.5' seq='14' part='1' rank='0' minImp='0' slots='0' flags='s' line='1642' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='14' part='1' rank='0' minImp='0' slots='0' flags='s' line='1649' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
-    <copy role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1644' flags='cin'>
+    <copy role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1651' flags='cin'>
      <applyT role='content' bSlot='38'>
       <sequence role='select'>
        <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
@@ -9303,16 +9098,16 @@
      </applyT>
     </copy>
    </templateRule>
-   <templateRule prec='0' prio='0.5' seq='15' rank='2' minImp='0' slots='0' flags='s' line='1653' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.5' seq='15' rank='2' minImp='0' slots='0' flags='s' line='1660' module='saxon-xforms.xsl'>
     <p.withPredicate role='match'>
      <p.nodeTest test='text()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===3;'/>
-     <axis ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1653' name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
+     <axis ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1660' name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
     </p.withPredicate>
     <empty role='action'/>
    </templateRule>
-   <templateRule prec='0' prio='-0.5' seq='14' rank='0' minImp='0' slots='0' flags='s' line='1642' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='14' rank='0' minImp='0' slots='0' flags='s' line='1649' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='( element() | text() | comment() | processing-instruction() )' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);'/>
-    <copy role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1644' flags='cin'>
+    <copy role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1651' flags='cin'>
      <applyT role='content' bSlot='38'>
       <sequence role='select'>
        <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
@@ -9323,9 +9118,9 @@
    </templateRule>
   </mode>
  </co>
- <co id='63' binds='62'>
-  <template name='Q{}getDataRef' flags='os' line='3353' module='saxon-xforms.xsl' slots='11'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3354'>
+ <co id='62' binds='61'>
+  <template name='Q{}getDataRef' flags='os' line='3326' module='saxon-xforms.xsl' slots='16'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3327'>
     <param name='Q{}this' slot='0' flags='r' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
       <check card='1' diag='8|0|XTTE0590|this'>
@@ -9333,7 +9128,7 @@
       </check>
      </treat>
     </param>
-    <param line='3355' name='Q{}nodeset' slot='1' flags='t' as='xs:string'>
+    <param line='3328' name='Q{}nodeset' slot='1' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -9345,7 +9140,7 @@
       </check>
      </treat>
     </param>
-    <param line='3356' name='Q{}bindingi' slot='2' as='node()?'>
+    <param line='3329' name='Q{}bindingi' slot='2' as='node()?'>
      <empty role='select'/>
      <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|bindingi'>
       <check card='?' diag='8|0|XTTE0590|bindingi'>
@@ -9353,7 +9148,7 @@
       </check>
      </treat>
     </param>
-    <let line='3364' var='Q{}this-ref' as='xs:string?' slot='3' eval='7'>
+    <let line='3337' var='Q{}this-ref' as='xs:string?' slot='3' eval='7'>
      <choose>
       <fn name='exists'>
        <slash simple='1'>
@@ -9388,12 +9183,12 @@
        </cast>
       </fn>
      </choose>
-     <let line='3367' var='Q{}this-binding-ref' as='xs:string?' slot='4' eval='7'>
-      <choose line='3369'>
+     <let line='3344' var='Q{}this-binding-ref' as='xs:string?' slot='4' eval='7'>
+      <choose line='3346'>
        <fn name='exists'>
         <varRef name='Q{}bindingi' slot='2'/>
        </fn>
-       <cvUntyped line='3380' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
+       <cvUntyped line='3357' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
         <cast as='xs:untypedAtomic' emptiable='0'>
          <choose>
           <fn name='exists'>
@@ -9427,23 +9222,23 @@
         </cast>
        </cvUntyped>
        <true/>
-       <let line='3384' var='Q{}this-binding' as='node()?' slot='5' eval='7'>
-        <treat line='3385' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|this-binding'>
+       <let line='3361' var='Q{}this-binding' as='node()?' slot='5' eval='7'>
+        <treat line='3362' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|this-binding'>
          <check card='?' diag='3|0|XTTE0570|this-binding'>
           <callT name='Q{}getBinding' bSlot='0'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <treat line='3386' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+            <treat line='3363' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
              <dot flags='a'/>
             </treat>
            </withParam>
           </callT>
          </check>
         </treat>
-        <choose line='3389'>
+        <choose line='3366'>
          <fn name='exists'>
           <varRef name='Q{}this-binding' slot='5'/>
          </fn>
-         <cvUntyped line='3396' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
+         <cvUntyped line='3373' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
           <cast as='xs:untypedAtomic' emptiable='0'>
            <choose>
             <fn name='exists'>
@@ -9479,72 +9274,235 @@
         </choose>
        </let>
       </choose>
-      <choose line='3406'>
+      <choose line='3383'>
        <fn name='exists'>
         <varRef name='Q{}bindingi' slot='2'/>
        </fn>
-       <let line='3408' var='Q{}relative' as='xs:string' slot='6' eval='16'>
+       <let line='3385' var='Q{}relative' as='xs:string' slot='6' eval='16'>
         <check card='1' diag='0|1||xforms:resolveXPathStrings'>
          <varRef name='Q{}this-binding-ref' slot='4'/>
         </check>
-        <choose line='836'>
+        <choose line='838'>
          <fn name='starts-with'>
           <varRef name='Q{}relative' slot='6'/>
           <str val='/'/>
          </fn>
-         <varRef line='837' name='Q{}relative' slot='6'/>
-         <fn line='839' name='starts-with'>
+         <varRef line='839' name='Q{}relative' slot='6'/>
+         <fn line='841' name='starts-with'>
           <varRef name='Q{}relative' slot='6'/>
           <str val='instance('/>
          </fn>
-         <varRef line='840' name='Q{}relative' slot='6'/>
+         <varRef line='842' name='Q{}relative' slot='6'/>
          <true/>
-         <varRef line='843' name='Q{}relative' slot='6'/>
+         <varRef line='845' name='Q{}relative' slot='6'/>
         </choose>
        </let>
-       <fn line='3410' name='exists'>
+       <and line='3387' op='and'>
+        <fn name='exists'>
+         <varRef name='Q{}this-ref' slot='3'/>
+        </fn>
+        <fn name='not'>
+         <varRef name='Q{}nodeset' slot='1'/>
+        </fn>
+       </and>
+       <let line='3342' var='Q{}base' as='xs:string' slot='7' eval='16'>
+        <choose>
+         <fn name='exists'>
+          <slash simple='1'>
+           <varRef name='Q{}this' slot='0'/>
+           <axis name='attribute' nodeTest='attribute(Q{}context)' jsTest='return item.name===&#39;context&#39;'/>
+          </slash>
+         </fn>
+         <fn name='normalize-space'>
+          <cast as='xs:string' emptiable='1'>
+           <data>
+            <slash simple='1'>
+             <varRef name='Q{}this' slot='0'/>
+             <axis name='attribute' nodeTest='attribute(Q{}context)' jsTest='return item.name===&#39;context&#39;'/>
+            </slash>
+           </data>
+          </cast>
+         </fn>
+         <true/>
+         <str val='.'/>
+        </choose>
+        <let line='3388' var='Q{}relative' as='xs:string' slot='8' eval='16'>
+         <check card='1' diag='0|1||xforms:resolveXPathStrings'>
+          <varRef name='Q{}this-ref' slot='3'/>
+         </check>
+         <choose line='838'>
+          <fn name='starts-with'>
+           <varRef name='Q{}relative' slot='8'/>
+           <str val='/'/>
+          </fn>
+          <varRef line='839' name='Q{}relative' slot='8'/>
+          <fn line='841' name='starts-with'>
+           <varRef name='Q{}relative' slot='8'/>
+           <str val='instance('/>
+          </fn>
+          <varRef line='842' name='Q{}relative' slot='8'/>
+          <fn line='844' name='not'>
+           <varRef name='Q{}base' slot='7'/>
+          </fn>
+          <varRef line='845' name='Q{}relative' slot='8'/>
+          <or line='847' op='or'>
+           <fn name='not'>
+            <varRef name='Q{}relative' slot='8'/>
+           </fn>
+           <vc op='eq' onEmpty='0' comp='CCC'>
+            <varRef name='Q{}relative' slot='8'/>
+            <str val='.'/>
+           </vc>
+          </or>
+          <varRef line='848' name='Q{}base' slot='7'/>
+          <true/>
+          <let line='852' var='Q{}parentCallCount' as='xs:integer' slot='9' eval='16'>
+           <choose>
+            <fn name='contains'>
+             <varRef name='Q{}relative' slot='8'/>
+             <str val='/'/>
+            </fn>
+            <fn name='count'>
+             <filter flags='b'>
+              <fn name='tokenize'>
+               <varRef name='Q{}relative' slot='8'/>
+               <str val='/'/>
+               <str val=''/>
+              </fn>
+              <vc op='eq' onEmpty='0' comp='CCC'>
+               <dot type='xs:string'/>
+               <str val='..'/>
+              </vc>
+             </filter>
+            </fn>
+            <fn name='contains'>
+             <varRef name='Q{}relative' slot='8'/>
+             <str val='..'/>
+            </fn>
+            <int val='1'/>
+            <true/>
+            <int val='0'/>
+           </choose>
+           <let line='855' var='Q{}slashes' as='xs:integer*' slot='10' eval='4'>
+            <choose>
+             <fn name='contains'>
+              <varRef name='Q{}base' slot='7'/>
+              <str val='/'/>
+             </fn>
+             <fn name='index-of'>
+              <fn name='string-to-codepoints'>
+               <varRef name='Q{}base' slot='7'/>
+              </fn>
+              <int val='47'/>
+             </fn>
+             <true/>
+             <int val='0'/>
+            </choose>
+            <choose line='887'>
+             <compareToInt op='gt' val='0'>
+              <varRef name='Q{}parentCallCount' slot='9'/>
+             </compareToInt>
+             <fn line='891' name='concat'>
+              <fn name='substring'>
+               <varRef name='Q{}base' slot='7'/>
+               <int val='1'/>
+               <choose line='866'>
+                <and op='and'>
+                 <vc op='ge' onEmpty='0' comp='CAVC'>
+                  <fn name='count'>
+                   <varRef name='Q{}slashes' slot='10'/>
+                  </fn>
+                  <varRef name='Q{}parentCallCount' slot='9'/>
+                 </vc>
+                 <compareToInt op='gt' val='0'>
+                  <varRef name='Q{}parentCallCount' slot='9'/>
+                 </compareToInt>
+                </and>
+                <let line='867' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='11' eval='13'>
+                 <arith op='-' calc='i-i'>
+                  <varRef name='Q{}parentCallCount' slot='9'/>
+                  <int val='1'/>
+                 </arith>
+                 <check card='1' diag='3|0|XTTE0570|parentSlash'>
+                  <filter flags='p'>
+                   <varRef name='Q{}slashes' slot='10'/>
+                   <arith op='-' calc='i-i'>
+                    <fn name='last'/>
+                    <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='11'/>
+                   </arith>
+                  </filter>
+                 </check>
+                </let>
+                <true/>
+                <check line='870' card='1' diag='3|0|XTTE0570|parentSlash'>
+                 <lastOf>
+                  <varRef name='Q{}slashes' slot='10'/>
+                 </lastOf>
+                </check>
+               </choose>
+              </fn>
+              <fn name='replace'>
+               <varRef name='Q{}relative' slot='8'/>
+               <str val='\.\./'/>
+               <str val=''/>
+               <str val=''/>
+              </fn>
+             </fn>
+             <true/>
+             <fn line='894' name='concat'>
+              <varRef name='Q{}base' slot='7'/>
+              <str val='/'/>
+              <varRef name='Q{}relative' slot='8'/>
+             </fn>
+            </choose>
+           </let>
+          </let>
+         </choose>
+        </let>
+       </let>
+       <fn line='3390' name='exists'>
         <varRef name='Q{}this-ref' slot='3'/>
        </fn>
-       <let line='3412' var='Q{}relative' as='xs:string' slot='7' eval='16'>
+       <let line='3392' var='Q{}relative' as='xs:string' slot='12' eval='16'>
         <check card='1' diag='0|1||xforms:resolveXPathStrings'>
          <varRef name='Q{}this-ref' slot='3'/>
         </check>
-        <choose line='836'>
+        <choose line='838'>
          <fn name='starts-with'>
-          <varRef name='Q{}relative' slot='7'/>
+          <varRef name='Q{}relative' slot='12'/>
           <str val='/'/>
          </fn>
-         <varRef line='837' name='Q{}relative' slot='7'/>
-         <fn line='839' name='starts-with'>
-          <varRef name='Q{}relative' slot='7'/>
+         <varRef line='839' name='Q{}relative' slot='12'/>
+         <fn line='841' name='starts-with'>
+          <varRef name='Q{}relative' slot='12'/>
           <str val='instance('/>
          </fn>
-         <varRef line='840' name='Q{}relative' slot='7'/>
-         <fn line='3412' name='not'>
+         <varRef line='842' name='Q{}relative' slot='12'/>
+         <fn line='3392' name='not'>
           <varRef name='Q{}nodeset' slot='1'/>
          </fn>
-         <varRef line='843' name='Q{}relative' slot='7'/>
-         <or line='845' op='or'>
+         <varRef line='845' name='Q{}relative' slot='12'/>
+         <or line='847' op='or'>
           <fn name='not'>
-           <varRef name='Q{}relative' slot='7'/>
+           <varRef name='Q{}relative' slot='12'/>
           </fn>
           <vc op='eq' onEmpty='0' comp='CCC'>
-           <varRef name='Q{}relative' slot='7'/>
+           <varRef name='Q{}relative' slot='12'/>
            <str val='.'/>
           </vc>
          </or>
-         <varRef line='3412' name='Q{}nodeset' slot='1'/>
+         <varRef line='3392' name='Q{}nodeset' slot='1'/>
          <true/>
-         <let line='850' var='Q{}parentCallCount' as='xs:integer' slot='8' eval='16'>
+         <let line='852' var='Q{}parentCallCount' as='xs:integer' slot='13' eval='16'>
           <choose>
            <fn name='contains'>
-            <varRef name='Q{}relative' slot='7'/>
+            <varRef name='Q{}relative' slot='12'/>
             <str val='/'/>
            </fn>
            <fn name='count'>
             <filter flags='b'>
              <fn name='tokenize'>
-              <varRef name='Q{}relative' slot='7'/>
+              <varRef name='Q{}relative' slot='12'/>
               <str val='/'/>
               <str val=''/>
              </fn>
@@ -9555,91 +9513,91 @@
             </filter>
            </fn>
            <fn name='contains'>
-            <varRef name='Q{}relative' slot='7'/>
+            <varRef name='Q{}relative' slot='12'/>
             <str val='..'/>
            </fn>
            <int val='1'/>
            <true/>
            <int val='0'/>
           </choose>
-          <let line='853' var='Q{}slashes' as='xs:integer*' slot='9' eval='4'>
+          <let line='855' var='Q{}slashes' as='xs:integer*' slot='14' eval='4'>
            <choose>
-            <fn line='3412' name='contains'>
+            <fn line='3392' name='contains'>
              <varRef name='Q{}nodeset' slot='1'/>
              <str val='/'/>
             </fn>
             <fn name='index-of'>
              <fn name='string-to-codepoints'>
-              <varRef line='3412' name='Q{}nodeset' slot='1'/>
+              <varRef line='3392' name='Q{}nodeset' slot='1'/>
              </fn>
              <int val='47'/>
             </fn>
             <true/>
             <int val='0'/>
            </choose>
-           <choose line='885'>
+           <choose line='887'>
             <compareToInt op='gt' val='0'>
-             <varRef name='Q{}parentCallCount' slot='8'/>
+             <varRef name='Q{}parentCallCount' slot='13'/>
             </compareToInt>
-            <fn line='889' name='concat'>
+            <fn line='891' name='concat'>
              <fn name='substring'>
-              <varRef line='3412' name='Q{}nodeset' slot='1'/>
+              <varRef line='3392' name='Q{}nodeset' slot='1'/>
               <int val='1'/>
-              <choose line='864'>
+              <choose line='866'>
                <and op='and'>
                 <vc op='ge' onEmpty='0' comp='CAVC'>
                  <fn name='count'>
-                  <varRef name='Q{}slashes' slot='9'/>
+                  <varRef name='Q{}slashes' slot='14'/>
                  </fn>
-                 <varRef name='Q{}parentCallCount' slot='8'/>
+                 <varRef name='Q{}parentCallCount' slot='13'/>
                 </vc>
                 <compareToInt op='gt' val='0'>
-                 <varRef name='Q{}parentCallCount' slot='8'/>
+                 <varRef name='Q{}parentCallCount' slot='13'/>
                 </compareToInt>
                </and>
-               <let line='865' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='10' eval='13'>
+               <let line='867' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='15' eval='13'>
                 <arith op='-' calc='i-i'>
-                 <varRef name='Q{}parentCallCount' slot='8'/>
+                 <varRef name='Q{}parentCallCount' slot='13'/>
                  <int val='1'/>
                 </arith>
                 <check card='1' diag='3|0|XTTE0570|parentSlash'>
                  <filter flags='p'>
-                  <varRef name='Q{}slashes' slot='9'/>
+                  <varRef name='Q{}slashes' slot='14'/>
                   <arith op='-' calc='i-i'>
                    <fn name='last'/>
-                   <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='10'/>
+                   <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='15'/>
                   </arith>
                  </filter>
                 </check>
                </let>
                <true/>
-               <check line='868' card='1' diag='3|0|XTTE0570|parentSlash'>
+               <check line='870' card='1' diag='3|0|XTTE0570|parentSlash'>
                 <lastOf>
-                 <varRef name='Q{}slashes' slot='9'/>
+                 <varRef name='Q{}slashes' slot='14'/>
                 </lastOf>
                </check>
               </choose>
              </fn>
              <fn name='replace'>
-              <varRef name='Q{}relative' slot='7'/>
+              <varRef name='Q{}relative' slot='12'/>
               <str val='\.\./'/>
               <str val=''/>
               <str val=''/>
              </fn>
             </fn>
             <true/>
-            <fn line='3412' name='concat'>
+            <fn line='3392' name='concat'>
              <varRef name='Q{}nodeset' slot='1'/>
              <str val='/'/>
-             <varRef line='892' name='Q{}relative' slot='7'/>
+             <varRef line='894' name='Q{}relative' slot='12'/>
             </fn>
            </choose>
           </let>
          </let>
         </choose>
        </let>
-       <varRef line='3414' name='Q{}nodeset' slot='1'/>
-       <choose line='3417'>
+       <varRef line='3394' name='Q{}nodeset' slot='1'/>
+       <choose line='3397'>
         <fn name='starts-with'>
          <varRef name='Q{}nodeset' slot='1'/>
          <str val='/'/>
@@ -9654,7 +9612,7 @@
         <varRef name='Q{}nodeset' slot='1'/>
        </choose>
        <true/>
-       <cvUntyped line='3421' to='xs:string' diag='3|0|XTTE0570|data-ref'>
+       <cvUntyped line='3401' to='xs:string' diag='3|0|XTTE0570|data-ref'>
         <cast as='xs:untypedAtomic' emptiable='0'>
          <varRef name='Q{}nodeset' slot='1'/>
         </cast>
@@ -9665,18 +9623,18 @@
    </sequence>
   </template>
  </co>
- <co id='5' binds='24'>
-  <function name='Q{http://www.w3.org/2002/xforms}setInstance-JS' line='3262' module='saxon-xforms.xsl' eval='7' flags='pU' as='empty-sequence()' slots='2'>
+ <co id='5' binds='23'>
+  <function name='Q{http://www.w3.org/2002/xforms}setInstance-JS' line='3235' module='saxon-xforms.xsl' eval='7' flags='pU' as='empty-sequence()' slots='2'>
    <arg name='Q{}ref' as='xs:string'/>
    <arg name='Q{}updatedInstance' as='element()'/>
-   <check role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3270' card='°' diag='5|0|XTTE0780|xforms:setInstance-JS#2'>
+   <check role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3243' card='°' diag='5|0|XTTE0780|xforms:setInstance-JS#2'>
     <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
      <check card='1' diag='0|0||ixsl:call'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
      </check>
      <str val='setInstance'/>
      <arrayBlock>
-      <check line='3268' card='1' diag='3|0|XTTE0570|this-instance-id'>
+      <check line='3241' card='1' diag='3|0|XTTE0570|this-instance-id'>
        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
         <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='0' eval='6'>
          <varRef name='Q{}ref' slot='0'/>
@@ -9690,15 +9648,15 @@
    </check>
   </function>
  </co>
- <co id='2' binds='43 24'>
-  <function name='Q{http://www.w3.org/2002/xforms}getInstance-JS' line='3235' module='saxon-xforms.xsl' eval='7' flags='pU' as='element()?' slots='1'>
+ <co id='34' binds='2 23'>
+  <function name='Q{http://www.w3.org/2002/xforms}getInstance-JS' line='3208' module='saxon-xforms.xsl' eval='7' flags='pU' as='element()?' slots='1'>
    <arg name='Q{}ref' as='xs:string'/>
-   <tailCallLoop role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3239'>
+   <tailCallLoop role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3212'>
     <choose>
      <fn name='not'>
       <varRef name='Q{}ref' slot='0'/>
      </fn>
-     <treat line='3240' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='5|0|XTTE0780|xforms:getInstance-JS#1'>
+     <treat line='3213' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='5|0|XTTE0780|xforms:getInstance-JS#1'>
       <message>
        <valueOf role='select'>
         <str val='[xforms:getInstance-JS] Empty ref supplied, no instance will be returned'/>
@@ -9708,8 +9666,8 @@
       </message>
      </treat>
      <true/>
-     <ufCall line='3245' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='foreign' bSlot='0' eval='16'>
-      <check line='3243' card='1' diag='3|0|XTTE0570|this-instance-id'>
+     <ufCall line='3218' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='foreign' bSlot='0' eval='16'>
+      <check line='3216' card='1' diag='3|0|XTTE0570|this-instance-id'>
        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
         <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='1' eval='6'>
          <varRef name='Q{}ref' slot='0'/>
@@ -9722,54 +9680,54 @@
    </tailCallLoop>
   </function>
  </co>
- <co id='24' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}getInstanceMap' line='3132' module='saxon-xforms.xsl' eval='8' flags='pU' as='map(xs:string, xs:string)' slots='3'>
+ <co id='23' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}getInstanceMap' line='3105' module='saxon-xforms.xsl' eval='8' flags='pU' as='map(xs:string, xs:string)' slots='3'>
    <arg name='Q{}nodeset' as='xs:string'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3153' var='Q{http://saxon.sf.net/generated-variable}v0' as='map(xs:string, xs:string)+' slot='1' eval='4'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3126' var='Q{http://saxon.sf.net/generated-variable}v0' as='map(xs:string, xs:string)+' slot='1' eval='4'>
     <sequence>
      <map size='1'>
       <str val='instance-id'/>
       <str val='saxon-forms-default'/>
      </map>
-     <ifCall line='3154' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+     <ifCall line='3127' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
       <str val='xpath'/>
       <fn name='normalize-space'>
        <varRef name='Q{}nodeset' slot='0'/>
       </fn>
      </ifCall>
     </sequence>
-    <ifCall line='3137' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+    <ifCall line='3110' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
      <analyzeString>
       <fn role='select' name='normalize-space'>
        <varRef name='Q{}nodeset' slot='0'/>
       </fn>
       <str role='regex' val='^instance\s*\(\s*&#39;([^&#39;]+)&#39;\s*\)\s*(/\s*(.*)|)$'/>
       <str role='flags' val=''/>
-      <let role='matching' line='3139' var='Q{}xpath' as='xs:string' slot='2' eval='16'>
-       <choose line='3141'>
+      <let role='matching' line='3112' var='Q{}xpath' as='xs:string' slot='2' eval='16'>
+       <choose line='3114'>
         <fn name='regex-group'>
          <int val='2'/>
         </fn>
-        <fn line='3142' name='regex-group'>
+        <fn line='3115' name='regex-group'>
          <int val='3'/>
         </fn>
         <true/>
         <str val='.'/>
        </choose>
-       <sequence line='3149'>
+       <sequence line='3122'>
         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
          <str val='instance-id'/>
          <fn name='regex-group'>
           <int val='1'/>
          </fn>
         </ifCall>
-        <ifCall line='3150' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+        <ifCall line='3123' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
          <str val='xpath'/>
          <varRef name='Q{}xpath' slot='2'/>
         </ifCall>
        </sequence>
       </let>
-      <varRef role='nonMatching' line='3153' name='Q{http://saxon.sf.net/generated-variable}v0' slot='1'/>
+      <varRef role='nonMatching' line='3126' name='Q{http://saxon.sf.net/generated-variable}v0' slot='1'/>
      </analyzeString>
      <map size='2'>
       <str val='duplicates'/>
@@ -9781,14 +9739,14 @@
    </let>
   </function>
  </co>
- <co id='1' binds='24'>
-  <function name='Q{http://www.w3.org/2002/xforms}getInstanceId' line='3119' module='saxon-xforms.xsl' eval='8' flags='pU' as='xs:string' slots='1'>
+ <co id='1' binds='23'>
+  <function name='Q{http://www.w3.org/2002/xforms}getInstanceId' line='3092' module='saxon-xforms.xsl' eval='8' flags='pU' as='xs:string' slots='1'>
    <arg name='Q{}nodeset' as='xs:string'/>
-   <cvUntyped role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3122' to='xs:string' diag='5|0|XTTE0780|xforms:getInstanceId#1'>
+   <cvUntyped role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3095' to='xs:string' diag='5|0|XTTE0780|xforms:getInstanceId#1'>
     <cast as='xs:untypedAtomic' emptiable='0'>
      <fn name='string'>
       <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-       <ufCall line='3121' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='0' eval='6'>
+       <ufCall line='3094' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='0' eval='6'>
         <varRef name='Q{}nodeset' slot='0'/>
        </ufCall>
        <str val='instance-id'/>
@@ -9798,20 +9756,28 @@
    </cvUntyped>
   </function>
  </co>
- <co id='65' binds=''>
-  <globalVariable name='Q{}debugMode' type='xs:boolean' line='73' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.boolean.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
+ <co id='46' binds='44'>
+  <globalVariable name='Q{http://saxon.sf.net/generated-variable}gg1399833911' type='element()*' line='4247' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='function test(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};if (test(val)) {return val;} else {throw SaxonJS.XError(&#39;Conversion failed&#39;, &#39;XTTE0590&#39;);}' jsCardCheck='function c() {return true;};'>
+   <slash ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4247' simple='1'>
+    <gVarRef name='Q{}xforms-doc' bSlot='0'/>
+    <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+   </slash>
+  </globalVariable>
+ </co>
+ <co id='64' binds=''>
+  <globalVariable name='Q{}debugMode' type='xs:boolean' line='75' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.boolean.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
    <true/>
   </globalVariable>
  </co>
- <co id='66' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}getWhileStatement' line='807' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
+ <co id='65' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}getWhileStatement' line='809' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
    <arg name='Q{}map' as='map(*)'/>
-   <choose role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='810'>
+   <choose role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='812'>
     <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
      <varRef name='Q{}map' slot='0'/>
      <str val='@while'/>
     </ifCall>
-    <treat line='811' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
+    <treat line='813' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
      <check card='?' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
       <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
        <data>
@@ -9824,7 +9790,7 @@
      </check>
     </treat>
     <true/>
-    <treat line='814' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
+    <treat line='816' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
      <check card='?' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
       <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
        <data>
@@ -9845,9 +9811,9 @@
    </choose>
   </function>
  </co>
- <co id='67' binds='2 16 1 21'>
-  <template name='Q{}DOMActivate' flags='os' line='4421' module='saxon-xforms.xsl' slots='6'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4422'>
+ <co id='66' binds='1 2 3 15 19 20'>
+  <template name='Q{}DOMActivate' flags='os' line='4488' module='saxon-xforms.xsl' slots='9'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4489'>
     <param name='Q{}form-control' slot='0' flags='i' as='node()'>
      <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|form-control'>
       <check card='1' diag='8|0|XTTE0590|form-control'>
@@ -9855,7 +9821,7 @@
       </check>
      </treat>
     </param>
-    <let line='4424' var='Q{}actions' as='map(*)?' slot='1' eval='7'>
+    <let line='4491' var='Q{}actions' as='map(*)?' slot='1' eval='7'>
      <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
@@ -9872,14 +9838,14 @@
        </arrayBlock>
       </ifCall>
      </treat>
-     <let line='4426' var='Q{}refi' as='attribute(Q{}data-ref)?' slot='2' eval='8'>
+     <let line='4493' var='Q{}refi' as='attribute(Q{}data-ref)?' slot='2' eval='8'>
       <slash simple='1'>
        <varRef name='Q{}form-control' slot='0'/>
        <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
       </slash>
-      <let line='4430' var='Q{}instanceXML' as='element()?' slot='3' eval='7'>
-       <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='0' eval='16'>
-        <check card='1' diag='0|0||xforms:getInstance-JS'>
+      <let line='4495' var='Q{}instance-id' as='xs:string' slot='3' eval='16'>
+       <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='16'>
+        <check card='1' diag='0|0||xforms:getInstanceId'>
          <cvUntyped to='xs:string'>
           <data>
            <varRef name='Q{}refi' slot='2'/>
@@ -9887,61 +9853,108 @@
          </cvUntyped>
         </check>
        </ufCall>
-       <let line='4432' var='Q{}updatedInstanceXML' as='element()?' slot='4' eval='7'>
-        <choose line='4433'>
-         <fn name='exists'>
-          <varRef name='Q{}instanceXML' slot='3'/>
-         </fn>
-         <treat line='4434' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
-          <check card='?' diag='3|0|XTTE0570|updatedInstanceXML'>
-           <applyT mode='Q{}form-check-initial' bSlot='1'>
-            <varRef role='select' name='Q{}instanceXML' slot='3'/>
-            <withParam name='Q{}instance-id' as='xs:string'>
-             <ufCall line='4428' name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='2' eval='16'>
-              <check card='1' diag='0|0||xforms:getInstanceId'>
-               <cvUntyped to='xs:string'>
-                <data>
-                 <varRef name='Q{}refi' slot='2'/>
-                </data>
-               </cvUntyped>
+       <let line='4508' var='Q{}instanceXML' as='element()?' slot='4' eval='7'>
+        <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='6'>
+         <varRef name='Q{}instance-id' slot='3'/>
+        </ufCall>
+        <let line='4510' var='Q{}updatedInstanceXML' as='element()?' slot='5' eval='7'>
+         <choose line='4512'>
+          <and op='and'>
+           <fn name='exists'>
+            <varRef name='Q{}refi' slot='2'/>
+           </fn>
+           <fn name='exists'>
+            <varRef name='Q{}instanceXML' slot='4'/>
+           </fn>
+          </and>
+          <let line='4513' var='Q{}updatedNode' as='node()' slot='6' eval='16'>
+           <treat line='4514' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|updatedNode'>
+            <check card='1' diag='3|0|XTTE0570|updatedNode'>
+             <evaluate dxns=''>
+              <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
+               <check card='1' diag='0|0||xforms:impose'>
+                <cvUntyped to='xs:string'>
+                 <data>
+                  <varRef name='Q{}refi' slot='2'/>
+                 </data>
+                </cvUntyped>
+               </check>
+              </ufCall>
+              <varRef role='cxt' name='Q{}instanceXML' slot='4'/>
+              <check role='nsCxt' card='1' diag='4|0|XTTE3170|xsl:evaluate/namespace-context'>
+               <varRef name='Q{}instanceXML' slot='4'/>
               </check>
-             </ufCall>
-            </withParam>
-           </applyT>
-          </check>
-         </treat>
-        </choose>
-        <forEach line='4440'>
-         <varRef name='Q{}actions' slot='1'/>
-         <let line='4441' var='Q{}action-map' as='map(*)' slot='5' eval='16'>
-          <dot type='map(*)'/>
-          <choose line='4444'>
-           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
-            <varRef name='Q{}action-map' slot='5'/>
-            <str val='@event'/>
-           </ifCall>
-           <choose line='4445'>
-            <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
-             <data>
-              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-               <varRef name='Q{}action-map' slot='5'/>
-               <str val='@event'/>
-              </ifCall>
-             </data>
-             <str val='DOMActivate'/>
-            </gc>
-            <callT line='4446' name='Q{}applyActions' bSlot='3' flags='t'>
-             <withParam name='Q{}action-map' flags='t' as='item()'>
-              <varRef line='4447' name='Q{}action-map' slot='5'/>
-             </withParam>
-             <withParam name='Q{}instanceXML' flags='t' as='element()?'>
-              <varRef line='4448' name='Q{}updatedInstanceXML' slot='4'/>
-             </withParam>
-            </callT>
+              <str role='sa' val='no'/>
+              <map role='options' size='0'/>
+              <map role='wp' size='0'/>
+             </evaluate>
+            </check>
+           </treat>
+           <let line='4516' var='Q{}new-value' as='xs:string' slot='7' eval='16'>
+            <treat line='4517' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-value'>
+             <check card='1' diag='3|0|XTTE0570|new-value'>
+              <cvUntyped to='xs:string' diag='3|0|XTTE0570|new-value'>
+               <data>
+                <applyT mode='Q{}get-field' bSlot='3'>
+                 <varRef role='select' name='Q{}form-control' slot='0'/>
+                </applyT>
+               </data>
+              </cvUntyped>
+             </check>
+            </treat>
+            <treat line='4519' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+             <check card='?' diag='3|0|XTTE0570|updatedInstanceXML'>
+              <applyT mode='Q{}recalculate' bSlot='4'>
+               <varRef role='select' name='Q{}instanceXML' slot='4'/>
+               <withParam name='Q{}instance-id' as='xs:string'>
+                <varRef line='4520' name='Q{}instance-id' slot='3'/>
+               </withParam>
+               <withParam name='Q{}updated-nodes' flags='t' as='node()'>
+                <varRef line='4521' name='Q{}updatedNode' slot='6'/>
+               </withParam>
+               <withParam name='Q{}updated-values' flags='t' as='xs:string'>
+                <varRef line='4522' name='Q{}new-value' slot='7'/>
+               </withParam>
+              </applyT>
+             </check>
+            </treat>
+           </let>
+          </let>
+          <true/>
+          <varRef line='4526' name='Q{}instanceXML' slot='4'/>
+         </choose>
+         <forEach line='4533'>
+          <varRef name='Q{}actions' slot='1'/>
+          <let line='4534' var='Q{}action-map' as='map(*)' slot='8' eval='16'>
+           <dot type='map(*)'/>
+           <choose line='4537'>
+            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+             <varRef name='Q{}action-map' slot='8'/>
+             <str val='@event'/>
+            </ifCall>
+            <choose line='4538'>
+             <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+              <data>
+               <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                <varRef name='Q{}action-map' slot='8'/>
+                <str val='@event'/>
+               </ifCall>
+              </data>
+              <str val='DOMActivate'/>
+             </gc>
+             <callT line='4539' name='Q{}applyActions' bSlot='5' flags='t'>
+              <withParam name='Q{}action-map' flags='t' as='item()'>
+               <varRef line='4540' name='Q{}action-map' slot='8'/>
+              </withParam>
+              <withParam name='Q{}instanceXML' flags='t' as='element()?'>
+               <varRef line='4541' name='Q{}updatedInstanceXML' slot='5'/>
+              </withParam>
+             </callT>
+            </choose>
            </choose>
-          </choose>
-         </let>
-        </forEach>
+          </let>
+         </forEach>
+        </let>
        </let>
       </let>
      </let>
@@ -9949,9 +9962,9 @@
    </sequence>
   </template>
  </co>
- <co id='64' binds='44'>
-  <template name='Q{}setActions' flags='os' line='3674' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3675'>
+ <co id='63' binds='43'>
+  <template name='Q{}setActions' flags='os' line='3654' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3655'>
     <param name='Q{}this' slot='0' flags='i' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
       <check card='1' diag='8|0|XTTE0590|this'>
@@ -9959,7 +9972,7 @@
       </check>
      </treat>
     </param>
-    <applyT line='3677' flags='t' bSlot='0'>
+    <applyT line='3657' flags='t' bSlot='0'>
      <union role='select' op='|'>
       <union op='|'>
        <union op='|'>
@@ -10022,9 +10035,9 @@
    </sequence>
   </template>
  </co>
- <co id='68' binds=''>
-  <template name='Q{}serverError' flags='os' line='1059' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1060'>
+ <co id='67' binds=''>
+  <template name='Q{}serverError' flags='os' line='1066' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1067'>
     <param name='Q{}responseMap' slot='0' flags='i' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|responseMap'>
       <check card='1' diag='8|0|XTTE0590|responseMap'>
@@ -10032,7 +10045,7 @@
       </check>
      </treat>
     </param>
-    <message line='1061'>
+    <message line='1068'>
      <sequence role='select'>
       <valueOf>
        <str val='Server side error HTTP response - '/>
@@ -10061,9 +10074,9 @@
    </sequence>
   </template>
  </co>
- <co id='61' binds='62 63 44'>
-  <template name='Q{}setAction' flags='os' line='3841' module='saxon-xforms.xsl' slots='15'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3842'>
+ <co id='60' binds='61 62 43'>
+  <template name='Q{}setAction' flags='os' line='3821' module='saxon-xforms.xsl' slots='15'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3822'>
     <param name='Q{}this' slot='0' flags='i' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
       <check card='1' diag='8|0|XTTE0590|this'>
@@ -10071,42 +10084,42 @@
       </check>
      </treat>
     </param>
-    <param line='3843' name='Q{}nodeset' slot='1' flags='t'>
+    <param line='3823' name='Q{}nodeset' slot='1' flags='t'>
      <str role='select' val=''/>
      <supplied role='conversion' slot='1'/>
     </param>
-    <let line='3846' var='Q{}bindingi' as='node()?' slot='2' eval='7'>
-     <treat line='3847' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+    <let line='3826' var='Q{}bindingi' as='node()?' slot='2' eval='7'>
+     <treat line='3827' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
       <check card='?' diag='3|0|XTTE0570|bindingi'>
        <callT name='Q{}getBinding' bSlot='0'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <treat line='3848' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+         <treat line='3828' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
           <dot flags='a'/>
          </treat>
         </withParam>
        </callT>
       </check>
      </treat>
-     <let line='3853' var='Q{}refi' as='xs:string' slot='3' eval='16'>
-      <treat line='3854' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+     <let line='3833' var='Q{}refi' as='xs:string' slot='3' eval='16'>
+      <treat line='3834' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
        <check card='1' diag='3|0|XTTE0570|refi'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
          <data>
           <callT name='Q{}getDataRef' bSlot='1'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <treat line='3855' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+            <treat line='3835' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
              <dot flags='a'/>
             </treat>
            </withParam>
            <withParam name='Q{}bindingi' flags='c' as='node()?'>
-            <varRef line='3856' name='Q{}bindingi' slot='2'/>
+            <varRef line='3836' name='Q{}bindingi' slot='2'/>
            </withParam>
           </callT>
          </data>
         </cvUntyped>
        </check>
       </treat>
-      <ifCall line='3864' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+      <ifCall line='3844' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
        <sequence>
         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
          <str val='name'/>
@@ -10116,14 +10129,14 @@
           </treat>
          </fn>
         </ifCall>
-        <choose line='3866'>
+        <choose line='3846'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}value)' jsTest='return item.name===&#39;value&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3867' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3847' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@value'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10133,7 +10146,7 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3869'>
+        <choose line='3849'>
          <and op='and'>
           <fn name='empty'>
            <slash simple='1'>
@@ -10150,25 +10163,25 @@
            </slash>
           </fn>
          </and>
-         <ifCall line='3870' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3850' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='value'/>
           <fn name='string'>
            <dot flags='a'/>
           </fn>
          </ifCall>
         </choose>
-        <ifCall line='3873' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+        <ifCall line='3853' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
          <str val='@ref'/>
          <varRef name='Q{}refi' slot='3'/>
         </ifCall>
-        <choose line='3879'>
+        <choose line='3859'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}position)' jsTest='return item.name===&#39;position&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3880' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3860' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@position'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10178,14 +10191,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3882'>
+        <choose line='3862'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}at)' jsTest='return item.name===&#39;at&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3883' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3863' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@at'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10195,14 +10208,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3887'>
+        <choose line='3867'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}if)' jsTest='return item.name===&#39;if&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3888' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3868' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@if'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10212,14 +10225,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3892'>
+        <choose line='3872'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}while)' jsTest='return item.name===&#39;while&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3893' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3873' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@while'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10229,14 +10242,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3896'>
+        <choose line='3876'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='@*:event' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===2&amp;&amp;q.local===&#39;event&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3897' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3877' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@event'/>
           <fn name='string'>
            <check card='?' diag='0|0||fn:string'>
@@ -10248,14 +10261,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3899'>
+        <choose line='3879'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}submission)' jsTest='return item.name===&#39;submission&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3900' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3880' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@submission'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10265,14 +10278,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3903'>
+        <choose line='3883'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}model)' jsTest='return item.name===&#39;model&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3904' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3884' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@model'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10282,14 +10295,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3907'>
+        <choose line='3887'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}control)' jsTest='return item.name===&#39;control&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3908' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3888' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@control'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10299,14 +10312,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3911'>
+        <choose line='3891'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}repeat)' jsTest='return item.name===&#39;repeat&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3912' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3892' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@repeat'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10316,14 +10329,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3915'>
+        <choose line='3895'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}index)' jsTest='return item.name===&#39;index&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3916' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3896' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@index'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10333,16 +10346,16 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3921'>
+        <choose line='3901'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}origin)' jsTest='return item.name===&#39;origin&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3929' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3909' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@origin'/>
-          <let line='3925' var='Q{}base' as='xs:string' slot='4' eval='16'>
+          <let line='3905' var='Q{}base' as='xs:string' slot='4' eval='16'>
            <choose>
             <fn name='exists'>
              <slash simple='1'>
@@ -10371,22 +10384,22 @@
                 </data>
                </cvUntyped>
               </check>
-              <choose line='836'>
+              <choose line='838'>
                <fn name='starts-with'>
                 <varRef name='Q{}relative' slot='6'/>
                 <str val='/'/>
                </fn>
-               <varRef line='837' name='Q{}relative' slot='6'/>
-               <fn line='839' name='starts-with'>
+               <varRef line='839' name='Q{}relative' slot='6'/>
+               <fn line='841' name='starts-with'>
                 <varRef name='Q{}relative' slot='6'/>
                 <str val='instance('/>
                </fn>
-               <varRef line='840' name='Q{}relative' slot='6'/>
-               <fn line='842' name='not'>
+               <varRef line='842' name='Q{}relative' slot='6'/>
+               <fn line='844' name='not'>
                 <varRef name='Q{}base' slot='5'/>
                </fn>
-               <varRef line='843' name='Q{}relative' slot='6'/>
-               <or line='845' op='or'>
+               <varRef line='845' name='Q{}relative' slot='6'/>
+               <or line='847' op='or'>
                 <fn name='not'>
                  <varRef name='Q{}relative' slot='6'/>
                 </fn>
@@ -10395,9 +10408,9 @@
                  <str val='.'/>
                 </vc>
                </or>
-               <varRef line='846' name='Q{}base' slot='5'/>
+               <varRef line='848' name='Q{}base' slot='5'/>
                <true/>
-               <let line='850' var='Q{}parentCallCount' as='xs:integer' slot='7' eval='16'>
+               <let line='852' var='Q{}parentCallCount' as='xs:integer' slot='7' eval='16'>
                 <choose>
                  <fn name='contains'>
                   <varRef name='Q{}relative' slot='6'/>
@@ -10424,7 +10437,7 @@
                  <true/>
                  <int val='0'/>
                 </choose>
-                <let line='853' var='Q{}slashes' as='xs:integer*' slot='8' eval='4'>
+                <let line='855' var='Q{}slashes' as='xs:integer*' slot='8' eval='4'>
                  <choose>
                   <fn name='contains'>
                    <varRef name='Q{}base' slot='5'/>
@@ -10439,15 +10452,15 @@
                   <true/>
                   <int val='0'/>
                  </choose>
-                 <choose line='885'>
+                 <choose line='887'>
                   <compareToInt op='gt' val='0'>
                    <varRef name='Q{}parentCallCount' slot='7'/>
                   </compareToInt>
-                  <fn line='889' name='concat'>
+                  <fn line='891' name='concat'>
                    <fn name='substring'>
                     <varRef name='Q{}base' slot='5'/>
                     <int val='1'/>
-                    <choose line='864'>
+                    <choose line='866'>
                      <and op='and'>
                       <vc op='ge' onEmpty='0' comp='CAVC'>
                        <fn name='count'>
@@ -10459,7 +10472,7 @@
                        <varRef name='Q{}parentCallCount' slot='7'/>
                       </compareToInt>
                      </and>
-                     <let line='865' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='9' eval='16'>
+                     <let line='867' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='9' eval='16'>
                       <arith op='-' calc='i-i'>
                        <varRef name='Q{}parentCallCount' slot='7'/>
                        <int val='1'/>
@@ -10475,7 +10488,7 @@
                       </check>
                      </let>
                      <true/>
-                     <check line='868' card='1' diag='3|0|XTTE0570|parentSlash'>
+                     <check line='870' card='1' diag='3|0|XTTE0570|parentSlash'>
                       <lastOf>
                        <varRef name='Q{}slashes' slot='8'/>
                       </lastOf>
@@ -10490,7 +10503,7 @@
                    </fn>
                   </fn>
                   <true/>
-                  <fn line='892' name='concat'>
+                  <fn line='894' name='concat'>
                    <varRef name='Q{}base' slot='5'/>
                    <str val='/'/>
                    <varRef name='Q{}relative' slot='6'/>
@@ -10512,7 +10525,7 @@
              </check>
             </treat>
            </choose>
-           <let line='3927' var='Q{}relative' as='xs:string' slot='10' eval='16'>
+           <let line='3907' var='Q{}relative' as='xs:string' slot='10' eval='16'>
             <check card='1' diag='0|1||xforms:resolveXPathStrings'>
              <cvUntyped to='xs:string'>
               <data>
@@ -10523,22 +10536,22 @@
               </data>
              </cvUntyped>
             </check>
-            <choose line='836'>
+            <choose line='838'>
              <fn name='starts-with'>
               <varRef name='Q{}relative' slot='10'/>
               <str val='/'/>
              </fn>
-             <varRef line='837' name='Q{}relative' slot='10'/>
-             <fn line='839' name='starts-with'>
+             <varRef line='839' name='Q{}relative' slot='10'/>
+             <fn line='841' name='starts-with'>
               <varRef name='Q{}relative' slot='10'/>
               <str val='instance('/>
              </fn>
-             <varRef line='840' name='Q{}relative' slot='10'/>
-             <fn line='842' name='not'>
+             <varRef line='842' name='Q{}relative' slot='10'/>
+             <fn line='844' name='not'>
               <varRef name='Q{}base' slot='4'/>
              </fn>
-             <varRef line='843' name='Q{}relative' slot='10'/>
-             <or line='845' op='or'>
+             <varRef line='845' name='Q{}relative' slot='10'/>
+             <or line='847' op='or'>
               <fn name='not'>
                <varRef name='Q{}relative' slot='10'/>
               </fn>
@@ -10547,9 +10560,9 @@
                <str val='.'/>
               </vc>
              </or>
-             <varRef line='846' name='Q{}base' slot='4'/>
+             <varRef line='848' name='Q{}base' slot='4'/>
              <true/>
-             <let line='850' var='Q{}parentCallCount' as='xs:integer' slot='11' eval='16'>
+             <let line='852' var='Q{}parentCallCount' as='xs:integer' slot='11' eval='16'>
               <choose>
                <fn name='contains'>
                 <varRef name='Q{}relative' slot='10'/>
@@ -10576,7 +10589,7 @@
                <true/>
                <int val='0'/>
               </choose>
-              <let line='853' var='Q{}slashes' as='xs:integer*' slot='12' eval='4'>
+              <let line='855' var='Q{}slashes' as='xs:integer*' slot='12' eval='4'>
                <choose>
                 <fn name='contains'>
                  <varRef name='Q{}base' slot='4'/>
@@ -10591,15 +10604,15 @@
                 <true/>
                 <int val='0'/>
                </choose>
-               <choose line='885'>
+               <choose line='887'>
                 <compareToInt op='gt' val='0'>
                  <varRef name='Q{}parentCallCount' slot='11'/>
                 </compareToInt>
-                <fn line='889' name='concat'>
+                <fn line='891' name='concat'>
                  <fn name='substring'>
                   <varRef name='Q{}base' slot='4'/>
                   <int val='1'/>
-                  <choose line='864'>
+                  <choose line='866'>
                    <and op='and'>
                     <vc op='ge' onEmpty='0' comp='CAVC'>
                      <fn name='count'>
@@ -10611,7 +10624,7 @@
                      <varRef name='Q{}parentCallCount' slot='11'/>
                     </compareToInt>
                    </and>
-                   <let line='865' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='13' eval='13'>
+                   <let line='867' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='13' eval='13'>
                     <arith op='-' calc='i-i'>
                      <varRef name='Q{}parentCallCount' slot='11'/>
                      <int val='1'/>
@@ -10627,7 +10640,7 @@
                     </check>
                    </let>
                    <true/>
-                   <check line='868' card='1' diag='3|0|XTTE0570|parentSlash'>
+                   <check line='870' card='1' diag='3|0|XTTE0570|parentSlash'>
                     <lastOf>
                      <varRef name='Q{}slashes' slot='12'/>
                     </lastOf>
@@ -10642,7 +10655,7 @@
                  </fn>
                 </fn>
                 <true/>
-                <fn line='892' name='concat'>
+                <fn line='894' name='concat'>
                  <varRef name='Q{}base' slot='4'/>
                  <str val='/'/>
                  <varRef name='Q{}relative' slot='10'/>
@@ -10655,28 +10668,28 @@
           </let>
          </ifCall>
         </choose>
-        <choose line='3933'>
+        <choose line='3913'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
           </slash>
          </fn>
-         <ifCall line='3934' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3914' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='nested-actions'/>
-          <let line='3935' var='Q{}array' as='map(*)*' slot='14' eval='3'>
-           <treat line='3936' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|array'>
+          <let line='3915' var='Q{}array' as='map(*)*' slot='14' eval='3'>
+           <treat line='3916' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|array'>
             <forEach>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
              </slash>
-             <applyT line='3937' bSlot='2'>
+             <applyT line='3917' bSlot='2'>
               <dot role='select' type='element()'/>
              </applyT>
             </forEach>
            </treat>
-           <ifCall line='3940' name='Q{http://www.w3.org/2005/xpath-functions/array}_from-sequence' type='array(*)'>
+           <ifCall line='3920' name='Q{http://www.w3.org/2005/xpath-functions/array}_from-sequence' type='array(*)'>
             <varRef name='Q{}array' slot='14'/>
            </ifCall>
           </let>
@@ -10695,10 +10708,10 @@
    </sequence>
   </template>
  </co>
- <co id='69' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}check-constraints-on-fields' line='957' module='saxon-xforms.xsl' eval='8' flags='pU' as='item()*' slots='4'>
+ <co id='68' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}check-constraints-on-fields' line='959' module='saxon-xforms.xsl' eval='8' flags='pU' as='item()*' slots='4'>
    <arg name='Q{}updatedInstanceXML' as='document-node()'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='960' var='Q{}constraint-fieldsi' as='element()*' slot='1' eval='8'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='962' var='Q{}constraint-fieldsi' as='element()*' slot='1' eval='8'>
     <filter flags='b'>
      <slash simple='1'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
@@ -10708,10 +10721,10 @@
       <axis name='attribute' nodeTest='attribute(Q{}data-constraint)' jsTest='return item.name===&#39;data-constraint&#39;'/>
      </fn>
     </filter>
-    <forEach line='964'>
+    <forEach line='966'>
      <varRef name='Q{}constraint-fieldsi' slot='1'/>
-     <let line='965' var='Q{}contexti' as='node()' slot='2' eval='16'>
-      <treat line='966' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|contexti'>
+     <let line='967' var='Q{}contexti' as='node()' slot='2' eval='16'>
+      <treat line='968' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|contexti'>
        <check card='1' diag='3|0|XTTE0570|contexti'>
         <evaluate dxns=''>
          <check role='xpath' card='1' diag='4|0||xsl:evaluate/xpath'>
@@ -10727,8 +10740,8 @@
         </evaluate>
        </check>
       </treat>
-      <let line='969' var='Q{}resulti' as='xs:boolean' slot='3' eval='16'>
-       <treat line='972' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|resulti'>
+      <let line='971' var='Q{}resulti' as='xs:boolean' slot='3' eval='16'>
+       <treat line='974' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|resulti'>
         <check card='1' diag='3|0|XTTE0570|resulti'>
          <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|resulti'>
           <data>
@@ -10748,7 +10761,7 @@
          </cvUntyped>
         </check>
        </treat>
-       <choose line='980'>
+       <choose line='982'>
         <fn name='not'>
          <varRef name='Q{}resulti' slot='3'/>
         </fn>
@@ -10760,98 +10773,37 @@
    </let>
   </function>
  </co>
- <co id='48' binds='57'>
-  <mode name='Q{}binding-calculation-initial' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='28' rank='0' minImp='0' slots='2' flags='s' line='2744' module='saxon-xforms.xsl'>
-    <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2745'>
-     <param name='Q{}instance-id' slot='0' as='xs:string'>
-      <str role='select' val='saxon-forms-default'/>
-      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|instance-id'>
-       <check card='1' diag='8|0|XTTE0590|instance-id'>
-        <cvUntyped to='xs:string' diag='8|0|XTTE0590|instance-id'>
-         <data>
-          <supplied slot='0'/>
-         </data>
-        </cvUntyped>
-       </check>
-      </treat>
-     </param>
-     <let line='2747' var='Q{}calculationMap' as='map(xs:string, xs:string)' slot='1' eval='16'>
-      <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|calculationMap'>
-       <check card='1' diag='3|0|XTTE0570|calculationMap'>
-        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-         <check card='1' diag='0|0||ixsl:call'>
-          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-         </check>
-         <str val='getCalculationMap'/>
-         <array size='0'/>
-        </ifCall>
-       </check>
-      </treat>
-      <copy line='2761' flags='cin'>
-       <applyT role='content' mode='Q{}binding-calculation' bSlot='0'>
-        <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-        <withParam name='Q{}curPath' as='xs:string'>
-         <choose line='2751'>
-          <vc op='eq' onEmpty='0' comp='CCC'>
-           <varRef name='Q{}instance-id' slot='0'/>
-           <str val='saxon-forms-default'/>
-          </vc>
-          <str val=''/>
-          <true/>
-          <cvUntyped line='2755' to='xs:string' diag='3|0|XTTE0570|curPath'>
-           <cast as='xs:untypedAtomic' emptiable='0'>
-            <fn name='concat'>
-             <str val='instance(&#39;'/>
-             <varRef name='Q{}instance-id' slot='0'/>
-             <str val='&#39;)/'/>
-            </fn>
-           </cast>
-          </cvUntyped>
-         </choose>
-        </withParam>
-        <withParam name='Q{}calculationMap' flags='t' as='map(xs:string, xs:string)'>
-         <varRef line='2763' name='Q{}calculationMap' slot='1'/>
-        </withParam>
-       </applyT>
-      </copy>
-     </let>
-    </sequence>
-   </templateRule>
-  </mode>
- </co>
- <co id='70' binds='20 20'>
+ <co id='69' binds='18 18'>
   <mode name='Q{http://saxonica.com/ns/interactiveXSLT}onchange' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='0.0' seq='1' rank='0' minImp='0' slots='0' flags='s' line='710' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='1' rank='0' minImp='0' slots='0' flags='s' line='712' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
-    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='711' name='Q{}xforms-value-changed' bSlot='0' flags='t'>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='713' name='Q{}xforms-value-changed' bSlot='0' flags='t'>
      <withParam name='Q{}form-control' flags='c' as='node()'>
-      <dot line='712' type='element(Q{}input)'/>
+      <dot line='714' type='element(Q{}input)'/>
      </withParam>
     </callT>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='2' rank='0' minImp='0' slots='0' flags='s' line='720' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='2' rank='0' minImp='0' slots='0' flags='s' line='722' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{}select)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;select&#39;;'/>
-    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='721' name='Q{}xforms-value-changed' bSlot='1' flags='t'>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='723' name='Q{}xforms-value-changed' bSlot='1' flags='t'>
      <withParam name='Q{}form-control' flags='c' as='node()'>
-      <dot line='722' type='element(Q{}select)'/>
+      <dot line='724' type='element(Q{}select)'/>
      </withParam>
     </callT>
    </templateRule>
   </mode>
  </co>
- <co id='54' binds='46 71 58 58 72 44'>
-  <template name='Q{}xformsjs-main' flags='os' line='111' module='saxon-xforms.xsl' slots='24'>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='608' var='Q{http://saxon.sf.net/generated-variable}v1' as='item()' slot='5' eval='13'>
+ <co id='54' binds='47 70 57 57 71 43'>
+  <template name='Q{}xformsjs-main' flags='os' line='113' module='saxon-xforms.xsl' slots='23'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='610' var='Q{http://saxon.sf.net/generated-variable}v1' as='item()' slot='5' eval='13'>
     <check card='1' diag='0|0||ixsl:call'>
      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
     </check>
-    <let line='577' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='6' eval='13'>
+    <let line='579' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='6' eval='13'>
      <check card='1' diag='0|0||ixsl:call'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
      </check>
-     <sequence line='112'>
+     <sequence line='114'>
       <param name='Q{}xforms-doc' slot='0' as='document-node()?'>
        <empty role='select'/>
        <treat role='conversion' as='document-node()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);' diag='8|0|XTTE0590|xforms-doc'>
@@ -10860,7 +10812,7 @@
         </check>
        </treat>
       </param>
-      <param line='113' name='Q{}xforms-file' slot='1' as='xs:string?'>
+      <param line='115' name='Q{}xforms-file' slot='1' as='xs:string?'>
        <empty role='select'/>
        <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|xforms-file'>
         <check card='?' diag='8|0|XTTE0590|xforms-file'>
@@ -10872,13 +10824,13 @@
         </check>
        </treat>
       </param>
-      <param line='122' name='Q{}instance-xml' slot='2' as='document-node()*'>
+      <param line='124' name='Q{}instance-xml' slot='2' as='document-node()*'>
        <empty role='select'/>
        <treat role='conversion' as='document-node()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);' diag='8|0|XTTE0590|instance-xml'>
         <supplied slot='2'/>
        </treat>
       </param>
-      <param line='123' name='Q{}instance-docs' slot='3' as='map(*)?'>
+      <param line='125' name='Q{}instance-docs' slot='3' as='map(*)?'>
        <empty role='select'/>
        <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|instance-docs'>
         <check card='?' diag='8|0|XTTE0590|instance-docs'>
@@ -10886,7 +10838,7 @@
         </check>
        </treat>
       </param>
-      <param line='125' name='Q{}xFormsId' slot='4' as='xs:string'>
+      <param line='127' name='Q{}xFormsId' slot='4' as='xs:string'>
        <gVarRef role='select' name='Q{}xform-html-id' bSlot='0'/>
        <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|xFormsId'>
         <check card='1' diag='8|0|XTTE0590|xFormsId'>
@@ -10898,14 +10850,14 @@
         </check>
        </treat>
       </param>
-      <message line='127'>
+      <message line='129'>
        <valueOf role='select'>
         <str val='[xformsjs-main] START'/>
        </valueOf>
        <str role='terminate' val='no'/>
        <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
       </message>
-      <let line='135' var='Q{}xforms-doci' as='document-node()?' slot='7' eval='7'>
+      <let line='137' var='Q{}xforms-doci' as='document-node()?' slot='7' eval='7'>
        <choose>
         <fn name='empty'>
          <varRef name='Q{}xforms-doc' slot='0'/>
@@ -10916,7 +10868,7 @@
         <true/>
         <varRef name='Q{}xforms-doc' slot='0'/>
        </choose>
-       <let line='137' var='Q{}xform' as='element(Q{http://www.w3.org/2002/xforms}xform, Q{http://www.w3.org/2001/XMLSchema}untyped)' slot='8' eval='16'>
+       <let line='139' var='Q{}xform' as='element(Q{http://www.w3.org/2002/xforms}xform, Q{http://www.w3.org/2001/XMLSchema}untyped)' slot='8' eval='16'>
         <treat as='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;' diag='3|0|XTTE0570|xform'>
          <let var='Q{}this' as='element()' slot='9' eval='16'>
           <check card='1' diag='0|0||xforms:addNamespaceDeclarations'>
@@ -10925,16 +10877,16 @@
             <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
            </slash>
           </check>
-          <compElem line='3035'>
+          <compElem line='3008'>
            <fn role='name' name='name'>
             <varRef name='Q{}this' slot='9'/>
            </fn>
-           <sequence role='content' line='3036'>
+           <sequence role='content' line='3009'>
             <namespace flags='l'>
              <str role='name' val='xforms'/>
              <str role='select' val='http://www.w3.org/2002/xforms'/>
             </namespace>
-            <forEach line='3037'>
+            <forEach line='3010'>
              <filter flags='b'>
               <filter flags='b'>
                <slash simple='1'>
@@ -10973,21 +10925,21 @@
                </gc>
               </fn>
              </filter>
-             <namespace line='3040' flags='l'>
-              <fn role='name' line='3039' name='substring-before'>
+             <namespace line='3013' flags='l'>
+              <fn role='name' line='3012' name='substring-before'>
                <fn name='name'>
                 <dot type='element()'/>
                </fn>
                <str val=':'/>
               </fn>
               <convert role='select' from='xs:anyURI' to='xs:string'>
-               <fn line='3038' name='namespace-uri'>
+               <fn line='3011' name='namespace-uri'>
                 <dot type='element()'/>
                </fn>
               </convert>
              </namespace>
             </forEach>
-            <copyOf line='3042' flags='vc'>
+            <copyOf line='3015' flags='vc'>
              <sequence>
               <slash simple='1'>
                <varRef name='Q{}this' slot='9'/>
@@ -11003,18 +10955,18 @@
           </compElem>
          </let>
         </treat>
-        <let line='141' var='Q{}xforms-instances' as='map(xs:string, element())' slot='10' eval='16'>
-         <choose line='143'>
+        <let line='143' var='Q{}xforms-instances' as='map(xs:string, element())' slot='10' eval='16'>
+         <choose line='145'>
           <fn name='empty'>
            <varRef name='Q{}instance-docs' slot='3'/>
           </fn>
-          <treat line='146' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|xforms-instances'>
+          <treat line='148' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|xforms-instances'>
            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
             <choose>
              <fn name='empty'>
               <varRef name='Q{}instance-xml' slot='2'/>
              </fn>
-             <let line='147' var='Q{}instances' as='element(Q{http://www.w3.org/2002/xforms}instance)*' slot='11' eval='4'>
+             <let line='149' var='Q{}instances' as='element(Q{http://www.w3.org/2002/xforms}instance)*' slot='11' eval='4'>
               <slash simple='2'>
                <slash simple='2'>
                 <slash simple='1'>
@@ -11025,7 +10977,7 @@
                </slash>
                <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}instance)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;instance&#39;;'/>
               </slash>
-              <sequence line='148'>
+              <sequence line='150'>
                <choose>
                 <fn name='exists'>
                  <filter flags='b'>
@@ -11035,7 +10987,7 @@
                   </fn>
                  </filter>
                 </fn>
-                <treat line='150' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='20|0|XTTE3375|xsl:map sequence constructor'>
+                <treat line='152' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='20|0|XTTE3375|xsl:map sequence constructor'>
                  <message>
                   <str role='select' val='[xformsjs-main] FATAL ERROR: The XForm contains more than one instance with no ID. At most one instance may have no ID.'/>
                   <str role='terminate' val='yes'/>
@@ -11043,17 +10995,17 @@
                  </message>
                 </treat>
                </choose>
-               <forEach line='153'>
+               <forEach line='155'>
                 <varRef name='Q{}instances' slot='11'/>
-                <let line='154' var='Q{}instance-with-explicit-namespaces' as='element()' slot='12' eval='16'>
-                 <treat line='155' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-explicit-namespaces'>
+                <let line='156' var='Q{}instance-with-explicit-namespaces' as='element()' slot='12' eval='16'>
+                 <treat line='157' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-explicit-namespaces'>
                   <check card='1' diag='3|0|XTTE0570|instance-with-explicit-namespaces'>
                    <applyT mode='Q{}namespace-fix' bSlot='1'>
                     <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
                    </applyT>
                   </check>
                  </treat>
-                 <ifCall line='164' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                 <ifCall line='166' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                   <check card='1' diag='0|0||map:entry'>
                    <cast as='xs:string' emptiable='1'>
                     <choose>
@@ -11073,7 +11025,7 @@
               </sequence>
              </let>
              <true/>
-             <ifCall line='174' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+             <ifCall line='176' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
               <check card='1' diag='0|0||map:entry'>
                <cast as='xs:string' emptiable='1'>
                 <choose>
@@ -11133,18 +11085,18 @@
            </ifCall>
           </treat>
           <true/>
-          <treat line='180' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|xforms-instances'>
+          <treat line='182' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|xforms-instances'>
            <check card='1' diag='3|0|XTTE0570|xforms-instances'>
             <varRef name='Q{}instance-docs' slot='3'/>
            </check>
           </treat>
          </choose>
-         <let line='187' var='Q{}default-instance' as='element()' slot='13' eval='16'>
-          <choose line='189'>
+         <let line='189' var='Q{}default-instance' as='element()' slot='13' eval='16'>
+          <choose line='191'>
            <fn name='empty'>
             <varRef name='Q{}instance-docs' slot='3'/>
            </fn>
-           <choose line='191'>
+           <choose line='193'>
             <fn name='exists'>
              <filter flags='b'>
               <slash simple='2'>
@@ -11162,7 +11114,7 @@
               </fn>
              </filter>
             </fn>
-            <check line='192' card='1' diag='3|0|XTTE0570|default-instance'>
+            <check line='194' card='1' diag='3|0|XTTE0570|default-instance'>
              <slash simple='2'>
               <slash>
                <slash simple='2'>
@@ -11185,7 +11137,7 @@
              </slash>
             </check>
             <true/>
-            <check line='195' card='1' diag='3|0|XTTE0570|default-instance'>
+            <check line='197' card='1' diag='3|0|XTTE0570|default-instance'>
              <slash simple='2'>
               <slash>
                <slash simple='2'>
@@ -11204,7 +11156,7 @@
             </check>
            </choose>
            <true/>
-           <treat line='201' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|default-instance'>
+           <treat line='203' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|default-instance'>
             <check card='1' diag='3|0|XTTE0570|default-instance'>
              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
               <check card='1' diag='0|0||ixsl:call'>
@@ -11216,8 +11168,8 @@
             </check>
            </treat>
           </choose>
-          <let line='207' var='Q{}bindings' as='map(xs:string, element(Q{http://www.w3.org/2002/xforms}bind))' slot='14' eval='8'>
-           <ifCall line='209' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+          <let line='209' var='Q{}bindings' as='map(xs:string, element(Q{http://www.w3.org/2002/xforms}bind))' slot='14' eval='8'>
+           <ifCall line='211' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
             <forEach>
              <slash simple='2'>
               <slash simple='2'>
@@ -11229,7 +11181,7 @@
               </slash>
               <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}bind)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;bind&#39;;'/>
              </slash>
-             <ifCall line='217' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+             <ifCall line='219' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
               <check card='1' diag='0|0||map:entry'>
                <cast as='xs:string' emptiable='1'>
                 <choose>
@@ -11252,16 +11204,16 @@
              <str val='XTDE3365'/>
             </map>
            </ifCall>
-           <let line='231' var='Q{}bindingKeys' as='xs:anyAtomicType*' slot='15' eval='3'>
+           <let line='233' var='Q{}bindingKeys' as='xs:anyAtomicType*' slot='15' eval='3'>
             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
              <varRef name='Q{}bindings' slot='14'/>
             </ifCall>
-            <let line='233' var='Q{}RelevantBindings' as='map(xs:string, xs:string)' slot='16' eval='16'>
-             <treat line='235' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|RelevantBindings'>
+            <let line='235' var='Q{}RelevantBindings' as='map(xs:string, xs:string)' slot='16' eval='16'>
+             <treat line='237' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|RelevantBindings'>
               <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
                <forEach>
                 <varRef name='Q{}bindingKeys' slot='15'/>
-                <let line='236' var='Q{}bindingNode' as='element(Q{http://www.w3.org/2002/xforms}bind)' slot='17' eval='16'>
+                <let line='238' var='Q{}bindingNode' as='element(Q{http://www.w3.org/2002/xforms}bind)' slot='17' eval='16'>
                  <check card='1' diag='3|0|XTTE0570|bindingNode'>
                   <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
                    <varRef name='Q{}bindings' slot='14'/>
@@ -11270,7 +11222,7 @@
                    </cast>
                   </ifCall>
                  </check>
-                 <choose line='238'>
+                 <choose line='240'>
                   <fn name='exists'>
                    <filter flags='b'>
                     <varRef name='Q{}bindingNode' slot='17'/>
@@ -11279,8 +11231,8 @@
                     </fn>
                    </filter>
                   </fn>
-                  <ifCall line='240' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
-                   <check line='239' card='1' diag='3|0|XTTE0570|keyi'>
+                  <ifCall line='242' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                   <check line='241' card='1' diag='3|0|XTTE0570|keyi'>
                     <cast as='xs:string' emptiable='1'>
                      <data>
                       <slash simple='1'>
@@ -11310,12 +11262,12 @@
                </map>
               </ifCall>
              </treat>
-             <let line='249' var='Q{}CalculationBindings' as='map(xs:string, xs:string)' slot='18' eval='16'>
-              <treat line='251' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|CalculationBindings'>
+             <let line='251' var='Q{}CalculationBindings' as='map(xs:string, xs:string)' slot='18' eval='16'>
+              <treat line='253' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|CalculationBindings'>
                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
                 <forEach>
                  <varRef name='Q{}bindingKeys' slot='15'/>
-                 <let line='252' var='Q{}bindingNode' as='element(Q{http://www.w3.org/2002/xforms}bind)' slot='19' eval='16'>
+                 <let line='254' var='Q{}bindingNode' as='element(Q{http://www.w3.org/2002/xforms}bind)' slot='19' eval='16'>
                   <check card='1' diag='3|0|XTTE0570|bindingNode'>
                    <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
                     <varRef name='Q{}bindings' slot='14'/>
@@ -11324,7 +11276,7 @@
                     </cast>
                    </ifCall>
                   </check>
-                  <choose line='254'>
+                  <choose line='256'>
                    <fn name='exists'>
                     <filter flags='b'>
                      <varRef name='Q{}bindingNode' slot='19'/>
@@ -11333,8 +11285,8 @@
                      </fn>
                     </filter>
                    </fn>
-                   <ifCall line='256' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
-                    <check line='255' card='1' diag='3|0|XTTE0570|keyi'>
+                   <ifCall line='258' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                    <check line='257' card='1' diag='3|0|XTTE0570|keyi'>
                      <cast as='xs:string' emptiable='1'>
                       <data>
                        <slash simple='1'>
@@ -11364,7 +11316,7 @@
                 </map>
                </ifCall>
               </treat>
-              <sequence line='268'>
+              <sequence line='270'>
                <choose>
                 <gc op='=' card='M:N' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
                  <data>
@@ -11380,7 +11332,7 @@
                   <gVarRef name='Q{}xforms-cache-id' bSlot='2'/>
                  </data>
                 </gc>
-                <sequence line='269'>
+                <sequence line='271'>
                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                   <check card='1' diag='0|0||ixsl:call'>
                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -11390,7 +11342,7 @@
                    <varRef name='Q{}xforms-doc' slot='0'/>
                   </arrayBlock>
                  </ifCall>
-                 <ifCall line='270' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <ifCall line='272' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                   <check card='1' diag='0|0||ixsl:call'>
                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                   </check>
@@ -11399,7 +11351,7 @@
                    <varRef name='Q{}xform' slot='8'/>
                   </arrayBlock>
                  </ifCall>
-                 <ifCall line='271' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <ifCall line='273' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                   <check card='1' diag='0|0||ixsl:call'>
                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                   </check>
@@ -11408,7 +11360,7 @@
                    <varRef name='Q{}xFormsId' slot='4'/>
                   </arrayBlock>
                  </ifCall>
-                 <ifCall line='272' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <ifCall line='274' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                   <check card='1' diag='0|0||ixsl:call'>
                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                   </check>
@@ -11417,7 +11369,7 @@
                    <varRef name='Q{}RelevantBindings' slot='16'/>
                   </arrayBlock>
                  </ifCall>
-                 <ifCall line='273' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <ifCall line='275' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                   <check card='1' diag='0|0||ixsl:call'>
                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                   </check>
@@ -11428,15 +11380,15 @@
                  </ifCall>
                 </sequence>
                 <true/>
-                <sequence line='284'>
+                <sequence line='286'>
                  <forEach>
                   <slash simple='1'>
                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
                    <axis name='descendant' nodeTest='element(Q{}head)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;head&#39;;'/>
                   </slash>
-                  <resultDoc line='293' global='#&#xA;#Sat Feb 22 22:54:41 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sat Feb 22 22:54:41 GMT 2020&#xA;'>
+                  <resultDoc line='295' global='#&#xA;#Sun Feb 23 16:30:38 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sun Feb 23 16:30:38 GMT 2020&#xA;'>
                    <str role='href' val='?.'/>
-                   <elem role='content' line='294' name='script' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+                   <elem role='content' line='296' name='script' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
                     <sequence>
                      <att name='type' flags='l'>
                       <str val='text/javascript'/>
@@ -11456,7 +11408,7 @@
                      <valueOf flags='l'>
                       <str val='                &#xA;                            var XFormsDoc = null;&#xA;                            var XForm = null;&#xA;                            var defaultInstanceDoc = null;&#xA;                            &#xA;                            // MD 2018: OND&#39;s suggestion for multiple instances&#xA;                            var instanceDocs = {};&#xA;                            &#xA;                            var pendingUpdatesMap = null;&#xA;                            var updatesMap = null;&#xA;                            var XFormsID = &#39;'/>
                      </valueOf>
-                     <valueOf line='304' flags='l'>
+                     <valueOf line='306' flags='l'>
                       <varRef name='Q{}xFormsId' slot='4'/>
                      </valueOf>
                      <valueOf flags='l'>
@@ -11466,7 +11418,7 @@
                    </elem>
                   </resultDoc>
                  </forEach>
-                 <ifCall line='556' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <ifCall line='558' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                   <check card='1' diag='0|0||ixsl:call'>
                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                   </check>
@@ -11475,7 +11427,7 @@
                    <varRef name='Q{}xforms-doc' slot='0'/>
                   </arrayBlock>
                  </ifCall>
-                 <ifCall line='557' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <ifCall line='559' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                   <check card='1' diag='0|0||ixsl:call'>
                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                   </check>
@@ -11484,7 +11436,7 @@
                    <varRef name='Q{}xform' slot='8'/>
                   </arrayBlock>
                  </ifCall>
-                 <ifCall line='558' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <ifCall line='560' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                   <check card='1' diag='0|0||ixsl:call'>
                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                   </check>
@@ -11493,7 +11445,7 @@
                    <varRef name='Q{}default-instance' slot='13'/>
                   </arrayBlock>
                  </ifCall>
-                 <ifCall line='559' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <ifCall line='561' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                   <check card='1' diag='0|0||ixsl:call'>
                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                   </check>
@@ -11502,7 +11454,7 @@
                    <varRef name='Q{}RelevantBindings' slot='16'/>
                   </arrayBlock>
                  </ifCall>
-                 <ifCall line='560' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <ifCall line='562' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                   <check card='1' diag='0|0||ixsl:call'>
                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                   </check>
@@ -11511,44 +11463,44 @@
                    <varRef name='Q{}CalculationBindings' slot='18'/>
                   </arrayBlock>
                  </ifCall>
-                 <ifCall line='565' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <ifCall line='567' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                   <check card='1' diag='0|0||ixsl:call'>
                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                   </check>
                   <str val='setPendingUpdates'/>
                   <arrayBlock>
-                   <treat line='562' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||pendingInstanceUpdates'>
+                   <treat line='564' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||pendingInstanceUpdates'>
                     <map size='0'/>
                    </treat>
                   </arrayBlock>
                  </ifCall>
-                 <ifCall line='566' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <ifCall line='568' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                   <check card='1' diag='0|0||ixsl:call'>
                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                   </check>
                   <str val='setUpdates'/>
                   <arrayBlock>
-                   <treat line='563' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||instanceUpdates'>
+                   <treat line='565' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||instanceUpdates'>
                     <map size='0'/>
                    </treat>
                   </arrayBlock>
                  </ifCall>
                 </sequence>
                </choose>
-               <forEach line='575'>
-                <treat line='573' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|instanceKeys'>
+               <forEach line='577'>
+                <treat line='575' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|instanceKeys'>
                  <cvUntyped to='xs:string' diag='3|0|XTTE0570|instanceKeys'>
                   <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
                    <varRef name='Q{}xforms-instances' slot='10'/>
                   </ifCall>
                  </cvUntyped>
                 </treat>
-                <ifCall line='577' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                <ifCall line='579' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                  <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='6'/>
                  <str val='setInstance'/>
                  <arrayBlock>
                   <dot type='xs:string'/>
-                  <check line='576' card='1' diag='3|0|XTTE0570|instance'>
+                  <check line='578' card='1' diag='3|0|XTTE0570|instance'>
                    <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
                     <varRef name='Q{}xforms-instances' slot='10'/>
                     <dot type='xs:string'/>
@@ -11557,8 +11509,8 @@
                  </arrayBlock>
                 </ifCall>
                </forEach>
-               <let line='582' var='Q{}submissions' as='map(xs:string, map(*))' slot='20' eval='8'>
-                <ifCall line='584' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+               <let line='584' var='Q{}submissions' as='map(xs:string, map(*))' slot='20' eval='8'>
+                <ifCall line='586' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
                  <forEach>
                   <slash simple='2'>
                    <slash simple='2'>
@@ -11570,7 +11522,7 @@
                    </slash>
                    <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}submission)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;submission&#39;;'/>
                   </slash>
-                  <let line='588' var='Q{}map-key' as='xs:string' slot='21' eval='16'>
+                  <let line='590' var='Q{}map-key' as='xs:string' slot='21' eval='16'>
                    <choose>
                     <fn name='exists'>
                      <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -11583,20 +11535,20 @@
                     <true/>
                     <str val='saxon-forms-default-submission'/>
                    </choose>
-                   <let line='589' var='Q{}map-value' as='map(*)' slot='22' eval='16'>
-                    <treat line='590' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|map-value'>
+                   <let line='591' var='Q{}map-value' as='map(*)' slot='22' eval='16'>
+                    <treat line='592' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|map-value'>
                      <check card='1' diag='3|0|XTTE0570|map-value'>
                       <callT name='Q{}setSubmission' bSlot='4'>
                        <withParam name='Q{}this' flags='c' as='element()'>
-                        <dot line='591' type='element(Q{http://www.w3.org/2002/xforms}submission)'/>
+                        <dot line='593' type='element(Q{http://www.w3.org/2002/xforms}submission)'/>
                        </withParam>
                        <withParam name='Q{}submission-id' flags='c' as='xs:string'>
-                        <varRef line='592' name='Q{}map-key' slot='21'/>
+                        <varRef line='594' name='Q{}map-key' slot='21'/>
                        </withParam>
                       </callT>
                      </check>
                     </treat>
-                    <ifCall line='595' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                    <ifCall line='597' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                      <varRef name='Q{}map-key' slot='21'/>
                      <varRef name='Q{}map-value' slot='22'/>
                     </ifCall>
@@ -11610,84 +11562,47 @@
                   <str val='XTDE3365'/>
                  </map>
                 </ifCall>
-                <sequence line='604'>
+                <sequence line='606'>
                  <forEach>
-                  <treat line='602' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|submissionKeys'>
+                  <treat line='604' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|submissionKeys'>
                    <cvUntyped to='xs:string' diag='3|0|XTTE0570|submissionKeys'>
                     <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
                      <varRef name='Q{}submissions' slot='20'/>
                     </ifCall>
                    </cvUntyped>
                   </treat>
-                  <let line='605' var='Q{}submission' as='map(*)' slot='23' eval='16'>
-                   <check card='1' diag='3|0|XTTE0570|submission'>
-                    <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                     <varRef name='Q{}submissions' slot='20'/>
-                     <dot type='xs:string'/>
-                    </ifCall>
-                   </check>
-                   <sequence line='606'>
-                    <message>
-                     <sequence role='select'>
-                      <valueOf>
-                       <str val='Setting submission with ID &#39;'/>
-                      </valueOf>
-                      <valueOf>
-                       <dot type='xs:string'/>
-                      </valueOf>
-                      <valueOf flags='S'>
-                       <str val='&#39;'/>
-                      </valueOf>
-                     </sequence>
-                     <str role='terminate' val='no'/>
-                     <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-                    </message>
-                    <message line='607'>
-                     <sequence role='select'>
-                      <valueOf>
-                       <str val='Submission map: &#39;'/>
-                      </valueOf>
-                      <valueOf>
-                       <fn name='serialize'>
-                        <varRef name='Q{}submission' slot='23'/>
-                       </fn>
-                      </valueOf>
-                      <valueOf flags='S'>
-                       <str val='&#39;'/>
-                      </valueOf>
-                     </sequence>
-                     <str role='terminate' val='no'/>
-                     <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-                    </message>
-                    <ifCall line='608' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                     <varRef name='Q{http://saxon.sf.net/generated-variable}v1' slot='5'/>
-                     <str val='addSubmission'/>
-                     <arrayBlock>
+                  <ifCall line='610' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                   <varRef name='Q{http://saxon.sf.net/generated-variable}v1' slot='5'/>
+                   <str val='addSubmission'/>
+                   <arrayBlock>
+                    <dot type='xs:string'/>
+                    <check line='607' card='1' diag='3|0|XTTE0570|submission'>
+                     <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                      <varRef name='Q{}submissions' slot='20'/>
                       <dot type='xs:string'/>
-                      <varRef name='Q{}submission' slot='23'/>
-                     </arrayBlock>
-                    </ifCall>
-                   </sequence>
-                  </let>
+                     </ifCall>
+                    </check>
+                   </arrayBlock>
+                  </ifCall>
                  </forEach>
-                 <resultDoc line='617' global='#&#xA;#Sat Feb 22 22:54:41 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sat Feb 22 22:54:41 GMT 2020&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xA;'>
+                 <resultDoc line='619' global='#&#xA;#Sun Feb 23 16:30:38 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sun Feb 23 16:30:38 GMT 2020&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xA;'>
                   <fn role='href' name='concat'>
                    <str val='#'/>
                    <varRef name='Q{}xFormsId' slot='4'/>
                   </fn>
-                  <applyT role='content' line='618' bSlot='5'>
+                  <applyT role='content' line='620' bSlot='5'>
                    <slash role='select' simple='1'>
                     <varRef name='Q{}xforms-doci' slot='7'/>
                     <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
                    </slash>
                    <withParam name='Q{}instances' flags='t' as='map(xs:string, element())'>
-                    <varRef line='619' name='Q{}xforms-instances' slot='10'/>
+                    <varRef line='621' name='Q{}xforms-instances' slot='10'/>
                    </withParam>
                    <withParam name='Q{}bindings' flags='t' as='map(xs:string, node())'>
-                    <varRef line='620' name='Q{}bindings' slot='14'/>
+                    <varRef line='622' name='Q{}bindings' slot='14'/>
                    </withParam>
                    <withParam name='Q{}submissions' flags='t' as='map(xs:string, map(*))'>
-                    <varRef line='621' name='Q{}submissions' slot='20'/>
+                    <varRef line='623' name='Q{}submissions' slot='20'/>
                    </withParam>
                    <withParam name='Q{}nodeset' flags='t' as='xs:string'>
                     <str val=''/>
@@ -11710,17 +11625,17 @@
    </let>
   </template>
  </co>
- <co id='71' binds='71'>
+ <co id='70' binds='70'>
   <mode name='Q{}namespace-fix' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='31' rank='0' minImp='0' slots='1' flags='s' line='2899' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='31' rank='0' minImp='0' slots='1' flags='s' line='2845' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2900' var='Q{}current-namespace' as='xs:anyURI' slot='0' eval='8'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2846' var='Q{}current-namespace' as='xs:anyURI' slot='0' eval='8'>
      <fn name='namespace-uri'>
       <dot type='element()'/>
      </fn>
-     <compElem line='2902'>
+     <compElem line='2848'>
       <convert role='name' from='xs:QName' to='xs:string'>
-       <fn line='2901' name='QName'>
+       <fn line='2847' name='QName'>
         <convert from='xs:anyURI' to='xs:string'>
          <varRef name='Q{}current-namespace' slot='0'/>
         </convert>
@@ -11732,12 +11647,12 @@
       <convert role='namespace' from='xs:anyURI' to='xs:string'>
        <varRef name='Q{}current-namespace' slot='0'/>
       </convert>
-      <sequence role='content' line='2903'>
+      <sequence role='content' line='2849'>
        <namespace flags='l'>
         <str role='name' val='xforms'/>
         <str role='select' val='http://www.w3.org/2002/xforms'/>
        </namespace>
-       <applyT line='2905' mode='Q{}namespace-fix' bSlot='0'>
+       <applyT line='2851' mode='Q{}namespace-fix' bSlot='0'>
         <sequence role='select'>
          <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
          <axis name='child' nodeTest='( element() | text() | comment() | processing-instruction() )' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);'/>
@@ -11749,9 +11664,9 @@
    </templateRule>
   </mode>
  </co>
- <co id='53' binds='68 5 37'>
-  <template name='Q{}HTTPsubmit' cxt='map(*)' jsTest='return SaxonJS.U.isMap(item)' flags='s' line='1009' module='saxon-xforms.xsl' slots='5'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1015'>
+ <co id='53' binds='67 5 7'>
+  <template name='Q{}HTTPsubmit' cxt='map(*)' jsTest='return SaxonJS.U.isMap(item)' flags='s' line='1011' module='saxon-xforms.xsl' slots='5'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1017'>
     <param name='Q{}instance-id' slot='0' as='xs:string'>
      <str role='select' val='saxon-forms-default'/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|instance-id'>
@@ -11764,7 +11679,7 @@
       </check>
      </treat>
     </param>
-    <param line='1016' name='Q{}targetref' slot='1' as='xs:string?'>
+    <param line='1018' name='Q{}targetref' slot='1' as='xs:string?'>
      <empty role='select'/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|targetref'>
       <check card='?' diag='8|0|XTTE0590|targetref'>
@@ -11776,7 +11691,7 @@
       </check>
      </treat>
     </param>
-    <param line='1017' name='Q{}replace' slot='2' as='xs:string?'>
+    <param line='1019' name='Q{}replace' slot='2' as='xs:string?'>
      <empty role='select'/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|replace'>
       <check card='?' diag='8|0|XTTE0590|replace'>
@@ -11788,13 +11703,13 @@
       </check>
      </treat>
     </param>
-    <let line='1019' var='Q{}refi' as='xs:string' slot='3' eval='8'>
+    <let line='1021' var='Q{}refi' as='xs:string' slot='3' eval='8'>
      <fn name='concat'>
       <str val='instance(&#39;'/>
       <varRef name='Q{}instance-id' slot='0'/>
       <str val='&#39;)/'/>
      </fn>
-     <let line='1021' var='Q{}responseXML' as='document-node()' slot='4' eval='16'>
+     <let line='1025' var='Q{}responseXML' as='document-node()' slot='4' eval='16'>
       <treat as='document-node()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);' diag='3|0|XTTE0570|responseXML'>
        <check card='1' diag='3|0|XTTE0570|responseXML'>
         <lookup>
@@ -11803,38 +11718,52 @@
         </lookup>
        </check>
       </treat>
-      <choose line='1024'>
-       <fn name='empty'>
-        <varRef name='Q{}responseXML' slot='4'/>
-       </fn>
-       <callT line='1025' name='Q{}serverError' bSlot='0' flags='t'>
-        <withParam name='Q{}responseMap' flags='c' as='map(*)'>
-         <dot line='1026' type='map(*)'/>
-        </withParam>
-       </callT>
-       <vc line='1038' op='eq' onEmpty='0' comp='CCC'>
-        <varRef name='Q{}replace' slot='2'/>
-        <str val='instance'/>
-       </vc>
-       <sequence line='1039'>
-        <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='1' eval='6 16'>
-         <varRef name='Q{}refi' slot='3'/>
-         <check card='1' diag='0|1||xforms:setInstance-JS'>
-          <slash simple='1'>
-           <varRef name='Q{}responseXML' slot='4'/>
-           <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-          </slash>
-         </check>
-        </ufCall>
-        <callT line='1041' name='Q{}xforms-rebuild' bSlot='2' flags='t'/>
-       </sequence>
-      </choose>
+      <sequence line='1027'>
+       <message>
+        <sequence role='select'>
+         <valueOf>
+          <str val='[HTTPsubmit] Response body: '/>
+         </valueOf>
+         <fn name='serialize'>
+          <varRef name='Q{}responseXML' slot='4'/>
+         </fn>
+        </sequence>
+        <str role='terminate' val='no'/>
+        <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+       </message>
+       <choose line='1030'>
+        <fn name='empty'>
+         <varRef name='Q{}responseXML' slot='4'/>
+        </fn>
+        <callT line='1031' name='Q{}serverError' bSlot='0' flags='t'>
+         <withParam name='Q{}responseMap' flags='c' as='map(*)'>
+          <dot line='1032' type='map(*)'/>
+         </withParam>
+        </callT>
+        <vc line='1044' op='eq' onEmpty='0' comp='CCC'>
+         <varRef name='Q{}replace' slot='2'/>
+         <str val='instance'/>
+        </vc>
+        <sequence line='1045'>
+         <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='1' eval='6 16'>
+          <varRef name='Q{}refi' slot='3'/>
+          <check card='1' diag='0|1||xforms:setInstance-JS'>
+           <slash simple='1'>
+            <varRef name='Q{}responseXML' slot='4'/>
+            <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+           </slash>
+          </check>
+         </ufCall>
+         <callT line='1047' name='Q{}xforms-recalculate' bSlot='2' flags='t'/>
+        </sequence>
+       </choose>
+      </sequence>
      </let>
     </let>
    </sequence>
   </template>
  </co>
- <co id='43' binds=''>
+ <co id='2' binds=''>
   <function name='Q{http://www.w3.org/2002/xforms}instance' line='126' module='xforms-function-library.xsl' eval='7' flags='pU' as='element()?' slots='1'>
    <arg name='Q{}instance-id' as='xs:string'/>
    <treat role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='128' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='5|0|XTTE0780|xforms:instance#1'>
@@ -11850,20 +11779,20 @@
    </treat>
   </function>
  </co>
- <co id='73' binds='49 67 11'>
+ <co id='72' binds='49 66 11'>
   <mode name='Q{http://saxonica.com/ns/interactiveXSLT}onclick' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='0.5' seq='3' rank='0' minImp='0' slots='3' flags='s' line='732' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.5' seq='3' rank='0' minImp='0' slots='1' flags='s' line='734' module='saxon-xforms.xsl'>
     <p.withUpper role='match' axis='ancestor' upFirst='false'>
      <p.withPredicate>
       <p.nodeTest test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-      <or ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='732' op='or'>
+      <or ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='734' op='or'>
        <axis name='self' nodeTest='element(Q{}span)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;span&#39;;'/>
        <axis name='self' nodeTest='element(Q{}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
       </or>
      </p.withPredicate>
      <p.withPredicate>
       <p.nodeTest test='element(Q{}div)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;div&#39;;'/>
-      <vc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='732' op='eq' onEmpty='0' comp='CCC'>
+      <vc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='734' op='eq' onEmpty='0' comp='CCC'>
        <cast as='xs:string' emptiable='1'>
         <data>
          <axis name='attribute' nodeTest='attribute(Q{}data-repeat-item)' jsTest='return item.name===&#39;data-repeat-item&#39;'/>
@@ -11873,11 +11802,11 @@
       </vc>
      </p.withPredicate>
     </p.withUpper>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='741' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='0' eval='13'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='743' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='0' eval='13'>
      <check card='1' diag='0|0||ixsl:call'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
      </check>
-     <sequence line='733'>
+     <sequence line='735'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -11889,7 +11818,7 @@
         </fn>
        </arrayBlock>
       </ifCall>
-      <forEach line='736'>
+      <forEach line='738'>
        <fn name='reverse'>
         <filter flags='b'>
          <axis name='ancestor' nodeTest='element(Q{}div)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;div&#39;;'/>
@@ -11901,26 +11830,28 @@
          </vc>
         </filter>
        </fn>
-       <let line='737' var='Q{}repeat-id' as='xs:string' slot='1' eval='16'>
-        <check card='1' diag='3|0|XTTE0570|repeat-id'>
-         <cvUntyped to='xs:string' diag='3|0|XTTE0570|repeat-id'>
-          <data>
-           <slash simple='1'>
-            <first>
-             <filter flags='b'>
-              <axis name='ancestor' nodeTest='element(Q{}div)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;div&#39;;'/>
-              <fn name='exists'>
-               <axis name='attribute' nodeTest='attribute(Q{}data-repeatable-context)' jsTest='return item.name===&#39;data-repeatable-context&#39;'/>
-              </fn>
-             </filter>
-            </first>
-            <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
-           </slash>
-          </data>
-         </cvUntyped>
-        </check>
-        <let line='738' var='Q{}item-position' as='xs:integer' slot='2' eval='16'>
-         <arith op='+' calc='i+i'>
+       <ifCall line='743' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='0'/>
+        <str val='setRepeatIndex'/>
+        <arrayBlock>
+         <check line='739' card='1' diag='3|0|XTTE0570|repeat-id'>
+          <cvUntyped to='xs:string' diag='3|0|XTTE0570|repeat-id'>
+           <data>
+            <slash simple='1'>
+             <first>
+              <filter flags='b'>
+               <axis name='ancestor' nodeTest='element(Q{}div)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;div&#39;;'/>
+               <fn name='exists'>
+                <axis name='attribute' nodeTest='attribute(Q{}data-repeatable-context)' jsTest='return item.name===&#39;data-repeatable-context&#39;'/>
+               </fn>
+              </filter>
+             </first>
+             <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+            </slash>
+           </data>
+          </cvUntyped>
+         </check>
+         <arith line='740' op='+' calc='i+i'>
           <fn name='count'>
            <filter flags='b'>
             <axis name='preceding-sibling' nodeTest='element(Q{}div)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;div&#39;;'/>
@@ -11934,74 +11865,41 @@
           </fn>
           <int val='1'/>
          </arith>
-         <sequence line='740'>
-          <message>
-           <sequence role='select'>
-            <valueOf>
-             <str val='[div onclick] Setting repeat index &#39;'/>
-            </valueOf>
-            <valueOf>
-             <varRef name='Q{}repeat-id' slot='1'/>
-            </valueOf>
-            <valueOf>
-             <str val='&#39; to value &#39;'/>
-            </valueOf>
-            <valueOf>
-             <convert from='xs:integer' to='xs:string'>
-              <varRef name='Q{}item-position' slot='2'/>
-             </convert>
-            </valueOf>
-            <valueOf flags='S'>
-             <str val='&#39;'/>
-            </valueOf>
-           </sequence>
-           <str role='terminate' val='no'/>
-           <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-          </message>
-          <ifCall line='741' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-           <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='0'/>
-           <str val='setRepeatIndex'/>
-           <arrayBlock>
-            <varRef name='Q{}repeat-id' slot='1'/>
-            <varRef name='Q{}item-position' slot='2'/>
-           </arrayBlock>
-          </ifCall>
-         </sequence>
-        </let>
-       </let>
+        </arrayBlock>
+       </ifCall>
       </forEach>
-      <choose line='744'>
+      <choose line='746'>
        <fn name='exists'>
         <axis name='self' nodeTest='element(Q{}span)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;span&#39;;'/>
        </fn>
-       <callT line='745' name='Q{}refreshElementsUsingIndexFunction-JS' bSlot='0' flags='t'/>
+       <callT line='747' name='Q{}refreshElementsUsingIndexFunction-JS' bSlot='0' flags='t'/>
       </choose>
      </sequence>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.5' seq='23' rank='0' minImp='0' slots='0' flags='s' line='2017' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.5' seq='23' rank='0' minImp='0' slots='0' flags='s' line='2024' module='saxon-xforms.xsl'>
     <p.withPredicate role='match'>
      <p.nodeTest test='element(Q{}button)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;button&#39;;'/>
-     <fn ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2017' name='exists'>
+     <fn ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2024' name='exists'>
       <axis name='attribute' nodeTest='attribute(Q{}data-action)' jsTest='return item.name===&#39;data-action&#39;'/>
      </fn>
     </p.withPredicate>
-    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2019' name='Q{}DOMActivate' bSlot='1' flags='t'>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2026' name='Q{}DOMActivate' bSlot='1' flags='t'>
      <withParam name='Q{}form-control' flags='c' as='node()'>
-      <dot line='2020' type='element(Q{}button)'/>
+      <dot line='2027' type='element(Q{}button)'/>
      </withParam>
     </callT>
    </templateRule>
-   <templateRule prec='0' prio='0.5' seq='4' rank='0' minImp='0' slots='0' flags='s' line='992' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.5' seq='4' rank='0' minImp='0' slots='0' flags='s' line='994' module='saxon-xforms.xsl'>
     <p.withPredicate role='match'>
      <p.nodeTest test='element(Q{}button)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;button&#39;;'/>
-     <fn ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='992' name='exists'>
+     <fn ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='994' name='exists'>
       <axis name='attribute' nodeTest='attribute(Q{}data-submit)' jsTest='return item.name===&#39;data-submit&#39;'/>
      </fn>
     </p.withPredicate>
-    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='994' name='Q{}xforms-submit' bSlot='2' flags='t'>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='996' name='Q{}xforms-submit' bSlot='2' flags='t'>
      <withParam name='Q{}submission' flags='c' as='xs:string'>
-      <fn line='995' name='string'>
+      <fn line='997' name='string'>
        <axis name='attribute' nodeTest='attribute(Q{}data-submit)' jsTest='return item.name===&#39;data-submit&#39;'/>
       </fn>
      </withParam>
@@ -12009,9 +11907,9 @@
    </templateRule>
   </mode>
  </co>
- <co id='72' binds='62 63 64'>
-  <template name='Q{}setSubmission' flags='os' line='3958' module='saxon-xforms.xsl' slots='5'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3959'>
+ <co id='71' binds='61 62 63'>
+  <template name='Q{}setSubmission' flags='os' line='3938' module='saxon-xforms.xsl' slots='5'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3939'>
     <param name='Q{}this' slot='0' flags='i' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
       <check card='1' diag='8|0|XTTE0590|this'>
@@ -12019,7 +11917,7 @@
       </check>
      </treat>
     </param>
-    <param line='3960' name='Q{}submission-id' slot='1' flags='i' as='xs:string'>
+    <param line='3940' name='Q{}submission-id' slot='1' flags='i' as='xs:string'>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|submission-id'>
       <check card='1' diag='8|0|XTTE0590|submission-id'>
        <cvUntyped to='xs:string' diag='8|0|XTTE0590|submission-id'>
@@ -12030,52 +11928,52 @@
       </check>
      </treat>
     </param>
-    <let line='3963' var='Q{}bindingi' as='node()?' slot='2' eval='7'>
-     <treat line='3964' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+    <let line='3943' var='Q{}bindingi' as='node()?' slot='2' eval='7'>
+     <treat line='3944' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
       <check card='?' diag='3|0|XTTE0570|bindingi'>
        <callT name='Q{}getBinding' bSlot='0'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <varRef line='3965' name='Q{}this' slot='0'/>
+         <varRef line='3945' name='Q{}this' slot='0'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <let line='3970' var='Q{}refi' as='xs:string' slot='3' eval='16'>
-      <treat line='3971' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+     <let line='3950' var='Q{}refi' as='xs:string' slot='3' eval='16'>
+      <treat line='3951' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
        <check card='1' diag='3|0|XTTE0570|refi'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
          <data>
           <callT name='Q{}getDataRef' bSlot='1'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <varRef line='3972' name='Q{}this' slot='0'/>
+            <varRef line='3952' name='Q{}this' slot='0'/>
            </withParam>
            <withParam name='Q{}bindingi' flags='c' as='node()?'>
-            <varRef line='3973' name='Q{}bindingi' slot='2'/>
+            <varRef line='3953' name='Q{}bindingi' slot='2'/>
            </withParam>
           </callT>
          </data>
         </cvUntyped>
        </check>
       </treat>
-      <let line='3978' var='Q{}actions' as='map(*)*' slot='4' eval='8'>
-       <treat line='3979' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+      <let line='3958' var='Q{}actions' as='map(*)*' slot='4' eval='8'>
+       <treat line='3959' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
         <callT name='Q{}setActions' bSlot='2'>
          <withParam name='Q{}this' flags='c' as='element()'>
-          <treat line='3980' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+          <treat line='3960' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
            <dot flags='a'/>
           </treat>
          </withParam>
          <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-          <varRef line='3981' name='Q{}refi' slot='3'/>
+          <varRef line='3961' name='Q{}refi' slot='3'/>
          </withParam>
         </callT>
        </treat>
-       <sequence line='3985'>
+       <sequence line='3965'>
         <choose>
          <fn name='exists'>
           <varRef name='Q{}actions' slot='4'/>
          </fn>
-         <ifCall line='3986' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+         <ifCall line='3966' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
           <check card='1' diag='0|0||ixsl:call'>
            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
           </check>
@@ -12086,20 +11984,20 @@
           </arrayBlock>
          </ifCall>
         </choose>
-        <ifCall line='3991' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+        <ifCall line='3971' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
          <sequence>
-          <ifCall line='3992' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <ifCall line='3972' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
            <str val='@ref'/>
            <varRef name='Q{}refi' slot='3'/>
           </ifCall>
-          <choose line='3995'>
+          <choose line='3975'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}resource)' jsTest='return item.name===&#39;resource&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3996' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='3976' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@resource'/>
             <cast as='xs:string' emptiable='1'>
              <data>
@@ -12111,14 +12009,14 @@
             </cast>
            </ifCall>
           </choose>
-          <choose line='3998'>
+          <choose line='3978'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}mode)' jsTest='return item.name===&#39;mode&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3999' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='3979' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@mode'/>
             <cast as='xs:string' emptiable='1'>
              <data>
@@ -12130,16 +12028,16 @@
             </cast>
            </ifCall>
           </choose>
-          <ifCall line='4002' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <ifCall line='3982' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
            <str val='@method'/>
-           <choose line='4004'>
+           <choose line='3984'>
             <fn name='exists'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='attribute' nodeTest='attribute(Q{}method)' jsTest='return item.name===&#39;method&#39;'/>
              </slash>
             </fn>
-            <fn line='4005' name='string'>
+            <fn line='3985' name='string'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='attribute' nodeTest='attribute(Q{}method)' jsTest='return item.name===&#39;method&#39;'/>
@@ -12149,14 +12047,14 @@
             <str val='POST'/>
            </choose>
           </ifCall>
-          <choose line='4014'>
+          <choose line='3994'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}validate)' jsTest='return item.name===&#39;validate&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4015' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='3995' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@validate'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12166,14 +12064,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='4017'>
+          <choose line='3997'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}relevant)' jsTest='return item.name===&#39;relevant&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4018' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='3998' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@relevant'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12183,14 +12081,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='4020'>
+          <choose line='4000'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}serialization)' jsTest='return item.name===&#39;serialization&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4021' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4001' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@serialization'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12200,14 +12098,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='4023'>
+          <choose line='4003'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}version)' jsTest='return item.name===&#39;version&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4024' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4004' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@version'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12217,14 +12115,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='4026'>
+          <choose line='4006'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}indent)' jsTest='return item.name===&#39;indent&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4027' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4007' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@indent'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12234,16 +12132,16 @@
             </fn>
            </ifCall>
           </choose>
-          <ifCall line='4031' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <ifCall line='4011' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
            <str val='@mediatype'/>
-           <choose line='4033'>
+           <choose line='4013'>
             <fn name='exists'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='attribute' nodeTest='attribute(Q{}mediatype)' jsTest='return item.name===&#39;mediatype&#39;'/>
              </slash>
             </fn>
-            <fn line='4034' name='string'>
+            <fn line='4014' name='string'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='attribute' nodeTest='attribute(Q{}mediatype)' jsTest='return item.name===&#39;mediatype&#39;'/>
@@ -12253,14 +12151,14 @@
             <str val='text/plain'/>
            </choose>
           </ifCall>
-          <choose line='4044'>
+          <choose line='4024'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}encoding)' jsTest='return item.name===&#39;encoding&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4045' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4025' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@encoding'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12270,14 +12168,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='4047'>
+          <choose line='4027'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}omit-xml-declaration)' jsTest='return item.name===&#39;omit-xml-declaration&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4048' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4028' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@omit-xml-declaration'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12287,14 +12185,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='4050'>
+          <choose line='4030'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}standalone)' jsTest='return item.name===&#39;standalone&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4051' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4031' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@standalone'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12304,14 +12202,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='4053'>
+          <choose line='4033'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}cdata-section-elements)' jsTest='return item.name===&#39;cdata-section-elements&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4054' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4034' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@cdata-section-elements'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12321,16 +12219,16 @@
             </fn>
            </ifCall>
           </choose>
-          <ifCall line='4057' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <ifCall line='4037' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
            <str val='@replace'/>
-           <choose line='4059'>
+           <choose line='4039'>
             <fn name='exists'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='attribute' nodeTest='attribute(Q{}replace)' jsTest='return item.name===&#39;replace&#39;'/>
              </slash>
             </fn>
-            <fn line='4060' name='string'>
+            <fn line='4040' name='string'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='attribute' nodeTest='attribute(Q{}replace)' jsTest='return item.name===&#39;replace&#39;'/>
@@ -12340,14 +12238,14 @@
             <str val='all'/>
            </choose>
           </ifCall>
-          <choose line='4071'>
+          <choose line='4051'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}instance)' jsTest='return item.name===&#39;instance&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4072' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4052' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@instance'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12357,14 +12255,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='4074'>
+          <choose line='4054'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}targetref)' jsTest='return item.name===&#39;targetref&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4075' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4055' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@targetref'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12374,14 +12272,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='4077'>
+          <choose line='4057'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}separator)' jsTest='return item.name===&#39;separator&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4078' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4058' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@separator'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12391,14 +12289,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='4080'>
+          <choose line='4060'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}includenamespaceprefixes)' jsTest='return item.name===&#39;includenamespaceprefixes&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4081' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4061' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@includenamespaceprefixes'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12423,18 +12321,18 @@
    </sequence>
   </template>
  </co>
- <co id='74' binds='20'>
+ <co id='73' binds='18'>
   <mode name='Q{http://saxonica.com/ns/interactiveXSLT}onkeyup' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='0.5' seq='0' rank='0' minImp='0' slots='0' flags='s' line='699' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.5' seq='0' rank='0' minImp='0' slots='0' flags='s' line='701' module='saxon-xforms.xsl'>
     <p.withPredicate role='match'>
      <p.nodeTest test='element(Q{}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
-     <gc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='699' op='=' card='N:1' comp='CCC'>
+     <gc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='701' op='=' card='N:1' comp='CCC'>
       <fn name='tokenize'>
        <cvUntyped to='xs:string' diag='3|0|XTTE0570|class'>
         <data>
          <slash simple='1'>
           <dot type='element(Q{}input)'/>
-          <axis line='3071' name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
+          <axis line='3044' name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
          </slash>
         </data>
        </cvUntyped>
@@ -12442,17 +12340,17 @@
       <str val='incremental'/>
      </gc>
     </p.withPredicate>
-    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='701' name='Q{}xforms-value-changed' bSlot='0' flags='t'>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='703' name='Q{}xforms-value-changed' bSlot='0' flags='t'>
      <withParam name='Q{}form-control' flags='c' as='node()'>
-      <dot line='702' type='element(Q{}input)'/>
+      <dot line='704' type='element(Q{}input)'/>
      </withParam>
     </callT>
    </templateRule>
   </mode>
  </co>
- <co id='62' binds=''>
-  <template name='Q{}getBinding' flags='os' line='3309' module='saxon-xforms.xsl' slots='4'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3310'>
+ <co id='61' binds=''>
+  <template name='Q{}getBinding' flags='os' line='3282' module='saxon-xforms.xsl' slots='4'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3283'>
     <param name='Q{}this' slot='0' flags='r' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
       <check card='1' diag='8|0|XTTE0590|this'>
@@ -12460,7 +12358,7 @@
       </check>
      </treat>
     </param>
-    <param line='3311' name='Q{}bindings' slot='1' flags='t' as='map(xs:string, node())'>
+    <param line='3284' name='Q{}bindings' slot='1' flags='t' as='map(xs:string, node())'>
      <map role='select' size='0'/>
      <treat role='conversion' as='map(xs:string, node())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|bindings'>
       <check card='1' diag='8|0|XTTE0590|bindings'>
@@ -12468,7 +12366,7 @@
       </check>
      </treat>
     </param>
-    <let line='3320' var='Q{}ref-binding' as='xs:string' slot='2' eval='16'>
+    <let line='3293' var='Q{}ref-binding' as='xs:string' slot='2' eval='16'>
      <choose>
       <fn name='exists'>
        <slash simple='1'>
@@ -12505,8 +12403,8 @@
       <true/>
       <str val=''/>
      </choose>
-     <let line='3322' var='Q{}binding' as='element()?' slot='3' eval='7'>
-      <choose line='3327'>
+     <let line='3295' var='Q{}binding' as='element()?' slot='3' eval='7'>
+      <choose line='3300'>
        <fn name='empty'>
         <varRef name='Q{}ref-binding' slot='2'/>
        </fn>
@@ -12519,12 +12417,12 @@
         </ifCall>
        </treat>
       </choose>
-      <sequence line='3330'>
+      <sequence line='3303'>
        <choose>
         <fn name='exists'>
          <varRef name='Q{}binding' slot='3'/>
         </fn>
-        <message line='3336'>
+        <message line='3309'>
          <sequence role='select'>
           <valueOf>
            <str val='[getBinding for '/>
@@ -12547,28 +12445,28 @@
          <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
         </message>
        </choose>
-       <varRef line='3340' name='Q{}binding' slot='3'/>
+       <varRef line='3313' name='Q{}binding' slot='3'/>
       </sequence>
      </let>
     </let>
    </sequence>
   </template>
  </co>
- <co id='75' binds=''>
-  <globalVariable name='Q{}default-instance-id' type='xs:string' line='75' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
+ <co id='74' binds=''>
+  <globalVariable name='Q{}default-instance-id' type='xs:string' line='77' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
    <str val='saxon-forms-default'/>
   </globalVariable>
  </co>
- <co id='76' binds=''>
-  <globalVariable name='Q{}debugTiming' type='xs:boolean' line='74' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.boolean.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
+ <co id='75' binds=''>
+  <globalVariable name='Q{}debugTiming' type='xs:boolean' line='76' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.boolean.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
    <false/>
   </globalVariable>
  </co>
- <co id='45' binds='62'>
-  <function name='Q{http://www.w3.org/2002/xforms}getDataRef' line='3168' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:string' slots='11'>
+ <co id='45' binds='61'>
+  <function name='Q{http://www.w3.org/2002/xforms}getDataRef' line='3141' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:string' slots='11'>
    <arg name='Q{}this' as='element()'/>
    <arg name='Q{}nodeset' as='xs:string?'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3177' var='Q{}this-ref' as='xs:string?' slot='2' eval='7'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3150' var='Q{}this-ref' as='xs:string?' slot='2' eval='7'>
     <choose>
      <fn name='exists'>
       <slash simple='1'>
@@ -12603,27 +12501,27 @@
       </cast>
      </fn>
     </choose>
-    <let line='3180' var='Q{}this-binding' as='node()?' slot='3' eval='7'>
-     <treat line='3181' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|this-binding'>
+    <let line='3153' var='Q{}this-binding' as='node()?' slot='3' eval='7'>
+     <treat line='3154' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|this-binding'>
       <check card='?' diag='3|0|XTTE0570|this-binding'>
        <callT name='Q{}getBinding' bSlot='0'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <varRef line='3182' name='Q{}this' slot='0'/>
+         <varRef line='3155' name='Q{}this' slot='0'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <choose line='3207'>
+     <choose line='3180'>
       <fn name='exists'>
        <varRef name='Q{}this-binding' slot='3'/>
       </fn>
-      <let line='3188' var='Q{}relative' as='xs:string' slot='4' eval='16'>
+      <let line='3161' var='Q{}relative' as='xs:string' slot='4' eval='16'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
         <choose>
          <fn name='exists'>
           <varRef name='Q{}this-binding' slot='3'/>
          </fn>
-         <cvUntyped line='3199' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
+         <cvUntyped line='3172' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
           <cast as='xs:untypedAtomic' emptiable='0'>
            <choose>
             <fn name='exists'>
@@ -12658,25 +12556,25 @@
          </cvUntyped>
         </choose>
        </check>
-       <choose line='836'>
+       <choose line='838'>
         <fn name='starts-with'>
          <varRef name='Q{}relative' slot='4'/>
          <str val='/'/>
         </fn>
-        <varRef line='837' name='Q{}relative' slot='4'/>
-        <fn line='839' name='starts-with'>
+        <varRef line='839' name='Q{}relative' slot='4'/>
+        <fn line='841' name='starts-with'>
          <varRef name='Q{}relative' slot='4'/>
          <str val='instance('/>
         </fn>
-        <varRef line='840' name='Q{}relative' slot='4'/>
+        <varRef line='842' name='Q{}relative' slot='4'/>
         <true/>
-        <varRef line='843' name='Q{}relative' slot='4'/>
+        <varRef line='845' name='Q{}relative' slot='4'/>
        </choose>
       </let>
-      <fn line='3210' name='exists'>
+      <fn line='3183' name='exists'>
        <varRef name='Q{}this-ref' slot='2'/>
       </fn>
-      <let line='3211' var='Q{}base' as='xs:string' slot='5' eval='16'>
+      <let line='3184' var='Q{}base' as='xs:string' slot='5' eval='16'>
        <check card='1' diag='0|0||xforms:resolveXPathStrings'>
         <varRef name='Q{}nodeset' slot='1'/>
        </check>
@@ -12684,22 +12582,22 @@
         <check card='1' diag='0|1||xforms:resolveXPathStrings'>
          <varRef name='Q{}this-ref' slot='2'/>
         </check>
-        <choose line='836'>
+        <choose line='838'>
          <fn name='starts-with'>
           <varRef name='Q{}relative' slot='6'/>
           <str val='/'/>
          </fn>
-         <varRef line='837' name='Q{}relative' slot='6'/>
-         <fn line='839' name='starts-with'>
+         <varRef line='839' name='Q{}relative' slot='6'/>
+         <fn line='841' name='starts-with'>
           <varRef name='Q{}relative' slot='6'/>
           <str val='instance('/>
          </fn>
-         <varRef line='840' name='Q{}relative' slot='6'/>
-         <fn line='842' name='not'>
+         <varRef line='842' name='Q{}relative' slot='6'/>
+         <fn line='844' name='not'>
           <varRef name='Q{}base' slot='5'/>
          </fn>
-         <varRef line='843' name='Q{}relative' slot='6'/>
-         <or line='845' op='or'>
+         <varRef line='845' name='Q{}relative' slot='6'/>
+         <or line='847' op='or'>
           <fn name='not'>
            <varRef name='Q{}relative' slot='6'/>
           </fn>
@@ -12708,9 +12606,9 @@
            <str val='.'/>
           </vc>
          </or>
-         <varRef line='846' name='Q{}base' slot='5'/>
+         <varRef line='848' name='Q{}base' slot='5'/>
          <true/>
-         <let line='850' var='Q{}parentCallCount' as='xs:integer' slot='7' eval='16'>
+         <let line='852' var='Q{}parentCallCount' as='xs:integer' slot='7' eval='16'>
           <choose>
            <fn name='contains'>
             <varRef name='Q{}relative' slot='6'/>
@@ -12737,7 +12635,7 @@
            <true/>
            <int val='0'/>
           </choose>
-          <let line='853' var='Q{}slashes' as='xs:integer*' slot='8' eval='4'>
+          <let line='855' var='Q{}slashes' as='xs:integer*' slot='8' eval='4'>
            <choose>
             <fn name='contains'>
              <varRef name='Q{}base' slot='5'/>
@@ -12752,15 +12650,15 @@
             <true/>
             <int val='0'/>
            </choose>
-           <choose line='885'>
+           <choose line='887'>
             <compareToInt op='gt' val='0'>
              <varRef name='Q{}parentCallCount' slot='7'/>
             </compareToInt>
-            <fn line='889' name='concat'>
+            <fn line='891' name='concat'>
              <fn name='substring'>
               <varRef name='Q{}base' slot='5'/>
               <int val='1'/>
-              <choose line='864'>
+              <choose line='866'>
                <and op='and'>
                 <vc op='ge' onEmpty='0' comp='CAVC'>
                  <fn name='count'>
@@ -12772,7 +12670,7 @@
                  <varRef name='Q{}parentCallCount' slot='7'/>
                 </compareToInt>
                </and>
-               <let line='865' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='9' eval='16'>
+               <let line='867' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='9' eval='16'>
                 <arith op='-' calc='i-i'>
                  <varRef name='Q{}parentCallCount' slot='7'/>
                  <int val='1'/>
@@ -12788,7 +12686,7 @@
                 </check>
                </let>
                <true/>
-               <check line='868' card='1' diag='3|0|XTTE0570|parentSlash'>
+               <check line='870' card='1' diag='3|0|XTTE0570|parentSlash'>
                 <lastOf>
                  <varRef name='Q{}slashes' slot='8'/>
                 </lastOf>
@@ -12803,7 +12701,7 @@
              </fn>
             </fn>
             <true/>
-            <fn line='892' name='concat'>
+            <fn line='894' name='concat'>
              <varRef name='Q{}base' slot='5'/>
              <str val='/'/>
              <varRef name='Q{}relative' slot='6'/>
@@ -12814,24 +12712,24 @@
         </choose>
        </let>
       </let>
-      <varRef line='3213' name='Q{}nodeset' slot='1'/>
-      <let line='3214' var='Q{}relative' as='xs:string' slot='10' eval='16'>
+      <varRef line='3186' name='Q{}nodeset' slot='1'/>
+      <let line='3187' var='Q{}relative' as='xs:string' slot='10' eval='16'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
         <varRef name='Q{}nodeset' slot='1'/>
        </check>
-       <choose line='836'>
+       <choose line='838'>
         <fn name='starts-with'>
          <varRef name='Q{}relative' slot='10'/>
          <str val='/'/>
         </fn>
-        <varRef line='837' name='Q{}relative' slot='10'/>
-        <fn line='839' name='starts-with'>
+        <varRef line='839' name='Q{}relative' slot='10'/>
+        <fn line='841' name='starts-with'>
          <varRef name='Q{}relative' slot='10'/>
          <str val='instance('/>
         </fn>
-        <varRef line='840' name='Q{}relative' slot='10'/>
+        <varRef line='842' name='Q{}relative' slot='10'/>
         <true/>
-        <varRef line='843' name='Q{}relative' slot='10'/>
+        <varRef line='845' name='Q{}relative' slot='10'/>
        </choose>
       </let>
       <true/>
@@ -12841,9 +12739,153 @@
    </let>
   </function>
  </co>
- <co id='25' binds=''>
-  <template name='Q{}getInstance' flags='os' as='element()?' line='3283' module='saxon-xforms.xsl' slots='2'>
-   <check role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3284' card='?' diag='7|0|XTTE0505|getInstance'>
+ <co id='19' binds='19 19'>
+  <mode name='Q{}recalculate' onNo='TC' flags='W' patternSlots='0'>
+   <templateRule prec='0' prio='-0.5' seq='28' rank='0' minImp='0' slots='5' flags='s' line='2754' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2755'>
+     <param name='Q{}updated-nodes' slot='0' flags='t' as='node()*'>
+      <empty role='select'/>
+      <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|updated-nodes'>
+       <supplied slot='0'/>
+      </treat>
+     </param>
+     <param line='2756' name='Q{}updated-values' slot='1' flags='t' as='xs:string*'>
+      <empty role='select'/>
+      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|updated-values'>
+       <cvUntyped to='xs:string' diag='8|0|XTTE0590|updated-values'>
+        <data>
+         <supplied slot='1'/>
+        </data>
+       </cvUntyped>
+      </treat>
+     </param>
+     <copy line='2761' flags='cin'>
+      <sequence role='content'>
+       <applyT mode='Q{}recalculate' bSlot='0'>
+        <axis role='select' name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+       </applyT>
+       <choose line='2764'>
+        <fn name='exists'>
+         <let line='2758' var='Q{http://saxon.sf.net/generated-variable}current887200931' as='element()' slot='2' eval='16'>
+          <dot type='element()'/>
+          <treat as='element()' jsTest='return item.nodeType===1;' diag='3|0|XTTE0570|updated-node'>
+           <check card='?' diag='3|0|XTTE0570|updated-node'>
+            <filter flags=''>
+             <varRef name='Q{}updated-nodes' slot='0'/>
+             <is op='is'>
+              <dot type='node()'/>
+              <varRef name='Q{http://saxon.sf.net/generated-variable}current887200931' slot='2'/>
+             </is>
+            </filter>
+           </check>
+          </treat>
+         </let>
+        </fn>
+        <let line='2765' var='Q{}updated-node-position' as='xs:integer' slot='3' eval='16'>
+         <let var='Q{http://saxon.sf.net/generated-variable}current80799437' as='element()' slot='4' eval='16'>
+          <dot type='element()'/>
+          <check card='1' diag='3|0|XTTE0570|updated-node-position'>
+           <slash>
+            <filter flags=''>
+             <varRef name='Q{}updated-nodes' slot='0'/>
+             <is op='is'>
+              <dot type='node()'/>
+              <varRef name='Q{http://saxon.sf.net/generated-variable}current80799437' slot='4'/>
+             </is>
+            </filter>
+            <fn name='position'/>
+           </slash>
+          </check>
+         </let>
+         <subscript line='2766'>
+          <varRef name='Q{}updated-values' slot='1'/>
+          <varRef name='Q{}updated-node-position' slot='3'/>
+         </subscript>
+        </let>
+        <true/>
+        <applyT line='2769' mode='Q{}recalculate' bSlot='1'>
+         <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
+        </applyT>
+       </choose>
+      </sequence>
+     </copy>
+    </sequence>
+   </templateRule>
+   <templateRule prec='0' prio='-0.5' seq='29' rank='0' minImp='0' slots='5' flags='s' line='2782' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2783'>
+     <param name='Q{}updated-nodes' slot='0' flags='t' as='node()*'>
+      <empty role='select'/>
+      <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|updated-nodes'>
+       <supplied slot='0'/>
+      </treat>
+     </param>
+     <param line='2784' name='Q{}updated-values' slot='1' flags='t' as='xs:string*'>
+      <empty role='select'/>
+      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|updated-values'>
+       <cvUntyped to='xs:string' diag='8|0|XTTE0590|updated-values'>
+        <data>
+         <supplied slot='1'/>
+        </data>
+       </cvUntyped>
+      </treat>
+     </param>
+     <choose line='2789'>
+      <fn name='exists'>
+       <let line='2786' var='Q{http://saxon.sf.net/generated-variable}current887200928' as='attribute()' slot='2' eval='16'>
+        <dot type='attribute()'/>
+        <treat as='attribute()' jsTest='return SaxonJS.U.isAttr(item)' diag='3|0|XTTE0570|updated-node'>
+         <check card='?' diag='3|0|XTTE0570|updated-node'>
+          <filter flags=''>
+           <varRef name='Q{}updated-nodes' slot='0'/>
+           <is op='is'>
+            <dot type='node()'/>
+            <varRef name='Q{http://saxon.sf.net/generated-variable}current887200928' slot='2'/>
+           </is>
+          </filter>
+         </check>
+        </treat>
+       </let>
+      </fn>
+      <let line='2790' var='Q{}updated-node-position' as='xs:integer' slot='3' eval='16'>
+       <let var='Q{http://saxon.sf.net/generated-variable}current80799437' as='attribute()' slot='4' eval='16'>
+        <dot type='attribute()'/>
+        <check card='1' diag='3|0|XTTE0570|updated-node-position'>
+         <slash>
+          <filter flags=''>
+           <varRef name='Q{}updated-nodes' slot='0'/>
+           <is op='is'>
+            <dot type='node()'/>
+            <varRef name='Q{http://saxon.sf.net/generated-variable}current80799437' slot='4'/>
+           </is>
+          </filter>
+          <fn name='position'/>
+         </slash>
+        </check>
+       </let>
+       <compAtt line='2791'>
+        <fn role='name' name='name'>
+         <dot type='attribute()'/>
+        </fn>
+        <subscript role='select'>
+         <varRef name='Q{}updated-values' slot='1'/>
+         <varRef name='Q{}updated-node-position' slot='3'/>
+        </subscript>
+       </compAtt>
+      </let>
+      <true/>
+      <copyOf line='2794' flags='vc'>
+       <dot type='attribute()'/>
+      </copyOf>
+     </choose>
+    </sequence>
+   </templateRule>
+  </mode>
+ </co>
+ <co id='24' binds=''>
+  <template name='Q{}getInstance' flags='os' as='element()?' line='3256' module='saxon-xforms.xsl' slots='2'>
+   <check role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3257' card='?' diag='7|0|XTTE0505|getInstance'>
     <sequence>
      <param name='Q{}instance-id' slot='0' as='xs:string'>
       <str role='select' val=''/>
@@ -12857,21 +12899,21 @@
        </check>
       </treat>
      </param>
-     <param line='3285' name='Q{}instances' slot='1' flags='ti' as='map(xs:string, element())'>
+     <param line='3258' name='Q{}instances' slot='1' flags='ti' as='map(xs:string, element())'>
       <treat role='conversion' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|instances'>
        <check card='1' diag='8|0|XTTE0590|instances'>
         <supplied slot='1'/>
        </check>
       </treat>
      </param>
-     <choose line='3289'>
+     <choose line='3262'>
       <varRef name='Q{}instance-id' slot='0'/>
-      <ifCall line='3290' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+      <ifCall line='3263' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
        <varRef name='Q{}instances' slot='1'/>
        <varRef name='Q{}instance-id' slot='0'/>
       </ifCall>
       <true/>
-      <copyOf line='3294' flags='vc'>
+      <copyOf line='3267' flags='vc'>
        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
         <varRef name='Q{}instances' slot='1'/>
         <str val='saxon-forms-default'/>
@@ -12894,4 +12936,4 @@
  </output>
  <decimalFormat/>
 </package>
-<?Σ 1bf0edc6?>
+<?Σ 966b6e1b?>

--- a/sef/saxon-xforms.sef.xml
+++ b/sef/saxon-xforms.sef.xml
@@ -1,0 +1,12678 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns='http://ns.saxonica.com/xslt/export' xmlns:fn='http://www.w3.org/2005/xpath-functions' xmlns:xs='http://www.w3.org/2001/XMLSchema' xmlns:vv='http://saxon.sf.net/generated-variable' xmlns:java-type='http://saxon.sf.net/java-type' when='2020-02-22T17:48:53.047Z' id='0' version='30' packageVersion='1' saxonVersion='9.9.1.5' target='JS' targetVersion='1' relocatable='true' implicit='true'>
+ <co id='0' binds='1 2 1 2 3 3 4 5 6 3 7'>
+  <template name='Q{}action-insert' flags='os' line='4496' module='saxon-xforms.xsl' slots='18'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4497'>
+    <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
+     <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
+      <check card='1' diag='8|0|XTTE0590|action-map'>
+       <supplied slot='0'/>
+      </check>
+     </treat>
+    </param>
+    <param line='4498' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
+     <empty role='select'/>
+     <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|instanceXML'>
+      <check card='?' diag='8|0|XTTE0590|instanceXML'>
+       <supplied slot='1'/>
+      </check>
+     </treat>
+    </param>
+    <param line='4499' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
+     <str role='select' val=''/>
+     <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
+      <check card='1' diag='8|0|XTTE0590|nodeset'>
+       <cvUntyped to='xs:string' diag='8|0|XTTE0590|nodeset'>
+        <data>
+         <supplied slot='2'/>
+        </data>
+       </cvUntyped>
+      </check>
+     </treat>
+    </param>
+    <let line='4501' var='Q{}ref' as='xs:string' slot='3' eval='16'>
+     <let var='Q{}relative' as='xs:string' slot='4' eval='16'>
+      <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|1||xforms:resolveXPathStrings'>
+       <check card='1' diag='0|1||xforms:resolveXPathStrings'>
+        <cvUntyped to='xs:string'>
+         <data>
+          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+           <varRef name='Q{}action-map' slot='0'/>
+           <str val='@ref'/>
+          </ifCall>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+      <choose line='835'>
+       <fn name='starts-with'>
+        <varRef name='Q{}relative' slot='4'/>
+        <str val='/'/>
+       </fn>
+       <varRef line='836' name='Q{}relative' slot='4'/>
+       <fn line='838' name='starts-with'>
+        <varRef name='Q{}relative' slot='4'/>
+        <str val='instance('/>
+       </fn>
+       <varRef line='839' name='Q{}relative' slot='4'/>
+       <fn line='4501' name='not'>
+        <varRef name='Q{}nodeset' slot='2'/>
+       </fn>
+       <varRef line='842' name='Q{}relative' slot='4'/>
+       <or line='844' op='or'>
+        <fn name='not'>
+         <varRef name='Q{}relative' slot='4'/>
+        </fn>
+        <vc op='eq' onEmpty='0' comp='CCC'>
+         <varRef name='Q{}relative' slot='4'/>
+         <str val='.'/>
+        </vc>
+       </or>
+       <varRef line='4501' name='Q{}nodeset' slot='2'/>
+       <true/>
+       <let line='849' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
+        <choose>
+         <fn name='contains'>
+          <varRef name='Q{}relative' slot='4'/>
+          <str val='/'/>
+         </fn>
+         <fn name='count'>
+          <filter flags='b'>
+           <fn name='tokenize'>
+            <varRef name='Q{}relative' slot='4'/>
+            <str val='/'/>
+            <str val=''/>
+           </fn>
+           <vc op='eq' onEmpty='0' comp='CCC'>
+            <dot type='xs:string'/>
+            <str val='..'/>
+           </vc>
+          </filter>
+         </fn>
+         <fn name='contains'>
+          <varRef name='Q{}relative' slot='4'/>
+          <str val='..'/>
+         </fn>
+         <int val='1'/>
+         <true/>
+         <int val='0'/>
+        </choose>
+        <let line='852' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
+         <choose>
+          <fn line='4501' name='contains'>
+           <varRef name='Q{}nodeset' slot='2'/>
+           <str val='/'/>
+          </fn>
+          <fn name='index-of'>
+           <fn name='string-to-codepoints'>
+            <varRef line='4501' name='Q{}nodeset' slot='2'/>
+           </fn>
+           <int val='47'/>
+          </fn>
+          <true/>
+          <int val='0'/>
+         </choose>
+         <choose line='884'>
+          <compareToInt op='gt' val='0'>
+           <varRef name='Q{}parentCallCount' slot='5'/>
+          </compareToInt>
+          <fn line='888' name='concat'>
+           <fn name='substring'>
+            <varRef line='4501' name='Q{}nodeset' slot='2'/>
+            <int val='1'/>
+            <choose line='863'>
+             <and op='and'>
+              <vc op='ge' onEmpty='0' comp='CAVC'>
+               <fn name='count'>
+                <varRef name='Q{}slashes' slot='6'/>
+               </fn>
+               <varRef name='Q{}parentCallCount' slot='5'/>
+              </vc>
+              <compareToInt op='gt' val='0'>
+               <varRef name='Q{}parentCallCount' slot='5'/>
+              </compareToInt>
+             </and>
+             <let line='864' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='7' eval='13'>
+              <arith op='-' calc='i-i'>
+               <varRef name='Q{}parentCallCount' slot='5'/>
+               <int val='1'/>
+              </arith>
+              <check card='1' diag='3|0|XTTE0570|parentSlash'>
+               <filter flags='p'>
+                <varRef name='Q{}slashes' slot='6'/>
+                <arith op='-' calc='i-i'>
+                 <fn name='last'/>
+                 <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='7'/>
+                </arith>
+               </filter>
+              </check>
+             </let>
+             <true/>
+             <check line='867' card='1' diag='3|0|XTTE0570|parentSlash'>
+              <lastOf>
+               <varRef name='Q{}slashes' slot='6'/>
+              </lastOf>
+             </check>
+            </choose>
+           </fn>
+           <fn name='replace'>
+            <varRef name='Q{}relative' slot='4'/>
+            <str val='\.\./'/>
+            <str val=''/>
+            <str val=''/>
+           </fn>
+          </fn>
+          <true/>
+          <fn line='4501' name='concat'>
+           <varRef name='Q{}nodeset' slot='2'/>
+           <str val='/'/>
+           <varRef line='891' name='Q{}relative' slot='4'/>
+          </fn>
+         </choose>
+        </let>
+       </let>
+      </choose>
+     </let>
+     <let line='4502' var='Q{}at' as='xs:string?' slot='8' eval='7'>
+      <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|at'>
+       <check card='?' diag='3|0|XTTE0570|at'>
+        <cvUntyped to='xs:string' diag='3|0|XTTE0570|at'>
+         <data>
+          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+           <varRef name='Q{}action-map' slot='0'/>
+           <str val='@at'/>
+          </ifCall>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+      <let line='4503' var='Q{}position' as='xs:string?' slot='9' eval='7'>
+       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|position'>
+        <check card='?' diag='3|0|XTTE0570|position'>
+         <cvUntyped to='xs:string' diag='3|0|XTTE0570|position'>
+          <data>
+           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+            <varRef name='Q{}action-map' slot='0'/>
+            <str val='@position'/>
+           </ifCall>
+          </data>
+         </cvUntyped>
+        </check>
+       </treat>
+       <let line='4504' var='Q{}origin-ref' as='xs:string?' slot='10' eval='7'>
+        <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|origin-ref'>
+         <check card='?' diag='3|0|XTTE0570|origin-ref'>
+          <cvUntyped to='xs:string' diag='3|0|XTTE0570|origin-ref'>
+           <data>
+            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+             <varRef name='Q{}action-map' slot='0'/>
+             <str val='@origin'/>
+            </ifCall>
+           </data>
+          </cvUntyped>
+         </check>
+        </treat>
+        <let line='4519' var='Q{}instanceXML2' as='element()' slot='11' eval='16'>
+         <choose line='4521'>
+          <and op='and'>
+           <vc op='eq' onEmpty='0' comp='CCC'>
+            <ufCall line='4517' name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='6'>
+             <varRef name='Q{}ref' slot='3'/>
+            </ufCall>
+            <str val='saxon-forms-default'/>
+           </vc>
+           <fn name='exists'>
+            <varRef name='Q{}instanceXML' slot='1'/>
+           </fn>
+          </and>
+          <check line='4522' card='1' diag='3|0|XTTE0570|instanceXML2'>
+           <varRef name='Q{}instanceXML' slot='1'/>
+          </check>
+          <true/>
+          <check line='4525' card='1' diag='3|0|XTTE0570|instanceXML2'>
+           <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='1' eval='6'>
+            <varRef name='Q{}ref' slot='3'/>
+           </ufCall>
+          </check>
+         </choose>
+         <let line='4532' var='Q{}instanceXML-origin' as='element()' slot='12' eval='16'>
+          <choose line='4534'>
+           <and op='and'>
+            <vc op='eq' onEmpty='0' comp='CCC'>
+             <ufCall line='4530' name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='2' eval='16'>
+              <check card='1' diag='0|0||xforms:getInstanceId'>
+               <varRef name='Q{}origin-ref' slot='10'/>
+              </check>
+             </ufCall>
+             <str val='saxon-forms-default'/>
+            </vc>
+            <fn name='exists'>
+             <varRef name='Q{}instanceXML' slot='1'/>
+            </fn>
+           </and>
+           <check line='4535' card='1' diag='3|0|XTTE0570|instanceXML-origin'>
+            <varRef name='Q{}instanceXML' slot='1'/>
+           </check>
+           <true/>
+           <check line='4538' card='1' diag='3|0|XTTE0570|instanceXML-origin'>
+            <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='3' eval='16'>
+             <check card='1' diag='0|0||xforms:getInstance-JS'>
+              <varRef name='Q{}origin-ref' slot='10'/>
+             </check>
+            </ufCall>
+           </check>
+          </choose>
+          <let line='4549' var='Q{}origin-node' as='node()?' slot='13' eval='7'>
+           <treat line='4550' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|origin-node'>
+            <check card='?' diag='3|0|XTTE0570|origin-node'>
+             <evaluate dxns=''>
+              <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='4' eval='16'>
+               <check card='1' diag='0|0||xforms:impose'>
+                <varRef name='Q{}origin-ref' slot='10'/>
+               </check>
+              </ufCall>
+              <varRef role='cxt' name='Q{}instanceXML-origin' slot='12'/>
+              <varRef role='nsCxt' name='Q{}instanceXML-origin' slot='12'/>
+              <str role='sa' val='no'/>
+              <map role='options' size='0'/>
+              <map role='wp' size='0'/>
+             </evaluate>
+            </check>
+           </treat>
+           <let line='4553' var='Q{}insert-node-location' as='node()' slot='14' eval='16'>
+            <treat line='4554' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|insert-node-location'>
+             <check card='1' diag='3|0|XTTE0570|insert-node-location'>
+              <evaluate dxns=''>
+               <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='5' eval='16'>
+                <check card='1' diag='0|0||xforms:impose'>
+                 <choose line='4515'>
+                  <vc op='ne' onEmpty='0' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+                   <varRef name='Q{}ref' slot='3'/>
+                   <str val=''/>
+                  </vc>
+                  <choose>
+                   <fn name='exists'>
+                    <varRef name='Q{}at' slot='8'/>
+                   </fn>
+                   <fn name='concat'>
+                    <varRef name='Q{}ref' slot='3'/>
+                    <str val='['/>
+                    <varRef name='Q{}at' slot='8'/>
+                    <str val=']'/>
+                   </fn>
+                   <true/>
+                   <varRef name='Q{}ref' slot='3'/>
+                  </choose>
+                 </choose>
+                </check>
+               </ufCall>
+               <varRef role='cxt' name='Q{}instanceXML2' slot='11'/>
+               <varRef role='nsCxt' name='Q{}instanceXML2' slot='11'/>
+               <str role='sa' val='no'/>
+               <map role='options' size='0'/>
+               <map role='wp' size='0'/>
+              </evaluate>
+             </check>
+            </treat>
+            <sequence line='4557'>
+             <message>
+              <sequence role='select'>
+               <valueOf>
+                <str val='[action-insert] $insert-node-location = '/>
+               </valueOf>
+               <valueOf>
+                <fn name='serialize'>
+                 <varRef name='Q{}insert-node-location' slot='14'/>
+                </fn>
+               </valueOf>
+              </sequence>
+              <str role='terminate' val='no'/>
+              <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+             </message>
+             <message line='4558'>
+              <sequence role='select'>
+               <valueOf>
+                <str val='[action-insert] $origin-node = '/>
+               </valueOf>
+               <valueOf>
+                <fn name='serialize'>
+                 <varRef name='Q{}origin-node' slot='13'/>
+                </fn>
+               </valueOf>
+              </sequence>
+              <str role='terminate' val='no'/>
+              <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+             </message>
+             <let line='4575' var='Q{}instance-with-insert' as='element()' slot='15' eval='16'>
+              <treat line='4576' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-insert'>
+               <check card='1' diag='3|0|XTTE0570|instance-with-insert'>
+                <applyT mode='Q{}insert-node' bSlot='6'>
+                 <varRef role='select' name='Q{}instanceXML2' slot='11'/>
+                 <withParam name='Q{}insert-node-location' flags='t' as='node()'>
+                  <varRef line='4577' name='Q{}insert-node-location' slot='14'/>
+                 </withParam>
+                 <withParam name='Q{}node-to-insert' flags='t' as='node()?'>
+                  <choose line='4564'>
+                   <fn name='exists'>
+                    <varRef name='Q{}origin-node' slot='13'/>
+                   </fn>
+                   <copyOf line='4565' flags='vc'>
+                    <varRef name='Q{}origin-node' slot='13'/>
+                   </copyOf>
+                   <true/>
+                   <copyOf line='4568' flags='vc'>
+                    <varRef name='Q{}insert-node-location' slot='14'/>
+                   </copyOf>
+                  </choose>
+                 </withParam>
+                 <withParam name='Q{}position-relative' flags='t' as='xs:string?'>
+                  <varRef line='4579' name='Q{}position' slot='9'/>
+                 </withParam>
+                </applyT>
+               </check>
+              </treat>
+              <sequence line='4583'>
+               <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='7' eval='6 6'>
+                <varRef name='Q{}ref' slot='3'/>
+                <varRef name='Q{}instance-with-insert' slot='15'/>
+               </ufCall>
+               <choose line='4587'>
+                <fn name='matches'>
+                 <varRef name='Q{}at' slot='8'/>
+                 <str val='index\s*\('/>
+                 <str val=''/>
+                </fn>
+                <let line='4588' var='Q{}repeat-id' as='xs:string?' slot='16' eval='7'>
+                 <ufCall name='Q{http://www.w3.org/2002/xforms}getRepeatID' tailCall='false' bSlot='8' eval='16'>
+                  <check card='1' diag='0|0||xforms:getRepeatID'>
+                   <varRef name='Q{}at' slot='8'/>
+                  </check>
+                 </ufCall>
+                 <let line='4589' var='Q{}at-position' as='xs:integer' slot='17' eval='16'>
+                  <treat line='4590' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|at-position'>
+                   <check card='1' diag='3|0|XTTE0570|at-position'>
+                    <cvUntyped to='xs:integer' diag='3|0|XTTE0570|at-position'>
+                     <data>
+                      <evaluate dxns=''>
+                       <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='9' eval='16'>
+                        <check card='1' diag='0|0||xforms:impose'>
+                         <varRef name='Q{}at' slot='8'/>
+                        </check>
+                       </ufCall>
+                       <empty role='cxt'/>
+                       <str role='sa' val='no'/>
+                       <map role='options' size='0'/>
+                       <map role='wp' size='0'/>
+                      </evaluate>
+                     </data>
+                    </cvUntyped>
+                   </check>
+                  </treat>
+                  <sequence line='4592'>
+                   <message>
+                    <sequence role='select'>
+                     <valueOf>
+                      <str val='[action-insert] $repeat-id = '/>
+                     </valueOf>
+                     <valueOf>
+                      <varRef name='Q{}repeat-id' slot='16'/>
+                     </valueOf>
+                    </sequence>
+                    <str role='terminate' val='no'/>
+                    <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+                   </message>
+                   <message line='4593'>
+                    <sequence role='select'>
+                     <valueOf>
+                      <str val='[action-insert] $at-position evaluated as '/>
+                     </valueOf>
+                     <valueOf>
+                      <convert from='xs:integer' to='xs:string'>
+                       <varRef name='Q{}at-position' slot='17'/>
+                      </convert>
+                     </valueOf>
+                    </sequence>
+                    <str role='terminate' val='no'/>
+                    <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+                   </message>
+                   <choose line='4595'>
+                    <fn name='exists'>
+                     <varRef name='Q{}repeat-id' slot='16'/>
+                    </fn>
+                    <choose line='4597'>
+                     <vc op='eq' onEmpty='0' comp='CCC'>
+                      <varRef name='Q{}position' slot='9'/>
+                      <str val='before'/>
+                     </vc>
+                     <ifCall line='4598' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                      <check card='1' diag='0|0||ixsl:call'>
+                       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                      </check>
+                      <str val='setRepeatIndex'/>
+                      <arrayBlock>
+                       <varRef name='Q{}repeat-id' slot='16'/>
+                       <varRef name='Q{}at-position' slot='17'/>
+                      </arrayBlock>
+                     </ifCall>
+                     <true/>
+                     <ifCall line='4601' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                      <check card='1' diag='0|0||ixsl:call'>
+                       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                      </check>
+                      <str val='setRepeatIndex'/>
+                      <arrayBlock>
+                       <varRef name='Q{}repeat-id' slot='16'/>
+                       <arith op='+' calc='i+i'>
+                        <varRef name='Q{}at-position' slot='17'/>
+                        <int val='1'/>
+                       </arith>
+                      </arrayBlock>
+                     </ifCall>
+                    </choose>
+                   </choose>
+                  </sequence>
+                 </let>
+                </let>
+               </choose>
+               <callT line='4611' name='Q{}xforms-recalculate' bSlot='10' flags='t'/>
+              </sequence>
+             </let>
+            </sequence>
+           </let>
+          </let>
+         </let>
+        </let>
+       </let>
+      </let>
+     </let>
+    </let>
+   </sequence>
+  </template>
+ </co>
+ <co id='8' binds='1 2 3 3 9 5 6 3 7'>
+  <template name='Q{}action-delete' flags='os' line='4624' module='saxon-xforms.xsl' slots='18'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4625'>
+    <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
+     <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
+      <check card='1' diag='8|0|XTTE0590|action-map'>
+       <supplied slot='0'/>
+      </check>
+     </treat>
+    </param>
+    <param line='4626' name='Q{}instanceXML' slot='1' flags='ti' as='element()'>
+     <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|instanceXML'>
+      <check card='1' diag='8|0|XTTE0590|instanceXML'>
+       <supplied slot='1'/>
+      </check>
+     </treat>
+    </param>
+    <param line='4627' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
+     <str role='select' val=''/>
+     <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
+      <check card='1' diag='8|0|XTTE0590|nodeset'>
+       <cvUntyped to='xs:string' diag='8|0|XTTE0590|nodeset'>
+        <data>
+         <supplied slot='2'/>
+        </data>
+       </cvUntyped>
+      </check>
+     </treat>
+    </param>
+    <let line='4629' var='Q{}ref' as='xs:string' slot='3' eval='16'>
+     <let var='Q{}relative' as='xs:string' slot='4' eval='16'>
+      <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|1||xforms:resolveXPathStrings'>
+       <check card='1' diag='0|1||xforms:resolveXPathStrings'>
+        <cvUntyped to='xs:string'>
+         <data>
+          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+           <varRef name='Q{}action-map' slot='0'/>
+           <str val='@ref'/>
+          </ifCall>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+      <choose line='835'>
+       <fn name='starts-with'>
+        <varRef name='Q{}relative' slot='4'/>
+        <str val='/'/>
+       </fn>
+       <varRef line='836' name='Q{}relative' slot='4'/>
+       <fn line='838' name='starts-with'>
+        <varRef name='Q{}relative' slot='4'/>
+        <str val='instance('/>
+       </fn>
+       <varRef line='839' name='Q{}relative' slot='4'/>
+       <fn line='4629' name='not'>
+        <varRef name='Q{}nodeset' slot='2'/>
+       </fn>
+       <varRef line='842' name='Q{}relative' slot='4'/>
+       <or line='844' op='or'>
+        <fn name='not'>
+         <varRef name='Q{}relative' slot='4'/>
+        </fn>
+        <vc op='eq' onEmpty='0' comp='CCC'>
+         <varRef name='Q{}relative' slot='4'/>
+         <str val='.'/>
+        </vc>
+       </or>
+       <varRef line='4629' name='Q{}nodeset' slot='2'/>
+       <true/>
+       <let line='849' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
+        <choose>
+         <fn name='contains'>
+          <varRef name='Q{}relative' slot='4'/>
+          <str val='/'/>
+         </fn>
+         <fn name='count'>
+          <filter flags='b'>
+           <fn name='tokenize'>
+            <varRef name='Q{}relative' slot='4'/>
+            <str val='/'/>
+            <str val=''/>
+           </fn>
+           <vc op='eq' onEmpty='0' comp='CCC'>
+            <dot type='xs:string'/>
+            <str val='..'/>
+           </vc>
+          </filter>
+         </fn>
+         <fn name='contains'>
+          <varRef name='Q{}relative' slot='4'/>
+          <str val='..'/>
+         </fn>
+         <int val='1'/>
+         <true/>
+         <int val='0'/>
+        </choose>
+        <let line='852' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
+         <choose>
+          <fn line='4629' name='contains'>
+           <varRef name='Q{}nodeset' slot='2'/>
+           <str val='/'/>
+          </fn>
+          <fn name='index-of'>
+           <fn name='string-to-codepoints'>
+            <varRef line='4629' name='Q{}nodeset' slot='2'/>
+           </fn>
+           <int val='47'/>
+          </fn>
+          <true/>
+          <int val='0'/>
+         </choose>
+         <choose line='884'>
+          <compareToInt op='gt' val='0'>
+           <varRef name='Q{}parentCallCount' slot='5'/>
+          </compareToInt>
+          <fn line='888' name='concat'>
+           <fn name='substring'>
+            <varRef line='4629' name='Q{}nodeset' slot='2'/>
+            <int val='1'/>
+            <choose line='863'>
+             <and op='and'>
+              <vc op='ge' onEmpty='0' comp='CAVC'>
+               <fn name='count'>
+                <varRef name='Q{}slashes' slot='6'/>
+               </fn>
+               <varRef name='Q{}parentCallCount' slot='5'/>
+              </vc>
+              <compareToInt op='gt' val='0'>
+               <varRef name='Q{}parentCallCount' slot='5'/>
+              </compareToInt>
+             </and>
+             <let line='864' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='7' eval='13'>
+              <arith op='-' calc='i-i'>
+               <varRef name='Q{}parentCallCount' slot='5'/>
+               <int val='1'/>
+              </arith>
+              <check card='1' diag='3|0|XTTE0570|parentSlash'>
+               <filter flags='p'>
+                <varRef name='Q{}slashes' slot='6'/>
+                <arith op='-' calc='i-i'>
+                 <fn name='last'/>
+                 <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='7'/>
+                </arith>
+               </filter>
+              </check>
+             </let>
+             <true/>
+             <check line='867' card='1' diag='3|0|XTTE0570|parentSlash'>
+              <lastOf>
+               <varRef name='Q{}slashes' slot='6'/>
+              </lastOf>
+             </check>
+            </choose>
+           </fn>
+           <fn name='replace'>
+            <varRef name='Q{}relative' slot='4'/>
+            <str val='\.\./'/>
+            <str val=''/>
+            <str val=''/>
+           </fn>
+          </fn>
+          <true/>
+          <fn line='4629' name='concat'>
+           <varRef name='Q{}nodeset' slot='2'/>
+           <str val='/'/>
+           <varRef line='891' name='Q{}relative' slot='4'/>
+          </fn>
+         </choose>
+        </let>
+       </let>
+      </choose>
+     </let>
+     <let line='4630' var='Q{}at' as='xs:string?' slot='8' eval='7'>
+      <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|at'>
+       <check card='?' diag='3|0|XTTE0570|at'>
+        <cvUntyped to='xs:string' diag='3|0|XTTE0570|at'>
+         <data>
+          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+           <varRef name='Q{}action-map' slot='0'/>
+           <str val='@at'/>
+          </ifCall>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+      <let line='4640' var='Q{}ref-qualified' as='xs:string' slot='9' eval='16'>
+       <choose>
+        <fn name='exists'>
+         <varRef name='Q{}at' slot='8'/>
+        </fn>
+        <fn name='concat'>
+         <varRef name='Q{}ref' slot='3'/>
+         <str val='['/>
+         <varRef name='Q{}at' slot='8'/>
+         <str val=']'/>
+        </fn>
+        <true/>
+        <varRef name='Q{}ref' slot='3'/>
+       </choose>
+       <let line='4644' var='Q{}instanceXML2' as='element()' slot='10' eval='16'>
+        <choose line='4646'>
+         <vc op='eq' onEmpty='0' comp='CCC'>
+          <ufCall line='4642' name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='6'>
+           <varRef name='Q{}ref' slot='3'/>
+          </ufCall>
+          <str val='saxon-forms-default'/>
+         </vc>
+         <varRef line='4647' name='Q{}instanceXML' slot='1'/>
+         <true/>
+         <check line='4650' card='1' diag='3|0|XTTE0570|instanceXML2'>
+          <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='1' eval='6'>
+           <varRef name='Q{}ref' slot='3'/>
+          </ufCall>
+         </check>
+        </choose>
+        <let line='4655' var='Q{}ifVar' as='xs:string?' slot='11' eval='7'>
+         <choose line='790'>
+          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+           <varRef line='4655' name='Q{}action-map' slot='0'/>
+           <str val='@if'/>
+          </ifCall>
+          <treat line='791' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
+           <check card='?' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
+            <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
+             <data>
+              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+               <varRef line='4655' name='Q{}action-map' slot='0'/>
+               <str val='@if'/>
+              </ifCall>
+             </data>
+            </cvUntyped>
+           </check>
+          </treat>
+         </choose>
+         <let line='4658' var='Q{}delete-node' as='node()?' slot='12' eval='7'>
+          <choose line='4660'>
+           <and op='and'>
+            <fn name='exists'>
+             <varRef name='Q{}ref-qualified' slot='9'/>
+            </fn>
+            <vc op='ne' onEmpty='1' comp='CCC'>
+             <varRef name='Q{}ref-qualified' slot='9'/>
+             <str val=''/>
+            </vc>
+           </and>
+           <treat line='4661' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|delete-node'>
+            <check card='?' diag='3|0|XTTE0570|delete-node'>
+             <evaluate dxns=''>
+              <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
+               <check card='1' diag='0|0||xforms:impose'>
+                <varRef name='Q{}ref-qualified' slot='9'/>
+               </check>
+              </ufCall>
+              <varRef role='cxt' name='Q{}instanceXML2' slot='10'/>
+              <varRef role='nsCxt' name='Q{}instanceXML2' slot='10'/>
+              <str role='sa' val='no'/>
+              <map role='options' size='0'/>
+              <map role='wp' size='0'/>
+             </evaluate>
+            </check>
+           </treat>
+          </choose>
+          <let line='4666' var='Q{}ifExecuted' as='xs:boolean' slot='13' eval='16'>
+           <choose line='4668'>
+            <fn name='exists'>
+             <varRef name='Q{}ifVar' slot='11'/>
+            </fn>
+            <treat line='4669' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|ifExecuted'>
+             <check card='1' diag='3|0|XTTE0570|ifExecuted'>
+              <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|ifExecuted'>
+               <data>
+                <evaluate dxns=''>
+                 <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='3' eval='16'>
+                  <check card='1' diag='0|0||xforms:impose'>
+                   <varRef name='Q{}ifVar' slot='11'/>
+                  </check>
+                 </ufCall>
+                 <varRef role='cxt' name='Q{}delete-node' slot='12'/>
+                 <check role='nsCxt' card='1' diag='4|0|XTTE3170|xsl:evaluate/namespace-context'>
+                  <varRef name='Q{}delete-node' slot='12'/>
+                 </check>
+                 <str role='sa' val='no'/>
+                 <map role='options' size='0'/>
+                 <map role='wp' size='0'/>
+                </evaluate>
+               </data>
+              </cvUntyped>
+             </check>
+            </treat>
+            <true/>
+            <true/>
+           </choose>
+           <choose line='4677'>
+            <varRef name='Q{}ifExecuted' slot='13'/>
+            <let line='4678' var='Q{}instance-with-delete' as='element()' slot='14' eval='16'>
+             <treat line='4679' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-delete'>
+              <check card='1' diag='3|0|XTTE0570|instance-with-delete'>
+               <applyT mode='Q{}delete-node' bSlot='4'>
+                <varRef role='select' name='Q{}instanceXML2' slot='10'/>
+                <withParam name='Q{}delete-node' flags='t' as='node()?'>
+                 <varRef line='4680' name='Q{}delete-node' slot='12'/>
+                </withParam>
+               </applyT>
+              </check>
+             </treat>
+             <sequence line='4684'>
+              <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='5' eval='6 6'>
+               <varRef name='Q{}ref' slot='3'/>
+               <varRef name='Q{}instance-with-delete' slot='14'/>
+              </ufCall>
+              <choose line='4687'>
+               <fn name='matches'>
+                <varRef name='Q{}at' slot='8'/>
+                <str val='index\s*\('/>
+                <str val=''/>
+               </fn>
+               <let line='4688' var='Q{}repeat-id' as='xs:string?' slot='15' eval='7'>
+                <ufCall name='Q{http://www.w3.org/2002/xforms}getRepeatID' tailCall='false' bSlot='6' eval='16'>
+                 <check card='1' diag='0|0||xforms:getRepeatID'>
+                  <varRef name='Q{}at' slot='8'/>
+                 </check>
+                </ufCall>
+                <let line='4689' var='Q{}at-position' as='xs:integer' slot='16' eval='16'>
+                 <treat line='4690' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|at-position'>
+                  <check card='1' diag='3|0|XTTE0570|at-position'>
+                   <cvUntyped to='xs:integer' diag='3|0|XTTE0570|at-position'>
+                    <data>
+                     <evaluate dxns=''>
+                      <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='7' eval='16'>
+                       <check card='1' diag='0|0||xforms:impose'>
+                        <varRef name='Q{}at' slot='8'/>
+                       </check>
+                      </ufCall>
+                      <empty role='cxt'/>
+                      <str role='sa' val='no'/>
+                      <map role='options' size='0'/>
+                      <map role='wp' size='0'/>
+                     </evaluate>
+                    </data>
+                   </cvUntyped>
+                  </check>
+                 </treat>
+                 <choose line='4693'>
+                  <fn name='exists'>
+                   <varRef name='Q{}repeat-id' slot='15'/>
+                  </fn>
+                  <let line='4694' var='Q{}repeat-size' as='xs:double' slot='17' eval='16'>
+                   <check card='1' diag='3|0|XTTE0570|repeat-size'>
+                    <convert from='xs:anyAtomicType' to='xs:double' flags='p' diag='3|0|XTTE0570|repeat-size'>
+                     <cvUntyped to='xs:double' diag='3|0|XTTE0570|repeat-size'>
+                      <data>
+                       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                        <check card='1' diag='0|0||ixsl:call'>
+                         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                        </check>
+                        <str val='getRepeatSize'/>
+                        <arrayBlock>
+                         <varRef name='Q{}repeat-id' slot='15'/>
+                        </arrayBlock>
+                       </ifCall>
+                      </data>
+                     </cvUntyped>
+                    </convert>
+                   </check>
+                   <sequence line='4696'>
+                    <message>
+                     <sequence role='select'>
+                      <valueOf>
+                       <str val='[action-delete] Size of repeat &#39;'/>
+                      </valueOf>
+                      <valueOf>
+                       <varRef name='Q{}repeat-id' slot='15'/>
+                      </valueOf>
+                      <valueOf>
+                       <str val='&#39; is '/>
+                      </valueOf>
+                      <valueOf>
+                       <convert from='xs:double' to='xs:string'>
+                        <varRef name='Q{}repeat-size' slot='17'/>
+                       </convert>
+                      </valueOf>
+                      <valueOf>
+                       <str val=', index is '/>
+                      </valueOf>
+                      <valueOf>
+                       <convert from='xs:integer' to='xs:string'>
+                        <varRef name='Q{}at-position' slot='16'/>
+                       </convert>
+                      </valueOf>
+                     </sequence>
+                     <str role='terminate' val='no'/>
+                     <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+                    </message>
+                    <choose line='4699'>
+                     <vc op='eq' onEmpty='0' comp='CAVC'>
+                      <varRef name='Q{}at-position' slot='16'/>
+                      <varRef name='Q{}repeat-size' slot='17'/>
+                     </vc>
+                     <ifCall line='4701' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                      <check card='1' diag='0|0||ixsl:call'>
+                       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                      </check>
+                      <str val='setRepeatIndex'/>
+                      <arrayBlock>
+                       <varRef name='Q{}repeat-id' slot='15'/>
+                       <arith op='-' calc='d-d'>
+                        <varRef name='Q{}repeat-size' slot='17'/>
+                        <dbl val='1'/>
+                       </arith>
+                      </arrayBlock>
+                     </ifCall>
+                    </choose>
+                   </sequence>
+                  </let>
+                 </choose>
+                </let>
+               </let>
+              </choose>
+              <callT line='4710' name='Q{}xforms-recalculate' bSlot='8' flags='t'/>
+             </sequence>
+            </let>
+           </choose>
+          </let>
+         </let>
+        </let>
+       </let>
+      </let>
+     </let>
+    </let>
+   </sequence>
+  </template>
+ </co>
+ <co id='10' binds='11'>
+  <template name='Q{}action-send' flags='os' line='4755' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4756'>
+    <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
+     <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
+      <check card='1' diag='8|0|XTTE0590|action-map'>
+       <supplied slot='0'/>
+      </check>
+     </treat>
+    </param>
+    <callT line='4762' name='Q{}xforms-submit' bSlot='0' flags='t'>
+     <withParam name='Q{}submission' flags='c' as='xs:string'>
+      <treat line='4760' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|submission'>
+       <check card='1' diag='3|0|XTTE0570|submission'>
+        <cvUntyped to='xs:string' diag='3|0|XTTE0570|submission'>
+         <data>
+          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+           <varRef name='Q{}action-map' slot='0'/>
+           <str val='@submission'/>
+          </ifCall>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </withParam>
+    </callT>
+   </sequence>
+  </template>
+ </co>
+ <co id='12' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}usesIndexFunction' line='2954' module='saxon-xforms.xsl' eval='8' flags='pU' as='xs:boolean' slots='1'>
+   <arg name='Q{}this' as='element()'/>
+   <fn role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2990' name='exists'>
+    <sequence line='2965'>
+     <analyzeString>
+      <cvUntyped role='select' to='xs:string'>
+       <data>
+        <slash simple='1'>
+         <varRef name='Q{}this' slot='0'/>
+         <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+        </slash>
+       </data>
+      </cvUntyped>
+      <str role='regex' val='\i\c*\('/>
+      <str role='flags' val=''/>
+      <choose role='matching' line='2968'>
+       <vc op='eq' onEmpty='0' comp='CCC'>
+        <fn name='substring-before'>
+         <dot type='xs:string'/>
+         <str val='('/>
+        </fn>
+        <str val='index'/>
+       </vc>
+       <str val='i'/>
+      </choose>
+      <empty role='nonMatching'/>
+     </analyzeString>
+     <analyzeString line='2977'>
+      <cvUntyped role='select' to='xs:string'>
+       <data>
+        <slash simple='1'>
+         <varRef name='Q{}this' slot='0'/>
+         <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+        </slash>
+       </data>
+      </cvUntyped>
+      <str role='regex' val='\i\c*\('/>
+      <str role='flags' val=''/>
+      <choose role='matching' line='2980'>
+       <vc op='eq' onEmpty='0' comp='CCC'>
+        <fn name='substring-before'>
+         <dot type='xs:string'/>
+         <str val='('/>
+        </fn>
+        <str val='index'/>
+       </vc>
+       <str val='i'/>
+      </choose>
+      <empty role='nonMatching'/>
+     </analyzeString>
+    </sequence>
+   </fn>
+  </function>
+ </co>
+ <co id='13' binds='13 14 15 13 13 15'>
+  <mode name='Q{}form-check' onNo='TC' flags='W' patternSlots='0'>
+   <templateRule prec='0' prio='-0.5' seq='27' rank='0' minImp='0' slots='10' flags='s' line='2606' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2607'>
+     <param name='Q{}curPath' slot='0'>
+      <str role='select' val=''/>
+      <supplied role='conversion' slot='0'/>
+     </param>
+     <param line='2608' name='Q{}position' slot='1'>
+      <int role='select' val='0'/>
+      <supplied role='conversion' slot='1'/>
+     </param>
+     <param line='2609' name='Q{}pendingUpdates' slot='2' flags='t' as='map(xs:string, xs:string)?'>
+      <empty role='select'/>
+      <treat role='conversion' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|pendingUpdates'>
+       <check card='?' diag='8|0|XTTE0590|pendingUpdates'>
+        <supplied slot='2'/>
+       </check>
+      </treat>
+     </param>
+     <let line='2615' var='Q{}updatedPath' as='xs:string' slot='3' eval='16'>
+      <choose>
+       <gc op='&gt;' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+        <data>
+         <varRef name='Q{}position' slot='1'/>
+        </data>
+        <int val='0'/>
+       </gc>
+       <fn name='concat'>
+        <atomSing card='?' diag='0|0||fn:concat'>
+         <varRef name='Q{}curPath' slot='0'/>
+        </atomSing>
+        <fn name='name'>
+         <dot type='element()'/>
+        </fn>
+        <str val='['/>
+        <atomSing card='?' diag='0|3||fn:concat'>
+         <varRef name='Q{}position' slot='1'/>
+        </atomSing>
+        <str val=']'/>
+       </fn>
+       <true/>
+       <fn name='concat'>
+        <atomSing card='?' diag='0|0||fn:concat'>
+         <varRef name='Q{}curPath' slot='0'/>
+        </atomSing>
+        <fn name='name'>
+         <dot type='element()'/>
+        </fn>
+       </fn>
+      </choose>
+      <copy line='2623' flags='cin'>
+       <sequence role='content'>
+        <applyT mode='Q{}form-check' bSlot='0'>
+         <axis role='select' name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+         <withParam name='Q{}curPath' as='xs:string'>
+          <fn line='2624' name='concat'>
+           <varRef name='Q{}updatedPath' slot='3'/>
+           <str val='/'/>
+          </fn>
+         </withParam>
+        </applyT>
+        <let line='2630' var='Q{}associated-form-control' as='element()*' slot='4' eval='8'>
+         <filter flags='b'>
+          <filter flags='b'>
+           <slash simple='1'>
+            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
+            <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+           </slash>
+           <or op='or'>
+            <or op='or'>
+             <fn name='exists'>
+              <axis name='self' nodeTest='element(Q{}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
+             </fn>
+             <fn name='exists'>
+              <axis name='self' nodeTest='element(Q{}select)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;select&#39;;'/>
+             </fn>
+            </or>
+            <fn name='exists'>
+             <axis name='self' nodeTest='element(Q{}textarea)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;textarea&#39;;'/>
+            </fn>
+           </or>
+          </filter>
+          <vc op='eq' onEmpty='0' comp='CCC'>
+           <ufCall name='Q{http://www.w3.org/2002/xforms}resolve-index' tailCall='false' bSlot='1' eval='16'>
+            <check card='1' diag='0|0||xforms:resolve-index'>
+             <cvUntyped to='xs:string'>
+              <attVal name='Q{}data-ref' chk='0'/>
+             </cvUntyped>
+            </check>
+           </ufCall>
+           <varRef name='Q{}updatedPath' slot='3'/>
+          </vc>
+         </filter>
+         <sequence line='2632'>
+          <choose>
+           <fn name='exists'>
+            <tail start='2'>
+             <varRef name='Q{}associated-form-control' slot='4'/>
+            </tail>
+           </fn>
+           <message line='2633'>
+            <sequence role='select'>
+             <valueOf>
+              <str val='[form-check] More than one form element controls the value of XForm node at '/>
+             </valueOf>
+             <valueOf>
+              <varRef name='Q{}updatedPath' slot='3'/>
+             </valueOf>
+             <valueOf>
+              <str val='; Saxon-Forms will apply the value of the first'/>
+             </valueOf>
+            </sequence>
+            <str role='terminate' val='no'/>
+            <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+           </message>
+          </choose>
+          <choose line='2637'>
+           <fn name='exists'>
+            <varRef name='Q{}associated-form-control' slot='4'/>
+           </fn>
+           <valueOf line='2641' flags='l'>
+            <fn name='string-join'>
+             <convert from='xs:anyAtomicType' to='xs:string'>
+              <data>
+               <mergeAdj>
+                <applyT mode='Q{}get-field' bSlot='2'>
+                 <first role='select'>
+                  <varRef name='Q{}associated-form-control' slot='4'/>
+                 </first>
+                </applyT>
+               </mergeAdj>
+              </data>
+             </convert>
+             <str val=''/>
+            </fn>
+           </valueOf>
+           <and line='2644' op='and'>
+            <fn name='exists'>
+             <varRef name='Q{}pendingUpdates' slot='2'/>
+            </fn>
+            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+             <check card='1' diag='0|0||map:contains'>
+              <varRef name='Q{}pendingUpdates' slot='2'/>
+             </check>
+             <varRef name='Q{}updatedPath' slot='3'/>
+            </ifCall>
+           </and>
+           <valueOf line='2652' flags='l'>
+            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+             <check card='1' diag='0|0||map:get'>
+              <varRef name='Q{}pendingUpdates' slot='2'/>
+             </check>
+             <varRef name='Q{}updatedPath' slot='3'/>
+            </ifCall>
+           </valueOf>
+           <true/>
+           <valueOf line='2661' flags='l'>
+            <fn name='normalize-space'>
+             <fn name='string-join'>
+              <data>
+               <axis name='child' nodeTest='text()' jsTest='return item.nodeType===3;'/>
+              </data>
+              <str val=''/>
+             </fn>
+            </fn>
+           </valueOf>
+          </choose>
+          <forEachGroup line='2666' algorithm='by'>
+           <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+           <fn role='key' name='local-name'>
+            <dot type='element()'/>
+           </fn>
+           <str role='collation' val='http://www.w3.org/2005/xpath-functions/collation/codepoint'/>
+           <let role='content' line='2668' var='Q{}updatedChildPath' as='xs:string' slot='5' eval='8'>
+            <fn name='concat'>
+             <varRef name='Q{}updatedPath' slot='3'/>
+             <str val='/'/>
+             <check card='?' diag='0|2||fn:concat'>
+              <currentGroupingKey/>
+             </check>
+            </fn>
+            <let line='2673' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='6' eval='13'>
+             <fn name='concat'>
+              <varRef name='Q{}updatedChildPath' slot='5'/>
+              <str val='['/>
+             </fn>
+             <let var='Q{}dataRefWithFilter' as='element()*' slot='7' eval='8'>
+              <filter flags='b'>
+               <slash simple='1'>
+                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
+                <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+               </slash>
+               <fn name='starts-with'>
+                <cvUntyped to='xs:string'>
+                 <attVal name='Q{}data-ref' chk='0'/>
+                </cvUntyped>
+                <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='6'/>
+               </fn>
+              </filter>
+              <choose line='2676'>
+               <or op='or'>
+                <fn name='exists'>
+                 <tail start='2'>
+                  <currentGroup/>
+                 </tail>
+                </fn>
+                <fn name='exists'>
+                 <varRef name='Q{}dataRefWithFilter' slot='7'/>
+                </fn>
+               </or>
+               <let line='2679' var='Q{http://saxon.sf.net/generated-variable}v1' as='xs:string' slot='8' eval='13'>
+                <fn name='concat'>
+                 <varRef name='Q{}updatedPath' slot='3'/>
+                 <str val='/'/>
+                </fn>
+                <forEach line='2677'>
+                 <currentGroup/>
+                 <applyT line='2678' mode='Q{}form-check' bSlot='3'>
+                  <dot role='select'/>
+                  <withParam name='Q{}curPath' as='xs:string'>
+                   <varRef line='2679' name='Q{http://saxon.sf.net/generated-variable}v1' slot='8'/>
+                  </withParam>
+                  <withParam name='Q{}position' as='xs:integer'>
+                   <fn line='2680' name='position'/>
+                  </withParam>
+                 </applyT>
+                </forEach>
+               </let>
+               <true/>
+               <let line='2688' var='Q{http://saxon.sf.net/generated-variable}v2' as='xs:string' slot='9' eval='13'>
+                <fn name='concat'>
+                 <varRef name='Q{}updatedPath' slot='3'/>
+                 <str val='/'/>
+                </fn>
+                <forEach line='2686'>
+                 <currentGroup/>
+                 <applyT line='2687' mode='Q{}form-check' bSlot='4'>
+                  <dot role='select'/>
+                  <withParam name='Q{}curPath' as='xs:string'>
+                   <varRef line='2688' name='Q{http://saxon.sf.net/generated-variable}v2' slot='9'/>
+                  </withParam>
+                 </applyT>
+                </forEach>
+               </let>
+              </choose>
+             </let>
+            </let>
+           </let>
+          </forEachGroup>
+         </sequence>
+        </let>
+       </sequence>
+      </copy>
+     </let>
+    </sequence>
+   </templateRule>
+   <templateRule prec='0' prio='-0.5' seq='30' rank='0' minImp='0' slots='4' flags='s' line='2826' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2827'>
+     <param name='Q{}curPath' slot='0'>
+      <str role='select' val=''/>
+      <supplied role='conversion' slot='0'/>
+     </param>
+     <param line='2828' name='Q{}pendingUpdates' slot='1' flags='t' as='map(xs:string, xs:string)?'>
+      <empty role='select'/>
+      <treat role='conversion' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|pendingUpdates'>
+       <check card='?' diag='8|0|XTTE0590|pendingUpdates'>
+        <supplied slot='1'/>
+       </check>
+      </treat>
+     </param>
+     <let line='2829' var='Q{}updatedPath' as='xs:string' slot='2' eval='8'>
+      <fn name='concat'>
+       <atomSing card='?' diag='0|0||fn:concat'>
+        <varRef name='Q{}curPath' slot='0'/>
+       </atomSing>
+       <str val='@'/>
+       <fn name='local-name'>
+        <dot type='attribute()'/>
+       </fn>
+      </fn>
+      <let line='2838' var='Q{}associated-form-control' as='element()*' slot='3' eval='8'>
+       <filter flags='b'>
+        <slash simple='1'>
+         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
+         <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+        </slash>
+        <vc op='eq' onEmpty='0' comp='CCC'>
+         <cast as='xs:string' emptiable='1'>
+          <attVal name='Q{}data-ref' chk='0'/>
+         </cast>
+         <varRef name='Q{}updatedPath' slot='2'/>
+        </vc>
+       </filter>
+       <choose line='2841'>
+        <fn name='exists'>
+         <varRef name='Q{}associated-form-control' slot='3'/>
+        </fn>
+        <compAtt line='2844'>
+         <fn role='name' name='local-name'>
+          <dot type='attribute()'/>
+         </fn>
+         <fn role='select' line='2845' name='string-join'>
+          <convert from='xs:anyAtomicType' to='xs:string'>
+           <data>
+            <mergeAdj>
+             <applyT mode='Q{}get-field' bSlot='5'>
+              <varRef role='select' name='Q{}associated-form-control' slot='3'/>
+             </applyT>
+            </mergeAdj>
+           </data>
+          </convert>
+          <str val=''/>
+         </fn>
+        </compAtt>
+        <and line='2848' op='and'>
+         <fn name='exists'>
+          <varRef name='Q{}pendingUpdates' slot='1'/>
+         </fn>
+         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+          <check card='1' diag='0|0||map:contains'>
+           <varRef name='Q{}pendingUpdates' slot='1'/>
+          </check>
+          <varRef name='Q{}updatedPath' slot='2'/>
+         </ifCall>
+        </and>
+        <compAtt line='2849'>
+         <fn role='name' name='local-name'>
+          <dot type='attribute()'/>
+         </fn>
+         <ifCall role='select' line='2850' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+          <check card='1' diag='0|0||map:get'>
+           <varRef name='Q{}pendingUpdates' slot='1'/>
+          </check>
+          <varRef name='Q{}updatedPath' slot='2'/>
+         </ifCall>
+        </compAtt>
+        <true/>
+        <forEach line='2854'>
+         <dot type='attribute()'/>
+         <copyOf flags='vsc'>
+          <dot type='attribute()'/>
+         </copyOf>
+        </forEach>
+       </choose>
+      </let>
+     </let>
+    </sequence>
+   </templateRule>
+  </mode>
+ </co>
+ <co id='16' binds='13 13'>
+  <mode name='Q{}form-check-initial' onNo='TC' flags='W' patternSlots='0'>
+   <templateRule prec='0' prio='-0.5' seq='26' rank='0' minImp='0' slots='6' flags='s' line='2544' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2545'>
+     <param name='Q{}instance-id' slot='0' as='xs:string'>
+      <str role='select' val='saxon-forms-default'/>
+      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|instance-id'>
+       <check card='1' diag='8|0|XTTE0590|instance-id'>
+        <cvUntyped to='xs:string' diag='8|0|XTTE0590|instance-id'>
+         <data>
+          <supplied slot='0'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <param line='2546' name='Q{}pendingUpdates' slot='1' flags='t' as='map(xs:string, xs:string)?'>
+      <empty role='select'/>
+      <treat role='conversion' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|pendingUpdates'>
+       <check card='?' diag='8|0|XTTE0590|pendingUpdates'>
+        <supplied slot='1'/>
+       </check>
+      </treat>
+     </param>
+     <let line='2552' var='Q{}curPath' as='xs:string' slot='2' eval='16'>
+      <choose line='2554'>
+       <vc op='eq' onEmpty='0' comp='CCC'>
+        <varRef name='Q{}instance-id' slot='0'/>
+        <str val='saxon-forms-default'/>
+       </vc>
+       <str val=''/>
+       <true/>
+       <cvUntyped line='2558' to='xs:string' diag='3|0|XTTE0570|curPath'>
+        <cast as='xs:untypedAtomic' emptiable='0'>
+         <fn name='concat'>
+          <str val='instance(&#39;'/>
+          <varRef name='Q{}instance-id' slot='0'/>
+          <str val='&#39;)/'/>
+         </fn>
+        </cast>
+       </cvUntyped>
+      </choose>
+      <copy line='2565' flags='cin'>
+       <forEachGroup role='content' algorithm='by'>
+        <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+        <fn role='key' name='local-name'>
+         <dot type='element()'/>
+        </fn>
+        <str role='collation' val='http://www.w3.org/2005/xpath-functions/collation/codepoint'/>
+        <let role='content' line='2567' var='Q{}updatedChildPath' as='xs:string' slot='3' eval='8'>
+         <fn name='concat'>
+          <varRef name='Q{}curPath' slot='2'/>
+          <check card='?' diag='0|1||fn:concat'>
+           <currentGroupingKey/>
+          </check>
+         </fn>
+         <let line='2572' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='4' eval='13'>
+          <fn name='concat'>
+           <varRef name='Q{}updatedChildPath' slot='3'/>
+           <str val='['/>
+          </fn>
+          <let var='Q{}dataRefWithFilter' as='element()*' slot='5' eval='8'>
+           <filter flags='b'>
+            <slash simple='1'>
+             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
+             <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+            </slash>
+            <fn name='starts-with'>
+             <cvUntyped to='xs:string'>
+              <attVal name='Q{}data-ref' chk='0'/>
+             </cvUntyped>
+             <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='4'/>
+            </fn>
+           </filter>
+           <choose line='2574'>
+            <or op='or'>
+             <fn name='exists'>
+              <tail start='2'>
+               <currentGroup/>
+              </tail>
+             </fn>
+             <fn name='exists'>
+              <varRef name='Q{}dataRefWithFilter' slot='5'/>
+             </fn>
+            </or>
+            <forEach line='2575'>
+             <currentGroup/>
+             <applyT line='2576' mode='Q{}form-check' bSlot='0'>
+              <dot role='select'/>
+              <withParam name='Q{}curPath' as='xs:string'>
+               <varRef line='2577' name='Q{}curPath' slot='2'/>
+              </withParam>
+              <withParam name='Q{}position' as='xs:integer'>
+               <fn line='2578' name='position'/>
+              </withParam>
+             </applyT>
+            </forEach>
+            <true/>
+            <forEach line='2584'>
+             <currentGroup/>
+             <applyT line='2585' mode='Q{}form-check' bSlot='1'>
+              <dot role='select'/>
+              <withParam name='Q{}curPath' as='xs:string'>
+               <varRef line='2586' name='Q{}curPath' slot='2'/>
+              </withParam>
+             </applyT>
+            </forEach>
+           </choose>
+          </let>
+         </let>
+        </let>
+       </forEachGroup>
+      </copy>
+     </let>
+    </sequence>
+   </templateRule>
+  </mode>
+ </co>
+ <co id='6' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}getRepeatID' line='763' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
+   <arg name='Q{}string-to-parse' as='xs:string'/>
+   <treat role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='766' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getRepeatID#1'>
+    <check card='?' diag='5|0|XTTE0780|xforms:getRepeatID#1'>
+     <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getRepeatID#1'>
+      <data>
+       <analyzeString>
+        <varRef role='select' name='Q{}string-to-parse' slot='0'/>
+        <str role='regex' val='^.*index\s*\(\s*&#39;([^&#39;]+)&#39;\s*\).*$'/>
+        <str role='flags' val=''/>
+        <fn role='matching' line='768' name='regex-group'>
+         <int val='1'/>
+        </fn>
+        <message role='nonMatching' line='771'>
+         <sequence role='select'>
+          <valueOf>
+           <str val='[xforms:getRepeatID] No repeat identifiable from value &#39;'/>
+          </valueOf>
+          <valueOf>
+           <varRef name='Q{}string-to-parse' slot='0'/>
+          </valueOf>
+          <valueOf flags='S'>
+           <str val='&#39;'/>
+          </valueOf>
+         </sequence>
+         <str role='terminate' val='no'/>
+         <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+        </message>
+       </analyzeString>
+      </data>
+     </cvUntyped>
+    </check>
+   </treat>
+  </function>
+ </co>
+ <co id='17' binds=''>
+  <template name='Q{}action-reset' flags='os' line='4802' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4803'>
+    <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
+     <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
+      <check card='1' diag='8|0|XTTE0590|action-map'>
+       <supplied slot='0'/>
+      </check>
+     </treat>
+    </param>
+    <message line='4805'>
+     <valueOf role='select'>
+      <str val='[action-reset] Reset triggered!'/>
+     </valueOf>
+     <str role='terminate' val='no'/>
+     <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+    </message>
+   </sequence>
+  </template>
+ </co>
+ <co id='18' binds='16 2 1 5 19 7 20'>
+  <template name='Q{}xforms-value-changed' flags='os' line='4121' module='saxon-xforms.xsl' slots='5'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4122'>
+    <param name='Q{}form-control' slot='0' flags='i' as='node()'>
+     <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|form-control'>
+      <check card='1' diag='8|0|XTTE0590|form-control'>
+       <supplied slot='0'/>
+      </check>
+     </treat>
+    </param>
+    <let line='4124' var='Q{}refi' as='attribute(Q{}data-ref)?' slot='1' eval='8'>
+     <slash simple='1'>
+      <varRef name='Q{}form-control' slot='0'/>
+      <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
+     </slash>
+     <let line='4128' var='Q{}actions' as='item()?' slot='2' eval='8'>
+      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+       <check card='1' diag='0|0||ixsl:call'>
+        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+       </check>
+       <str val='getAction'/>
+       <arrayBlock>
+        <fn name='string'>
+         <slash simple='1'>
+          <varRef name='Q{}form-control' slot='0'/>
+          <axis name='attribute' nodeTest='attribute(Q{}data-action)' jsTest='return item.name===&#39;data-action&#39;'/>
+         </slash>
+        </fn>
+       </arrayBlock>
+      </ifCall>
+      <let line='4132' var='Q{}updatedInstanceXML' as='element()' slot='3' eval='16'>
+       <treat line='4133' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+        <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
+         <applyT mode='Q{}form-check-initial' bSlot='0'>
+          <check role='select' line='4131' card='1' diag='3|0|XTTE0570|instanceXML'>
+           <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='1' eval='16'>
+            <check card='1' diag='0|0||xforms:getInstance-JS'>
+             <cvUntyped to='xs:string'>
+              <data>
+               <varRef name='Q{}refi' slot='1'/>
+              </data>
+             </cvUntyped>
+            </check>
+           </ufCall>
+          </check>
+          <withParam name='Q{}instance-id' as='xs:string'>
+           <ufCall line='4127' name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='2' eval='16'>
+            <check card='1' diag='0|0||xforms:getInstanceId'>
+             <cvUntyped to='xs:string'>
+              <data>
+               <varRef name='Q{}refi' slot='1'/>
+              </data>
+             </cvUntyped>
+            </check>
+           </ufCall>
+          </withParam>
+         </applyT>
+        </check>
+       </treat>
+       <sequence line='4139'>
+        <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='3' eval='16 6'>
+         <check card='1' diag='0|0||xforms:setInstance-JS'>
+          <cvUntyped to='xs:string'>
+           <data>
+            <varRef name='Q{}refi' slot='1'/>
+           </data>
+          </cvUntyped>
+         </check>
+         <varRef name='Q{}updatedInstanceXML' slot='3'/>
+        </ufCall>
+        <ifCall line='4146' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+         <check card='1' diag='0|0||ixsl:call'>
+          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+         </check>
+         <str val='setPendingUpdates'/>
+         <arrayBlock>
+          <treat line='4143' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||pendingInstanceUpdates'>
+           <map size='0'/>
+          </treat>
+         </arrayBlock>
+        </ifCall>
+        <ifCall line='4147' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+         <check card='1' diag='0|0||ixsl:call'>
+          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+         </check>
+         <str val='setUpdates'/>
+         <arrayBlock>
+          <treat line='4144' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||instanceUpdates'>
+           <map size='0'/>
+          </treat>
+         </arrayBlock>
+        </ifCall>
+        <forEach line='4149'>
+         <varRef name='Q{}actions' slot='2'/>
+         <let line='4150' var='Q{}action-map' as='item()' slot='4' eval='16'>
+          <dot/>
+          <choose line='4152'>
+           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+            <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:contains'>
+             <varRef name='Q{}action-map' slot='4'/>
+            </treat>
+            <str val='@event'/>
+           </ifCall>
+           <choose line='4153'>
+            <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+             <data>
+              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+               <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:get'>
+                <varRef name='Q{}action-map' slot='4'/>
+               </treat>
+               <str val='@event'/>
+              </ifCall>
+             </data>
+             <str val='xforms-value-changed'/>
+            </gc>
+            <callT line='4155' name='Q{}applyActions' bSlot='4'>
+             <withParam name='Q{}action-map' flags='t' as='item()'>
+              <varRef line='4156' name='Q{}action-map' slot='4'/>
+             </withParam>
+             <withParam name='Q{}nodeset' flags='t' as='xs:string'>
+              <check line='4157' card='1' diag='8|0|XTTE0590|nodeset'>
+               <cvUntyped to='xs:string' diag='8|0|XTTE0590|nodeset'>
+                <data>
+                 <varRef name='Q{}refi' slot='1'/>
+                </data>
+               </cvUntyped>
+              </check>
+             </withParam>
+             <withParam name='Q{}instanceXML' flags='t' as='element()'>
+              <varRef line='4158' name='Q{}updatedInstanceXML' slot='3'/>
+             </withParam>
+            </callT>
+           </choose>
+          </choose>
+         </let>
+        </forEach>
+        <callT line='4164' name='Q{}xforms-recalculate' bSlot='5'/>
+        <ufCall line='4166' name='Q{http://www.w3.org/2002/xforms}checkRelevantFields' tailCall='false' bSlot='6' eval='16'>
+         <check card='1' diag='0|0||xforms:checkRelevantFields'>
+          <cvUntyped to='xs:string'>
+           <data>
+            <slash line='4125' simple='1'>
+             <varRef name='Q{}form-control' slot='0'/>
+             <axis name='attribute' nodeTest='attribute(Q{}data-element)' jsTest='return item.name===&#39;data-element&#39;'/>
+            </slash>
+           </data>
+          </cvUntyped>
+         </check>
+        </ufCall>
+       </sequence>
+      </let>
+     </let>
+    </let>
+   </sequence>
+  </template>
+ </co>
+ <co id='21' binds='22 23 3 23'>
+  <template name='Q{}getReferencedInstanceField' flags='os' line='3405' module='saxon-xforms.xsl' slots='5'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3406'>
+    <param name='Q{}refi' slot='0' as='xs:string'>
+     <str role='select' val=''/>
+     <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|refi'>
+      <check card='1' diag='8|0|XTTE0590|refi'>
+       <cvUntyped to='xs:string' diag='8|0|XTTE0590|refi'>
+        <data>
+         <supplied slot='0'/>
+        </data>
+       </cvUntyped>
+      </check>
+     </treat>
+    </param>
+    <message line='3408'>
+     <sequence role='select'>
+      <valueOf>
+       <str val='[getReferencedInstanceField] $refi = &#39;'/>
+      </valueOf>
+      <valueOf>
+       <varRef name='Q{}refi' slot='0'/>
+      </valueOf>
+      <valueOf flags='S'>
+       <str val='&#39;'/>
+      </valueOf>
+     </sequence>
+     <str role='terminate' val='no'/>
+     <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+    </message>
+    <let line='3410' var='Q{}field' as='node()*' slot='1' eval='8'>
+     <choose line='3412'>
+      <varRef name='Q{}refi' slot='0'/>
+      <let line='3413' var='Q{}instance-map' as='map(xs:string, xs:string)' slot='2' eval='16'>
+       <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='0' eval='6'>
+        <varRef name='Q{}refi' slot='0'/>
+       </ufCall>
+       <let line='3420' var='Q{}this-instance' as='element()?' slot='3' eval='9'>
+        <callT line='3421' name='Q{}getInstance' bSlot='1'>
+         <withParam name='Q{}instance-id' flags='c' as='xs:string'>
+          <check line='3422' card='1' diag='8|0|XTTE0590|instance-id'>
+           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+            <varRef name='Q{}instance-map' slot='2'/>
+            <str val='instance-id'/>
+           </ifCall>
+          </check>
+         </withParam>
+        </callT>
+        <treat line='3430' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|field'>
+         <evaluate dxns=''>
+          <ufCall role='xpath' line='3426' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
+           <check card='1' diag='0|0||xforms:impose'>
+            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+             <varRef name='Q{}instance-map' slot='2'/>
+             <str val='xpath'/>
+            </ifCall>
+           </check>
+          </ufCall>
+          <varRef role='cxt' name='Q{}this-instance' slot='3'/>
+          <check role='nsCxt' card='1' diag='4|0|XTTE3170|xsl:evaluate/namespace-context'>
+           <varRef name='Q{}this-instance' slot='3'/>
+          </check>
+          <str role='sa' val='no'/>
+          <map role='options' size='0'/>
+          <map role='wp' size='0'/>
+         </evaluate>
+        </treat>
+       </let>
+      </let>
+      <true/>
+      <let line='3435' var='Q{}default-instance' as='element()?' slot='4' eval='9'>
+       <callT line='3436' name='Q{}getInstance' bSlot='3'>
+        <withParam name='Q{}instance-id' flags='c' as='xs:string'>
+         <str val='saxon-forms-default'/>
+        </withParam>
+       </callT>
+       <varRef line='3440' name='Q{}default-instance' slot='4'/>
+      </let>
+     </choose>
+     <varRef line='3445' name='Q{}field' slot='1'/>
+    </let>
+   </sequence>
+  </template>
+ </co>
+ <co id='24' binds=''>
+  <template name='Q{}action-message' flags='os' line='4722' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4723'>
+    <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
+     <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
+      <check card='1' diag='8|0|XTTE0590|action-map'>
+       <supplied slot='0'/>
+      </check>
+     </treat>
+    </param>
+    <message line='4727'>
+     <sequence role='select'>
+      <valueOf>
+       <str val='[action-message] Message reads "'/>
+      </valueOf>
+      <valueOf>
+       <treat line='4725' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|message-value'>
+        <check card='1' diag='3|0|XTTE0570|message-value'>
+         <cvUntyped to='xs:string' diag='3|0|XTTE0570|message-value'>
+          <data>
+           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+            <varRef name='Q{}action-map' slot='0'/>
+            <str val='value'/>
+           </ifCall>
+          </data>
+         </cvUntyped>
+        </check>
+       </treat>
+      </valueOf>
+      <valueOf flags='S'>
+       <str val='"'/>
+      </valueOf>
+     </sequence>
+     <str role='terminate' val='no'/>
+     <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+    </message>
+   </sequence>
+  </template>
+ </co>
+ <co id='25' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}resolveXPathStrings' line='828' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:string' slots='5'>
+   <arg name='Q{}base' as='xs:string'/>
+   <arg name='Q{}relative' as='xs:string'/>
+   <choose role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='835'>
+    <fn name='starts-with'>
+     <varRef name='Q{}relative' slot='1'/>
+     <str val='/'/>
+    </fn>
+    <varRef line='836' name='Q{}relative' slot='1'/>
+    <fn line='838' name='starts-with'>
+     <varRef name='Q{}relative' slot='1'/>
+     <str val='instance('/>
+    </fn>
+    <varRef line='839' name='Q{}relative' slot='1'/>
+    <fn line='841' name='not'>
+     <varRef name='Q{}base' slot='0'/>
+    </fn>
+    <varRef line='842' name='Q{}relative' slot='1'/>
+    <or line='844' op='or'>
+     <fn name='not'>
+      <varRef name='Q{}relative' slot='1'/>
+     </fn>
+     <vc op='eq' onEmpty='0' comp='CCC'>
+      <varRef name='Q{}relative' slot='1'/>
+      <str val='.'/>
+     </vc>
+    </or>
+    <varRef line='845' name='Q{}base' slot='0'/>
+    <true/>
+    <let line='849' var='Q{}parentCallCount' as='xs:integer' slot='2' eval='16'>
+     <choose>
+      <fn name='contains'>
+       <varRef name='Q{}relative' slot='1'/>
+       <str val='/'/>
+      </fn>
+      <fn name='count'>
+       <filter flags='b'>
+        <fn name='tokenize'>
+         <varRef name='Q{}relative' slot='1'/>
+         <str val='/'/>
+         <str val=''/>
+        </fn>
+        <vc op='eq' onEmpty='0' comp='CCC'>
+         <dot type='xs:string'/>
+         <str val='..'/>
+        </vc>
+       </filter>
+      </fn>
+      <fn name='contains'>
+       <varRef name='Q{}relative' slot='1'/>
+       <str val='..'/>
+      </fn>
+      <int val='1'/>
+      <true/>
+      <int val='0'/>
+     </choose>
+     <let line='852' var='Q{}slashes' as='xs:integer*' slot='3' eval='4'>
+      <choose>
+       <fn name='contains'>
+        <varRef name='Q{}base' slot='0'/>
+        <str val='/'/>
+       </fn>
+       <fn name='index-of'>
+        <fn name='string-to-codepoints'>
+         <varRef name='Q{}base' slot='0'/>
+        </fn>
+        <int val='47'/>
+       </fn>
+       <true/>
+       <int val='0'/>
+      </choose>
+      <choose line='884'>
+       <compareToInt op='gt' val='0'>
+        <varRef name='Q{}parentCallCount' slot='2'/>
+       </compareToInt>
+       <fn line='888' name='concat'>
+        <fn name='substring'>
+         <varRef name='Q{}base' slot='0'/>
+         <int val='1'/>
+         <choose line='863'>
+          <and op='and'>
+           <vc op='ge' onEmpty='0' comp='CAVC'>
+            <fn name='count'>
+             <varRef name='Q{}slashes' slot='3'/>
+            </fn>
+            <varRef name='Q{}parentCallCount' slot='2'/>
+           </vc>
+           <compareToInt op='gt' val='0'>
+            <varRef name='Q{}parentCallCount' slot='2'/>
+           </compareToInt>
+          </and>
+          <let line='864' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='4' eval='13'>
+           <arith op='-' calc='i-i'>
+            <varRef name='Q{}parentCallCount' slot='2'/>
+            <int val='1'/>
+           </arith>
+           <check card='1' diag='3|0|XTTE0570|parentSlash'>
+            <filter flags='p'>
+             <varRef name='Q{}slashes' slot='3'/>
+             <arith op='-' calc='i-i'>
+              <fn name='last'/>
+              <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='4'/>
+             </arith>
+            </filter>
+           </check>
+          </let>
+          <true/>
+          <check line='867' card='1' diag='3|0|XTTE0570|parentSlash'>
+           <lastOf>
+            <varRef name='Q{}slashes' slot='3'/>
+           </lastOf>
+          </check>
+         </choose>
+        </fn>
+        <fn name='replace'>
+         <varRef name='Q{}relative' slot='1'/>
+         <str val='\.\./'/>
+         <str val=''/>
+         <str val=''/>
+        </fn>
+       </fn>
+       <true/>
+       <fn line='891' name='concat'>
+        <varRef name='Q{}base' slot='0'/>
+        <str val='/'/>
+        <varRef name='Q{}relative' slot='1'/>
+       </fn>
+      </choose>
+     </let>
+    </let>
+   </choose>
+  </function>
+ </co>
+ <co id='26' binds=''>
+  <function name='Q{http://saxonica.com/ns/forms-local}current-date' line='118' module='xforms-function-library.xsl' eval='16' flags='pU' as='xs:string' slots='0'>
+   <treat role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='119' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|today'>
+    <check card='1' diag='3|0|XTTE0570|today'>
+     <cvUntyped to='xs:string' diag='3|0|XTTE0570|today'>
+      <data>
+       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <check card='1' diag='0|0||ixsl:call'>
+         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+        </check>
+        <str val='getCurrentDate'/>
+        <array size='0'/>
+       </ifCall>
+      </data>
+     </cvUntyped>
+    </check>
+   </treat>
+  </function>
+ </co>
+ <co id='14' binds='27'>
+  <function name='Q{http://www.w3.org/2002/xforms}resolve-index' line='72' module='xforms-function-library.xsl' eval='8' flags='pU' as='xs:string' slots='2'>
+   <arg name='Q{}input' as='xs:string'/>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='74' var='Q{}parts' as='xs:string*' slot='1' eval='8'>
+    <analyzeString line='75'>
+     <varRef role='select' name='Q{}input' slot='0'/>
+     <str role='regex' val='index\s*\(\s*&#39;([^&#39;]+)&#39;\s*\)'/>
+     <str role='flags' val=''/>
+     <cast role='matching' line='78' as='xs:string' emptiable='0'>
+      <ufCall name='Q{http://www.w3.org/2002/xforms}index' tailCall='false' bSlot='0' eval='16'>
+       <fn name='regex-group'>
+        <int val='1'/>
+       </fn>
+      </ufCall>
+     </cast>
+     <dot role='nonMatching' line='81' type='xs:string'/>
+    </analyzeString>
+    <fn line='87' name='string-join'>
+     <varRef name='Q{}parts' slot='1'/>
+    </fn>
+   </let>
+  </function>
+ </co>
+ <co id='28' binds='3'>
+  <template name='Q{}action-setindex' flags='os' line='4775' module='saxon-xforms.xsl' slots='2'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4776'>
+    <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
+     <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
+      <check card='1' diag='8|0|XTTE0590|action-map'>
+       <supplied slot='0'/>
+      </check>
+     </treat>
+    </param>
+    <let line='4782' var='Q{}new-index' as='xs:integer' slot='1' eval='16'>
+     <treat line='4783' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|new-index'>
+      <check card='1' diag='3|0|XTTE0570|new-index'>
+       <cvUntyped to='xs:integer' diag='3|0|XTTE0570|new-index'>
+        <data>
+         <evaluate dxns=''>
+          <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='0' eval='16'>
+           <treat line='4779' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-index-ref'>
+            <check card='1' diag='3|0|XTTE0570|new-index-ref'>
+             <cvUntyped to='xs:string' diag='3|0|XTTE0570|new-index-ref'>
+              <data>
+               <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                <varRef name='Q{}action-map' slot='0'/>
+                <str val='@index'/>
+               </ifCall>
+              </data>
+             </cvUntyped>
+            </check>
+           </treat>
+          </ufCall>
+          <empty role='cxt'/>
+          <str role='sa' val='no'/>
+          <map role='options' size='0'/>
+          <map role='wp' size='0'/>
+         </evaluate>
+        </data>
+       </cvUntyped>
+      </check>
+     </treat>
+     <sequence line='4786'>
+      <message>
+       <sequence role='select'>
+        <valueOf>
+         <str val='[action-setindex] $action-map = '/>
+        </valueOf>
+        <valueOf>
+         <fn name='serialize'>
+          <varRef name='Q{}action-map' slot='0'/>
+         </fn>
+        </valueOf>
+       </sequence>
+       <str role='terminate' val='no'/>
+       <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+      </message>
+      <ifCall line='4788' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+       <check card='1' diag='0|0||ixsl:call'>
+        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+       </check>
+       <str val='setRepeatIndex'/>
+       <arrayBlock>
+        <treat line='4778' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|repeatID'>
+         <check card='1' diag='3|0|XTTE0570|repeatID'>
+          <cvUntyped to='xs:string' diag='3|0|XTTE0570|repeatID'>
+           <data>
+            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+             <varRef name='Q{}action-map' slot='0'/>
+             <str val='@repeat'/>
+            </ifCall>
+           </data>
+          </cvUntyped>
+         </check>
+        </treat>
+        <varRef name='Q{}new-index' slot='1'/>
+       </arrayBlock>
+      </ifCall>
+     </sequence>
+    </let>
+   </sequence>
+  </template>
+ </co>
+ <co id='29' binds='30'>
+  <template name='Q{}action-setfocus' flags='os' line='4737' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4738'>
+    <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
+     <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
+      <check card='1' diag='8|0|XTTE0590|action-map'>
+       <supplied slot='0'/>
+      </check>
+     </treat>
+    </param>
+    <callT line='4742' name='Q{}xforms-focus' bSlot='0' flags='t'>
+     <withParam name='Q{}control' flags='c' as='xs:string'>
+      <treat line='4740' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|control'>
+       <check card='1' diag='3|0|XTTE0570|control'>
+        <cvUntyped to='xs:string' diag='3|0|XTTE0570|control'>
+         <data>
+          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+           <varRef name='Q{}action-map' slot='0'/>
+           <str val='@control'/>
+          </ifCall>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </withParam>
+    </callT>
+   </sequence>
+  </template>
+ </co>
+ <co id='31' binds='1 3 3 32 16 2 5 33'>
+  <template name='Q{}action-setvalue' flags='os' line='4408' module='saxon-xforms.xsl' slots='14'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4409'>
+    <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
+     <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
+      <check card='1' diag='8|0|XTTE0590|action-map'>
+       <supplied slot='0'/>
+      </check>
+     </treat>
+    </param>
+    <param line='4410' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
+     <empty role='select'/>
+     <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|instanceXML'>
+      <check card='?' diag='8|0|XTTE0590|instanceXML'>
+       <supplied slot='1'/>
+      </check>
+     </treat>
+    </param>
+    <param line='4411' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
+     <str role='select' val=''/>
+     <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
+      <check card='1' diag='8|0|XTTE0590|nodeset'>
+       <cvUntyped to='xs:string' diag='8|0|XTTE0590|nodeset'>
+        <data>
+         <supplied slot='2'/>
+        </data>
+       </cvUntyped>
+      </check>
+     </treat>
+    </param>
+    <let line='4415' var='Q{}refz' as='xs:string' slot='3' eval='16'>
+     <let var='Q{}relative' as='xs:string' slot='4' eval='16'>
+      <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|1||xforms:resolveXPathStrings'>
+       <check card='1' diag='0|1||xforms:resolveXPathStrings'>
+        <cvUntyped to='xs:string'>
+         <data>
+          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+           <varRef name='Q{}action-map' slot='0'/>
+           <str val='@ref'/>
+          </ifCall>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+      <choose line='835'>
+       <fn name='starts-with'>
+        <varRef name='Q{}relative' slot='4'/>
+        <str val='/'/>
+       </fn>
+       <varRef line='836' name='Q{}relative' slot='4'/>
+       <fn line='838' name='starts-with'>
+        <varRef name='Q{}relative' slot='4'/>
+        <str val='instance('/>
+       </fn>
+       <varRef line='839' name='Q{}relative' slot='4'/>
+       <fn line='4415' name='not'>
+        <varRef name='Q{}nodeset' slot='2'/>
+       </fn>
+       <varRef line='842' name='Q{}relative' slot='4'/>
+       <or line='844' op='or'>
+        <fn name='not'>
+         <varRef name='Q{}relative' slot='4'/>
+        </fn>
+        <vc op='eq' onEmpty='0' comp='CCC'>
+         <varRef name='Q{}relative' slot='4'/>
+         <str val='.'/>
+        </vc>
+       </or>
+       <varRef line='4415' name='Q{}nodeset' slot='2'/>
+       <true/>
+       <let line='849' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
+        <choose>
+         <fn name='contains'>
+          <varRef name='Q{}relative' slot='4'/>
+          <str val='/'/>
+         </fn>
+         <fn name='count'>
+          <filter flags='b'>
+           <fn name='tokenize'>
+            <varRef name='Q{}relative' slot='4'/>
+            <str val='/'/>
+            <str val=''/>
+           </fn>
+           <vc op='eq' onEmpty='0' comp='CCC'>
+            <dot type='xs:string'/>
+            <str val='..'/>
+           </vc>
+          </filter>
+         </fn>
+         <fn name='contains'>
+          <varRef name='Q{}relative' slot='4'/>
+          <str val='..'/>
+         </fn>
+         <int val='1'/>
+         <true/>
+         <int val='0'/>
+        </choose>
+        <let line='852' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
+         <choose>
+          <fn line='4415' name='contains'>
+           <varRef name='Q{}nodeset' slot='2'/>
+           <str val='/'/>
+          </fn>
+          <fn name='index-of'>
+           <fn name='string-to-codepoints'>
+            <varRef line='4415' name='Q{}nodeset' slot='2'/>
+           </fn>
+           <int val='47'/>
+          </fn>
+          <true/>
+          <int val='0'/>
+         </choose>
+         <choose line='884'>
+          <compareToInt op='gt' val='0'>
+           <varRef name='Q{}parentCallCount' slot='5'/>
+          </compareToInt>
+          <fn line='888' name='concat'>
+           <fn name='substring'>
+            <varRef line='4415' name='Q{}nodeset' slot='2'/>
+            <int val='1'/>
+            <choose line='863'>
+             <and op='and'>
+              <vc op='ge' onEmpty='0' comp='CAVC'>
+               <fn name='count'>
+                <varRef name='Q{}slashes' slot='6'/>
+               </fn>
+               <varRef name='Q{}parentCallCount' slot='5'/>
+              </vc>
+              <compareToInt op='gt' val='0'>
+               <varRef name='Q{}parentCallCount' slot='5'/>
+              </compareToInt>
+             </and>
+             <let line='864' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='7' eval='13'>
+              <arith op='-' calc='i-i'>
+               <varRef name='Q{}parentCallCount' slot='5'/>
+               <int val='1'/>
+              </arith>
+              <check card='1' diag='3|0|XTTE0570|parentSlash'>
+               <filter flags='p'>
+                <varRef name='Q{}slashes' slot='6'/>
+                <arith op='-' calc='i-i'>
+                 <fn name='last'/>
+                 <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='7'/>
+                </arith>
+               </filter>
+              </check>
+             </let>
+             <true/>
+             <check line='867' card='1' diag='3|0|XTTE0570|parentSlash'>
+              <lastOf>
+               <varRef name='Q{}slashes' slot='6'/>
+              </lastOf>
+             </check>
+            </choose>
+           </fn>
+           <fn name='replace'>
+            <varRef name='Q{}relative' slot='4'/>
+            <str val='\.\./'/>
+            <str val=''/>
+            <str val=''/>
+           </fn>
+          </fn>
+          <true/>
+          <fn line='4415' name='concat'>
+           <varRef name='Q{}nodeset' slot='2'/>
+           <str val='/'/>
+           <varRef line='891' name='Q{}relative' slot='4'/>
+          </fn>
+         </choose>
+        </let>
+       </let>
+      </choose>
+     </let>
+     <let line='4417' var='Q{}instance-id' as='xs:string' slot='8' eval='16'>
+      <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='6'>
+       <varRef name='Q{}refz' slot='3'/>
+      </ufCall>
+      <let line='4430' var='Q{}valuez' as='document-node()' slot='9' eval='16'>
+       <doc line='4432' validation='preserve'>
+        <choose>
+         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+          <varRef name='Q{}action-map' slot='0'/>
+          <str val='@value'/>
+         </ifCall>
+         <let line='4433' var='Q{}contexti' as='node()' slot='10' eval='8'>
+          <evaluate line='4434' as='node()' dxns=''>
+           <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='1' eval='6'>
+            <varRef name='Q{}nodeset' slot='2'/>
+           </ufCall>
+           <varRef role='cxt' name='Q{}instanceXML' slot='1'/>
+           <check role='nsCxt' card='1' diag='4|0|XTTE3170|xsl:evaluate/namespace-context'>
+            <varRef name='Q{}instanceXML' slot='1'/>
+           </check>
+           <str role='sa' val='no'/>
+           <map role='options' size='0'/>
+           <map role='wp' size='0'/>
+          </evaluate>
+          <evaluate line='4437' dxns=''>
+           <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
+            <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:impose'>
+             <check card='1' diag='0|0||xforms:impose'>
+              <cvUntyped to='xs:string'>
+               <data>
+                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                 <varRef name='Q{}action-map' slot='0'/>
+                 <str val='@value'/>
+                </ifCall>
+               </data>
+              </cvUntyped>
+             </check>
+            </treat>
+           </ufCall>
+           <varRef role='cxt' name='Q{}contexti' slot='10'/>
+           <varRef role='nsCxt' name='Q{}contexti' slot='10'/>
+           <str role='sa' val='no'/>
+           <map role='options' size='0'/>
+           <map role='wp' size='0'/>
+          </evaluate>
+         </let>
+         <ifCall line='4440' name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+          <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:contains'>
+           <dot flags='a'/>
+          </treat>
+          <str val='value'/>
+         </ifCall>
+         <ifCall line='4441' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+          <varRef name='Q{}action-map' slot='0'/>
+          <str val='value'/>
+         </ifCall>
+         <true/>
+         <str val=''/>
+        </choose>
+       </doc>
+       <sequence line='4451'>
+        <let line='4453' var='Q{}associated-form-control' as='element()?' slot='11' eval='7'>
+         <check card='?' diag='3|0|XTTE0570|associated-form-control'>
+          <filter flags='b'>
+           <slash simple='1'>
+            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
+            <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+           </slash>
+           <vc op='eq' onEmpty='0' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+            <cast as='xs:string' emptiable='1'>
+             <attVal name='Q{}data-ref' chk='0'/>
+            </cast>
+            <varRef name='Q{}refz' slot='3'/>
+           </vc>
+          </filter>
+         </check>
+         <choose line='4455'>
+          <fn name='exists'>
+           <varRef name='Q{}associated-form-control' slot='11'/>
+          </fn>
+          <sequence line='4456'>
+           <applyT mode='Q{}set-field' bSlot='3'>
+            <varRef role='select' name='Q{}associated-form-control' slot='11'/>
+            <withParam name='Q{}value' flags='t' as='xs:string'>
+             <cast line='4457' as='xs:string' emptiable='0'>
+              <data>
+               <varRef name='Q{}valuez' slot='9'/>
+              </data>
+             </cast>
+            </withParam>
+           </applyT>
+           <ifCall line='4459' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+            <check card='1' diag='0|0||ixsl:call'>
+             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+            </check>
+            <str val='setUpdates'/>
+            <arrayBlock>
+             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}put' type='map(*)'>
+              <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:put'>
+               <check card='1' diag='0|0||map:put'>
+                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <check card='1' diag='0|0||ixsl:call'>
+                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                 </check>
+                 <str val='getUpdates'/>
+                 <array size='0'/>
+                </ifCall>
+               </check>
+              </treat>
+              <varRef name='Q{}refz' slot='3'/>
+              <cast as='xs:string' emptiable='0'>
+               <data>
+                <varRef name='Q{}valuez' slot='9'/>
+               </data>
+              </cast>
+             </ifCall>
+            </arrayBlock>
+           </ifCall>
+          </sequence>
+          <true/>
+          <ifCall line='4462' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+           <check card='1' diag='0|0||ixsl:call'>
+            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+           </check>
+           <str val='setPendingUpdates'/>
+           <arrayBlock>
+            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}put' type='map(*)'>
+             <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:put'>
+              <check card='1' diag='0|0||map:put'>
+               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                <check card='1' diag='0|0||ixsl:call'>
+                 <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                </check>
+                <str val='getPendingUpdates'/>
+                <array size='0'/>
+               </ifCall>
+              </check>
+             </treat>
+             <varRef name='Q{}refz' slot='3'/>
+             <cast as='xs:string' emptiable='0'>
+              <data>
+               <varRef name='Q{}valuez' slot='9'/>
+              </data>
+             </cast>
+            </ifCall>
+           </arrayBlock>
+          </ifCall>
+         </choose>
+        </let>
+        <choose line='4468'>
+         <vc op='ne' onEmpty='1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+          <varRef name='Q{}refz' slot='3'/>
+          <str val=''/>
+         </vc>
+         <let line='4470' var='Q{}pendingUpdates' as='map(xs:string, xs:string)?' slot='12' eval='7'>
+          <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|pendingUpdates'>
+           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+            <check card='1' diag='0|0||ixsl:call'>
+             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+            </check>
+            <str val='getPendingUpdates'/>
+            <array size='0'/>
+           </ifCall>
+          </treat>
+          <let line='4472' var='Q{}updatedInstanceXML' as='element()' slot='13' eval='16'>
+           <treat line='4473' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+            <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
+             <applyT mode='Q{}form-check-initial' bSlot='4'>
+              <choose role='select' line='4421'>
+               <and op='and'>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <varRef name='Q{}instance-id' slot='8'/>
+                 <str val='saxon-forms-default'/>
+                </vc>
+                <fn name='exists'>
+                 <varRef name='Q{}instanceXML' slot='1'/>
+                </fn>
+               </and>
+               <check line='4422' card='1' diag='3|0|XTTE0570|instanceXML2'>
+                <varRef name='Q{}instanceXML' slot='1'/>
+               </check>
+               <true/>
+               <check line='4425' card='1' diag='3|0|XTTE0570|instanceXML2'>
+                <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='5' eval='6'>
+                 <varRef name='Q{}refz' slot='3'/>
+                </ufCall>
+               </check>
+              </choose>
+              <withParam name='Q{}instance-id' as='xs:string'>
+               <varRef line='4474' name='Q{}instance-id' slot='8'/>
+              </withParam>
+              <withParam name='Q{}pendingUpdates' flags='t' as='map(xs:string, xs:string)?'>
+               <varRef line='4475' name='Q{}pendingUpdates' slot='12'/>
+              </withParam>
+             </applyT>
+            </check>
+           </treat>
+           <sequence line='4480'>
+            <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='6' eval='6 6'>
+             <varRef name='Q{}refz' slot='3'/>
+             <varRef name='Q{}updatedInstanceXML' slot='13'/>
+            </ufCall>
+            <callT line='4481' name='Q{}refreshOutputs-JS' bSlot='7' flags='t'/>
+           </sequence>
+          </let>
+         </let>
+        </choose>
+       </sequence>
+      </let>
+     </let>
+    </let>
+   </sequence>
+  </template>
+ </co>
+ <co id='34' binds=''>
+  <globalVariable name='Q{}default-submission-id' type='xs:string' line='76' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
+   <str val='saxon-forms-default-submission'/>
+  </globalVariable>
+ </co>
+ <co id='19' binds='1 2 3 3 31 0 8 28 29 35 7 17 10 24 19'>
+  <template name='Q{}applyActions' flags='os' line='3653' module='saxon-xforms.xsl' slots='12'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3654'>
+    <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
+     <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
+      <check card='1' diag='8|0|XTTE0590|action-map'>
+       <supplied slot='0'/>
+      </check>
+     </treat>
+    </param>
+    <param line='3655' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
+     <empty role='select'/>
+     <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|instanceXML'>
+      <check card='?' diag='8|0|XTTE0590|instanceXML'>
+       <supplied slot='1'/>
+      </check>
+     </treat>
+    </param>
+    <param line='3656' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
+     <str role='select' val=''/>
+     <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
+      <check card='1' diag='8|0|XTTE0590|nodeset'>
+       <cvUntyped to='xs:string' diag='8|0|XTTE0590|nodeset'>
+        <data>
+         <supplied slot='2'/>
+        </data>
+       </cvUntyped>
+      </check>
+     </treat>
+    </param>
+    <let line='3658' var='Q{}ref' as='xs:string?' slot='3' eval='7'>
+     <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|ref'>
+      <check card='?' diag='3|0|XTTE0570|ref'>
+       <cvUntyped to='xs:string' diag='3|0|XTTE0570|ref'>
+        <data>
+         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+          <varRef name='Q{}action-map' slot='0'/>
+          <str val='@ref'/>
+         </ifCall>
+        </data>
+       </cvUntyped>
+      </check>
+     </treat>
+     <let line='3659' var='Q{}at' as='xs:string?' slot='4' eval='7'>
+      <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|at'>
+       <check card='?' diag='3|0|XTTE0570|at'>
+        <cvUntyped to='xs:string' diag='3|0|XTTE0570|at'>
+         <data>
+          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+           <varRef name='Q{}action-map' slot='0'/>
+           <str val='@at'/>
+          </ifCall>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+      <let line='3671' var='Q{}ref-qualified' as='xs:string?' slot='5' eval='7'>
+       <choose>
+        <and op='and'>
+         <fn name='exists'>
+          <varRef name='Q{}ref' slot='3'/>
+         </fn>
+         <varRef name='Q{}ref' slot='3'/>
+        </and>
+        <choose>
+         <fn name='exists'>
+          <varRef name='Q{}at' slot='4'/>
+         </fn>
+         <fn name='concat'>
+          <varRef name='Q{}ref' slot='3'/>
+          <str val='['/>
+          <varRef name='Q{}at' slot='4'/>
+          <str val=']'/>
+         </fn>
+         <true/>
+         <varRef name='Q{}ref' slot='3'/>
+        </choose>
+       </choose>
+       <let line='3673' var='Q{}instance-id' as='xs:string' slot='6' eval='16'>
+        <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='16'>
+         <check card='1' diag='0|0||xforms:getInstanceId'>
+          <varRef name='Q{}ref' slot='3'/>
+         </check>
+        </ufCall>
+        <let line='3675' var='Q{}instanceXML2' as='element()?' slot='7' eval='7'>
+         <choose line='3677'>
+          <and op='and'>
+           <vc op='eq' onEmpty='0' comp='CCC'>
+            <varRef name='Q{}instance-id' slot='6'/>
+            <str val='saxon-forms-default'/>
+           </vc>
+           <fn name='exists'>
+            <varRef name='Q{}instanceXML' slot='1'/>
+           </fn>
+          </and>
+          <varRef line='3678' name='Q{}instanceXML' slot='1'/>
+          <fn line='3680' name='exists'>
+           <varRef name='Q{}ref-qualified' slot='5'/>
+          </fn>
+          <ufCall line='3681' name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='1' eval='16'>
+           <check card='1' diag='0|0||xforms:getInstance-JS'>
+            <varRef name='Q{}ref-qualified' slot='5'/>
+           </check>
+          </ufCall>
+         </choose>
+         <let line='3689' var='Q{}context' as='node()?' slot='8' eval='7'>
+          <choose line='3691'>
+           <and op='and'>
+            <and op='and'>
+             <fn name='exists'>
+              <varRef name='Q{}ref-qualified' slot='5'/>
+             </fn>
+             <vc op='ne' onEmpty='1' comp='CCC'>
+              <varRef name='Q{}ref-qualified' slot='5'/>
+              <str val=''/>
+             </vc>
+            </and>
+            <fn name='exists'>
+             <varRef name='Q{}instanceXML2' slot='7'/>
+            </fn>
+           </and>
+           <treat line='3692' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|context'>
+            <check card='?' diag='3|0|XTTE0570|context'>
+             <evaluate dxns=''>
+              <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
+               <check card='1' diag='0|0||xforms:impose'>
+                <varRef name='Q{}ref-qualified' slot='5'/>
+               </check>
+              </ufCall>
+              <varRef role='cxt' name='Q{}instanceXML2' slot='7'/>
+              <check role='nsCxt' card='1' diag='4|0|XTTE3170|xsl:evaluate/namespace-context'>
+               <varRef name='Q{}instanceXML2' slot='7'/>
+              </check>
+              <str role='sa' val='no'/>
+              <map role='options' size='0'/>
+              <map role='wp' size='0'/>
+             </evaluate>
+            </check>
+           </treat>
+          </choose>
+          <let line='3699' var='Q{}ifVar' as='xs:string?' slot='9' eval='7'>
+           <choose line='790'>
+            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+             <varRef line='3699' name='Q{}action-map' slot='0'/>
+             <str val='@if'/>
+            </ifCall>
+            <treat line='791' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
+             <check card='?' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
+              <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
+               <data>
+                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                 <varRef line='3699' name='Q{}action-map' slot='0'/>
+                 <str val='@if'/>
+                </ifCall>
+               </data>
+              </cvUntyped>
+             </check>
+            </treat>
+           </choose>
+           <let line='3703' var='Q{}ifExecuted' as='xs:boolean' slot='10' eval='16'>
+            <choose line='3705'>
+             <and op='and'>
+              <fn name='exists'>
+               <varRef name='Q{}ifVar' slot='9'/>
+              </fn>
+              <fn name='exists'>
+               <varRef name='Q{}context' slot='8'/>
+              </fn>
+             </and>
+             <treat line='3706' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|ifExecuted'>
+              <check card='1' diag='3|0|XTTE0570|ifExecuted'>
+               <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|ifExecuted'>
+                <data>
+                 <evaluate dxns=''>
+                  <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='3' eval='16'>
+                   <check card='1' diag='0|0||xforms:impose'>
+                    <varRef name='Q{}ifVar' slot='9'/>
+                   </check>
+                  </ufCall>
+                  <varRef role='cxt' name='Q{}context' slot='8'/>
+                  <check role='nsCxt' card='1' diag='4|0|XTTE3170|xsl:evaluate/namespace-context'>
+                   <varRef name='Q{}context' slot='8'/>
+                  </check>
+                  <str role='sa' val='no'/>
+                  <map role='options' size='0'/>
+                  <map role='wp' size='0'/>
+                 </evaluate>
+                </data>
+               </cvUntyped>
+              </check>
+             </treat>
+             <true/>
+             <true/>
+            </choose>
+            <choose line='3716'>
+             <varRef name='Q{}ifExecuted' slot='10'/>
+             <let line='3717' var='Q{}action-name' as='xs:string' slot='11' eval='16'>
+              <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|action-name'>
+               <check card='1' diag='3|0|XTTE0570|action-name'>
+                <cvUntyped to='xs:string' diag='3|0|XTTE0570|action-name'>
+                 <data>
+                  <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                   <varRef name='Q{}action-map' slot='0'/>
+                   <str val='name'/>
+                  </ifCall>
+                 </data>
+                </cvUntyped>
+               </check>
+              </treat>
+              <sequence line='3720'>
+               <choose>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <varRef name='Q{}action-name' slot='11'/>
+                 <str val='action'/>
+                </vc>
+                <empty/>
+                <vc line='3723' op='eq' onEmpty='0' comp='CCC'>
+                 <varRef name='Q{}action-name' slot='11'/>
+                 <str val='setvalue'/>
+                </vc>
+                <callT line='3724' name='Q{}action-setvalue' bSlot='4'>
+                 <withParam name='Q{}nodeset' flags='t' as='xs:string'>
+                  <check line='3725' card='1' diag='8|0|XTTE0590|nodeset'>
+                   <varRef name='Q{}ref' slot='3'/>
+                  </check>
+                 </withParam>
+                 <withParam name='Q{}instanceXML' flags='t' as='element()'>
+                  <check line='3726' card='1' diag='8|0|XTTE0590|instanceXML'>
+                   <varRef name='Q{}instanceXML2' slot='7'/>
+                  </check>
+                 </withParam>
+                </callT>
+                <vc line='3729' op='eq' onEmpty='0' comp='CCC'>
+                 <varRef name='Q{}action-name' slot='11'/>
+                 <str val='insert'/>
+                </vc>
+                <callT line='3730' name='Q{}action-insert' bSlot='5'>
+                 <withParam name='Q{}nodeset' flags='t' as='xs:string'>
+                  <check line='3731' card='1' diag='8|0|XTTE0590|nodeset'>
+                   <varRef name='Q{}ref-qualified' slot='5'/>
+                  </check>
+                 </withParam>
+                 <withParam name='Q{}instanceXML' flags='t' as='element()'>
+                  <check line='3732' card='1' diag='8|0|XTTE0590|instanceXML'>
+                   <varRef name='Q{}instanceXML2' slot='7'/>
+                  </check>
+                 </withParam>
+                </callT>
+                <vc line='3735' op='eq' onEmpty='0' comp='CCC'>
+                 <varRef name='Q{}action-name' slot='11'/>
+                 <str val='delete'/>
+                </vc>
+                <callT line='3736' name='Q{}action-delete' bSlot='6'>
+                 <withParam name='Q{}nodeset' flags='t' as='xs:string'>
+                  <check line='3737' card='1' diag='8|0|XTTE0590|nodeset'>
+                   <varRef name='Q{}ref-qualified' slot='5'/>
+                  </check>
+                 </withParam>
+                 <withParam name='Q{}instanceXML' flags='t' as='element()'>
+                  <check line='3738' card='1' diag='8|0|XTTE0590|instanceXML'>
+                   <varRef name='Q{}instanceXML2' slot='7'/>
+                  </check>
+                 </withParam>
+                </callT>
+                <vc line='3741' op='eq' onEmpty='0' comp='CCC'>
+                 <varRef name='Q{}action-name' slot='11'/>
+                 <str val='setindex'/>
+                </vc>
+                <callT line='3742' name='Q{}action-setindex' bSlot='7'/>
+                <vc line='3747' op='eq' onEmpty='0' comp='CCC'>
+                 <varRef name='Q{}action-name' slot='11'/>
+                 <str val='setfocus'/>
+                </vc>
+                <callT line='3748' name='Q{}action-setfocus' bSlot='8'/>
+                <vc line='3753' op='eq' onEmpty='0' comp='CCC'>
+                 <varRef name='Q{}action-name' slot='11'/>
+                 <str val='rebuild'/>
+                </vc>
+                <callT line='3754' name='Q{}xforms-rebuild' bSlot='9'/>
+                <vc line='3756' op='eq' onEmpty='0' comp='CCC'>
+                 <varRef name='Q{}action-name' slot='11'/>
+                 <str val='recalculate'/>
+                </vc>
+                <callT line='3757' name='Q{}xforms-recalculate' bSlot='10'/>
+                <vc line='3765' op='eq' onEmpty='0' comp='CCC'>
+                 <varRef name='Q{}action-name' slot='11'/>
+                 <str val='reset'/>
+                </vc>
+                <callT line='3766' name='Q{}action-reset' bSlot='11'/>
+                <vc line='3771' op='eq' onEmpty='0' comp='CCC'>
+                 <varRef name='Q{}action-name' slot='11'/>
+                 <str val='send'/>
+                </vc>
+                <callT line='3772' name='Q{}action-send' bSlot='12'/>
+                <vc line='3774' op='eq' onEmpty='0' comp='CCC'>
+                 <varRef name='Q{}action-name' slot='11'/>
+                 <str val='message'/>
+                </vc>
+                <callT line='3775' name='Q{}action-message' bSlot='13'/>
+                <true/>
+                <message line='3778'>
+                 <sequence role='select'>
+                  <valueOf>
+                   <str val='[applyActions] action &#39;'/>
+                  </valueOf>
+                  <valueOf>
+                   <varRef name='Q{}action-name' slot='11'/>
+                  </valueOf>
+                  <valueOf>
+                   <str val='&#39; not yet handled!'/>
+                  </valueOf>
+                 </sequence>
+                 <str role='terminate' val='no'/>
+                 <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+                </message>
+               </choose>
+               <forEach line='3787'>
+                <ifCall line='3783' name='Q{http://www.w3.org/2005/xpath-functions/array}flatten' type='item()*'>
+                 <treat as='array(map(*))' jsTest='function v(item) {return SaxonJS.U.isMap(item)};function c(n) {return n==1;};return SaxonJS.U.isArray(item) &amp;&amp; SaxonJS.U.ForArray(item.value).every(function(seq){return c(seq.length) &amp;&amp; SaxonJS.U.ForArray(seq).every(v)});' diag='3|0|XTTE0570|nested-actions-array'>
+                  <check card='?' diag='3|0|XTTE0570|nested-actions-array'>
+                   <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                    <varRef name='Q{}action-map' slot='0'/>
+                    <str val='nested-actions'/>
+                   </ifCall>
+                  </check>
+                 </treat>
+                </ifCall>
+                <callT line='3788' name='Q{}applyActions' bSlot='14'>
+                 <withParam name='Q{}action-map' flags='t' as='item()'>
+                  <dot line='3789'/>
+                 </withParam>
+                </callT>
+               </forEach>
+              </sequence>
+             </let>
+            </choose>
+           </let>
+          </let>
+         </let>
+        </let>
+       </let>
+      </let>
+     </let>
+    </let>
+   </sequence>
+  </template>
+ </co>
+ <co id='4' binds='4'>
+  <mode name='Q{}insert-node' onNo='TC' flags='W' patternSlots='0'>
+   <templateRule prec='0' prio='-0.5' seq='21' rank='0' minImp='0' slots='3' flags='s' line='1909' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1910'>
+     <param name='Q{}insert-node-location' slot='0' flags='ti' as='node()'>
+      <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|insert-node-location'>
+       <check card='1' diag='8|0|XTTE0590|insert-node-location'>
+        <supplied slot='0'/>
+       </check>
+      </treat>
+     </param>
+     <param line='1911' name='Q{}node-to-insert' slot='1' flags='ti' as='node()'>
+      <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|node-to-insert'>
+       <check card='1' diag='8|0|XTTE0590|node-to-insert'>
+        <supplied slot='1'/>
+       </check>
+      </treat>
+     </param>
+     <param line='1912' name='Q{}position-relative' slot='2' flags='t' as='xs:string?'>
+      <str role='select' val='after'/>
+      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|position-relative'>
+       <check card='?' diag='8|0|XTTE0590|position-relative'>
+        <cvUntyped to='xs:string' diag='8|0|XTTE0590|position-relative'>
+         <data>
+          <supplied slot='2'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <choose line='1915'>
+      <and op='and'>
+       <is op='is'>
+        <dot type='element()'/>
+        <varRef name='Q{}insert-node-location' slot='0'/>
+       </is>
+       <vc op='eq' onEmpty='0' comp='CCC'>
+        <varRef name='Q{}position-relative' slot='2'/>
+        <str val='before'/>
+       </vc>
+      </and>
+      <copyOf line='1917' flags='vc'>
+       <varRef name='Q{}node-to-insert' slot='1'/>
+      </copyOf>
+     </choose>
+     <copy line='1920' flags='cin'>
+      <sequence role='content'>
+       <copyOf flags='vc'>
+        <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+       </copyOf>
+       <applyT line='1921' mode='Q{}insert-node' bSlot='0'>
+        <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
+       </applyT>
+      </sequence>
+     </copy>
+     <choose line='1923'>
+      <and op='and'>
+       <is op='is'>
+        <dot type='element()'/>
+        <varRef name='Q{}insert-node-location' slot='0'/>
+       </is>
+       <vc op='eq' onEmpty='0' comp='CCC'>
+        <varRef name='Q{}position-relative' slot='2'/>
+        <str val='after'/>
+       </vc>
+      </and>
+      <copyOf line='1924' flags='vc'>
+       <varRef name='Q{}node-to-insert' slot='1'/>
+      </copyOf>
+     </choose>
+    </sequence>
+   </templateRule>
+  </mode>
+ </co>
+ <co id='36' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}hasClass' line='3032' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:boolean' slots='2'>
+   <arg name='Q{}element' as='element()'/>
+   <arg name='Q{}string' as='xs:string'/>
+   <gc role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3036' op='=' card='N:1' comp='CCC'>
+    <fn name='tokenize'>
+     <cvUntyped to='xs:string' diag='3|0|XTTE0570|class'>
+      <data>
+       <slash simple='1'>
+        <varRef name='Q{}element' slot='0'/>
+        <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
+       </slash>
+      </data>
+     </cvUntyped>
+    </fn>
+    <varRef line='3039' name='Q{}string' slot='1'/>
+   </gc>
+  </function>
+ </co>
+ <co id='37' binds=''>
+  <globalParam name='Q{}xforms-instance-id' type='item()*' line='63' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return val;' jsCardCheck='function c() {return true;};'>
+   <str val='xforms-jinstance'/>
+  </globalParam>
+ </co>
+ <co id='38' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}getIfStatement' line='787' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
+   <arg name='Q{}map' as='map(*)'/>
+   <choose role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='790'>
+    <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+     <varRef name='Q{}map' slot='0'/>
+     <str val='@if'/>
+    </ifCall>
+    <treat line='791' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
+     <check card='?' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
+      <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
+       <data>
+        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+         <varRef name='Q{}map' slot='0'/>
+         <str val='@if'/>
+        </ifCall>
+       </data>
+      </cvUntyped>
+     </check>
+    </treat>
+   </choose>
+  </function>
+ </co>
+ <co id='39' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}getClass' line='3053' module='saxon-xforms.xsl' eval='7' flags='pU' as='attribute(Q{}class)?' slots='3'>
+   <arg name='Q{}element' as='element()'/>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3056' var='Q{}class' as='xs:string?' slot='1' eval='7'>
+    <choose line='3057'>
+     <fn name='exists'>
+      <slash simple='1'>
+       <varRef name='Q{}element' slot='0'/>
+       <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
+      </slash>
+     </fn>
+     <cvUntyped line='3058' to='xs:string' diag='3|0|XTTE0570|class'>
+      <cast as='xs:untypedAtomic' emptiable='0'>
+       <fn name='string'>
+        <convert from='xs:untypedAtomic' to='xs:string'>
+         <data>
+          <slash simple='1'>
+           <varRef name='Q{}element' slot='0'/>
+           <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
+          </slash>
+         </data>
+        </convert>
+       </fn>
+      </cast>
+     </cvUntyped>
+    </choose>
+    <let line='3061' var='Q{}class-mod' as='xs:string?' slot='2' eval='7'>
+     <choose line='3063'>
+      <fn name='exists'>
+       <slash simple='1'>
+        <varRef name='Q{}element' slot='0'/>
+        <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
+       </slash>
+      </fn>
+      <cvUntyped line='3064' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+       <cast as='xs:untypedAtomic' emptiable='0'>
+        <fn name='string-join'>
+         <sequence>
+          <varRef name='Q{}class' slot='1'/>
+          <str val='incremental'/>
+         </sequence>
+         <str val=' '/>
+        </fn>
+       </cast>
+      </cvUntyped>
+      <true/>
+      <varRef line='3067' name='Q{}class' slot='1'/>
+     </choose>
+     <choose line='3071'>
+      <fn name='exists'>
+       <varRef name='Q{}class-mod' slot='2'/>
+      </fn>
+      <treat line='3072' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+       <att name='class'>
+        <varRef name='Q{}class-mod' slot='2'/>
+       </att>
+      </treat>
+     </choose>
+    </let>
+   </let>
+  </function>
+ </co>
+ <co id='40' binds='41 22 42 43 44'>
+  <template name='Q{}refreshRepeats-JS' flags='os' line='3533' module='saxon-xforms.xsl' slots='8'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3535'>
+    <message>
+     <valueOf role='select'>
+      <str val='[refreshRepeats-JS] START refreshRepeats'/>
+     </valueOf>
+     <str role='terminate' val='no'/>
+     <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+    </message>
+    <let line='3538' var='Q{}repeat-keys' as='item()?' slot='0' eval='8'>
+     <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+      <check card='1' diag='0|0||ixsl:call'>
+       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+      </check>
+      <str val='getRepeatKeys'/>
+      <array size='0'/>
+     </ifCall>
+     <forEach line='3540'>
+      <varRef name='Q{}repeat-keys' slot='0'/>
+      <let line='3541' var='Q{}this-key' as='xs:string' slot='1' eval='16'>
+       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|this-key'>
+        <check card='1' diag='3|0|XTTE0570|this-key'>
+         <cvUntyped to='xs:string' diag='3|0|XTTE0570|this-key'>
+          <data>
+           <dot/>
+          </data>
+         </cvUntyped>
+        </check>
+       </treat>
+       <let line='3542' var='Q{}this-repeat-nodeset' as='xs:string' slot='2' eval='16'>
+        <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|this-repeat-nodeset'>
+         <check card='1' diag='3|0|XTTE0570|this-repeat-nodeset'>
+          <cvUntyped to='xs:string' diag='3|0|XTTE0570|this-repeat-nodeset'>
+           <data>
+            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+             <check card='1' diag='0|0||ixsl:call'>
+              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+             </check>
+             <str val='getRepeat'/>
+             <arrayBlock>
+              <varRef name='Q{}this-key' slot='1'/>
+             </arrayBlock>
+            </ifCall>
+           </data>
+          </cvUntyped>
+         </check>
+        </treat>
+        <sequence line='3544'>
+         <message>
+          <sequence role='select'>
+           <valueOf>
+            <str val='[refreshRepeats-JS] Refreshing repeat ID = &#39;'/>
+           </valueOf>
+           <varRef name='Q{}this-key' slot='1'/>
+           <valueOf flags='S'>
+            <str val='&#39;'/>
+           </valueOf>
+          </sequence>
+          <str role='terminate' val='no'/>
+          <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+         </message>
+         <let line='3555' var='Q{}contexti' as='element()?' slot='3' eval='7'>
+          <ufCall line='3556' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='0' eval='16'>
+           <check line='3548' card='1' diag='3|0|XTTE0570|this-instance-id'>
+            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+             <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='1' eval='6'>
+              <varRef name='Q{}this-repeat-nodeset' slot='2'/>
+             </ufCall>
+             <str val='instance-id'/>
+            </ifCall>
+           </check>
+          </ufCall>
+          <let line='3563' var='Q{}namespace-context-item' as='element()' slot='4' eval='16'>
+           <choose>
+            <fn name='exists'>
+             <varRef name='Q{}contexti' slot='3'/>
+            </fn>
+            <check card='1' diag='3|0|XTTE0570|namespace-context-item'>
+             <varRef name='Q{}contexti' slot='3'/>
+            </check>
+            <true/>
+            <treat as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|namespace-context-item'>
+             <check card='1' diag='3|0|XTTE0570|namespace-context-item'>
+              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+               <check card='1' diag='0|0||ixsl:call'>
+                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+               </check>
+               <str val='getXForm'/>
+               <array size='0'/>
+              </ifCall>
+             </check>
+            </treat>
+           </choose>
+           <let line='3565' var='Q{}page-element' as='element()?' slot='5' eval='7'>
+            <check card='?' diag='3|0|XTTE0570|page-element'>
+             <filter flags='b'>
+              <slash simple='1'>
+               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
+               <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+              </slash>
+              <vc op='eq' onEmpty='0' comp='CCC'>
+               <cast as='xs:string' emptiable='1'>
+                <attVal name='Q{}id' chk='0'/>
+               </cast>
+               <varRef name='Q{}this-key' slot='1'/>
+              </vc>
+             </filter>
+            </check>
+            <choose line='3568'>
+             <fn name='exists'>
+              <varRef name='Q{}page-element' slot='5'/>
+             </fn>
+             <let line='3569' var='Q{}instance-keys' as='item()?' slot='6' eval='8'>
+              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+               <check card='1' diag='0|0||ixsl:call'>
+                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+               </check>
+               <str val='getInstanceKeys'/>
+               <array size='0'/>
+              </ifCall>
+              <let line='3570' var='Q{}instances' as='map(xs:string, element())' slot='7' eval='16'>
+               <treat line='3572' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances'>
+                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+                 <forEach>
+                  <varRef name='Q{}instance-keys' slot='6'/>
+                  <ifCall line='3573' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                   <atomSing diag='0|0||map:entry'>
+                    <dot/>
+                   </atomSing>
+                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                    <check card='1' diag='0|0||ixsl:call'>
+                     <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                    </check>
+                    <str val='getInstance'/>
+                    <arrayBlock>
+                     <dot/>
+                    </arrayBlock>
+                   </ifCall>
+                  </ifCall>
+                 </forEach>
+                 <map size='2'>
+                  <str val='duplicates'/>
+                  <str val='reject'/>
+                  <str val='duplicates-error-code'/>
+                  <str val='XTDE3365'/>
+                 </map>
+                </ifCall>
+               </treat>
+               <resultDoc line='3577' global='#&#xA;#Sat Feb 22 17:48:53 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sat Feb 22 17:48:53 GMT 2020&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xA;'>
+                <fn role='href' name='concat'>
+                 <str val='#'/>
+                 <varRef name='Q{}this-key' slot='1'/>
+                </fn>
+                <applyT role='content' line='3578' bSlot='2'>
+                 <filter role='select' flags='b'>
+                  <slash simple='1'>
+                   <gVarRef name='Q{}xforms-doc' bSlot='3'/>
+                   <axis name='descendant' nodeTest='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
+                  </slash>
+                  <vc op='eq' onEmpty='0' comp='CCC'>
+                   <ufCall name='Q{http://www.w3.org/2002/xforms}getDataRef' tailCall='false' bSlot='4' eval='16 0'>
+                    <dot type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
+                    <str val=''/>
+                   </ufCall>
+                   <varRef name='Q{}this-repeat-nodeset' slot='2'/>
+                  </vc>
+                 </filter>
+                 <withParam name='Q{}recalculate' as='xs:boolean'>
+                  <true/>
+                 </withParam>
+                 <withParam name='Q{}refreshRepeats' as='xs:boolean'>
+                  <true/>
+                 </withParam>
+                 <withParam name='Q{}instances' flags='t' as='map(xs:string, element())'>
+                  <varRef line='3579' name='Q{}instances' slot='7'/>
+                 </withParam>
+                </applyT>
+               </resultDoc>
+              </let>
+             </let>
+            </choose>
+           </let>
+          </let>
+         </let>
+        </sequence>
+       </let>
+      </let>
+     </forEach>
+    </let>
+   </sequence>
+  </template>
+ </co>
+ <co id='33' binds='3 41 22 22'>
+  <template name='Q{}refreshOutputs-JS' flags='os' line='3454' module='saxon-xforms.xsl' slots='8'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3461' var='Q{}output-keys' as='item()?' slot='0' eval='8'>
+    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+     <check card='1' diag='0|0||ixsl:call'>
+      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+     </check>
+     <str val='getOutputKeys'/>
+     <array size='0'/>
+    </ifCall>
+    <forEach line='3463'>
+     <varRef name='Q{}output-keys' slot='0'/>
+     <let line='3464' var='Q{}this-key' as='xs:string' slot='1' eval='16'>
+      <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|this-key'>
+       <check card='1' diag='3|0|XTTE0570|this-key'>
+        <cvUntyped to='xs:string' diag='3|0|XTTE0570|this-key'>
+         <data>
+          <dot/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+      <let line='3465' var='Q{}this-output' as='map(*)' slot='2' eval='16'>
+       <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|this-output'>
+        <check card='1' diag='3|0|XTTE0570|this-output'>
+         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+          <check card='1' diag='0|0||ixsl:call'>
+           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+          </check>
+          <str val='getOutput'/>
+          <arrayBlock>
+           <varRef name='Q{}this-key' slot='1'/>
+          </arrayBlock>
+         </ifCall>
+        </check>
+       </treat>
+       <sequence line='3467'>
+        <message>
+         <sequence role='select'>
+          <valueOf>
+           <str val='[refreshOutputs-JS] Refreshing output ID = &#39;'/>
+          </valueOf>
+          <varRef name='Q{}this-key' slot='1'/>
+          <valueOf flags='S'>
+           <str val='&#39;'/>
+          </valueOf>
+         </sequence>
+         <str role='terminate' val='no'/>
+         <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+        </message>
+        <let line='3484' var='Q{}xpath-mod' as='xs:string' slot='3' eval='16'>
+         <ufCall name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='0' eval='16'>
+          <choose line='3472'>
+           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+            <varRef name='Q{}this-output' slot='2'/>
+            <str val='@value'/>
+           </ifCall>
+           <treat line='3473' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|xpath'>
+            <check card='1' diag='3|0|XTTE0570|xpath'>
+             <cvUntyped to='xs:string' diag='3|0|XTTE0570|xpath'>
+              <data>
+               <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                <varRef name='Q{}this-output' slot='2'/>
+                <str val='@value'/>
+               </ifCall>
+              </data>
+             </cvUntyped>
+            </check>
+           </treat>
+           <ifCall line='3475' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+            <varRef name='Q{}this-output' slot='2'/>
+            <str val='@ref'/>
+           </ifCall>
+           <treat line='3476' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|xpath'>
+            <check card='1' diag='3|0|XTTE0570|xpath'>
+             <cvUntyped to='xs:string' diag='3|0|XTTE0570|xpath'>
+              <data>
+               <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                <varRef name='Q{}this-output' slot='2'/>
+                <str val='@ref'/>
+               </ifCall>
+              </data>
+             </cvUntyped>
+            </check>
+           </treat>
+           <true/>
+           <str val=''/>
+          </choose>
+         </ufCall>
+         <sequence line='3486'>
+          <message>
+           <sequence role='select'>
+            <valueOf>
+             <str val='[refreshOutputs-JS] $xpath-mod = &#39;'/>
+            </valueOf>
+            <varRef name='Q{}xpath-mod' slot='3'/>
+            <valueOf flags='S'>
+             <str val='&#39;'/>
+            </valueOf>
+           </sequence>
+           <str role='terminate' val='no'/>
+           <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+          </message>
+          <let line='3502' var='Q{}contexti' as='element()?' slot='4' eval='7'>
+           <ufCall line='3503' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='16'>
+            <check line='3490' card='1' diag='3|0|XTTE0570|this-instance-id'>
+             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+              <choose>
+               <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+                <varRef name='Q{}this-output' slot='2'/>
+                <str val='@ref'/>
+               </ifCall>
+               <ufCall line='3492' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='2' eval='16'>
+                <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:getInstanceMap'>
+                 <check card='1' diag='0|0||xforms:getInstanceMap'>
+                  <cvUntyped to='xs:string'>
+                   <data>
+                    <ifCall line='3491' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                     <varRef name='Q{}this-output' slot='2'/>
+                     <str val='@ref'/>
+                    </ifCall>
+                   </data>
+                  </cvUntyped>
+                 </check>
+                </treat>
+               </ufCall>
+               <true/>
+               <ufCall line='3495' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='3' eval='0'>
+                <str val='saxon-forms-default'/>
+               </ufCall>
+              </choose>
+              <str val='instance-id'/>
+             </ifCall>
+            </check>
+           </ufCall>
+           <let line='3510' var='Q{}namespace-context-item' as='element()' slot='5' eval='16'>
+            <choose>
+             <fn name='exists'>
+              <varRef name='Q{}contexti' slot='4'/>
+             </fn>
+             <check card='1' diag='3|0|XTTE0570|namespace-context-item'>
+              <varRef name='Q{}contexti' slot='4'/>
+             </check>
+             <true/>
+             <treat as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|namespace-context-item'>
+              <check card='1' diag='3|0|XTTE0570|namespace-context-item'>
+               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                <check card='1' diag='0|0||ixsl:call'>
+                 <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                </check>
+                <str val='getXForm'/>
+                <array size='0'/>
+               </ifCall>
+              </check>
+             </treat>
+            </choose>
+            <let line='3512' var='Q{}value' as='xs:string?' slot='6' eval='7'>
+             <treat line='3513' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|value'>
+              <check card='?' diag='3|0|XTTE0570|value'>
+               <cvUntyped to='xs:string' diag='3|0|XTTE0570|value'>
+                <data>
+                 <evaluate dxns=''>
+                  <varRef role='xpath' name='Q{}xpath-mod' slot='3'/>
+                  <varRef role='cxt' name='Q{}contexti' slot='4'/>
+                  <varRef role='nsCxt' name='Q{}namespace-context-item' slot='5'/>
+                  <str role='sa' val='no'/>
+                  <map role='options' size='0'/>
+                  <map role='wp' size='0'/>
+                 </evaluate>
+                </data>
+               </cvUntyped>
+              </check>
+             </treat>
+             <let line='3516' var='Q{}associated-form-control' as='element()?' slot='7' eval='7'>
+              <check card='?' diag='3|0|XTTE0570|associated-form-control'>
+               <filter flags='b'>
+                <slash simple='1'>
+                 <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
+                 <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+                </slash>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <cast as='xs:string' emptiable='1'>
+                  <attVal name='Q{}id' chk='0'/>
+                 </cast>
+                 <varRef name='Q{}this-key' slot='1'/>
+                </vc>
+               </filter>
+              </check>
+              <choose line='3519'>
+               <fn name='exists'>
+                <varRef name='Q{}associated-form-control' slot='7'/>
+               </fn>
+               <resultDoc line='3520' global='#&#xA;#Sat Feb 22 17:48:53 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sat Feb 22 17:48:53 GMT 2020&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xA;'>
+                <fn role='href' name='concat'>
+                 <str val='#'/>
+                 <varRef name='Q{}this-key' slot='1'/>
+                </fn>
+                <valueOf role='content' line='3521'>
+                 <varRef name='Q{}value' slot='6'/>
+                </valueOf>
+               </resultDoc>
+              </choose>
+             </let>
+            </let>
+           </let>
+          </let>
+         </sequence>
+        </let>
+       </sequence>
+      </let>
+     </let>
+    </forEach>
+   </let>
+  </template>
+ </co>
+ <co id='30' binds='45'>
+  <template name='Q{}xforms-focus' flags='os' line='4177' module='saxon-xforms.xsl' slots='5'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4178'>
+    <param name='Q{}control' slot='0' flags='i' as='xs:string'>
+     <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|control'>
+      <check card='1' diag='8|0|XTTE0590|control'>
+       <cvUntyped to='xs:string' diag='8|0|XTTE0590|control'>
+        <data>
+         <supplied slot='0'/>
+        </data>
+       </cvUntyped>
+      </check>
+     </treat>
+    </param>
+    <let line='4179' var='Q{}xforms-control' as='element()' slot='1' eval='16'>
+     <check card='1' diag='3|0|XTTE0570|xforms-control'>
+      <filter flags='b'>
+       <gVarRef name='Q{http://saxon.sf.net/generated-variable}gg893415836' bSlot='0'/>
+       <vc op='eq' onEmpty='0' comp='CCC'>
+        <cast as='xs:string' emptiable='1'>
+         <attVal name='Q{}id' chk='0'/>
+        </cast>
+        <varRef name='Q{}control' slot='0'/>
+       </vc>
+      </filter>
+     </check>
+     <choose line='4184'>
+      <fn name='exists'>
+       <slash simple='1'>
+        <varRef name='Q{}xforms-control' slot='1'/>
+        <axis name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
+       </slash>
+      </fn>
+      <let line='4188' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='2' eval='13'>
+       <check card='1' diag='0|0||ixsl:call'>
+        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+       </check>
+       <let line='4185' var='Q{}context-indexes' as='xs:double*' slot='3' eval='8'>
+        <convert line='4186' from='xs:anyAtomicType' to='xs:double' flags='p' diag='3|0|XTTE0570|context-indexes'>
+         <cvUntyped to='xs:double' diag='3|0|XTTE0570|context-indexes'>
+          <data>
+           <forEach>
+            <sort>
+             <slash role='select'>
+              <varRef name='Q{}xforms-control' slot='1'/>
+              <fn name='reverse'>
+               <axis name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
+              </fn>
+             </slash>
+             <sortKey line='4187' comp='DESC|NC11'>
+              <fn role='select' name='position'/>
+              <str role='order' val='descending'/>
+              <str role='dataType' val='number'/>
+              <str role='lang' val=''/>
+              <str role='caseOrder' val='#default'/>
+              <str role='stable' val='yes'/>
+              <str role='collation' val='http://www.w3.org/2005/xpath-functions/collation/codepoint'/>
+             </sortKey>
+            </sort>
+            <ifCall line='4188' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+             <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='2'/>
+             <str val='getRepeatIndex'/>
+             <arrayBlock>
+              <cast as='xs:string' emptiable='1'>
+               <attVal name='Q{}id' chk='0'/>
+              </cast>
+             </arrayBlock>
+            </ifCall>
+           </forEach>
+          </data>
+         </cvUntyped>
+        </convert>
+        <let line='4192' var='Q{}control-index' as='xs:string' slot='4' eval='8'>
+         <fn name='string-join'>
+          <varRef name='Q{}context-indexes' slot='3'/>
+          <str val='.'/>
+         </fn>
+         <sequence line='4193'>
+          <message>
+           <sequence role='select'>
+            <valueOf>
+             <str val='[xforms-focus] Control &#39;'/>
+            </valueOf>
+            <varRef name='Q{}control' slot='0'/>
+            <valueOf>
+             <str val='&#39; has index &#39;'/>
+            </valueOf>
+            <varRef name='Q{}control-index' slot='4'/>
+            <valueOf flags='S'>
+             <str val='&#39;'/>
+            </valueOf>
+           </sequence>
+           <str role='terminate' val='no'/>
+           <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+          </message>
+          <ifCall line='4194' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+           <check card='1' diag='0|0||ixsl:call'>
+            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+           </check>
+           <str val='setFocus'/>
+           <arrayBlock>
+            <fn name='concat'>
+             <varRef name='Q{}control' slot='0'/>
+             <str val='-'/>
+             <varRef name='Q{}control-index' slot='4'/>
+            </fn>
+           </arrayBlock>
+          </ifCall>
+         </sequence>
+        </let>
+       </let>
+      </let>
+      <true/>
+      <ifCall line='4197' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+       <check card='1' diag='0|0||ixsl:call'>
+        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+       </check>
+       <str val='setFocus'/>
+       <arrayBlock>
+        <varRef name='Q{}control' slot='0'/>
+       </arrayBlock>
+      </ifCall>
+     </choose>
+    </let>
+   </sequence>
+  </template>
+ </co>
+ <co id='20' binds='2'>
+  <function name='Q{http://www.w3.org/2002/xforms}checkRelevantFields' line='630' module='saxon-xforms.xsl' eval='8' flags='pU' as='item()*' slots='13'>
+   <arg name='Q{}refElement' as='xs:string'/>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='633' var='Q{}pendingUpdatesi' as='map(xs:string, xs:string)?' slot='1' eval='7'>
+    <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|pendingUpdatesi'>
+     <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+      <check card='1' diag='0|0||ixsl:call'>
+       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+      </check>
+      <str val='getPendingUpdates'/>
+      <array size='0'/>
+     </ifCall>
+    </treat>
+    <let line='636' var='Q{}updatesi' as='map(xs:string, xs:string)?' slot='2' eval='7'>
+     <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|updatesi'>
+      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+       <check card='1' diag='0|0||ixsl:call'>
+        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+       </check>
+       <str val='getUpdates'/>
+       <array size='0'/>
+      </ifCall>
+     </treat>
+     <let line='639' var='Q{}relevantMap' as='map(xs:string, xs:string)' slot='3' eval='16'>
+      <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|relevantMap'>
+       <check card='1' diag='3|0|XTTE0570|relevantMap'>
+        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+         <check card='1' diag='0|0||ixsl:call'>
+          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+         </check>
+         <str val='getRelevantMap'/>
+         <array size='0'/>
+        </ifCall>
+       </check>
+      </treat>
+      <let line='640' var='Q{}mapKeys' as='xs:anyAtomicType*' slot='4' eval='4'>
+       <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
+        <varRef name='Q{}relevantMap' slot='3'/>
+       </ifCall>
+       <sequence line='670'>
+        <forEach>
+         <sequence line='643'>
+          <forEach>
+           <varRef name='Q{}mapKeys' slot='4'/>
+           <choose line='644'>
+            <fn name='matches'>
+             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+              <varRef name='Q{}relevantMap' slot='3'/>
+              <dot type='xs:anyAtomicType'/>
+             </ifCall>
+             <varRef name='Q{}refElement' slot='0'/>
+             <str val=''/>
+            </fn>
+            <dot line='645' type='xs:anyAtomicType'/>
+           </choose>
+          </forEach>
+          <forEach line='634'>
+           <choose>
+            <fn name='exists'>
+             <varRef name='Q{}pendingUpdatesi' slot='1'/>
+            </fn>
+            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
+             <check card='1' diag='0|0||map:keys'>
+              <varRef name='Q{}pendingUpdatesi' slot='1'/>
+             </check>
+            </ifCall>
+           </choose>
+           <let line='651' var='Q{}keyi' as='xs:string?' slot='5' eval='7'>
+            <lastOf>
+             <fn name='tokenize'>
+              <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||fn:tokenize'>
+               <cvUntyped to='xs:string'>
+                <dot type='xs:anyAtomicType'/>
+               </cvUntyped>
+              </treat>
+              <str val='/'/>
+              <str val=''/>
+             </fn>
+            </lastOf>
+            <let line='653' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='6' eval='13'>
+             <check card='1' diag='0|1||fn:matches'>
+              <varRef name='Q{}keyi' slot='5'/>
+             </check>
+             <forEach line='652'>
+              <varRef name='Q{}mapKeys' slot='4'/>
+              <choose line='653'>
+               <fn name='matches'>
+                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                 <varRef name='Q{}relevantMap' slot='3'/>
+                 <dot type='xs:anyAtomicType'/>
+                </ifCall>
+                <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='6'/>
+                <str val=''/>
+               </fn>
+               <dot line='654' type='xs:anyAtomicType'/>
+              </choose>
+             </forEach>
+            </let>
+           </let>
+          </forEach>
+          <forEach line='637'>
+           <choose>
+            <fn name='exists'>
+             <varRef name='Q{}updatesi' slot='2'/>
+            </fn>
+            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
+             <check card='1' diag='0|0||map:keys'>
+              <varRef name='Q{}updatesi' slot='2'/>
+             </check>
+            </ifCall>
+           </choose>
+           <let line='660' var='Q{}keyi' as='xs:string?' slot='7' eval='7'>
+            <lastOf>
+             <fn name='tokenize'>
+              <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||fn:tokenize'>
+               <cvUntyped to='xs:string'>
+                <dot type='xs:anyAtomicType'/>
+               </cvUntyped>
+              </treat>
+              <str val='/'/>
+              <str val=''/>
+             </fn>
+            </lastOf>
+            <let line='662' var='Q{http://saxon.sf.net/generated-variable}v1' as='xs:string' slot='8' eval='13'>
+             <check card='1' diag='0|1||fn:matches'>
+              <varRef name='Q{}keyi' slot='7'/>
+             </check>
+             <forEach line='661'>
+              <varRef name='Q{}mapKeys' slot='4'/>
+              <choose line='662'>
+               <fn name='matches'>
+                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                 <varRef name='Q{}relevantMap' slot='3'/>
+                 <dot type='xs:anyAtomicType'/>
+                </ifCall>
+                <varRef name='Q{http://saxon.sf.net/generated-variable}v1' slot='8'/>
+                <str val=''/>
+               </fn>
+               <dot line='663' type='xs:anyAtomicType'/>
+              </choose>
+             </forEach>
+            </let>
+           </let>
+          </forEach>
+         </sequence>
+         <let line='671' var='Q{}keyi' as='xs:anyAtomicType' slot='9' eval='16'>
+          <dot type='xs:anyAtomicType'/>
+          <let line='672' var='Q{}context' as='element()*' slot='10' eval='8'>
+           <filter flags='b'>
+            <slash simple='1'>
+             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
+             <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+            </slash>
+            <gc op='=' card='1:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+             <attVal name='Q{}data-ref' chk='0'/>
+             <varRef name='Q{}keyi' slot='9'/>
+            </gc>
+           </filter>
+           <let line='673' var='Q{}updatedInstanceXML4' as='element()?' slot='11' eval='7'>
+            <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='0' eval='16'>
+             <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:getInstance-JS'>
+              <cvUntyped to='xs:string'>
+               <varRef name='Q{}keyi' slot='9'/>
+              </cvUntyped>
+             </treat>
+            </ufCall>
+            <let line='675' var='Q{}relevantCheck' as='xs:boolean' slot='12' eval='16'>
+             <treat line='676' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantCheck'>
+              <check card='1' diag='3|0|XTTE0570|relevantCheck'>
+               <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|relevantCheck'>
+                <data>
+                 <evaluate dxns=''>
+                  <fn role='xpath' name='concat'>
+                   <dot type='xs:anyAtomicType'/>
+                   <str val='/'/>
+                   <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                    <varRef name='Q{}relevantMap' slot='3'/>
+                    <dot type='xs:anyAtomicType'/>
+                   </ifCall>
+                  </fn>
+                  <varRef role='cxt' name='Q{}updatedInstanceXML4' slot='11'/>
+                  <check role='nsCxt' card='1' diag='4|0|XTTE3170|xsl:evaluate/namespace-context'>
+                   <varRef name='Q{}updatedInstanceXML4' slot='11'/>
+                  </check>
+                  <str role='sa' val='no'/>
+                  <map role='options' size='0'/>
+                  <map role='wp' size='0'/>
+                 </evaluate>
+                </data>
+               </cvUntyped>
+              </check>
+             </treat>
+             <choose line='679'>
+              <varRef name='Q{}relevantCheck' slot='12'/>
+              <ifCall line='682' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+               <str val='style.display'/>
+               <str val='inline'/>
+               <check card='1' diag='0|2||ixsl:set-property'>
+                <conditionalSort>
+                 <fn name='exists'>
+                  <tail start='2'>
+                   <varRef name='Q{}context' slot='10'/>
+                  </tail>
+                 </fn>
+                 <docOrder intra='1'>
+                  <slash simple='2'>
+                   <varRef name='Q{}context' slot='10'/>
+                   <axis name='parent' nodeTest='(document-node()|element())' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11||item.nodeType===1);'/>
+                  </slash>
+                 </docOrder>
+                </conditionalSort>
+               </check>
+              </ifCall>
+              <true/>
+              <ifCall line='685' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+               <str val='style.display'/>
+               <str val='none'/>
+               <check card='1' diag='0|2||ixsl:set-property'>
+                <conditionalSort>
+                 <fn name='exists'>
+                  <tail start='2'>
+                   <varRef name='Q{}context' slot='10'/>
+                  </tail>
+                 </fn>
+                 <docOrder intra='1'>
+                  <slash simple='2'>
+                   <varRef name='Q{}context' slot='10'/>
+                   <axis name='parent' nodeTest='(document-node()|element())' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11||item.nodeType===1);'/>
+                  </slash>
+                 </docOrder>
+                </conditionalSort>
+               </check>
+              </ifCall>
+             </choose>
+            </let>
+           </let>
+          </let>
+         </let>
+        </forEach>
+        <ifCall line='690' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+         <check card='1' diag='0|0||ixsl:call'>
+          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+         </check>
+         <str val='clearPendingUpdates'/>
+         <array size='0'/>
+        </ifCall>
+        <ifCall line='691' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+         <check card='1' diag='0|0||ixsl:call'>
+          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+         </check>
+         <str val='clearUpdates'/>
+         <array size='0'/>
+        </ifCall>
+       </sequence>
+      </let>
+     </let>
+    </let>
+   </let>
+  </function>
+ </co>
+ <co id='46' binds=''>
+  <globalParam name='Q{}xform-html-id' type='xs:string' line='67' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
+   <str val='xForm'/>
+  </globalParam>
+ </co>
+ <co id='47' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}random' line='108' module='xforms-function-library.xsl' eval='16' flags='pU' as='xs:double' slots='0'>
+   <check role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='109' card='1' diag='3|0|XTTE0570|randomNumber'>
+    <convert from='xs:anyAtomicType' to='xs:double' flags='p' diag='3|0|XTTE0570|randomNumber'>
+     <cvUntyped to='xs:double' diag='3|0|XTTE0570|randomNumber'>
+      <data>
+       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <check card='1' diag='0|0||ixsl:call'>
+         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+        </check>
+        <str val='Math.random'/>
+        <array size='0'/>
+       </ifCall>
+      </data>
+     </cvUntyped>
+    </convert>
+   </check>
+  </function>
+ </co>
+ <co id='7' binds='2 48 2 33 40 49'>
+  <template name='Q{}xforms-recalculate' flags='os' line='4089' module='saxon-xforms.xsl' slots='3'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4090'>
+    <message>
+     <valueOf role='select'>
+      <str val='[xforms-recalculate] START'/>
+     </valueOf>
+     <str role='terminate' val='no'/>
+     <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+    </message>
+    <let line='4091' var='Q{}instance-keys' as='item()?' slot='0' eval='8'>
+     <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+      <check card='1' diag='0|0||ixsl:call'>
+       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+      </check>
+      <str val='getInstanceKeys'/>
+      <array size='0'/>
+     </ifCall>
+     <forEach line='4092'>
+      <varRef name='Q{}instance-keys' slot='0'/>
+      <let line='4093' var='Q{}refz' as='xs:string' slot='1' eval='8'>
+       <fn name='concat'>
+        <str val='instance(&#39;'/>
+        <atomSing card='?' diag='0|1||fn:concat'>
+         <dot/>
+        </atomSing>
+        <str val='&#39;)/'/>
+       </fn>
+       <sequence line='4094'>
+        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <atomSing diag='0|0||map:entry'>
+          <dot/>
+         </atomSing>
+         <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='0' eval='6'>
+          <varRef name='Q{}refz' slot='1'/>
+         </ufCall>
+        </ifCall>
+        <let line='4097' var='Q{}updatedInstanceXML' as='element()' slot='2' eval='16'>
+         <treat line='4098' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+          <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
+           <applyT mode='Q{}binding-calculation-initial' bSlot='1'>
+            <check role='select' line='4096' card='1' diag='3|0|XTTE0570|instanceXML'>
+             <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='2' eval='6'>
+              <varRef name='Q{}refz' slot='1'/>
+             </ufCall>
+            </check>
+            <withParam name='Q{}instance-id' as='item()'>
+             <dot line='4099'/>
+            </withParam>
+           </applyT>
+          </check>
+         </treat>
+         <sequence line='4105'>
+          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+           <check card='1' diag='0|0||ixsl:call'>
+            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+           </check>
+           <str val='setInstance'/>
+           <arrayBlock>
+            <dot/>
+            <varRef name='Q{}updatedInstanceXML' slot='2'/>
+           </arrayBlock>
+          </ifCall>
+          <callT line='4106' name='Q{}refreshOutputs-JS' bSlot='3'/>
+          <callT line='4107' name='Q{}refreshRepeats-JS' bSlot='4'/>
+          <callT line='4108' name='Q{}refreshElementsUsingIndexFunction-JS' bSlot='5' flags='t'/>
+         </sequence>
+        </let>
+       </sequence>
+      </let>
+     </forEach>
+    </let>
+   </sequence>
+  </template>
+ </co>
+ <co id='43' binds='50 50 50'>
+  <globalVariable name='Q{}xforms-doc' type='document-node()?' line='71' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='function test(item) {return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);};if (test(val)) {return val;} else {throw SaxonJS.XError(&#39;Conversion failed&#39;, &#39;XTTE0590&#39;);}' jsCardCheck='function c(n) {return n&lt;=1;};'>
+   <choose ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='71'>
+    <and op='and'>
+     <fn name='exists'>
+      <gVarRef name='Q{}xforms-file' bSlot='0'/>
+     </fn>
+     <fn name='doc-available'>
+      <gVarRef name='Q{}xforms-file' bSlot='1'/>
+     </fn>
+    </and>
+    <fn name='doc'>
+     <gVarRef name='Q{}xforms-file' bSlot='2'/>
+    </fn>
+   </choose>
+  </globalVariable>
+ </co>
+ <co id='50' binds=''>
+  <globalParam name='Q{}xforms-file' type='xs:string?' line='69' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n&lt;=1;};'>
+   <empty/>
+  </globalParam>
+ </co>
+ <co id='51' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}addNamespaceDeclarations' line='2998' module='saxon-xforms.xsl' eval='16' flags='pU' as='element()' slots='1'>
+   <arg name='Q{}this' as='element()'/>
+   <compElem role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3000'>
+    <fn role='name' name='name'>
+     <varRef name='Q{}this' slot='0'/>
+    </fn>
+    <sequence role='content' line='3001'>
+     <namespace flags='l'>
+      <str role='name' val='xforms'/>
+      <str role='select' val='http://www.w3.org/2002/xforms'/>
+     </namespace>
+     <forEach line='3002'>
+      <filter flags='b'>
+       <filter flags='b'>
+        <slash simple='1'>
+         <varRef name='Q{}this' slot='0'/>
+         <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+        </slash>
+        <fn name='boolean'>
+         <fn name='namespace-uri'>
+          <dot type='element()'/>
+         </fn>
+        </fn>
+       </filter>
+       <fn name='not'>
+        <gc op='=' card='N:1' comp='CCC'>
+         <sequence>
+          <slash>
+           <fn name='reverse'>
+            <axis name='ancestor' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+           </fn>
+           <fn name='namespace-uri'>
+            <dot type='element()'/>
+           </fn>
+          </slash>
+          <slash>
+           <fn name='reverse'>
+            <axis name='preceding' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+           </fn>
+           <fn name='namespace-uri'>
+            <dot type='element()'/>
+           </fn>
+          </slash>
+         </sequence>
+         <fn name='namespace-uri'>
+          <dot type='element()'/>
+         </fn>
+        </gc>
+       </fn>
+      </filter>
+      <namespace line='3005' flags='l'>
+       <fn role='name' line='3004' name='substring-before'>
+        <fn name='name'>
+         <dot type='element()'/>
+        </fn>
+        <str val=':'/>
+       </fn>
+       <convert role='select' from='xs:anyURI' to='xs:string'>
+        <fn line='3003' name='namespace-uri'>
+         <dot type='element()'/>
+        </fn>
+       </convert>
+      </namespace>
+     </forEach>
+     <copyOf line='3007' flags='vc'>
+      <sequence>
+       <slash simple='1'>
+        <varRef name='Q{}this' slot='0'/>
+        <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+       </slash>
+       <slash simple='1'>
+        <varRef name='Q{}this' slot='0'/>
+        <axis name='child' nodeTest='( element() | text() | comment() | processing-instruction() )' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);'/>
+       </slash>
+      </sequence>
+     </copyOf>
+    </sequence>
+   </compElem>
+  </function>
+ </co>
+ <co id='11' binds='2 41 16 52 3 53 19'>
+  <template name='Q{}xforms-submit' flags='os' line='4210' module='saxon-xforms.xsl' slots='16'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4211'>
+    <param name='Q{}submission' slot='0' flags='i' as='xs:string'>
+     <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|submission'>
+      <check card='1' diag='8|0|XTTE0590|submission'>
+       <cvUntyped to='xs:string' diag='8|0|XTTE0590|submission'>
+        <data>
+         <supplied slot='0'/>
+        </data>
+       </cvUntyped>
+      </check>
+     </treat>
+    </param>
+    <let line='4213' var='Q{}submission-map' as='map(*)' slot='1' eval='16'>
+     <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|submission-map'>
+      <check card='1' diag='3|0|XTTE0570|submission-map'>
+       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <check card='1' diag='0|0||ixsl:call'>
+         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+        </check>
+        <str val='getSubmission'/>
+        <arrayBlock>
+         <varRef name='Q{}submission' slot='0'/>
+        </arrayBlock>
+       </ifCall>
+      </check>
+     </treat>
+     <let line='4214' var='Q{}actions' as='map(*)?' slot='2' eval='7'>
+      <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <check card='1' diag='0|0||ixsl:call'>
+         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+        </check>
+        <str val='getAction'/>
+        <arrayBlock>
+         <varRef name='Q{}submission' slot='0'/>
+        </arrayBlock>
+       </ifCall>
+      </treat>
+      <sequence line='4216'>
+       <message>
+        <sequence role='select'>
+         <valueOf>
+          <str val='[xforms-submit] Submitting: '/>
+         </valueOf>
+         <valueOf>
+          <fn name='serialize'>
+           <varRef name='Q{}submission-map' slot='1'/>
+          </fn>
+         </valueOf>
+        </sequence>
+        <str role='terminate' val='no'/>
+        <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+       </message>
+       <let line='4218' var='Q{}refi' as='xs:string?' slot='3' eval='7'>
+        <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+         <check card='?' diag='3|0|XTTE0570|refi'>
+          <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
+           <data>
+            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+             <varRef name='Q{}submission-map' slot='1'/>
+             <str val='@ref'/>
+            </ifCall>
+           </data>
+          </cvUntyped>
+         </check>
+        </treat>
+        <let line='4220' var='Q{}instance-id' as='xs:string' slot='4' eval='16'>
+         <choose line='4222'>
+          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+           <varRef name='Q{}submission-map' slot='1'/>
+           <str val='@instance'/>
+          </ifCall>
+          <treat line='4223' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|instance-id'>
+           <check card='1' diag='3|0|XTTE0570|instance-id'>
+            <cvUntyped to='xs:string' diag='3|0|XTTE0570|instance-id'>
+             <data>
+              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+               <varRef name='Q{}submission-map' slot='1'/>
+               <str val='@instance'/>
+              </ifCall>
+             </data>
+            </cvUntyped>
+           </check>
+          </treat>
+          <true/>
+          <str val='saxon-forms-default'/>
+         </choose>
+         <let line='4234' var='Q{}instanceXML' as='element()' slot='5' eval='16'>
+          <choose>
+           <varRef name='Q{}refi' slot='3'/>
+           <check card='1' diag='3|0|XTTE0570|instanceXML'>
+            <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='0' eval='16'>
+             <check card='1' diag='0|0||xforms:getInstance-JS'>
+              <varRef name='Q{}refi' slot='3'/>
+             </check>
+            </ufCall>
+           </check>
+           <true/>
+           <check card='1' diag='3|0|XTTE0570|instanceXML'>
+            <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='6'>
+             <varRef name='Q{}instance-id' slot='4'/>
+            </ufCall>
+           </check>
+          </choose>
+          <let line='4236' var='Q{}updatedInstanceXML' as='element()' slot='6' eval='16'>
+           <treat line='4237' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+            <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
+             <applyT mode='Q{}form-check-initial' bSlot='2'>
+              <varRef role='select' name='Q{}instanceXML' slot='5'/>
+              <withParam name='Q{}instance-id' as='xs:string'>
+               <varRef line='4238' name='Q{}instance-id' slot='4'/>
+              </withParam>
+             </applyT>
+            </check>
+           </treat>
+           <let line='4242' var='Q{}required-fieldsi' as='element()*' slot='7' eval='8'>
+            <filter flags='b'>
+             <slash simple='1'>
+              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
+              <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+             </slash>
+             <fn name='exists'>
+              <axis name='attribute' nodeTest='attribute(Q{}data-required)' jsTest='return item.name===&#39;data-required&#39;'/>
+             </fn>
+            </filter>
+            <let line='4244' var='Q{}required-fields-check' as='element()*' slot='8' eval='3'>
+             <ufCall name='Q{http://www.w3.org/2002/xforms}check-required-fields' tailCall='false' bSlot='3' eval='6'>
+              <varRef name='Q{}updatedInstanceXML' slot='6'/>
+             </ufCall>
+             <choose line='4250'>
+              <fn name='empty'>
+               <varRef name='Q{}required-fields-check' slot='8'/>
+              </fn>
+              <let line='4251' var='Q{}requestBodyXML' as='element()' slot='9' eval='16'>
+               <choose line='4253'>
+                <varRef name='Q{}refi' slot='3'/>
+                <treat line='4254' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|requestBodyXML'>
+                 <check card='1' diag='3|0|XTTE0570|requestBodyXML'>
+                  <evaluate dxns=''>
+                   <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='4' eval='16'>
+                    <check card='1' diag='0|0||xforms:impose'>
+                     <varRef name='Q{}refi' slot='3'/>
+                    </check>
+                   </ufCall>
+                   <varRef role='cxt' name='Q{}instanceXML' slot='5'/>
+                   <varRef role='nsCxt' name='Q{}instanceXML' slot='5'/>
+                   <str role='sa' val='no'/>
+                   <map role='options' size='0'/>
+                   <map role='wp' size='0'/>
+                  </evaluate>
+                 </check>
+                </treat>
+                <true/>
+                <varRef line='4257' name='Q{}instanceXML' slot='5'/>
+               </choose>
+               <let line='4271' var='Q{}method' as='xs:string' slot='10' eval='16'>
+                <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|method'>
+                 <check card='1' diag='3|0|XTTE0570|method'>
+                  <cvUntyped to='xs:string' diag='3|0|XTTE0570|method'>
+                   <data>
+                    <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                     <varRef name='Q{}submission-map' slot='1'/>
+                     <str val='@method'/>
+                    </ifCall>
+                   </data>
+                  </cvUntyped>
+                 </check>
+                </treat>
+                <let line='4273' var='Q{}serialization' as='xs:string?' slot='11' eval='7'>
+                 <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|serialization'>
+                  <check card='?' diag='3|0|XTTE0570|serialization'>
+                   <cvUntyped to='xs:string' diag='3|0|XTTE0570|serialization'>
+                    <data>
+                     <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                      <varRef name='Q{}submission-map' slot='1'/>
+                      <str val='@serialization'/>
+                     </ifCall>
+                    </data>
+                   </cvUntyped>
+                  </check>
+                 </treat>
+                 <let line='4275' var='Q{}query-parameters' as='xs:string?' slot='12' eval='7'>
+                  <choose line='4276'>
+                   <and op='and'>
+                    <fn name='exists'>
+                     <varRef name='Q{}serialization' slot='11'/>
+                    </fn>
+                    <vc op='eq' onEmpty='0' comp='CCC'>
+                     <varRef name='Q{}serialization' slot='11'/>
+                     <str val='application/x-www-form-urlencoded'/>
+                    </vc>
+                   </and>
+                   <fn line='4287' name='string-join'>
+                    <forEach line='4278'>
+                     <slash simple='1'>
+                      <varRef name='Q{}requestBodyXML' slot='9'/>
+                      <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+                     </slash>
+                     <let line='4279' var='Q{}query-part' as='xs:string' slot='13' eval='8'>
+                      <fn name='concat'>
+                       <fn name='name'>
+                        <dot type='element()'/>
+                       </fn>
+                       <str val='='/>
+                       <fn name='string'>
+                        <dot type='element()'/>
+                       </fn>
+                      </fn>
+                      <sequence line='4280'>
+                       <varRef name='Q{}query-part' slot='13'/>
+                       <message line='4281'>
+                        <sequence role='select'>
+                         <valueOf>
+                          <str val='[xforms-submit] Query part: '/>
+                         </valueOf>
+                         <valueOf>
+                          <varRef name='Q{}query-part' slot='13'/>
+                         </valueOf>
+                        </sequence>
+                        <str role='terminate' val='no'/>
+                        <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+                       </message>
+                      </sequence>
+                     </let>
+                    </forEach>
+                    <str val='&amp;'/>
+                   </fn>
+                  </choose>
+                  <let line='4291' var='Q{}href-base' as='xs:string' slot='14' eval='16'>
+                   <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|href-base'>
+                    <check card='1' diag='3|0|XTTE0570|href-base'>
+                     <cvUntyped to='xs:string' diag='3|0|XTTE0570|href-base'>
+                      <data>
+                       <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                        <varRef name='Q{}submission-map' slot='1'/>
+                        <str val='@resource'/>
+                       </ifCall>
+                      </data>
+                     </cvUntyped>
+                    </check>
+                   </treat>
+                   <sequence line='4322'>
+                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}schedule-action' type='item()*'>
+                     <int val='0'/>
+                     <empty/>
+                     <callT name='Q{}HTTPsubmit' bSlot='5'>
+                      <withParam name='Q{}instance-id' flags='c' as='xs:string'>
+                       <varRef line='4323' name='Q{}instance-id' slot='4'/>
+                      </withParam>
+                      <withParam name='Q{}targetref' flags='c' as='xs:string?'>
+                       <treat line='4324' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|targetref'>
+                        <check card='?' diag='8|0|XTTE0590|targetref'>
+                         <cvUntyped to='xs:string' diag='8|0|XTTE0590|targetref'>
+                          <data>
+                           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                            <varRef name='Q{}submission-map' slot='1'/>
+                            <str val='@targetref'/>
+                           </ifCall>
+                          </data>
+                         </cvUntyped>
+                        </check>
+                       </treat>
+                      </withParam>
+                      <withParam name='Q{}replace' flags='c' as='xs:string?'>
+                       <treat line='4325' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|replace'>
+                        <check card='?' diag='8|0|XTTE0590|replace'>
+                         <cvUntyped to='xs:string' diag='8|0|XTTE0590|replace'>
+                          <data>
+                           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                            <varRef name='Q{}submission-map' slot='1'/>
+                            <str val='@replace'/>
+                           </ifCall>
+                          </data>
+                         </cvUntyped>
+                        </check>
+                       </treat>
+                      </withParam>
+                     </callT>
+                     <ifCall line='4309' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+                      <sequence>
+                       <choose>
+                        <vc op='ne' onEmpty='1' comp='CCC'>
+                         <fn name='upper-case'>
+                          <varRef name='Q{}method' slot='10'/>
+                         </fn>
+                         <str val='GET'/>
+                        </vc>
+                        <ifCall line='4310' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                         <str val='body'/>
+                         <doc line='4266' validation='preserve'>
+                          <doc flags='l'>
+                           <varRef line='4267' name='Q{}requestBodyXML' slot='9'/>
+                          </doc>
+                         </doc>
+                        </ifCall>
+                       </choose>
+                       <ifCall line='4312' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                        <str val='method'/>
+                        <varRef name='Q{}method' slot='10'/>
+                       </ifCall>
+                       <ifCall line='4313' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                        <str val='href'/>
+                        <choose line='4295'>
+                         <fn name='exists'>
+                          <varRef name='Q{}query-parameters' slot='12'/>
+                         </fn>
+                         <fn line='4296' name='concat'>
+                          <varRef name='Q{}href-base' slot='14'/>
+                          <str val='?'/>
+                          <varRef name='Q{}query-parameters' slot='12'/>
+                         </fn>
+                         <true/>
+                         <varRef line='4299' name='Q{}href-base' slot='14'/>
+                        </choose>
+                       </ifCall>
+                       <ifCall line='4314' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                        <str val='media-type'/>
+                        <treat line='4304' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|mediatype'>
+                         <check card='1' diag='3|0|XTTE0570|mediatype'>
+                          <cvUntyped to='xs:string' diag='3|0|XTTE0570|mediatype'>
+                           <data>
+                            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                             <varRef name='Q{}submission-map' slot='1'/>
+                             <str val='@mediatype'/>
+                            </ifCall>
+                           </data>
+                          </cvUntyped>
+                         </check>
+                        </treat>
+                       </ifCall>
+                      </sequence>
+                      <map size='2'>
+                       <str val='duplicates'/>
+                       <str val='reject'/>
+                       <str val='duplicates-error-code'/>
+                       <str val='XTDE3365'/>
+                      </map>
+                     </ifCall>
+                    </ifCall>
+                    <forEach line='4329'>
+                     <varRef name='Q{}actions' slot='2'/>
+                     <let line='4330' var='Q{}action-map' as='map(*)' slot='15' eval='16'>
+                      <dot type='map(*)'/>
+                      <choose line='4333'>
+                       <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+                        <varRef name='Q{}action-map' slot='15'/>
+                        <str val='@event'/>
+                       </ifCall>
+                       <choose line='4334'>
+                        <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+                         <data>
+                          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                           <varRef name='Q{}action-map' slot='15'/>
+                           <str val='@event'/>
+                          </ifCall>
+                         </data>
+                         <str val='xforms-submit-done'/>
+                        </gc>
+                        <callT line='4335' name='Q{}applyActions' bSlot='6' flags='t'>
+                         <withParam name='Q{}action-map' flags='t' as='item()'>
+                          <varRef line='4336' name='Q{}action-map' slot='15'/>
+                         </withParam>
+                         <withParam name='Q{}nodeset' flags='t' as='xs:string'>
+                          <check line='4337' card='1' diag='8|0|XTTE0590|nodeset'>
+                           <varRef name='Q{}refi' slot='3'/>
+                          </check>
+                         </withParam>
+                         <withParam name='Q{}instanceXML' flags='t' as='element()'>
+                          <varRef line='4338' name='Q{}instanceXML' slot='5'/>
+                         </withParam>
+                        </callT>
+                       </choose>
+                      </choose>
+                     </let>
+                    </forEach>
+                   </sequence>
+                  </let>
+                 </let>
+                </let>
+               </let>
+              </let>
+              <true/>
+              <ifCall line='4351' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+               <check card='1' diag='0|0||ixsl:call'>
+                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+               </check>
+               <str val='alert'/>
+               <arrayBlock>
+                <fn name='serialize'>
+                 <doc line='4346' flags='t' validation='preserve'>
+                  <forEach>
+                   <varRef name='Q{}required-fields-check' slot='8'/>
+                   <valueOf line='4348' flags='l'>
+                    <fn name='concat'>
+                     <str val='Value error see: '/>
+                     <fn name='serialize'>
+                      <slash line='4347' simple='1'>
+                       <dot type='element()'/>
+                       <axis line='4348' name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
+                      </slash>
+                     </fn>
+                     <str val='&#xA;'/>
+                    </fn>
+                   </valueOf>
+                  </forEach>
+                 </doc>
+                </fn>
+               </arrayBlock>
+              </ifCall>
+             </choose>
+            </let>
+           </let>
+          </let>
+         </let>
+        </let>
+       </let>
+      </sequence>
+     </let>
+    </let>
+   </sequence>
+  </template>
+ </co>
+ <co id='35' binds='2 54 50'>
+  <template name='Q{}xforms-rebuild' flags='os' line='4064' module='saxon-xforms.xsl' slots='2'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4065'>
+    <message>
+     <valueOf role='select'>
+      <str val='[xforms-rebuild] START'/>
+     </valueOf>
+     <str role='terminate' val='no'/>
+     <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+    </message>
+    <let line='4066' var='Q{}instanceDocs' as='map(xs:anyAtomicType, element()?)' slot='0' eval='8'>
+     <let line='4067' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
+      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+       <check card='1' diag='0|0||ixsl:call'>
+        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+       </check>
+       <str val='getInstanceKeys'/>
+       <array size='0'/>
+      </ifCall>
+      <ifCall line='4069' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+       <forEach>
+        <varRef name='Q{}instance-keys' slot='1'/>
+        <ifCall line='4071' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <atomSing diag='0|0||map:entry'>
+          <dot/>
+         </atomSing>
+         <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='0' eval='16'>
+          <fn line='4070' name='concat'>
+           <str val='instance(&#39;'/>
+           <atomSing card='?' diag='0|1||fn:concat'>
+            <dot/>
+           </atomSing>
+           <str val='&#39;)/'/>
+          </fn>
+         </ufCall>
+        </ifCall>
+       </forEach>
+       <map size='2'>
+        <str val='duplicates'/>
+        <str val='reject'/>
+        <str val='duplicates-error-code'/>
+        <str val='XTDE3365'/>
+       </map>
+      </ifCall>
+     </let>
+     <callT line='4076' name='Q{}xformsjs-main' bSlot='1' flags='t'>
+      <withParam name='Q{}xforms-file' flags='c' as='xs:string?'>
+       <gVarRef line='4077' name='Q{}xforms-file' bSlot='2'/>
+      </withParam>
+      <withParam name='Q{}instance-docs' flags='c' as='map(*)'>
+       <varRef line='4078' name='Q{}instanceDocs' slot='0'/>
+      </withParam>
+     </callT>
+    </let>
+   </sequence>
+  </template>
+ </co>
+ <co id='32' binds=''>
+  <mode name='Q{}set-field' onNo='TC' flags='W' patternSlots='0'>
+   <templateRule prec='0' prio='-0.25' seq='37' rank='0' minImp='0' slots='1' flags='s' line='2932' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='*:textarea' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;textarea&#39;'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2933'>
+     <param name='Q{}value' slot='0' flags='t'>
+      <str role='select' val=''/>
+      <supplied role='conversion' slot='0'/>
+     </param>
+     <ifCall line='2935' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+      <dot type='*:textarea'/>
+      <str val='value'/>
+     </ifCall>
+    </sequence>
+   </templateRule>
+   <templateRule prec='0' prio='-0.25' seq='36' rank='0' minImp='0' slots='1' flags='s' line='2924' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='*:select' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;select&#39;'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2925'>
+     <param name='Q{}value' slot='0' flags='t'>
+      <str role='select' val=''/>
+      <supplied role='conversion' slot='0'/>
+     </param>
+     <forEach line='2927'>
+      <filter flags='b'>
+       <axis name='child' nodeTest='element(Q{}option)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;option&#39;;'/>
+       <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+        <data>
+         <varRef name='Q{}value' slot='0'/>
+        </data>
+        <attVal name='Q{}value' chk='0'/>
+       </gc>
+      </filter>
+      <ifCall line='2928' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+       <str val='selected'/>
+       <true/>
+       <dot type='element(Q{}option)'/>
+      </ifCall>
+     </forEach>
+    </sequence>
+   </templateRule>
+   <templateRule prec='0' prio='-0.25' seq='35' rank='0' minImp='0' slots='1' flags='s' line='2903' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='*:input' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;input&#39;'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2904'>
+     <param name='Q{}value' slot='0' flags='t'>
+      <str role='select' val=''/>
+      <supplied role='conversion' slot='0'/>
+     </param>
+     <forEach line='2907'>
+      <dot type='*:input'/>
+      <choose line='2909'>
+       <and op='and'>
+        <fn name='exists'>
+         <axis name='attribute' nodeTest='attribute(Q{}type)' jsTest='return item.name===&#39;type&#39;'/>
+        </fn>
+        <vc op='eq' onEmpty='0' comp='CCC'>
+         <cast as='xs:string' emptiable='1'>
+          <attVal name='Q{}type' chk='0'/>
+         </cast>
+         <str val='checkbox'/>
+        </vc>
+       </and>
+       <ifCall line='2910' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+        <str val='checked'/>
+        <choose>
+         <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+          <data>
+           <varRef name='Q{}value' slot='0'/>
+          </data>
+          <str val='true'/>
+         </gc>
+         <check card='?' diag='0|1||ixsl:set-property'>
+          <varRef name='Q{}value' slot='0'/>
+         </check>
+         <true/>
+         <str val=''/>
+        </choose>
+        <dot type='*:input'/>
+       </ifCall>
+       <true/>
+       <ifCall line='2913' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+        <str val='value'/>
+        <check card='?' diag='0|1||ixsl:set-property'>
+         <varRef name='Q{}value' slot='0'/>
+        </check>
+        <dot type='*:input'/>
+       </ifCall>
+      </choose>
+     </forEach>
+    </sequence>
+   </templateRule>
+  </mode>
+ </co>
+ <co id='49' binds='42'>
+  <template name='Q{}refreshElementsUsingIndexFunction-JS' flags='os' line='3597' module='saxon-xforms.xsl' slots='6'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3598'>
+    <message>
+     <valueOf role='select'>
+      <str val='[refreshElementsUsingIndexFunction-JS] START'/>
+     </valueOf>
+     <str role='terminate' val='no'/>
+     <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+    </message>
+    <let line='3599' var='Q{}ElementsUsingIndexFunction-keys' as='item()?' slot='0' eval='8'>
+     <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+      <check card='1' diag='0|0||ixsl:call'>
+       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+      </check>
+      <str val='getElementsUsingIndexFunctionKeys'/>
+      <array size='0'/>
+     </ifCall>
+     <let line='3601' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
+      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+       <check card='1' diag='0|0||ixsl:call'>
+        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+       </check>
+       <str val='getInstanceKeys'/>
+       <array size='0'/>
+      </ifCall>
+      <let line='3602' var='Q{}instances' as='map(xs:string, element())' slot='2' eval='16'>
+       <treat line='3604' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances'>
+        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+         <forEach>
+          <varRef name='Q{}instance-keys' slot='1'/>
+          <ifCall line='3605' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <atomSing diag='0|0||map:entry'>
+            <dot/>
+           </atomSing>
+           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+            <check card='1' diag='0|0||ixsl:call'>
+             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+            </check>
+            <str val='getInstance'/>
+            <arrayBlock>
+             <dot/>
+            </arrayBlock>
+           </ifCall>
+          </ifCall>
+         </forEach>
+         <map size='2'>
+          <str val='duplicates'/>
+          <str val='reject'/>
+          <str val='duplicates-error-code'/>
+          <str val='XTDE3365'/>
+         </map>
+        </ifCall>
+       </treat>
+       <forEach line='3610'>
+        <varRef name='Q{}ElementsUsingIndexFunction-keys' slot='0'/>
+        <let line='3611' var='Q{}this-key' as='xs:string' slot='3' eval='16'>
+         <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|this-key'>
+          <check card='1' diag='3|0|XTTE0570|this-key'>
+           <cvUntyped to='xs:string' diag='3|0|XTTE0570|this-key'>
+            <data>
+             <dot/>
+            </data>
+           </cvUntyped>
+          </check>
+         </treat>
+         <let line='3612' var='Q{}this-element' as='element()' slot='4' eval='16'>
+          <treat as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|this-element'>
+           <check card='1' diag='3|0|XTTE0570|this-element'>
+            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+             <check card='1' diag='0|0||ixsl:call'>
+              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+             </check>
+             <str val='getElementUsingIndexFunction'/>
+             <arrayBlock>
+              <varRef name='Q{}this-key' slot='3'/>
+             </arrayBlock>
+            </ifCall>
+           </check>
+          </treat>
+          <let line='3613' var='Q{}this-element-refi' as='xs:string?' slot='5' eval='7'>
+           <choose line='3615'>
+            <fn name='exists'>
+             <slash simple='1'>
+              <varRef name='Q{}this-element' slot='4'/>
+              <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+             </slash>
+            </fn>
+            <cvUntyped to='xs:string' diag='3|0|XTTE0570|this-element-refi'>
+             <data>
+              <slash simple='1'>
+               <varRef name='Q{}this-element' slot='4'/>
+               <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+              </slash>
+             </data>
+            </cvUntyped>
+            <fn line='3616' name='exists'>
+             <slash simple='1'>
+              <varRef name='Q{}this-element' slot='4'/>
+              <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+             </slash>
+            </fn>
+            <cvUntyped line='3616' to='xs:string' diag='3|0|XTTE0570|this-element-refi'>
+             <data>
+              <slash simple='1'>
+               <varRef name='Q{}this-element' slot='4'/>
+               <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+              </slash>
+             </data>
+            </cvUntyped>
+           </choose>
+           <resultDoc line='3620' global='#&#xA;#Sat Feb 22 17:48:53 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sat Feb 22 17:48:53 GMT 2020&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xA;'>
+            <fn role='href' name='concat'>
+             <str val='#'/>
+             <varRef name='Q{}this-key' slot='3'/>
+            </fn>
+            <applyT role='content' line='3621' bSlot='0'>
+             <slash role='select' simple='1'>
+              <varRef name='Q{}this-element' slot='4'/>
+              <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+             </slash>
+             <withParam name='Q{}recalculate' as='xs:boolean'>
+              <true/>
+             </withParam>
+             <withParam name='Q{}instances' flags='t' as='map(xs:string, element())'>
+              <varRef line='3622' name='Q{}instances' slot='2'/>
+             </withParam>
+             <withParam name='Q{}nodeset' flags='t' as='xs:string?'>
+              <choose line='3623'>
+               <fn name='exists'>
+                <varRef name='Q{}this-element-refi' slot='5'/>
+               </fn>
+               <varRef name='Q{}this-element-refi' slot='5'/>
+               <true/>
+               <str val=''/>
+              </choose>
+             </withParam>
+            </applyT>
+           </resultDoc>
+          </let>
+         </let>
+        </let>
+       </forEach>
+      </let>
+     </let>
+    </let>
+   </sequence>
+  </template>
+ </co>
+ <co id='55' binds=''>
+  <globalVariable name='Q{}xforms-actions' type='xs:string+' line='95' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n&gt;=1;};'>
+   <literal count='15'>
+    <str val='setvalue'/>
+    <str val='insert'/>
+    <str val='delete'/>
+    <str val='setindex'/>
+    <str val='toggle'/>
+    <str val='setfocus'/>
+    <str val='dispatch'/>
+    <str val='rebuild'/>
+    <str val='recalculate'/>
+    <str val='revalidate'/>
+    <str val='refresh'/>
+    <str val='reset'/>
+    <str val='load'/>
+    <str val='send'/>
+    <str val='message'/>
+   </literal>
+  </globalVariable>
+ </co>
+ <co id='56' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}foo' line='90' module='xforms-function-library.xsl' eval='16' flags='pU' as='xs:boolean' slots='1'>
+   <arg name='Q{}num' as='xs:integer'/>
+   <compareToInt role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='93' op='lt' val='5'>
+    <varRef name='Q{}num' slot='0'/>
+   </compareToInt>
+  </function>
+ </co>
+ <co id='57' binds='57 3 57 57'>
+  <mode name='Q{}binding-calculation' onNo='TC' flags='W' patternSlots='0'>
+   <templateRule prec='0' prio='-0.5' seq='29' rank='0' minImp='0' slots='9' flags='s' line='2741' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2742'>
+     <param name='Q{}curPath' slot='0'>
+      <str role='select' val=''/>
+      <supplied role='conversion' slot='0'/>
+     </param>
+     <param line='2743' name='Q{}position' slot='1'>
+      <int role='select' val='0'/>
+      <supplied role='conversion' slot='1'/>
+     </param>
+     <param line='2744' name='Q{}calculationMap' slot='2' flags='ti' as='map(xs:string, xs:string)'>
+      <treat role='conversion' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|calculationMap'>
+       <check card='1' diag='8|0|XTTE0590|calculationMap'>
+        <supplied slot='2'/>
+       </check>
+      </treat>
+     </param>
+     <let line='2750' var='Q{}updatedPath' as='xs:string' slot='3' eval='16'>
+      <choose>
+       <gc op='&gt;' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+        <data>
+         <varRef name='Q{}position' slot='1'/>
+        </data>
+        <int val='0'/>
+       </gc>
+       <fn name='concat'>
+        <atomSing card='?' diag='0|0||fn:concat'>
+         <varRef name='Q{}curPath' slot='0'/>
+        </atomSing>
+        <fn name='name'>
+         <dot type='element()'/>
+        </fn>
+        <str val='['/>
+        <atomSing card='?' diag='0|3||fn:concat'>
+         <varRef name='Q{}position' slot='1'/>
+        </atomSing>
+        <str val=']'/>
+       </fn>
+       <true/>
+       <fn name='concat'>
+        <atomSing card='?' diag='0|0||fn:concat'>
+         <varRef name='Q{}curPath' slot='0'/>
+        </atomSing>
+        <fn name='name'>
+         <dot type='element()'/>
+        </fn>
+       </fn>
+      </choose>
+      <copy line='2755' flags='cin'>
+       <sequence role='content'>
+        <applyT mode='Q{}binding-calculation' bSlot='0'>
+         <axis role='select' name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+         <withParam name='Q{}curPath' as='xs:string'>
+          <fn line='2756' name='concat'>
+           <varRef name='Q{}updatedPath' slot='3'/>
+           <str val='/'/>
+          </fn>
+         </withParam>
+        </applyT>
+        <choose line='2765'>
+         <fn name='exists'>
+          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+           <varRef name='Q{}calculationMap' slot='2'/>
+           <varRef name='Q{}updatedPath' slot='3'/>
+          </ifCall>
+         </fn>
+         <evaluate line='2769' dxns=''>
+          <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='1' eval='16'>
+           <check line='2767' card='1' diag='3|0|XTTE0570|calculationXPath'>
+            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+             <varRef name='Q{}calculationMap' slot='2'/>
+             <varRef name='Q{}updatedPath' slot='3'/>
+            </ifCall>
+           </check>
+          </ufCall>
+          <dot role='cxt' type='element()'/>
+          <dot role='nsCxt' type='element()'/>
+          <str role='sa' val='no'/>
+          <map role='options' size='0'/>
+          <map role='wp' size='0'/>
+         </evaluate>
+         <true/>
+         <valueOf line='2779' flags='l'>
+          <fn name='normalize-space'>
+           <fn name='string-join'>
+            <data>
+             <axis name='child' nodeTest='text()' jsTest='return item.nodeType===3;'/>
+            </data>
+            <str val=''/>
+           </fn>
+          </fn>
+         </valueOf>
+        </choose>
+        <forEachGroup line='2784' algorithm='by'>
+         <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+         <fn role='key' name='local-name'>
+          <dot type='element()'/>
+         </fn>
+         <str role='collation' val='http://www.w3.org/2005/xpath-functions/collation/codepoint'/>
+         <let role='content' line='2786' var='Q{}updatedChildPath' as='xs:string' slot='4' eval='8'>
+          <fn name='concat'>
+           <varRef name='Q{}updatedPath' slot='3'/>
+           <str val='/'/>
+           <check card='?' diag='0|2||fn:concat'>
+            <currentGroupingKey/>
+           </check>
+          </fn>
+          <let line='2791' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='5' eval='13'>
+           <fn name='concat'>
+            <varRef name='Q{}updatedChildPath' slot='4'/>
+            <str val='['/>
+           </fn>
+           <let var='Q{}dataRefWithFilter' as='element()*' slot='6' eval='8'>
+            <filter flags='b'>
+             <slash simple='1'>
+              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
+              <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+             </slash>
+             <fn name='starts-with'>
+              <cvUntyped to='xs:string'>
+               <attVal name='Q{}data-ref' chk='0'/>
+              </cvUntyped>
+              <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='5'/>
+             </fn>
+            </filter>
+            <choose line='2794'>
+             <or op='or'>
+              <fn name='exists'>
+               <tail start='2'>
+                <currentGroup/>
+               </tail>
+              </fn>
+              <fn name='exists'>
+               <varRef name='Q{}dataRefWithFilter' slot='6'/>
+              </fn>
+             </or>
+             <let line='2797' var='Q{http://saxon.sf.net/generated-variable}v1' as='xs:string' slot='7' eval='13'>
+              <fn name='concat'>
+               <varRef name='Q{}updatedPath' slot='3'/>
+               <str val='/'/>
+              </fn>
+              <forEach line='2795'>
+               <currentGroup/>
+               <applyT line='2796' mode='Q{}binding-calculation' bSlot='2'>
+                <dot role='select'/>
+                <withParam name='Q{}curPath' as='xs:string'>
+                 <varRef line='2797' name='Q{http://saxon.sf.net/generated-variable}v1' slot='7'/>
+                </withParam>
+                <withParam name='Q{}position' as='xs:integer'>
+                 <fn line='2798' name='position'/>
+                </withParam>
+               </applyT>
+              </forEach>
+             </let>
+             <true/>
+             <let line='2806' var='Q{http://saxon.sf.net/generated-variable}v2' as='xs:string' slot='8' eval='13'>
+              <fn name='concat'>
+               <varRef name='Q{}updatedPath' slot='3'/>
+               <str val='/'/>
+              </fn>
+              <forEach line='2804'>
+               <currentGroup/>
+               <applyT line='2805' mode='Q{}binding-calculation' bSlot='3'>
+                <dot role='select'/>
+                <withParam name='Q{}curPath' as='xs:string'>
+                 <varRef line='2806' name='Q{http://saxon.sf.net/generated-variable}v2' slot='8'/>
+                </withParam>
+               </applyT>
+              </forEach>
+             </let>
+            </choose>
+           </let>
+          </let>
+         </let>
+        </forEachGroup>
+       </sequence>
+      </copy>
+     </let>
+    </sequence>
+   </templateRule>
+  </mode>
+ </co>
+ <co id='58' binds=''>
+  <globalParam name='Q{}xforms-cache-id' type='item()*' line='64' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return val;' jsCardCheck='function c() {return true;};'>
+   <str val='xforms-cache'/>
+  </globalParam>
+ </co>
+ <co id='3' binds='59'>
+  <function name='Q{http://www.w3.org/2002/xforms}impose' line='22' module='xforms-function-library.xsl' eval='8' flags='pU' as='xs:string' slots='3'>
+   <arg name='Q{}input' as='xs:string'/>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='36' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:anyAtomicType*' slot='1' eval='4'>
+    <data>
+     <gVarRef name='Q{}xform-functions' bSlot='0'/>
+    </data>
+    <let line='53' var='Q{}parts2' as='xs:string*' slot='2' eval='8'>
+     <analyzeString line='58'>
+      <fn role='select' line='33' name='string-join'>
+       <analyzeString>
+        <varRef role='select' name='Q{}input' slot='0'/>
+        <str role='regex' val='\i\c*\('/>
+        <str role='flags' val=''/>
+        <choose role='matching' line='36'>
+         <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+          <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='1'/>
+          <fn name='substring-before'>
+           <dot type='xs:string'/>
+           <str val='('/>
+          </fn>
+         </gc>
+         <fn line='37' name='concat'>
+          <str val='xforms:'/>
+          <dot type='xs:string'/>
+         </fn>
+         <true/>
+         <dot line='41' type='xs:string'/>
+        </choose>
+        <dot role='nonMatching' line='46' type='xs:string'/>
+       </analyzeString>
+      </fn>
+      <str role='regex' val='(^\s*|[^\i\c\]])/\i\c*(/)'/>
+      <str role='flags' val=''/>
+      <sequence role='matching' line='60'>
+       <fn name='regex-group'>
+        <int val='1'/>
+       </fn>
+       <fn line='61' name='regex-group'>
+        <int val='2'/>
+       </fn>
+      </sequence>
+      <dot role='nonMatching' line='64' type='xs:string'/>
+     </analyzeString>
+     <fn line='69' name='string-join'>
+      <varRef name='Q{}parts2' slot='2'/>
+     </fn>
+    </let>
+   </let>
+  </function>
+ </co>
+ <co id='59' binds=''>
+  <globalVariable name='Q{}xform-functions' type='item()+' line='20' module='xforms-function-library.xsl' visibility='PRIVATE' jsAcceptor='return val;' jsCardCheck='function c(n) {return n&gt;=1;};'>
+   <sequence ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='20'>
+    <literal count='5'>
+     <str val='instance'/>
+     <str val='index'/>
+     <str val='avg'/>
+     <str val='foo'/>
+     <str val='current-date'/>
+    </literal>
+    <slash simple='1'>
+     <treat as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='14|3|XPTY0020|'>
+      <dot flags='a'/>
+     </treat>
+     <axis name='child' nodeTest='element(Q{}random)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;random&#39;;'/>
+    </slash>
+   </sequence>
+  </globalVariable>
+ </co>
+ <co id='45' binds='43'>
+  <globalVariable name='Q{http://saxon.sf.net/generated-variable}gg893415836' type='element()*' line='4179' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='function test(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};if (test(val)) {return val;} else {throw SaxonJS.XError(&#39;Conversion failed&#39;, &#39;XTTE0590&#39;);}' jsCardCheck='function c() {return true;};'>
+   <slash ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4179' simple='1'>
+    <gVarRef name='Q{}xforms-doc' bSlot='0'/>
+    <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+   </slash>
+  </globalVariable>
+ </co>
+ <co id='52' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}check-required-fields' line='934' module='saxon-xforms.xsl' eval='8' flags='pU' as='item()*' slots='3'>
+   <arg name='Q{}instanceXML' as='element()'/>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='937' var='Q{}required-fieldsi' as='element()*' slot='1' eval='8'>
+    <filter flags='b'>
+     <slash simple='1'>
+      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
+      <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+     </slash>
+     <fn name='exists'>
+      <axis name='attribute' nodeTest='attribute(Q{}data-required)' jsTest='return item.name===&#39;data-required&#39;'/>
+     </fn>
+    </filter>
+    <forEach line='939'>
+     <varRef name='Q{}required-fieldsi' slot='1'/>
+     <let line='941' var='Q{}resulti' as='document-node()' slot='2' eval='16'>
+      <doc line='944' validation='preserve'>
+       <evaluate dxns=''>
+        <fn role='xpath' name='concat'>
+         <str val='boolean(normalize-space('/>
+         <attVal name='Q{}data-ref' chk='0'/>
+         <str val='))'/>
+         <str val='='/>
+         <attVal name='Q{}data-ref' chk='0'/>
+         <str val='/'/>
+         <attVal name='Q{}data-required' chk='0'/>
+        </fn>
+        <varRef role='cxt' name='Q{}instanceXML' slot='0'/>
+        <varRef role='nsCxt' name='Q{}instanceXML' slot='0'/>
+        <str role='sa' val='no'/>
+        <map role='options' size='0'/>
+        <map role='wp' size='0'/>
+       </evaluate>
+      </doc>
+      <choose line='950'>
+       <vc op='eq' onEmpty='0' comp='CCC'>
+        <cast as='xs:string' emptiable='0'>
+         <data>
+          <varRef name='Q{}resulti' slot='2'/>
+         </data>
+        </cast>
+        <str val='false'/>
+       </vc>
+       <dot type='element()'/>
+      </choose>
+     </let>
+    </forEach>
+   </let>
+  </function>
+ </co>
+ <co id='60' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}logToPage' line='3015' module='saxon-xforms.xsl' eval='7' flags='pU' as='empty-sequence()' slots='1'>
+   <arg name='Q{}message' as='xs:string'/>
+   <check role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='-1' card='°' diag='5|0|XTTE0780|xforms:logToPage#1'>
+    <error message='Call to xsl:result-document while in temporary output state' code='XTDE1480' isTypeErr='1'/>
+   </check>
+  </function>
+ </co>
+ <co id='27' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}index' line='97' module='xforms-function-library.xsl' eval='16' flags='pU' as='xs:integer' slots='2'>
+   <arg name='Q{}repeatID' as='xs:string'/>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='101' var='Q{}repeat-index' as='xs:double?' slot='1' eval='7'>
+    <check card='?' diag='3|0|XTTE0570|repeat-index'>
+     <convert from='xs:anyAtomicType' to='xs:double' flags='p' diag='3|0|XTTE0570|repeat-index'>
+      <cvUntyped to='xs:double' diag='3|0|XTTE0570|repeat-index'>
+       <data>
+        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+         <check card='1' diag='0|0||ixsl:call'>
+          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+         </check>
+         <str val='getRepeatIndex'/>
+         <arrayBlock>
+          <varRef name='Q{}repeatID' slot='0'/>
+         </arrayBlock>
+        </ifCall>
+       </data>
+      </cvUntyped>
+     </convert>
+    </check>
+    <choose line='104'>
+     <fn name='exists'>
+      <varRef name='Q{}repeat-index' slot='1'/>
+     </fn>
+     <check card='1' diag='5|0|XTTE0780|xforms:index#1'>
+      <cast as='xs:integer' emptiable='1'>
+       <varRef name='Q{}repeat-index' slot='1'/>
+      </cast>
+     </check>
+     <true/>
+     <int val='0'/>
+    </choose>
+   </let>
+  </function>
+ </co>
+ <co id='9' binds='9'>
+  <mode name='Q{}delete-node' onNo='TC' flags='W' patternSlots='0'>
+   <templateRule prec='0' prio='-0.5' seq='22' rank='0' minImp='0' slots='1' flags='s' line='1936' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1937'>
+     <param name='Q{}delete-node' slot='0' flags='ti' as='node()'>
+      <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|delete-node'>
+       <check card='1' diag='8|0|XTTE0590|delete-node'>
+        <supplied slot='0'/>
+       </check>
+      </treat>
+     </param>
+     <choose line='1940'>
+      <is op='is'>
+       <dot type='element()'/>
+       <varRef name='Q{}delete-node' slot='0'/>
+      </is>
+      <empty/>
+      <true/>
+      <copy line='1954' flags='cin'>
+       <sequence role='content'>
+        <copyOf flags='vc'>
+         <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+        </copyOf>
+        <applyT line='1955' mode='Q{}delete-node' bSlot='0'>
+         <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
+        </applyT>
+       </sequence>
+      </copy>
+     </choose>
+    </sequence>
+   </templateRule>
+  </mode>
+ </co>
+ <co id='15' binds=''>
+  <mode name='Q{}get-field' onNo='TC' flags='W' patternSlots='0'>
+   <templateRule prec='0' prio='-0.25' seq='34' rank='0' minImp='0' slots='0' flags='s' line='2896' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='*:textarea' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;textarea&#39;'/>
+    <ifCall role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2899' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+     <dot type='*:textarea'/>
+     <str val='value'/>
+    </ifCall>
+   </templateRule>
+   <templateRule prec='0' prio='-0.25' seq='33' rank='0' minImp='0' slots='0' flags='s' line='2891' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='*:select' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;select&#39;'/>
+    <ifCall role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2893' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+     <check card='?' diag='0|0||ixsl:get'>
+      <filter flags='b'>
+       <axis name='child' nodeTest='element(Q{}option)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;option&#39;;'/>
+       <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+        <data>
+         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+          <dot type='element(Q{}option)'/>
+          <str val='selected'/>
+         </ifCall>
+        </data>
+        <true/>
+       </gc>
+      </filter>
+     </check>
+     <str val='value'/>
+    </ifCall>
+   </templateRule>
+   <templateRule prec='0' prio='-0.25' seq='32' rank='0' minImp='0' slots='0' flags='s' line='2877' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='*:input' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;input&#39;'/>
+    <choose role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2881'>
+     <and op='and'>
+      <fn name='exists'>
+       <axis name='attribute' nodeTest='attribute(Q{}type)' jsTest='return item.name===&#39;type&#39;'/>
+      </fn>
+      <vc op='eq' onEmpty='0' comp='CCC'>
+       <cast as='xs:string' emptiable='1'>
+        <attVal name='Q{}type' chk='0'/>
+       </cast>
+       <str val='checkbox'/>
+      </vc>
+     </and>
+     <ifCall line='2882' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+      <dot type='*:input'/>
+      <str val='checked'/>
+     </ifCall>
+     <true/>
+     <ifCall line='2885' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+      <dot type='*:input'/>
+      <str val='value'/>
+     </ifCall>
+    </choose>
+   </templateRule>
+  </mode>
+ </co>
+ <co id='42' binds='54 46 61 62 63 21 64 42 42 62 63 21 42 42 42 62 63 21 3 3 42 42 42 42 62 63 21 3 64 42 62 63 21 64 62 63 64 42 42'>
+  <mode onNo='TC' flags='dW' patternSlots='0'>
+   <templateRule prec='0' prio='-0.5' seq='7' rank='0' minImp='0' slots='0' flags='s' line='1088' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='document-node()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);'/>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1089' name='Q{}xformsjs-main' bSlot='0' flags='t'>
+     <withParam name='Q{}xforms-doc' flags='c' as='document-node()'>
+      <dot line='1090' type='document-node()'/>
+     </withParam>
+     <withParam name='Q{}xFormsId' flags='c' as='xs:string'>
+      <gVarRef line='1091' name='Q{}xform-html-id' bSlot='1'/>
+     </withParam>
+    </callT>
+   </templateRule>
+   <templateRule prec='0' prio='0.5' seq='25' part='1' rank='2' minImp='0' slots='1' flags='s' line='2111' module='saxon-xforms.xsl'>
+    <p.withPredicate role='match'>
+     <p.nodeTest test='Q{http://www.w3.org/2002/xforms}*' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.uri===&#39;http://www.w3.org/2002/xforms&#39;'/>
+     <gc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2111' op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+      <literal count='15'>
+       <str val='setvalue'/>
+       <str val='insert'/>
+       <str val='delete'/>
+       <str val='setindex'/>
+       <str val='toggle'/>
+       <str val='setfocus'/>
+       <str val='dispatch'/>
+       <str val='rebuild'/>
+       <str val='recalculate'/>
+       <str val='revalidate'/>
+       <str val='refresh'/>
+       <str val='reset'/>
+       <str val='load'/>
+       <str val='send'/>
+       <str val='message'/>
+      </literal>
+      <fn name='local-name'>
+       <dot type='Q{http://www.w3.org/2002/xforms}*'/>
+      </fn>
+     </gc>
+    </p.withPredicate>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2117' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2118' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+      <check card='1' diag='3|0|XTTE0570|action-map'>
+       <callT name='Q{}setAction' bSlot='2'>
+        <withParam name='Q{}this' flags='c' as='element()'>
+         <dot line='2119' type='element()'/>
+        </withParam>
+       </callT>
+      </check>
+     </treat>
+     <varRef line='2132' name='Q{}action-map' slot='0'/>
+    </let>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='13' part='1' rank='1' minImp='0' slots='12' flags='s' line='1537' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}select)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;select&#39;;'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1538'>
+     <param name='Q{}position' slot='0' as='xs:integer'>
+      <int role='select' val='0'/>
+      <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
+       <check card='1' diag='8|0|XTTE0590|position'>
+        <cvUntyped to='xs:integer' diag='8|0|XTTE0590|position'>
+         <data>
+          <supplied slot='0'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <param line='1539' name='Q{}context-position' slot='1' as='xs:string'>
+      <str role='select' val=''/>
+      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
+       <check card='1' diag='8|0|XTTE0590|context-position'>
+        <cvUntyped to='xs:string' diag='8|0|XTTE0590|context-position'>
+         <data>
+          <supplied slot='1'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <let line='1543' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+      <choose>
+       <fn name='exists'>
+        <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+       </fn>
+       <check card='1' diag='3|0|XTTE0570|myid'>
+        <cvUntyped to='xs:string' diag='3|0|XTTE0570|myid'>
+         <attVal name='Q{}id' chk='0'/>
+        </cvUntyped>
+       </check>
+       <true/>
+       <fn name='concat'>
+        <fn name='generate-id'>
+         <dot type='element()'/>
+        </fn>
+        <str val='-'/>
+        <choose line='1541'>
+         <varRef name='Q{}context-position' slot='1'/>
+         <varRef name='Q{}context-position' slot='1'/>
+         <true/>
+         <fn name='string'>
+          <varRef name='Q{}position' slot='0'/>
+         </fn>
+        </choose>
+       </fn>
+      </choose>
+      <sequence line='1545'>
+       <choose>
+        <and op='and'>
+         <let var='Q{}this' as='element()' slot='3' eval='16'>
+          <dot type='element()'/>
+          <fn line='2990' name='exists'>
+           <sequence line='2965'>
+            <analyzeString>
+             <cvUntyped role='select' to='xs:string'>
+              <data>
+               <slash simple='1'>
+                <varRef name='Q{}this' slot='3'/>
+                <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+               </slash>
+              </data>
+             </cvUntyped>
+             <str role='regex' val='\i\c*\('/>
+             <str role='flags' val=''/>
+             <choose role='matching' line='2968'>
+              <vc op='eq' onEmpty='0' comp='CCC'>
+               <fn name='substring-before'>
+                <dot type='xs:string'/>
+                <str val='('/>
+               </fn>
+               <str val='index'/>
+              </vc>
+              <str val='i'/>
+             </choose>
+             <empty role='nonMatching'/>
+            </analyzeString>
+            <analyzeString line='2977'>
+             <cvUntyped role='select' to='xs:string'>
+              <data>
+               <slash simple='1'>
+                <varRef name='Q{}this' slot='3'/>
+                <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+               </slash>
+              </data>
+             </cvUntyped>
+             <str role='regex' val='\i\c*\('/>
+             <str role='flags' val=''/>
+             <choose role='matching' line='2980'>
+              <vc op='eq' onEmpty='0' comp='CCC'>
+               <fn name='substring-before'>
+                <dot type='xs:string'/>
+                <str val='('/>
+               </fn>
+               <str val='index'/>
+              </vc>
+              <str val='i'/>
+             </choose>
+             <empty role='nonMatching'/>
+            </analyzeString>
+           </sequence>
+          </fn>
+         </let>
+         <fn name='empty'>
+          <filter flags='b'>
+           <slash simple='1'>
+            <dot type='element()'/>
+            <axis name='ancestor' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+           </slash>
+           <let var='Q{}this' as='element()' slot='4' eval='16'>
+            <dot type='element()'/>
+            <fn line='2990' name='exists'>
+             <sequence line='2965'>
+              <analyzeString>
+               <cvUntyped role='select' to='xs:string'>
+                <data>
+                 <slash simple='1'>
+                  <varRef name='Q{}this' slot='4'/>
+                  <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+                 </slash>
+                </data>
+               </cvUntyped>
+               <str role='regex' val='\i\c*\('/>
+               <str role='flags' val=''/>
+               <choose role='matching' line='2968'>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <fn name='substring-before'>
+                  <dot type='xs:string'/>
+                  <str val='('/>
+                 </fn>
+                 <str val='index'/>
+                </vc>
+                <str val='i'/>
+               </choose>
+               <empty role='nonMatching'/>
+              </analyzeString>
+              <analyzeString line='2977'>
+               <cvUntyped role='select' to='xs:string'>
+                <data>
+                 <slash simple='1'>
+                  <varRef name='Q{}this' slot='4'/>
+                  <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+                 </slash>
+                </data>
+               </cvUntyped>
+               <str role='regex' val='\i\c*\('/>
+               <str role='flags' val=''/>
+               <choose role='matching' line='2980'>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <fn name='substring-before'>
+                  <dot type='xs:string'/>
+                  <str val='('/>
+                 </fn>
+                 <str val='index'/>
+                </vc>
+                <str val='i'/>
+               </choose>
+               <empty role='nonMatching'/>
+              </analyzeString>
+             </sequence>
+            </fn>
+           </let>
+          </filter>
+         </fn>
+        </and>
+        <ifCall line='1546' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+         <check card='1' diag='0|0||ixsl:call'>
+          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+         </check>
+         <str val='setElementUsingIndexFunction'/>
+         <arrayBlock>
+          <varRef name='Q{}myid' slot='2'/>
+          <dot type='element()'/>
+         </arrayBlock>
+        </ifCall>
+       </choose>
+       <let line='1553' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1554' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+         <check card='?' diag='3|0|XTTE0570|bindingi'>
+          <callT name='Q{}getBinding' bSlot='3'>
+           <withParam name='Q{}this' flags='c' as='element()'>
+            <dot line='1555' type='element()'/>
+           </withParam>
+          </callT>
+         </check>
+        </treat>
+        <let line='1560' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1561' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+          <check card='1' diag='3|0|XTTE0570|refi'>
+           <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
+            <data>
+             <callT name='Q{}getDataRef' bSlot='4'>
+              <withParam name='Q{}this' flags='c' as='element()'>
+               <dot line='1562' type='element()'/>
+              </withParam>
+              <withParam name='Q{}bindingi' flags='c' as='node()?'>
+               <varRef line='1563' name='Q{}bindingi' slot='5'/>
+              </withParam>
+             </callT>
+            </data>
+           </cvUntyped>
+          </check>
+         </treat>
+         <let line='1568' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
+          <treat line='1569' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+           <check card='?' diag='3|0|XTTE0570|instanceField'>
+            <callT name='Q{}getReferencedInstanceField' bSlot='5'>
+             <withParam name='Q{}refi' flags='c' as='xs:string'>
+              <varRef line='1570' name='Q{}refi' slot='6'/>
+             </withParam>
+            </callT>
+           </check>
+          </treat>
+          <let line='1575' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
+           <treat line='1576' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+            <callT name='Q{}setActions' bSlot='6'>
+             <withParam name='Q{}this' flags='c' as='element()'>
+              <dot line='1577' type='element()'/>
+             </withParam>
+             <withParam name='Q{}nodeset' flags='t' as='xs:string'>
+              <varRef line='1578' name='Q{}refi' slot='6'/>
+             </withParam>
+            </callT>
+           </treat>
+           <sequence line='1582'>
+            <choose>
+             <fn name='exists'>
+              <varRef name='Q{}actions' slot='8'/>
+             </fn>
+             <ifCall line='1583' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+              <check card='1' diag='0|0||ixsl:call'>
+               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+              </check>
+              <str val='addAction'/>
+              <arrayBlock>
+               <varRef name='Q{}myid' slot='2'/>
+               <varRef name='Q{}actions' slot='8'/>
+              </arrayBlock>
+             </ifCall>
+            </choose>
+            <elem line='1600' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+             <sequence>
+              <att name='class' flags='l'>
+               <str val='xforms-select'/>
+              </att>
+              <applyT line='1601' bSlot='7'>
+               <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
+              </applyT>
+              <elem line='1603' name='select' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+               <sequence line='1604'>
+                <let var='Q{}element' as='element()' slot='9' eval='16'>
+                 <dot type='element()'/>
+                 <let line='3056' var='Q{}class' as='xs:string?' slot='10' eval='7'>
+                  <choose line='3057'>
+                   <fn name='exists'>
+                    <slash simple='1'>
+                     <varRef name='Q{}element' slot='9'/>
+                     <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
+                    </slash>
+                   </fn>
+                   <cvUntyped line='3058' to='xs:string' diag='3|0|XTTE0570|class'>
+                    <cast as='xs:untypedAtomic' emptiable='0'>
+                     <fn name='string'>
+                      <convert from='xs:untypedAtomic' to='xs:string'>
+                       <data>
+                        <slash simple='1'>
+                         <varRef name='Q{}element' slot='9'/>
+                         <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
+                        </slash>
+                       </data>
+                      </convert>
+                     </fn>
+                    </cast>
+                   </cvUntyped>
+                  </choose>
+                  <let line='3061' var='Q{}class-mod' as='xs:string?' slot='11' eval='7'>
+                   <choose line='3063'>
+                    <fn name='exists'>
+                     <slash simple='1'>
+                      <varRef name='Q{}element' slot='9'/>
+                      <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
+                     </slash>
+                    </fn>
+                    <cvUntyped line='3064' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                     <cast as='xs:untypedAtomic' emptiable='0'>
+                      <fn name='string-join'>
+                       <sequence>
+                        <varRef name='Q{}class' slot='10'/>
+                        <str val='incremental'/>
+                       </sequence>
+                       <str val=' '/>
+                      </fn>
+                     </cast>
+                    </cvUntyped>
+                    <true/>
+                    <varRef line='3067' name='Q{}class' slot='10'/>
+                   </choose>
+                   <choose line='3071'>
+                    <fn name='exists'>
+                     <varRef name='Q{}class-mod' slot='11'/>
+                    </fn>
+                    <treat line='3072' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                     <att name='class' flags='l'>
+                      <varRef name='Q{}class-mod' slot='11'/>
+                     </att>
+                    </treat>
+                   </choose>
+                  </let>
+                 </let>
+                </let>
+                <copyOf line='1605' flags='vc'>
+                 <except op='except'>
+                  <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+                  <docOrder intra='1'>
+                   <sequence>
+                    <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
+                    <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+                    <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
+                   </sequence>
+                  </docOrder>
+                 </except>
+                </copyOf>
+                <att line='1607' name='data-ref' flags='l'>
+                 <varRef name='Q{}refi' slot='6'/>
+                </att>
+                <att line='1608' name='data-element' flags='l'>
+                 <lastOf line='1598'>
+                  <fn name='tokenize'>
+                   <varRef name='Q{}refi' slot='6'/>
+                   <str val='/'/>
+                   <str val=''/>
+                  </fn>
+                 </lastOf>
+                </att>
+                <choose line='1610'>
+                 <and op='and'>
+                  <fn name='exists'>
+                   <varRef name='Q{}bindingi' slot='5'/>
+                  </fn>
+                  <fn name='exists'>
+                   <slash simple='1'>
+                    <varRef name='Q{}bindingi' slot='5'/>
+                    <axis name='attribute' nodeTest='attribute(Q{}constraint)' jsTest='return item.name===&#39;constraint&#39;'/>
+                   </slash>
+                  </fn>
+                 </and>
+                 <att line='1611' name='data-constraint' flags='l'>
+                  <convert from='xs:untypedAtomic' to='xs:string'>
+                   <data>
+                    <slash simple='1'>
+                     <varRef name='Q{}bindingi' slot='5'/>
+                     <axis name='attribute' nodeTest='attribute(Q{}constraint)' jsTest='return item.name===&#39;constraint&#39;'/>
+                    </slash>
+                   </data>
+                  </convert>
+                 </att>
+                </choose>
+                <choose line='1614'>
+                 <vc op='eq' onEmpty='0' comp='CCC'>
+                  <fn name='local-name'>
+                   <dot type='element()'/>
+                  </fn>
+                  <str val='select'/>
+                 </vc>
+                 <sequence line='1615'>
+                  <att name='multiple' flags='l'>
+                   <str val='true'/>
+                  </att>
+                  <att line='1616' name='size' flags='l'>
+                   <convert line='1617' from='xs:integer' to='xs:string'>
+                    <fn name='count'>
+                     <axis name='descendant' nodeTest='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
+                    </fn>
+                   </convert>
+                  </att>
+                 </sequence>
+                </choose>
+                <choose line='1620'>
+                 <fn name='exists'>
+                  <varRef name='Q{}actions' slot='8'/>
+                 </fn>
+                 <att line='1621' name='data-action' flags='l'>
+                  <varRef name='Q{}myid' slot='2'/>
+                 </att>
+                </choose>
+                <applyT line='1624' bSlot='8'>
+                 <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
+                 <withParam name='Q{}selectedValue' as='xs:string'>
+                  <choose line='1589'>
+                   <fn name='exists'>
+                    <varRef name='Q{}instanceField' slot='7'/>
+                   </fn>
+                   <cvUntyped line='1590' to='xs:string' diag='3|0|XTTE0570|selectedValue'>
+                    <cast as='xs:untypedAtomic' emptiable='0'>
+                     <fn name='string'>
+                      <convert from='xs:anyAtomicType' to='xs:string'>
+                       <data>
+                        <varRef name='Q{}instanceField' slot='7'/>
+                       </data>
+                      </convert>
+                     </fn>
+                    </cast>
+                   </cvUntyped>
+                   <true/>
+                   <str val=''/>
+                  </choose>
+                 </withParam>
+                </applyT>
+               </sequence>
+              </elem>
+             </sequence>
+            </elem>
+           </sequence>
+          </let>
+         </let>
+        </let>
+       </let>
+      </sequence>
+     </let>
+    </sequence>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='25' rank='1' minImp='0' slots='1' flags='s' line='2111' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}action)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;action&#39;;'/>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2117' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2118' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+      <check card='1' diag='3|0|XTTE0570|action-map'>
+       <callT name='Q{}setAction' bSlot='2'>
+        <withParam name='Q{}this' flags='c' as='element()'>
+         <dot line='2119' type='element()'/>
+        </withParam>
+       </callT>
+      </check>
+     </treat>
+     <varRef line='2132' name='Q{}action-map' slot='0'/>
+    </let>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='19' rank='1' minImp='0' slots='15' flags='s' line='1745' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1746'>
+     <param name='Q{}position' slot='0' as='xs:integer'>
+      <int role='select' val='0'/>
+      <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
+       <check card='1' diag='8|0|XTTE0590|position'>
+        <cvUntyped to='xs:integer' diag='8|0|XTTE0590|position'>
+         <data>
+          <supplied slot='0'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <param line='1747' name='Q{}context-position' slot='1' as='xs:string'>
+      <str role='select' val=''/>
+      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
+       <check card='1' diag='8|0|XTTE0590|context-position'>
+        <cvUntyped to='xs:string' diag='8|0|XTTE0590|context-position'>
+         <data>
+          <supplied slot='1'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <param line='1748' name='Q{}recalculate' slot='2' as='xs:boolean'>
+      <false role='select'/>
+      <treat role='conversion' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='8|0|XTTE0590|recalculate'>
+       <check card='1' diag='8|0|XTTE0590|recalculate'>
+        <cvUntyped to='xs:boolean' diag='8|0|XTTE0590|recalculate'>
+         <data>
+          <supplied slot='2'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <param line='1749' name='Q{}refreshRepeats' slot='3' as='xs:boolean'>
+      <false role='select'/>
+      <treat role='conversion' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='8|0|XTTE0590|refreshRepeats'>
+       <check card='1' diag='8|0|XTTE0590|refreshRepeats'>
+        <cvUntyped to='xs:boolean' diag='8|0|XTTE0590|refreshRepeats'>
+         <data>
+          <supplied slot='3'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <let line='1753' var='Q{}myid' as='xs:string' slot='4' eval='16'>
+      <choose>
+       <fn name='exists'>
+        <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+       </fn>
+       <check card='1' diag='3|0|XTTE0570|myid'>
+        <cvUntyped to='xs:string' diag='3|0|XTTE0570|myid'>
+         <attVal name='Q{}id' chk='0'/>
+        </cvUntyped>
+       </check>
+       <true/>
+       <fn name='concat'>
+        <fn name='generate-id'>
+         <dot type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
+        </fn>
+        <str val='-'/>
+        <choose line='1751'>
+         <varRef name='Q{}context-position' slot='1'/>
+         <varRef name='Q{}context-position' slot='1'/>
+         <true/>
+         <fn name='string'>
+          <varRef name='Q{}position' slot='0'/>
+         </fn>
+        </choose>
+       </fn>
+      </choose>
+      <sequence line='1760'>
+       <choose>
+        <fn name='not'>
+         <varRef name='Q{}recalculate' slot='2'/>
+        </fn>
+        <ifCall line='1776' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+         <check card='1' diag='0|0||ixsl:call'>
+          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+         </check>
+         <str val='setRepeatIndex'/>
+         <arrayBlock>
+          <varRef name='Q{}myid' slot='4'/>
+          <choose line='1763'>
+           <fn name='empty'>
+            <axis name='attribute' nodeTest='attribute(Q{}startindex)' jsTest='return item.name===&#39;startindex&#39;'/>
+           </fn>
+           <dbl val='1'/>
+           <castable line='1766' as='xs:double' emptiable='0'>
+            <axis name='attribute' nodeTest='attribute(Q{}startindex)' jsTest='return item.name===&#39;startindex&#39;'/>
+           </castable>
+           <cvUntyped line='1767' to='xs:double' diag='3|0|XTTE0570|this-index'>
+            <convert from='xs:double' to='xs:untypedAtomic'>
+             <fn name='number'>
+              <attVal name='Q{}startindex' chk='0'/>
+             </fn>
+            </convert>
+           </cvUntyped>
+           <true/>
+           <check line='1770' card='1' diag='3|0|XTTE0570|this-index'>
+            <sequence>
+             <convert from='xs:anyAtomicType' to='xs:double' flags='p' diag='3|0|XTTE0570|this-index'>
+              <cvUntyped to='xs:double' diag='3|0|XTTE0570|this-index'>
+               <data>
+                <message>
+                 <sequence role='select'>
+                  <valueOf>
+                   <str val='[xforms:repeat] value of @startindex (&#39;'/>
+                  </valueOf>
+                  <valueOf>
+                   <convert from='xs:untypedAtomic' to='xs:string'>
+                    <attVal name='Q{}startindex' chk='0'/>
+                   </convert>
+                  </valueOf>
+                  <valueOf>
+                   <str val='&#39;) is not a number. Setting the index to &#39;1&#39;'/>
+                  </valueOf>
+                 </sequence>
+                 <str role='terminate' val='no'/>
+                 <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+                </message>
+               </data>
+              </cvUntyped>
+             </convert>
+             <dbl val='1'/>
+            </sequence>
+           </check>
+          </choose>
+         </arrayBlock>
+        </ifCall>
+       </choose>
+       <let line='1783' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1784' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+         <check card='?' diag='3|0|XTTE0570|bindingi'>
+          <callT name='Q{}getBinding' bSlot='9'>
+           <withParam name='Q{}this' flags='c' as='element()'>
+            <dot line='1785' type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
+           </withParam>
+          </callT>
+         </check>
+        </treat>
+        <let line='1790' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1791' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+          <check card='1' diag='3|0|XTTE0570|refi'>
+           <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
+            <data>
+             <callT name='Q{}getDataRef' bSlot='10'>
+              <withParam name='Q{}this' flags='c' as='element()'>
+               <dot line='1792' type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
+              </withParam>
+              <withParam name='Q{}bindingi' flags='c' as='node()?'>
+               <varRef line='1793' name='Q{}bindingi' slot='5'/>
+              </withParam>
+             </callT>
+            </data>
+           </cvUntyped>
+          </check>
+         </treat>
+         <let line='1799' var='Q{}selectedRepeatVar' as='element()*' slot='7' eval='8'>
+          <treat line='1801' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|selectedRepeatVar'>
+           <callT name='Q{}getReferencedInstanceField' bSlot='11'>
+            <withParam name='Q{}refi' flags='c' as='xs:string'>
+             <varRef line='1802' name='Q{}refi' slot='6'/>
+            </withParam>
+           </callT>
+          </treat>
+          <let line='1817' var='Q{}repeat-items' as='element(Q{}div, Q{http://www.w3.org/2001/XMLSchema}untyped)*' slot='8' eval='3'>
+           <let line='1818' var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}repeat)' slot='9' eval='16'>
+            <dot type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
+            <let line='1823' var='Q{http://saxon.sf.net/generated-variable}v0' as='element()*' slot='10' eval='4'>
+             <slash simple='1'>
+              <varRef name='Q{}this' slot='9'/>
+              <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+             </slash>
+             <forEach line='1819'>
+              <varRef name='Q{}selectedRepeatVar' slot='7'/>
+              <let line='1820' var='Q{}string-position' as='xs:string' slot='11' eval='8'>
+               <fn name='string'>
+                <fn name='position'/>
+               </fn>
+               <elem line='1822' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+                <sequence>
+                 <att name='data-repeat-item' flags='l'>
+                  <str val='true'/>
+                 </att>
+                 <applyT line='1823' bSlot='12'>
+                  <varRef role='select' name='Q{http://saxon.sf.net/generated-variable}v0' slot='10'/>
+                  <withParam name='Q{}position' as='xs:integer'>
+                   <fn line='1825' name='position'/>
+                  </withParam>
+                  <withParam name='Q{}context-position' as='xs:string'>
+                   <choose line='1821'>
+                    <varRef name='Q{}context-position' slot='1'/>
+                    <fn name='concat'>
+                     <varRef name='Q{}context-position' slot='1'/>
+                     <str val='.'/>
+                     <varRef name='Q{}string-position' slot='11'/>
+                    </fn>
+                    <true/>
+                    <varRef name='Q{}string-position' slot='11'/>
+                   </choose>
+                  </withParam>
+                  <withParam name='Q{}nodeset' flags='t' as='xs:string'>
+                   <fn line='1824' name='concat'>
+                    <varRef name='Q{}refi' slot='6'/>
+                    <str val='['/>
+                    <fn name='position'/>
+                    <str val=']'/>
+                   </fn>
+                  </withParam>
+                 </applyT>
+                </sequence>
+               </elem>
+              </let>
+             </forEach>
+            </let>
+           </let>
+           <sequence line='1834'>
+            <choose>
+             <varRef name='Q{}refreshRepeats' slot='3'/>
+             <varRef line='1835' name='Q{}repeat-items' slot='8'/>
+             <true/>
+             <elem line='1838' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+              <sequence line='1839'>
+               <let var='Q{}element' as='element(Q{http://www.w3.org/2002/xforms}repeat)' slot='12' eval='16'>
+                <dot type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
+                <let line='3056' var='Q{}class' as='xs:string?' slot='13' eval='7'>
+                 <choose line='3057'>
+                  <fn name='exists'>
+                   <slash simple='1'>
+                    <varRef name='Q{}element' slot='12'/>
+                    <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
+                   </slash>
+                  </fn>
+                  <cvUntyped line='3058' to='xs:string' diag='3|0|XTTE0570|class'>
+                   <cast as='xs:untypedAtomic' emptiable='0'>
+                    <fn name='string'>
+                     <convert from='xs:untypedAtomic' to='xs:string'>
+                      <data>
+                       <slash simple='1'>
+                        <varRef name='Q{}element' slot='12'/>
+                        <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
+                       </slash>
+                      </data>
+                     </convert>
+                    </fn>
+                   </cast>
+                  </cvUntyped>
+                 </choose>
+                 <let line='3061' var='Q{}class-mod' as='xs:string?' slot='14' eval='7'>
+                  <choose line='3063'>
+                   <fn name='exists'>
+                    <slash simple='1'>
+                     <varRef name='Q{}element' slot='12'/>
+                     <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
+                    </slash>
+                   </fn>
+                   <cvUntyped line='3064' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                    <cast as='xs:untypedAtomic' emptiable='0'>
+                     <fn name='string-join'>
+                      <sequence>
+                       <varRef name='Q{}class' slot='13'/>
+                       <str val='incremental'/>
+                      </sequence>
+                      <str val=' '/>
+                     </fn>
+                    </cast>
+                   </cvUntyped>
+                   <true/>
+                   <varRef line='3067' name='Q{}class' slot='13'/>
+                  </choose>
+                  <choose line='3071'>
+                   <fn name='exists'>
+                    <varRef name='Q{}class-mod' slot='14'/>
+                   </fn>
+                   <treat line='3072' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                    <att name='class' flags='l'>
+                     <varRef name='Q{}class-mod' slot='14'/>
+                    </att>
+                   </treat>
+                  </choose>
+                 </let>
+                </let>
+               </let>
+               <att line='1841' name='data-repeatable-context' flags='l'>
+                <varRef name='Q{}refi' slot='6'/>
+               </att>
+               <att line='1842' name='data-count' flags='l'>
+                <convert from='xs:integer' to='xs:string'>
+                 <fn name='count'>
+                  <varRef name='Q{}selectedRepeatVar' slot='7'/>
+                 </fn>
+                </convert>
+               </att>
+               <att line='1843' name='id' flags='l'>
+                <varRef name='Q{}myid' slot='4'/>
+               </att>
+               <varRef line='1845' name='Q{}repeat-items' slot='8'/>
+              </sequence>
+             </elem>
+            </choose>
+            <choose line='1853'>
+             <and op='and'>
+              <fn name='not'>
+               <varRef name='Q{}recalculate' slot='2'/>
+              </fn>
+              <fn name='empty'>
+               <slash simple='1'>
+                <dot type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
+                <axis name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
+               </slash>
+              </fn>
+             </and>
+             <sequence line='1855'>
+              <message>
+               <fn role='select' name='concat'>
+                <str val='[xforms:repeat] Registering repeat with ID '/>
+                <varRef name='Q{}myid' slot='4'/>
+                <str val=' and parsed nodeset '/>
+                <varRef name='Q{}refi' slot='6'/>
+               </fn>
+               <str role='terminate' val='no'/>
+               <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+              </message>
+              <ifCall line='1857' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+               <check card='1' diag='0|0||ixsl:call'>
+                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+               </check>
+               <str val='addRepeat'/>
+               <arrayBlock>
+                <varRef name='Q{}myid' slot='4'/>
+                <varRef name='Q{}refi' slot='6'/>
+               </arrayBlock>
+              </ifCall>
+             </sequence>
+            </choose>
+            <ifCall line='1861' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+             <check card='1' diag='0|0||ixsl:call'>
+              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+             </check>
+             <str val='setRepeatSize'/>
+             <arrayBlock>
+              <varRef name='Q{}myid' slot='4'/>
+              <fn name='count'>
+               <varRef name='Q{}selectedRepeatVar' slot='7'/>
+              </fn>
+             </arrayBlock>
+            </ifCall>
+           </sequence>
+          </let>
+         </let>
+        </let>
+       </let>
+      </sequence>
+     </let>
+    </sequence>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='18' rank='1' minImp='0' slots='6' flags='s' line='1701' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}group)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;group&#39;;'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1702'>
+     <param name='Q{}position' slot='0' as='xs:integer'>
+      <int role='select' val='0'/>
+      <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
+       <check card='1' diag='8|0|XTTE0590|position'>
+        <cvUntyped to='xs:integer' diag='8|0|XTTE0590|position'>
+         <data>
+          <supplied slot='0'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <param line='1703' name='Q{}context-position' slot='1' as='xs:string'>
+      <str role='select' val=''/>
+      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
+       <check card='1' diag='8|0|XTTE0590|context-position'>
+        <cvUntyped to='xs:string' diag='8|0|XTTE0590|context-position'>
+         <data>
+          <supplied slot='1'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <let line='1707' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+      <choose>
+       <fn name='exists'>
+        <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+       </fn>
+       <check card='1' diag='3|0|XTTE0570|myid'>
+        <cvUntyped to='xs:string' diag='3|0|XTTE0570|myid'>
+         <attVal name='Q{}id' chk='0'/>
+        </cvUntyped>
+       </check>
+       <true/>
+       <fn name='concat'>
+        <fn name='generate-id'>
+         <dot type='element(Q{http://www.w3.org/2002/xforms}group)'/>
+        </fn>
+        <str val='-'/>
+        <choose line='1705'>
+         <varRef name='Q{}context-position' slot='1'/>
+         <varRef name='Q{}context-position' slot='1'/>
+         <true/>
+         <fn name='string'>
+          <varRef name='Q{}position' slot='0'/>
+         </fn>
+        </choose>
+       </fn>
+      </choose>
+      <sequence line='1709'>
+       <choose>
+        <and op='and'>
+         <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}group)' slot='3' eval='16'>
+          <dot type='element(Q{http://www.w3.org/2002/xforms}group)'/>
+          <fn line='2990' name='exists'>
+           <sequence line='2965'>
+            <analyzeString>
+             <cvUntyped role='select' to='xs:string'>
+              <data>
+               <slash simple='1'>
+                <varRef name='Q{}this' slot='3'/>
+                <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+               </slash>
+              </data>
+             </cvUntyped>
+             <str role='regex' val='\i\c*\('/>
+             <str role='flags' val=''/>
+             <choose role='matching' line='2968'>
+              <vc op='eq' onEmpty='0' comp='CCC'>
+               <fn name='substring-before'>
+                <dot type='xs:string'/>
+                <str val='('/>
+               </fn>
+               <str val='index'/>
+              </vc>
+              <str val='i'/>
+             </choose>
+             <empty role='nonMatching'/>
+            </analyzeString>
+            <analyzeString line='2977'>
+             <cvUntyped role='select' to='xs:string'>
+              <data>
+               <slash simple='1'>
+                <varRef name='Q{}this' slot='3'/>
+                <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+               </slash>
+              </data>
+             </cvUntyped>
+             <str role='regex' val='\i\c*\('/>
+             <str role='flags' val=''/>
+             <choose role='matching' line='2980'>
+              <vc op='eq' onEmpty='0' comp='CCC'>
+               <fn name='substring-before'>
+                <dot type='xs:string'/>
+                <str val='('/>
+               </fn>
+               <str val='index'/>
+              </vc>
+              <str val='i'/>
+             </choose>
+             <empty role='nonMatching'/>
+            </analyzeString>
+           </sequence>
+          </fn>
+         </let>
+         <fn name='empty'>
+          <filter flags='b'>
+           <slash simple='1'>
+            <dot type='element(Q{http://www.w3.org/2002/xforms}group)'/>
+            <axis name='ancestor' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+           </slash>
+           <let var='Q{}this' as='element()' slot='4' eval='16'>
+            <dot type='element()'/>
+            <fn line='2990' name='exists'>
+             <sequence line='2965'>
+              <analyzeString>
+               <cvUntyped role='select' to='xs:string'>
+                <data>
+                 <slash simple='1'>
+                  <varRef name='Q{}this' slot='4'/>
+                  <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+                 </slash>
+                </data>
+               </cvUntyped>
+               <str role='regex' val='\i\c*\('/>
+               <str role='flags' val=''/>
+               <choose role='matching' line='2968'>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <fn name='substring-before'>
+                  <dot type='xs:string'/>
+                  <str val='('/>
+                 </fn>
+                 <str val='index'/>
+                </vc>
+                <str val='i'/>
+               </choose>
+               <empty role='nonMatching'/>
+              </analyzeString>
+              <analyzeString line='2977'>
+               <cvUntyped role='select' to='xs:string'>
+                <data>
+                 <slash simple='1'>
+                  <varRef name='Q{}this' slot='4'/>
+                  <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+                 </slash>
+                </data>
+               </cvUntyped>
+               <str role='regex' val='\i\c*\('/>
+               <str role='flags' val=''/>
+               <choose role='matching' line='2980'>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <fn name='substring-before'>
+                  <dot type='xs:string'/>
+                  <str val='('/>
+                 </fn>
+                 <str val='index'/>
+                </vc>
+                <str val='i'/>
+               </choose>
+               <empty role='nonMatching'/>
+              </analyzeString>
+             </sequence>
+            </fn>
+           </let>
+          </filter>
+         </fn>
+        </and>
+        <ifCall line='1710' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+         <check card='1' diag='0|0||ixsl:call'>
+          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+         </check>
+         <str val='setElementUsingIndexFunction'/>
+         <arrayBlock>
+          <varRef name='Q{}myid' slot='2'/>
+          <dot type='element(Q{http://www.w3.org/2002/xforms}group)'/>
+         </arrayBlock>
+        </ifCall>
+       </choose>
+       <let line='1713' var='Q{}refi' as='xs:string?' slot='5' eval='7'>
+        <choose line='1715'>
+         <fn name='exists'>
+          <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+         </fn>
+         <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
+          <attVal name='Q{}nodeset' chk='0'/>
+         </cvUntyped>
+         <fn line='1716' name='exists'>
+          <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+         </fn>
+         <cvUntyped line='1716' to='xs:string' diag='3|0|XTTE0570|refi'>
+          <attVal name='Q{}ref' chk='0'/>
+         </cvUntyped>
+        </choose>
+        <elem line='1722' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+         <sequence line='1723'>
+          <att name='id' flags='l'>
+           <varRef name='Q{}myid' slot='2'/>
+          </att>
+          <choose line='1724'>
+           <fn name='exists'>
+            <varRef name='Q{}refi' slot='5'/>
+           </fn>
+           <att line='1725' name='data-group-ref' flags='l'>
+            <varRef name='Q{}refi' slot='5'/>
+           </att>
+          </choose>
+          <applyT line='1727' bSlot='13'>
+           <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+           <withParam name='Q{}nodeset' flags='t' as='xs:string?'>
+            <choose line='1728'>
+             <fn name='exists'>
+              <varRef name='Q{}refi' slot='5'/>
+             </fn>
+             <varRef name='Q{}refi' slot='5'/>
+             <true/>
+             <str val=''/>
+            </choose>
+           </withParam>
+          </applyT>
+         </sequence>
+        </elem>
+       </let>
+      </sequence>
+     </let>
+    </sequence>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='8' rank='1' minImp='0' slots='0' flags='s' line='1105' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/1999/xhtml}html)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/1999/xhtml&#39;&amp;&amp;q.local===&#39;html&#39;;'/>
+    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1106' name='html' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+     <sequence line='1107'>
+      <copyOf flags='vc'>
+       <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+      </copyOf>
+      <elem line='1108' name='head' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+       <sequence line='1109'>
+        <copyOf flags='vc'>
+         <union op='|'>
+          <slash simple='2'>
+           <axis name='child' nodeTest='element(Q{http://www.w3.org/1999/xhtml}head)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/1999/xhtml&#39;&amp;&amp;q.local===&#39;head&#39;;'/>
+           <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+          </slash>
+          <slash simple='2'>
+           <axis name='child' nodeTest='element(Q{}head)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;head&#39;;'/>
+           <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+          </slash>
+         </union>
+        </copyOf>
+        <elem line='1110' name='meta' nsuri='' flags='l'>
+         <sequence>
+          <att name='http-equiv' flags='l'>
+           <str val='Content-Type'/>
+          </att>
+          <att name='content' flags='l'>
+           <str val='text/html;charset=utf-8'/>
+          </att>
+         </sequence>
+        </elem>
+        <forEach line='1112'>
+         <union op='|'>
+          <filter flags='b'>
+           <slash simple='2'>
+            <axis name='child' nodeTest='element(Q{http://www.w3.org/1999/xhtml}head)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/1999/xhtml&#39;&amp;&amp;q.local===&#39;head&#39;;'/>
+            <axis name='child' nodeTest='element(Q{http://www.w3.org/1999/xhtml}meta)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/1999/xhtml&#39;&amp;&amp;q.local===&#39;meta&#39;;'/>
+           </slash>
+           <vc op='ne' onEmpty='0' comp='CCC'>
+            <fn name='string'>
+             <axis name='attribute' nodeTest='attribute(Q{}http-equiv)' jsTest='return item.name===&#39;http-equiv&#39;'/>
+            </fn>
+            <str val='Content-Type'/>
+           </vc>
+          </filter>
+          <filter flags='b'>
+           <slash simple='2'>
+            <axis name='child' nodeTest='element(Q{}head)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;head&#39;;'/>
+            <axis name='child' nodeTest='element(Q{}meta)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;meta&#39;;'/>
+           </slash>
+           <vc op='ne' onEmpty='0' comp='CCC'>
+            <fn name='string'>
+             <axis name='attribute' nodeTest='attribute(Q{}http-equiv)' jsTest='return item.name===&#39;http-equiv&#39;'/>
+            </fn>
+            <str val='Content-Type'/>
+           </vc>
+          </filter>
+         </union>
+         <elem line='1113' name='meta' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+          <copyOf line='1114' flags='vc'>
+           <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+          </copyOf>
+         </elem>
+        </forEach>
+        <copyOf line='1119' flags='vc'>
+         <axis name='child' nodeTest='element(Q{}script)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;script&#39;;'/>
+        </copyOf>
+       </sequence>
+      </elem>
+      <elem line='1121' name='body' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+       <applyT line='1122' bSlot='14'>
+        <slash role='select' simple='2'>
+         <axis name='child' nodeTest='element(Q{}body)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;body&#39;;'/>
+         <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+        </slash>
+       </applyT>
+      </elem>
+     </sequence>
+    </elem>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='9' rank='1' minImp='0' slots='15' flags='s' line='1137' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}output)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;output&#39;;'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1138'>
+     <param name='Q{}position' slot='0' as='xs:integer'>
+      <int role='select' val='0'/>
+      <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
+       <check card='1' diag='8|0|XTTE0590|position'>
+        <cvUntyped to='xs:integer' diag='8|0|XTTE0590|position'>
+         <data>
+          <supplied slot='0'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <param line='1139' name='Q{}context-position' slot='1' as='xs:string'>
+      <str role='select' val=''/>
+      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
+       <check card='1' diag='8|0|XTTE0590|context-position'>
+        <cvUntyped to='xs:string' diag='8|0|XTTE0590|context-position'>
+         <data>
+          <supplied slot='1'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <let line='1143' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+      <choose>
+       <fn name='exists'>
+        <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+       </fn>
+       <check card='1' diag='3|0|XTTE0570|myid'>
+        <cvUntyped to='xs:string' diag='3|0|XTTE0570|myid'>
+         <attVal name='Q{}id' chk='0'/>
+        </cvUntyped>
+       </check>
+       <true/>
+       <fn name='concat'>
+        <fn name='generate-id'>
+         <dot type='element(Q{http://www.w3.org/2002/xforms}output)'/>
+        </fn>
+        <str val='-'/>
+        <choose line='1141'>
+         <varRef name='Q{}context-position' slot='1'/>
+         <varRef name='Q{}context-position' slot='1'/>
+         <true/>
+         <fn name='string'>
+          <varRef name='Q{}position' slot='0'/>
+         </fn>
+        </choose>
+       </fn>
+      </choose>
+      <sequence line='1145'>
+       <choose>
+        <and op='and'>
+         <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}output)' slot='3' eval='16'>
+          <dot type='element(Q{http://www.w3.org/2002/xforms}output)'/>
+          <fn line='2990' name='exists'>
+           <sequence line='2965'>
+            <analyzeString>
+             <cvUntyped role='select' to='xs:string'>
+              <data>
+               <slash simple='1'>
+                <varRef name='Q{}this' slot='3'/>
+                <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+               </slash>
+              </data>
+             </cvUntyped>
+             <str role='regex' val='\i\c*\('/>
+             <str role='flags' val=''/>
+             <choose role='matching' line='2968'>
+              <vc op='eq' onEmpty='0' comp='CCC'>
+               <fn name='substring-before'>
+                <dot type='xs:string'/>
+                <str val='('/>
+               </fn>
+               <str val='index'/>
+              </vc>
+              <str val='i'/>
+             </choose>
+             <empty role='nonMatching'/>
+            </analyzeString>
+            <analyzeString line='2977'>
+             <cvUntyped role='select' to='xs:string'>
+              <data>
+               <slash simple='1'>
+                <varRef name='Q{}this' slot='3'/>
+                <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+               </slash>
+              </data>
+             </cvUntyped>
+             <str role='regex' val='\i\c*\('/>
+             <str role='flags' val=''/>
+             <choose role='matching' line='2980'>
+              <vc op='eq' onEmpty='0' comp='CCC'>
+               <fn name='substring-before'>
+                <dot type='xs:string'/>
+                <str val='('/>
+               </fn>
+               <str val='index'/>
+              </vc>
+              <str val='i'/>
+             </choose>
+             <empty role='nonMatching'/>
+            </analyzeString>
+           </sequence>
+          </fn>
+         </let>
+         <fn name='empty'>
+          <filter flags='b'>
+           <slash simple='1'>
+            <dot type='element(Q{http://www.w3.org/2002/xforms}output)'/>
+            <axis name='ancestor' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+           </slash>
+           <let var='Q{}this' as='element()' slot='4' eval='16'>
+            <dot type='element()'/>
+            <fn line='2990' name='exists'>
+             <sequence line='2965'>
+              <analyzeString>
+               <cvUntyped role='select' to='xs:string'>
+                <data>
+                 <slash simple='1'>
+                  <varRef name='Q{}this' slot='4'/>
+                  <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+                 </slash>
+                </data>
+               </cvUntyped>
+               <str role='regex' val='\i\c*\('/>
+               <str role='flags' val=''/>
+               <choose role='matching' line='2968'>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <fn name='substring-before'>
+                  <dot type='xs:string'/>
+                  <str val='('/>
+                 </fn>
+                 <str val='index'/>
+                </vc>
+                <str val='i'/>
+               </choose>
+               <empty role='nonMatching'/>
+              </analyzeString>
+              <analyzeString line='2977'>
+               <cvUntyped role='select' to='xs:string'>
+                <data>
+                 <slash simple='1'>
+                  <varRef name='Q{}this' slot='4'/>
+                  <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+                 </slash>
+                </data>
+               </cvUntyped>
+               <str role='regex' val='\i\c*\('/>
+               <str role='flags' val=''/>
+               <choose role='matching' line='2980'>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <fn name='substring-before'>
+                  <dot type='xs:string'/>
+                  <str val='('/>
+                 </fn>
+                 <str val='index'/>
+                </vc>
+                <str val='i'/>
+               </choose>
+               <empty role='nonMatching'/>
+              </analyzeString>
+             </sequence>
+            </fn>
+           </let>
+          </filter>
+         </fn>
+        </and>
+        <ifCall line='1146' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+         <check card='1' diag='0|0||ixsl:call'>
+          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+         </check>
+         <str val='setElementUsingIndexFunction'/>
+         <arrayBlock>
+          <varRef name='Q{}myid' slot='2'/>
+          <dot type='element(Q{http://www.w3.org/2002/xforms}output)'/>
+         </arrayBlock>
+        </ifCall>
+       </choose>
+       <let line='1151' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1152' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+         <check card='?' diag='3|0|XTTE0570|bindingi'>
+          <callT name='Q{}getBinding' bSlot='15'>
+           <withParam name='Q{}this' flags='c' as='element()'>
+            <dot line='1153' type='element(Q{http://www.w3.org/2002/xforms}output)'/>
+           </withParam>
+          </callT>
+         </check>
+        </treat>
+        <let line='1158' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1159' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+          <check card='1' diag='3|0|XTTE0570|refi'>
+           <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
+            <data>
+             <callT name='Q{}getDataRef' bSlot='16'>
+              <withParam name='Q{}this' flags='c' as='element()'>
+               <dot line='1160' type='element(Q{http://www.w3.org/2002/xforms}output)'/>
+              </withParam>
+              <withParam name='Q{}bindingi' flags='c' as='node()?'>
+               <varRef line='1161' name='Q{}bindingi' slot='5'/>
+              </withParam>
+             </callT>
+            </data>
+           </cvUntyped>
+          </check>
+         </treat>
+         <let line='1166' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
+          <treat line='1167' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+           <check card='?' diag='3|0|XTTE0570|instanceField'>
+            <callT name='Q{}getReferencedInstanceField' bSlot='17'>
+             <withParam name='Q{}refi' flags='c' as='xs:string'>
+              <varRef line='1168' name='Q{}refi' slot='6'/>
+             </withParam>
+            </callT>
+           </check>
+          </treat>
+          <let line='1179' var='Q{}namespace-context-item' as='element()' slot='8' eval='16'>
+           <choose>
+            <fn name='exists'>
+             <varRef name='Q{}instanceField' slot='7'/>
+            </fn>
+            <choose>
+             <fn name='exists'>
+              <filter flags='b'>
+               <varRef name='Q{}instanceField' slot='7'/>
+               <fn name='exists'>
+                <axis name='self' nodeTest='text()' jsTest='return item.nodeType===3;'/>
+               </fn>
+              </filter>
+             </fn>
+             <check card='1' diag='3|0|XTTE0570|namespace-context-item'>
+              <slash simple='1'>
+               <varRef name='Q{}instanceField' slot='7'/>
+               <axis name='parent' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+              </slash>
+             </check>
+             <true/>
+             <treat as='element()' jsTest='return item.nodeType===1;' diag='3|0|XTTE0570|namespace-context-item'>
+              <check card='1' diag='3|0|XTTE0570|namespace-context-item'>
+               <varRef name='Q{}instanceField' slot='7'/>
+              </check>
+             </treat>
+            </choose>
+            <true/>
+            <let var='Q{}this' as='element()' slot='9' eval='16'>
+             <check card='1' diag='0|0||xforms:addNamespaceDeclarations'>
+              <slash simple='1'>
+               <root/>
+               <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+              </slash>
+             </check>
+             <compElem line='3000'>
+              <fn role='name' name='name'>
+               <varRef name='Q{}this' slot='9'/>
+              </fn>
+              <sequence role='content' line='3001'>
+               <namespace flags='l'>
+                <str role='name' val='xforms'/>
+                <str role='select' val='http://www.w3.org/2002/xforms'/>
+               </namespace>
+               <forEach line='3002'>
+                <filter flags='b'>
+                 <filter flags='b'>
+                  <slash simple='1'>
+                   <varRef name='Q{}this' slot='9'/>
+                   <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+                  </slash>
+                  <fn name='boolean'>
+                   <fn name='namespace-uri'>
+                    <dot type='element()'/>
+                   </fn>
+                  </fn>
+                 </filter>
+                 <fn name='not'>
+                  <gc op='=' card='N:1' comp='CCC'>
+                   <sequence>
+                    <slash>
+                     <fn name='reverse'>
+                      <axis name='ancestor' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+                     </fn>
+                     <fn name='namespace-uri'>
+                      <dot type='element()'/>
+                     </fn>
+                    </slash>
+                    <slash>
+                     <fn name='reverse'>
+                      <axis name='preceding' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+                     </fn>
+                     <fn name='namespace-uri'>
+                      <dot type='element()'/>
+                     </fn>
+                    </slash>
+                   </sequence>
+                   <fn name='namespace-uri'>
+                    <dot type='element()'/>
+                   </fn>
+                  </gc>
+                 </fn>
+                </filter>
+                <namespace line='3005' flags='l'>
+                 <fn role='name' line='3004' name='substring-before'>
+                  <fn name='name'>
+                   <dot type='element()'/>
+                  </fn>
+                  <str val=':'/>
+                 </fn>
+                 <convert role='select' from='xs:anyURI' to='xs:string'>
+                  <fn line='3003' name='namespace-uri'>
+                   <dot type='element()'/>
+                  </fn>
+                 </convert>
+                </namespace>
+               </forEach>
+               <copyOf line='3007' flags='vc'>
+                <sequence>
+                 <slash simple='1'>
+                  <varRef name='Q{}this' slot='9'/>
+                  <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+                 </slash>
+                 <slash simple='1'>
+                  <varRef name='Q{}this' slot='9'/>
+                  <axis name='child' nodeTest='( element() | text() | comment() | processing-instruction() )' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);'/>
+                 </slash>
+                </sequence>
+               </copyOf>
+              </sequence>
+             </compElem>
+            </let>
+           </choose>
+           <let line='1181' var='Q{}valueExecuted' as='xs:string' slot='10' eval='16'>
+            <choose line='1183'>
+             <fn name='exists'>
+              <axis name='attribute' nodeTest='attribute(Q{}value)' jsTest='return item.name===&#39;value&#39;'/>
+             </fn>
+             <evaluate line='1184' as='xs:string' dxns=''>
+              <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='18' eval='16'>
+               <check card='1' diag='0|0||xforms:impose'>
+                <cvUntyped to='xs:string'>
+                 <attVal name='Q{}value' chk='0'/>
+                </cvUntyped>
+               </check>
+              </ufCall>
+              <varRef role='cxt' name='Q{}instanceField' slot='7'/>
+              <varRef role='nsCxt' name='Q{}namespace-context-item' slot='8'/>
+              <str role='sa' val='no'/>
+              <map role='options' size='0'/>
+              <map role='wp' size='0'/>
+             </evaluate>
+             <true/>
+             <cvUntyped line='1187' to='xs:string' diag='3|0|XTTE0570|valueExecuted'>
+              <cast as='xs:untypedAtomic' emptiable='0'>
+               <fn name='string'>
+                <convert from='xs:anyAtomicType' to='xs:string'>
+                 <data>
+                  <varRef name='Q{}instanceField' slot='7'/>
+                 </data>
+                </convert>
+               </fn>
+              </cast>
+             </cvUntyped>
+            </choose>
+            <let line='1193' var='Q{}relevantVar' as='xs:boolean' slot='11' eval='16'>
+             <choose line='1195'>
+              <and op='and'>
+               <and op='and'>
+                <fn name='exists'>
+                 <varRef name='Q{}bindingi' slot='5'/>
+                </fn>
+                <fn name='exists'>
+                 <slash simple='1'>
+                  <varRef name='Q{}bindingi' slot='5'/>
+                  <axis name='attribute' nodeTest='attribute(Q{}relevant)' jsTest='return item.name===&#39;relevant&#39;'/>
+                 </slash>
+                </fn>
+               </and>
+               <fn name='exists'>
+                <varRef name='Q{}instanceField' slot='7'/>
+               </fn>
+              </and>
+              <treat line='1196' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantVar'>
+               <check card='1' diag='3|0|XTTE0570|relevantVar'>
+                <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|relevantVar'>
+                 <data>
+                  <evaluate dxns=''>
+                   <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='19' eval='16'>
+                    <check card='1' diag='0|0||xforms:impose'>
+                     <cvUntyped to='xs:string'>
+                      <data>
+                       <slash simple='1'>
+                        <varRef name='Q{}bindingi' slot='5'/>
+                        <axis name='attribute' nodeTest='attribute(Q{}relevant)' jsTest='return item.name===&#39;relevant&#39;'/>
+                       </slash>
+                      </data>
+                     </cvUntyped>
+                    </check>
+                   </ufCall>
+                   <varRef role='cxt' name='Q{}instanceField' slot='7'/>
+                   <varRef role='nsCxt' name='Q{}namespace-context-item' slot='8'/>
+                   <str role='sa' val='no'/>
+                   <map role='options' size='0'/>
+                   <map role='wp' size='0'/>
+                  </evaluate>
+                 </data>
+                </cvUntyped>
+               </check>
+              </treat>
+              <true/>
+              <true/>
+             </choose>
+             <sequence line='1207'>
+              <elem name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+               <sequence line='1208'>
+                <let var='Q{}element' as='element(Q{http://www.w3.org/2002/xforms}output)' slot='12' eval='16'>
+                 <dot type='element(Q{http://www.w3.org/2002/xforms}output)'/>
+                 <let line='3056' var='Q{}class' as='xs:string?' slot='13' eval='7'>
+                  <choose line='3057'>
+                   <fn name='exists'>
+                    <slash simple='1'>
+                     <varRef name='Q{}element' slot='12'/>
+                     <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
+                    </slash>
+                   </fn>
+                   <cvUntyped line='3058' to='xs:string' diag='3|0|XTTE0570|class'>
+                    <cast as='xs:untypedAtomic' emptiable='0'>
+                     <fn name='string'>
+                      <convert from='xs:untypedAtomic' to='xs:string'>
+                       <data>
+                        <slash simple='1'>
+                         <varRef name='Q{}element' slot='12'/>
+                         <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
+                        </slash>
+                       </data>
+                      </convert>
+                     </fn>
+                    </cast>
+                   </cvUntyped>
+                  </choose>
+                  <let line='3061' var='Q{}class-mod' as='xs:string?' slot='14' eval='7'>
+                   <choose line='3063'>
+                    <fn name='exists'>
+                     <slash simple='1'>
+                      <varRef name='Q{}element' slot='12'/>
+                      <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
+                     </slash>
+                    </fn>
+                    <cvUntyped line='3064' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                     <cast as='xs:untypedAtomic' emptiable='0'>
+                      <fn name='string-join'>
+                       <sequence>
+                        <varRef name='Q{}class' slot='13'/>
+                        <str val='incremental'/>
+                       </sequence>
+                       <str val=' '/>
+                      </fn>
+                     </cast>
+                    </cvUntyped>
+                    <true/>
+                    <varRef line='3067' name='Q{}class' slot='13'/>
+                   </choose>
+                   <choose line='3071'>
+                    <fn name='exists'>
+                     <varRef name='Q{}class-mod' slot='14'/>
+                    </fn>
+                    <treat line='3072' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                     <att name='class' flags='l'>
+                      <varRef name='Q{}class-mod' slot='14'/>
+                     </att>
+                    </treat>
+                   </choose>
+                  </let>
+                 </let>
+                </let>
+                <applyT line='1210' bSlot='20'>
+                 <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
+                </applyT>
+                <elem line='1212' name='span' nsuri='' flags='l'>
+                 <sequence line='1213'>
+                  <att name='id' flags='l'>
+                   <varRef name='Q{}myid' slot='2'/>
+                  </att>
+                  <att line='1214' name='style' flags='l'>
+                   <choose>
+                    <varRef name='Q{}relevantVar' slot='11'/>
+                    <str val='display:inline'/>
+                    <true/>
+                    <str val='display:none'/>
+                   </choose>
+                  </att>
+                  <att line='1215' name='data-ref' flags='l'>
+                   <varRef name='Q{}refi' slot='6'/>
+                  </att>
+                  <varRef line='1217' name='Q{}valueExecuted' slot='10'/>
+                 </sequence>
+                </elem>
+               </sequence>
+              </elem>
+              <choose line='1222'>
+               <fn name='empty'>
+                <slash simple='1'>
+                 <dot type='element(Q{http://www.w3.org/2002/xforms}output)'/>
+                 <axis name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
+                </slash>
+               </fn>
+               <sequence line='1239'>
+                <message>
+                 <fn role='select' name='concat'>
+                  <str val='[xforms:output] Registering output with ID '/>
+                  <varRef name='Q{}myid' slot='2'/>
+                 </fn>
+                 <str role='terminate' val='no'/>
+                 <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+                </message>
+                <ifCall line='1241' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <check card='1' diag='0|0||ixsl:call'>
+                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                 </check>
+                 <str val='addOutput'/>
+                 <arrayBlock>
+                  <varRef name='Q{}myid' slot='2'/>
+                  <ifCall line='1225' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+                   <sequence>
+                    <choose>
+                     <varRef name='Q{}refi' slot='6'/>
+                     <ifCall line='1226' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                      <str val='@ref'/>
+                      <varRef name='Q{}refi' slot='6'/>
+                     </ifCall>
+                    </choose>
+                    <choose line='1229'>
+                     <fn name='exists'>
+                      <axis name='attribute' nodeTest='attribute(Q{}value)' jsTest='return item.name===&#39;value&#39;'/>
+                     </fn>
+                     <ifCall line='1230' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                      <str val='@value'/>
+                      <cast as='xs:string' emptiable='1'>
+                       <attVal name='Q{}value' chk='0'/>
+                      </cast>
+                     </ifCall>
+                    </choose>
+                   </sequence>
+                   <map size='2'>
+                    <str val='duplicates'/>
+                    <str val='reject'/>
+                    <str val='duplicates-error-code'/>
+                    <str val='XTDE3365'/>
+                   </map>
+                  </ifCall>
+                 </arrayBlock>
+                </ifCall>
+               </sequence>
+              </choose>
+             </sequence>
+            </let>
+           </let>
+          </let>
+         </let>
+        </let>
+       </let>
+      </sequence>
+     </let>
+    </sequence>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='5' rank='1' minImp='0' slots='0' flags='s' line='1069' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
+    <applyT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1070' flags='t' bSlot='21'>
+     <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
+    </applyT>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='25' part='3' rank='1' minImp='0' slots='1' flags='s' line='2111' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}hide)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;hide&#39;;'/>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2117' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2118' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+      <check card='1' diag='3|0|XTTE0570|action-map'>
+       <callT name='Q{}setAction' bSlot='2'>
+        <withParam name='Q{}this' flags='c' as='element()'>
+         <dot line='2119' type='element()'/>
+        </withParam>
+       </callT>
+      </check>
+     </treat>
+     <varRef line='2132' name='Q{}action-map' slot='0'/>
+    </let>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='12' rank='1' minImp='0' slots='0' flags='s' line='1526' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}hint)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;hint&#39;;'/>
+    <empty role='action'/>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='20' rank='1' minImp='0' slots='2' flags='s' line='1874' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}submit)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;submit&#39;;'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1875'>
+     <param name='Q{}submissions' slot='0' flags='t' as='map(xs:string, map(*))'>
+      <map role='select' size='0'/>
+      <treat role='conversion' as='map(xs:string, map(*))' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isMap(item)};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|submissions'>
+       <check card='1' diag='8|0|XTTE0590|submissions'>
+        <supplied slot='0'/>
+       </check>
+      </treat>
+     </param>
+     <let line='1877' var='Q{}innerbody' as='document-node()' slot='1' eval='16'>
+      <doc line='1878' validation='preserve'>
+       <applyT bSlot='22'>
+        <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
+       </applyT>
+      </doc>
+      <choose line='1882'>
+       <vc op='eq' onEmpty='0' comp='CCC'>
+        <cast as='xs:string' emptiable='1'>
+         <attVal name='Q{}appearance' chk='0'/>
+        </cast>
+        <str val='minimal'/>
+       </vc>
+       <elem line='1883' name='a' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+        <copyOf line='1884' flags='vc'>
+         <varRef name='Q{}innerbody' slot='1'/>
+        </copyOf>
+       </elem>
+       <true/>
+       <elem line='1888' name='button' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+        <sequence>
+         <att name='type' flags='l'>
+          <str val='button'/>
+         </att>
+         <copyOf line='1889' flags='vc'>
+          <filter flags='b'>
+           <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+           <vc op='ne' onEmpty='0' comp='CCC'>
+            <fn name='local-name'>
+             <dot type='attribute()'/>
+            </fn>
+            <str val='submission'/>
+           </vc>
+          </filter>
+         </copyOf>
+         <choose line='1890'>
+          <and op='and'>
+           <fn name='exists'>
+            <axis name='attribute' nodeTest='attribute(Q{}submission)' jsTest='return item.name===&#39;submission&#39;'/>
+           </fn>
+           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+            <varRef name='Q{}submissions' slot='0'/>
+            <atomSing diag='0|1||map:contains'>
+             <axis name='attribute' nodeTest='attribute(Q{}submission)' jsTest='return item.name===&#39;submission&#39;'/>
+            </atomSing>
+           </ifCall>
+          </and>
+          <att line='1891' name='data-submit' flags='l'>
+           <convert from='xs:untypedAtomic' to='xs:string'>
+            <attVal name='Q{}submission' chk='0'/>
+           </convert>
+          </att>
+         </choose>
+         <copyOf line='1893' flags='vc'>
+          <varRef name='Q{}innerbody' slot='1'/>
+         </copyOf>
+        </sequence>
+       </elem>
+      </choose>
+     </let>
+    </sequence>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='8' part='1' rank='1' minImp='0' slots='0' flags='s' line='1105' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{}html)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;html&#39;;'/>
+    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1106' name='html' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+     <sequence line='1107'>
+      <copyOf flags='vc'>
+       <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+      </copyOf>
+      <elem line='1108' name='head' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+       <sequence line='1109'>
+        <copyOf flags='vc'>
+         <union op='|'>
+          <slash simple='2'>
+           <axis name='child' nodeTest='element(Q{http://www.w3.org/1999/xhtml}head)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/1999/xhtml&#39;&amp;&amp;q.local===&#39;head&#39;;'/>
+           <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+          </slash>
+          <slash simple='2'>
+           <axis name='child' nodeTest='element(Q{}head)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;head&#39;;'/>
+           <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+          </slash>
+         </union>
+        </copyOf>
+        <elem line='1110' name='meta' nsuri='' flags='l'>
+         <sequence>
+          <att name='http-equiv' flags='l'>
+           <str val='Content-Type'/>
+          </att>
+          <att name='content' flags='l'>
+           <str val='text/html;charset=utf-8'/>
+          </att>
+         </sequence>
+        </elem>
+        <forEach line='1112'>
+         <union op='|'>
+          <filter flags='b'>
+           <slash simple='2'>
+            <axis name='child' nodeTest='element(Q{http://www.w3.org/1999/xhtml}head)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/1999/xhtml&#39;&amp;&amp;q.local===&#39;head&#39;;'/>
+            <axis name='child' nodeTest='element(Q{http://www.w3.org/1999/xhtml}meta)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/1999/xhtml&#39;&amp;&amp;q.local===&#39;meta&#39;;'/>
+           </slash>
+           <vc op='ne' onEmpty='0' comp='CCC'>
+            <fn name='string'>
+             <axis name='attribute' nodeTest='attribute(Q{}http-equiv)' jsTest='return item.name===&#39;http-equiv&#39;'/>
+            </fn>
+            <str val='Content-Type'/>
+           </vc>
+          </filter>
+          <filter flags='b'>
+           <slash simple='2'>
+            <axis name='child' nodeTest='element(Q{}head)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;head&#39;;'/>
+            <axis name='child' nodeTest='element(Q{}meta)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;meta&#39;;'/>
+           </slash>
+           <vc op='ne' onEmpty='0' comp='CCC'>
+            <fn name='string'>
+             <axis name='attribute' nodeTest='attribute(Q{}http-equiv)' jsTest='return item.name===&#39;http-equiv&#39;'/>
+            </fn>
+            <str val='Content-Type'/>
+           </vc>
+          </filter>
+         </union>
+         <elem line='1113' name='meta' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+          <copyOf line='1114' flags='vc'>
+           <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+          </copyOf>
+         </elem>
+        </forEach>
+        <copyOf line='1119' flags='vc'>
+         <axis name='child' nodeTest='element(Q{}script)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;script&#39;;'/>
+        </copyOf>
+       </sequence>
+      </elem>
+      <elem line='1121' name='body' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+       <applyT line='1122' bSlot='14'>
+        <slash role='select' simple='2'>
+         <axis name='child' nodeTest='element(Q{}body)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;body&#39;;'/>
+         <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+        </slash>
+       </applyT>
+      </elem>
+     </sequence>
+    </elem>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='13' rank='1' minImp='0' slots='12' flags='s' line='1537' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}select1)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;select1&#39;;'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1538'>
+     <param name='Q{}position' slot='0' as='xs:integer'>
+      <int role='select' val='0'/>
+      <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
+       <check card='1' diag='8|0|XTTE0590|position'>
+        <cvUntyped to='xs:integer' diag='8|0|XTTE0590|position'>
+         <data>
+          <supplied slot='0'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <param line='1539' name='Q{}context-position' slot='1' as='xs:string'>
+      <str role='select' val=''/>
+      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
+       <check card='1' diag='8|0|XTTE0590|context-position'>
+        <cvUntyped to='xs:string' diag='8|0|XTTE0590|context-position'>
+         <data>
+          <supplied slot='1'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <let line='1543' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+      <choose>
+       <fn name='exists'>
+        <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+       </fn>
+       <check card='1' diag='3|0|XTTE0570|myid'>
+        <cvUntyped to='xs:string' diag='3|0|XTTE0570|myid'>
+         <attVal name='Q{}id' chk='0'/>
+        </cvUntyped>
+       </check>
+       <true/>
+       <fn name='concat'>
+        <fn name='generate-id'>
+         <dot type='element()'/>
+        </fn>
+        <str val='-'/>
+        <choose line='1541'>
+         <varRef name='Q{}context-position' slot='1'/>
+         <varRef name='Q{}context-position' slot='1'/>
+         <true/>
+         <fn name='string'>
+          <varRef name='Q{}position' slot='0'/>
+         </fn>
+        </choose>
+       </fn>
+      </choose>
+      <sequence line='1545'>
+       <choose>
+        <and op='and'>
+         <let var='Q{}this' as='element()' slot='3' eval='16'>
+          <dot type='element()'/>
+          <fn line='2990' name='exists'>
+           <sequence line='2965'>
+            <analyzeString>
+             <cvUntyped role='select' to='xs:string'>
+              <data>
+               <slash simple='1'>
+                <varRef name='Q{}this' slot='3'/>
+                <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+               </slash>
+              </data>
+             </cvUntyped>
+             <str role='regex' val='\i\c*\('/>
+             <str role='flags' val=''/>
+             <choose role='matching' line='2968'>
+              <vc op='eq' onEmpty='0' comp='CCC'>
+               <fn name='substring-before'>
+                <dot type='xs:string'/>
+                <str val='('/>
+               </fn>
+               <str val='index'/>
+              </vc>
+              <str val='i'/>
+             </choose>
+             <empty role='nonMatching'/>
+            </analyzeString>
+            <analyzeString line='2977'>
+             <cvUntyped role='select' to='xs:string'>
+              <data>
+               <slash simple='1'>
+                <varRef name='Q{}this' slot='3'/>
+                <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+               </slash>
+              </data>
+             </cvUntyped>
+             <str role='regex' val='\i\c*\('/>
+             <str role='flags' val=''/>
+             <choose role='matching' line='2980'>
+              <vc op='eq' onEmpty='0' comp='CCC'>
+               <fn name='substring-before'>
+                <dot type='xs:string'/>
+                <str val='('/>
+               </fn>
+               <str val='index'/>
+              </vc>
+              <str val='i'/>
+             </choose>
+             <empty role='nonMatching'/>
+            </analyzeString>
+           </sequence>
+          </fn>
+         </let>
+         <fn name='empty'>
+          <filter flags='b'>
+           <slash simple='1'>
+            <dot type='element()'/>
+            <axis name='ancestor' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+           </slash>
+           <let var='Q{}this' as='element()' slot='4' eval='16'>
+            <dot type='element()'/>
+            <fn line='2990' name='exists'>
+             <sequence line='2965'>
+              <analyzeString>
+               <cvUntyped role='select' to='xs:string'>
+                <data>
+                 <slash simple='1'>
+                  <varRef name='Q{}this' slot='4'/>
+                  <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+                 </slash>
+                </data>
+               </cvUntyped>
+               <str role='regex' val='\i\c*\('/>
+               <str role='flags' val=''/>
+               <choose role='matching' line='2968'>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <fn name='substring-before'>
+                  <dot type='xs:string'/>
+                  <str val='('/>
+                 </fn>
+                 <str val='index'/>
+                </vc>
+                <str val='i'/>
+               </choose>
+               <empty role='nonMatching'/>
+              </analyzeString>
+              <analyzeString line='2977'>
+               <cvUntyped role='select' to='xs:string'>
+                <data>
+                 <slash simple='1'>
+                  <varRef name='Q{}this' slot='4'/>
+                  <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+                 </slash>
+                </data>
+               </cvUntyped>
+               <str role='regex' val='\i\c*\('/>
+               <str role='flags' val=''/>
+               <choose role='matching' line='2980'>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <fn name='substring-before'>
+                  <dot type='xs:string'/>
+                  <str val='('/>
+                 </fn>
+                 <str val='index'/>
+                </vc>
+                <str val='i'/>
+               </choose>
+               <empty role='nonMatching'/>
+              </analyzeString>
+             </sequence>
+            </fn>
+           </let>
+          </filter>
+         </fn>
+        </and>
+        <ifCall line='1546' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+         <check card='1' diag='0|0||ixsl:call'>
+          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+         </check>
+         <str val='setElementUsingIndexFunction'/>
+         <arrayBlock>
+          <varRef name='Q{}myid' slot='2'/>
+          <dot type='element()'/>
+         </arrayBlock>
+        </ifCall>
+       </choose>
+       <let line='1553' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1554' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+         <check card='?' diag='3|0|XTTE0570|bindingi'>
+          <callT name='Q{}getBinding' bSlot='3'>
+           <withParam name='Q{}this' flags='c' as='element()'>
+            <dot line='1555' type='element()'/>
+           </withParam>
+          </callT>
+         </check>
+        </treat>
+        <let line='1560' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1561' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+          <check card='1' diag='3|0|XTTE0570|refi'>
+           <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
+            <data>
+             <callT name='Q{}getDataRef' bSlot='4'>
+              <withParam name='Q{}this' flags='c' as='element()'>
+               <dot line='1562' type='element()'/>
+              </withParam>
+              <withParam name='Q{}bindingi' flags='c' as='node()?'>
+               <varRef line='1563' name='Q{}bindingi' slot='5'/>
+              </withParam>
+             </callT>
+            </data>
+           </cvUntyped>
+          </check>
+         </treat>
+         <let line='1568' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
+          <treat line='1569' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+           <check card='?' diag='3|0|XTTE0570|instanceField'>
+            <callT name='Q{}getReferencedInstanceField' bSlot='5'>
+             <withParam name='Q{}refi' flags='c' as='xs:string'>
+              <varRef line='1570' name='Q{}refi' slot='6'/>
+             </withParam>
+            </callT>
+           </check>
+          </treat>
+          <let line='1575' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
+           <treat line='1576' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+            <callT name='Q{}setActions' bSlot='6'>
+             <withParam name='Q{}this' flags='c' as='element()'>
+              <dot line='1577' type='element()'/>
+             </withParam>
+             <withParam name='Q{}nodeset' flags='t' as='xs:string'>
+              <varRef line='1578' name='Q{}refi' slot='6'/>
+             </withParam>
+            </callT>
+           </treat>
+           <sequence line='1582'>
+            <choose>
+             <fn name='exists'>
+              <varRef name='Q{}actions' slot='8'/>
+             </fn>
+             <ifCall line='1583' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+              <check card='1' diag='0|0||ixsl:call'>
+               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+              </check>
+              <str val='addAction'/>
+              <arrayBlock>
+               <varRef name='Q{}myid' slot='2'/>
+               <varRef name='Q{}actions' slot='8'/>
+              </arrayBlock>
+             </ifCall>
+            </choose>
+            <elem line='1600' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+             <sequence>
+              <att name='class' flags='l'>
+               <str val='xforms-select'/>
+              </att>
+              <applyT line='1601' bSlot='7'>
+               <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
+              </applyT>
+              <elem line='1603' name='select' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+               <sequence line='1604'>
+                <let var='Q{}element' as='element()' slot='9' eval='16'>
+                 <dot type='element()'/>
+                 <let line='3056' var='Q{}class' as='xs:string?' slot='10' eval='7'>
+                  <choose line='3057'>
+                   <fn name='exists'>
+                    <slash simple='1'>
+                     <varRef name='Q{}element' slot='9'/>
+                     <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
+                    </slash>
+                   </fn>
+                   <cvUntyped line='3058' to='xs:string' diag='3|0|XTTE0570|class'>
+                    <cast as='xs:untypedAtomic' emptiable='0'>
+                     <fn name='string'>
+                      <convert from='xs:untypedAtomic' to='xs:string'>
+                       <data>
+                        <slash simple='1'>
+                         <varRef name='Q{}element' slot='9'/>
+                         <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
+                        </slash>
+                       </data>
+                      </convert>
+                     </fn>
+                    </cast>
+                   </cvUntyped>
+                  </choose>
+                  <let line='3061' var='Q{}class-mod' as='xs:string?' slot='11' eval='7'>
+                   <choose line='3063'>
+                    <fn name='exists'>
+                     <slash simple='1'>
+                      <varRef name='Q{}element' slot='9'/>
+                      <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
+                     </slash>
+                    </fn>
+                    <cvUntyped line='3064' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                     <cast as='xs:untypedAtomic' emptiable='0'>
+                      <fn name='string-join'>
+                       <sequence>
+                        <varRef name='Q{}class' slot='10'/>
+                        <str val='incremental'/>
+                       </sequence>
+                       <str val=' '/>
+                      </fn>
+                     </cast>
+                    </cvUntyped>
+                    <true/>
+                    <varRef line='3067' name='Q{}class' slot='10'/>
+                   </choose>
+                   <choose line='3071'>
+                    <fn name='exists'>
+                     <varRef name='Q{}class-mod' slot='11'/>
+                    </fn>
+                    <treat line='3072' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                     <att name='class' flags='l'>
+                      <varRef name='Q{}class-mod' slot='11'/>
+                     </att>
+                    </treat>
+                   </choose>
+                  </let>
+                 </let>
+                </let>
+                <copyOf line='1605' flags='vc'>
+                 <except op='except'>
+                  <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+                  <docOrder intra='1'>
+                   <sequence>
+                    <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
+                    <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+                    <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
+                   </sequence>
+                  </docOrder>
+                 </except>
+                </copyOf>
+                <att line='1607' name='data-ref' flags='l'>
+                 <varRef name='Q{}refi' slot='6'/>
+                </att>
+                <att line='1608' name='data-element' flags='l'>
+                 <lastOf line='1598'>
+                  <fn name='tokenize'>
+                   <varRef name='Q{}refi' slot='6'/>
+                   <str val='/'/>
+                   <str val=''/>
+                  </fn>
+                 </lastOf>
+                </att>
+                <choose line='1610'>
+                 <and op='and'>
+                  <fn name='exists'>
+                   <varRef name='Q{}bindingi' slot='5'/>
+                  </fn>
+                  <fn name='exists'>
+                   <slash simple='1'>
+                    <varRef name='Q{}bindingi' slot='5'/>
+                    <axis name='attribute' nodeTest='attribute(Q{}constraint)' jsTest='return item.name===&#39;constraint&#39;'/>
+                   </slash>
+                  </fn>
+                 </and>
+                 <att line='1611' name='data-constraint' flags='l'>
+                  <convert from='xs:untypedAtomic' to='xs:string'>
+                   <data>
+                    <slash simple='1'>
+                     <varRef name='Q{}bindingi' slot='5'/>
+                     <axis name='attribute' nodeTest='attribute(Q{}constraint)' jsTest='return item.name===&#39;constraint&#39;'/>
+                    </slash>
+                   </data>
+                  </convert>
+                 </att>
+                </choose>
+                <choose line='1614'>
+                 <vc op='eq' onEmpty='0' comp='CCC'>
+                  <fn name='local-name'>
+                   <dot type='element()'/>
+                  </fn>
+                  <str val='select'/>
+                 </vc>
+                 <sequence line='1615'>
+                  <att name='multiple' flags='l'>
+                   <str val='true'/>
+                  </att>
+                  <att line='1616' name='size' flags='l'>
+                   <convert line='1617' from='xs:integer' to='xs:string'>
+                    <fn name='count'>
+                     <axis name='descendant' nodeTest='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
+                    </fn>
+                   </convert>
+                  </att>
+                 </sequence>
+                </choose>
+                <choose line='1620'>
+                 <fn name='exists'>
+                  <varRef name='Q{}actions' slot='8'/>
+                 </fn>
+                 <att line='1621' name='data-action' flags='l'>
+                  <varRef name='Q{}myid' slot='2'/>
+                 </att>
+                </choose>
+                <applyT line='1624' bSlot='8'>
+                 <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
+                 <withParam name='Q{}selectedValue' as='xs:string'>
+                  <choose line='1589'>
+                   <fn name='exists'>
+                    <varRef name='Q{}instanceField' slot='7'/>
+                   </fn>
+                   <cvUntyped line='1590' to='xs:string' diag='3|0|XTTE0570|selectedValue'>
+                    <cast as='xs:untypedAtomic' emptiable='0'>
+                     <fn name='string'>
+                      <convert from='xs:anyAtomicType' to='xs:string'>
+                       <data>
+                        <varRef name='Q{}instanceField' slot='7'/>
+                       </data>
+                      </convert>
+                     </fn>
+                    </cast>
+                   </cvUntyped>
+                   <true/>
+                   <str val=''/>
+                  </choose>
+                 </withParam>
+                </applyT>
+               </sequence>
+              </elem>
+             </sequence>
+            </elem>
+           </sequence>
+          </let>
+         </let>
+        </let>
+       </let>
+      </sequence>
+     </let>
+    </sequence>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='16' rank='1' minImp='0' slots='0' flags='s' line='1662' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
+    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1663' name='label' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+     <choose line='1665'>
+      <fn name='exists'>
+       <axis name='child' nodeTest='( element() | text() | comment() | processing-instruction() )' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);'/>
+      </fn>
+      <applyT line='1666' bSlot='23'>
+       <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
+      </applyT>
+      <true/>
+      <valueOf flags='l'>
+       <str val=' '/>
+      </valueOf>
+     </choose>
+    </elem>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='25' part='5' rank='1' minImp='0' slots='1' flags='s' line='2111' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}unload)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;unload&#39;;'/>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2117' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2118' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+      <check card='1' diag='3|0|XTTE0570|action-map'>
+       <callT name='Q{}setAction' bSlot='2'>
+        <withParam name='Q{}this' flags='c' as='element()'>
+         <dot line='2119' type='element()'/>
+        </withParam>
+       </callT>
+      </check>
+     </treat>
+     <varRef line='2132' name='Q{}action-map' slot='0'/>
+    </let>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='25' part='2' rank='1' minImp='0' slots='1' flags='s' line='2111' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}show)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;show&#39;;'/>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2117' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2118' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+      <check card='1' diag='3|0|XTTE0570|action-map'>
+       <callT name='Q{}setAction' bSlot='2'>
+        <withParam name='Q{}this' flags='c' as='element()'>
+         <dot line='2119' type='element()'/>
+        </withParam>
+       </callT>
+      </check>
+     </treat>
+     <varRef line='2132' name='Q{}action-map' slot='0'/>
+    </let>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='10' rank='1' minImp='0' slots='17' flags='s' line='1255' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1256'>
+     <param name='Q{}position' slot='0' as='xs:integer'>
+      <int role='select' val='0'/>
+      <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
+       <check card='1' diag='8|0|XTTE0590|position'>
+        <cvUntyped to='xs:integer' diag='8|0|XTTE0590|position'>
+         <data>
+          <supplied slot='0'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <param line='1257' name='Q{}context-position' slot='1' as='xs:string'>
+      <str role='select' val=''/>
+      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
+       <check card='1' diag='8|0|XTTE0590|context-position'>
+        <cvUntyped to='xs:string' diag='8|0|XTTE0590|context-position'>
+         <data>
+          <supplied slot='1'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <let line='1259' var='Q{}string-position' as='xs:string' slot='2' eval='16'>
+      <choose>
+       <varRef name='Q{}context-position' slot='1'/>
+       <varRef name='Q{}context-position' slot='1'/>
+       <true/>
+       <fn name='string'>
+        <varRef name='Q{}position' slot='0'/>
+       </fn>
+      </choose>
+      <let line='1261' var='Q{}myid' as='xs:string' slot='3' eval='16'>
+       <choose>
+        <fn name='exists'>
+         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+        </fn>
+        <fn name='concat'>
+         <attVal name='Q{}id' chk='0'/>
+         <str val='-'/>
+         <varRef name='Q{}string-position' slot='2'/>
+        </fn>
+        <true/>
+        <fn name='concat'>
+         <fn name='generate-id'>
+          <dot type='element(Q{http://www.w3.org/2002/xforms}input)'/>
+         </fn>
+         <str val='-'/>
+         <varRef name='Q{}string-position' slot='2'/>
+        </fn>
+       </choose>
+       <sequence line='1263'>
+        <choose>
+         <and op='and'>
+          <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}input)' slot='4' eval='16'>
+           <dot type='element(Q{http://www.w3.org/2002/xforms}input)'/>
+           <fn line='2990' name='exists'>
+            <sequence line='2965'>
+             <analyzeString>
+              <cvUntyped role='select' to='xs:string'>
+               <data>
+                <slash simple='1'>
+                 <varRef name='Q{}this' slot='4'/>
+                 <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+                </slash>
+               </data>
+              </cvUntyped>
+              <str role='regex' val='\i\c*\('/>
+              <str role='flags' val=''/>
+              <choose role='matching' line='2968'>
+               <vc op='eq' onEmpty='0' comp='CCC'>
+                <fn name='substring-before'>
+                 <dot type='xs:string'/>
+                 <str val='('/>
+                </fn>
+                <str val='index'/>
+               </vc>
+               <str val='i'/>
+              </choose>
+              <empty role='nonMatching'/>
+             </analyzeString>
+             <analyzeString line='2977'>
+              <cvUntyped role='select' to='xs:string'>
+               <data>
+                <slash simple='1'>
+                 <varRef name='Q{}this' slot='4'/>
+                 <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+                </slash>
+               </data>
+              </cvUntyped>
+              <str role='regex' val='\i\c*\('/>
+              <str role='flags' val=''/>
+              <choose role='matching' line='2980'>
+               <vc op='eq' onEmpty='0' comp='CCC'>
+                <fn name='substring-before'>
+                 <dot type='xs:string'/>
+                 <str val='('/>
+                </fn>
+                <str val='index'/>
+               </vc>
+               <str val='i'/>
+              </choose>
+              <empty role='nonMatching'/>
+             </analyzeString>
+            </sequence>
+           </fn>
+          </let>
+          <fn name='empty'>
+           <filter flags='b'>
+            <slash simple='1'>
+             <dot type='element(Q{http://www.w3.org/2002/xforms}input)'/>
+             <axis name='ancestor' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+            </slash>
+            <let var='Q{}this' as='element()' slot='5' eval='16'>
+             <dot type='element()'/>
+             <fn line='2990' name='exists'>
+              <sequence line='2965'>
+               <analyzeString>
+                <cvUntyped role='select' to='xs:string'>
+                 <data>
+                  <slash simple='1'>
+                   <varRef name='Q{}this' slot='5'/>
+                   <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+                  </slash>
+                 </data>
+                </cvUntyped>
+                <str role='regex' val='\i\c*\('/>
+                <str role='flags' val=''/>
+                <choose role='matching' line='2968'>
+                 <vc op='eq' onEmpty='0' comp='CCC'>
+                  <fn name='substring-before'>
+                   <dot type='xs:string'/>
+                   <str val='('/>
+                  </fn>
+                  <str val='index'/>
+                 </vc>
+                 <str val='i'/>
+                </choose>
+                <empty role='nonMatching'/>
+               </analyzeString>
+               <analyzeString line='2977'>
+                <cvUntyped role='select' to='xs:string'>
+                 <data>
+                  <slash simple='1'>
+                   <varRef name='Q{}this' slot='5'/>
+                   <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+                  </slash>
+                 </data>
+                </cvUntyped>
+                <str role='regex' val='\i\c*\('/>
+                <str role='flags' val=''/>
+                <choose role='matching' line='2980'>
+                 <vc op='eq' onEmpty='0' comp='CCC'>
+                  <fn name='substring-before'>
+                   <dot type='xs:string'/>
+                   <str val='('/>
+                  </fn>
+                  <str val='index'/>
+                 </vc>
+                 <str val='i'/>
+                </choose>
+                <empty role='nonMatching'/>
+               </analyzeString>
+              </sequence>
+             </fn>
+            </let>
+           </filter>
+          </fn>
+         </and>
+         <ifCall line='1264' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+          <check card='1' diag='0|0||ixsl:call'>
+           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+          </check>
+          <str val='setElementUsingIndexFunction'/>
+          <arrayBlock>
+           <varRef name='Q{}myid' slot='3'/>
+           <dot type='element(Q{http://www.w3.org/2002/xforms}input)'/>
+          </arrayBlock>
+         </ifCall>
+        </choose>
+        <let line='1272' var='Q{}bindingi' as='node()?' slot='6' eval='7'>
+         <treat line='1273' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+          <check card='?' diag='3|0|XTTE0570|bindingi'>
+           <callT name='Q{}getBinding' bSlot='24'>
+            <withParam name='Q{}this' flags='c' as='element()'>
+             <dot line='1274' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
+            </withParam>
+           </callT>
+          </check>
+         </treat>
+         <let line='1282' var='Q{}refi' as='xs:string' slot='7' eval='16'>
+          <treat line='1283' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+           <check card='1' diag='3|0|XTTE0570|refi'>
+            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
+             <data>
+              <callT name='Q{}getDataRef' bSlot='25'>
+               <withParam name='Q{}this' flags='c' as='element()'>
+                <dot line='1284' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
+               </withParam>
+               <withParam name='Q{}bindingi' flags='c' as='node()?'>
+                <varRef line='1285' name='Q{}bindingi' slot='6'/>
+               </withParam>
+              </callT>
+             </data>
+            </cvUntyped>
+           </check>
+          </treat>
+          <let line='1292' var='Q{}instanceField' as='node()?' slot='8' eval='7'>
+           <treat line='1293' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+            <check card='?' diag='3|0|XTTE0570|instanceField'>
+             <callT name='Q{}getReferencedInstanceField' bSlot='26'>
+              <withParam name='Q{}refi' flags='c' as='xs:string'>
+               <varRef line='1294' name='Q{}refi' slot='7'/>
+              </withParam>
+             </callT>
+            </check>
+           </treat>
+           <let line='1308' var='Q{}relevantVar' as='xs:boolean' slot='9' eval='16'>
+            <choose line='1310'>
+             <and op='and'>
+              <and op='and'>
+               <fn name='exists'>
+                <varRef name='Q{}bindingi' slot='6'/>
+               </fn>
+               <fn name='exists'>
+                <slash simple='1'>
+                 <varRef name='Q{}bindingi' slot='6'/>
+                 <axis name='attribute' nodeTest='attribute(Q{}relevant)' jsTest='return item.name===&#39;relevant&#39;'/>
+                </slash>
+               </fn>
+              </and>
+              <fn name='exists'>
+               <varRef name='Q{}instanceField' slot='8'/>
+              </fn>
+             </and>
+             <treat line='1311' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantVar'>
+              <check card='1' diag='3|0|XTTE0570|relevantVar'>
+               <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|relevantVar'>
+                <data>
+                 <evaluate dxns=''>
+                  <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='27' eval='16'>
+                   <check card='1' diag='0|0||xforms:impose'>
+                    <cvUntyped to='xs:string'>
+                     <data>
+                      <slash simple='1'>
+                       <varRef name='Q{}bindingi' slot='6'/>
+                       <axis name='attribute' nodeTest='attribute(Q{}relevant)' jsTest='return item.name===&#39;relevant&#39;'/>
+                      </slash>
+                     </data>
+                    </cvUntyped>
+                   </check>
+                  </ufCall>
+                  <varRef role='cxt' name='Q{}instanceField' slot='8'/>
+                  <choose role='nsCxt' line='1303'>
+                   <fn name='exists'>
+                    <varRef name='Q{}instanceField' slot='8'/>
+                   </fn>
+                   <treat as='element()' jsTest='return item.nodeType===1;' diag='3|0|XTTE0570|namespace-context-item'>
+                    <check card='1' diag='3|0|XTTE0570|namespace-context-item'>
+                     <varRef name='Q{}instanceField' slot='8'/>
+                    </check>
+                   </treat>
+                   <true/>
+                   <let var='Q{}this' as='element()' slot='10' eval='16'>
+                    <check card='1' diag='0|0||xforms:addNamespaceDeclarations'>
+                     <slash simple='1'>
+                      <root/>
+                      <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+                     </slash>
+                    </check>
+                    <compElem line='3000'>
+                     <fn role='name' name='name'>
+                      <varRef name='Q{}this' slot='10'/>
+                     </fn>
+                     <sequence role='content' line='3001'>
+                      <namespace flags='l'>
+                       <str role='name' val='xforms'/>
+                       <str role='select' val='http://www.w3.org/2002/xforms'/>
+                      </namespace>
+                      <forEach line='3002'>
+                       <filter flags='b'>
+                        <filter flags='b'>
+                         <slash simple='1'>
+                          <varRef name='Q{}this' slot='10'/>
+                          <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+                         </slash>
+                         <fn name='boolean'>
+                          <fn name='namespace-uri'>
+                           <dot type='element()'/>
+                          </fn>
+                         </fn>
+                        </filter>
+                        <fn name='not'>
+                         <gc op='=' card='N:1' comp='CCC'>
+                          <sequence>
+                           <slash>
+                            <fn name='reverse'>
+                             <axis name='ancestor' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+                            </fn>
+                            <fn name='namespace-uri'>
+                             <dot type='element()'/>
+                            </fn>
+                           </slash>
+                           <slash>
+                            <fn name='reverse'>
+                             <axis name='preceding' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+                            </fn>
+                            <fn name='namespace-uri'>
+                             <dot type='element()'/>
+                            </fn>
+                           </slash>
+                          </sequence>
+                          <fn name='namespace-uri'>
+                           <dot type='element()'/>
+                          </fn>
+                         </gc>
+                        </fn>
+                       </filter>
+                       <namespace line='3005' flags='l'>
+                        <fn role='name' line='3004' name='substring-before'>
+                         <fn name='name'>
+                          <dot type='element()'/>
+                         </fn>
+                         <str val=':'/>
+                        </fn>
+                        <convert role='select' from='xs:anyURI' to='xs:string'>
+                         <fn line='3003' name='namespace-uri'>
+                          <dot type='element()'/>
+                         </fn>
+                        </convert>
+                       </namespace>
+                      </forEach>
+                      <copyOf line='3007' flags='vc'>
+                       <sequence>
+                        <slash simple='1'>
+                         <varRef name='Q{}this' slot='10'/>
+                         <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+                        </slash>
+                        <slash simple='1'>
+                         <varRef name='Q{}this' slot='10'/>
+                         <axis name='child' nodeTest='( element() | text() | comment() | processing-instruction() )' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);'/>
+                        </slash>
+                       </sequence>
+                      </copyOf>
+                     </sequence>
+                    </compElem>
+                   </let>
+                  </choose>
+                  <str role='sa' val='no'/>
+                  <map role='options' size='0'/>
+                  <map role='wp' size='0'/>
+                 </evaluate>
+                </data>
+               </cvUntyped>
+              </check>
+             </treat>
+             <true/>
+             <true/>
+            </choose>
+            <let line='1321' var='Q{}actions' as='map(*)*' slot='11' eval='8'>
+             <treat line='1322' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+              <callT name='Q{}setActions' bSlot='28'>
+               <withParam name='Q{}this' flags='c' as='element()'>
+                <dot line='1323' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
+               </withParam>
+               <withParam name='Q{}nodeset' flags='t' as='xs:string'>
+                <varRef line='1324' name='Q{}refi' slot='7'/>
+               </withParam>
+              </callT>
+             </treat>
+             <sequence line='1329'>
+              <choose>
+               <fn name='exists'>
+                <varRef name='Q{}actions' slot='11'/>
+               </fn>
+               <ifCall line='1330' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                <check card='1' diag='0|0||ixsl:call'>
+                 <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                </check>
+                <str val='addAction'/>
+                <arrayBlock>
+                 <varRef name='Q{}myid' slot='3'/>
+                 <varRef name='Q{}actions' slot='11'/>
+                </arrayBlock>
+               </ifCall>
+              </choose>
+              <elem line='1335' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+               <sequence>
+                <att name='class' flags='l'>
+                 <str val='xforms-input'/>
+                </att>
+                <att line='1336' name='style' flags='l'>
+                 <choose>
+                  <varRef name='Q{}relevantVar' slot='9'/>
+                  <str val='display:block'/>
+                  <true/>
+                  <str val='display:none'/>
+                 </choose>
+                </att>
+                <applyT line='1338' bSlot='29'>
+                 <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
+                </applyT>
+                <let line='1340' var='Q{}hints' as='text()*' slot='12' eval='4'>
+                 <slash simple='2'>
+                  <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}hint)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;hint&#39;;'/>
+                  <axis name='child' nodeTest='text()' jsTest='return item.nodeType===3;'/>
+                 </slash>
+                 <elem line='1344' name='input' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+                  <sequence line='1345'>
+                   <let var='Q{}element' as='element(Q{http://www.w3.org/2002/xforms}input)' slot='13' eval='16'>
+                    <dot type='element(Q{http://www.w3.org/2002/xforms}input)'/>
+                    <let line='3056' var='Q{}class' as='xs:string?' slot='14' eval='7'>
+                     <choose line='3057'>
+                      <fn name='exists'>
+                       <slash simple='1'>
+                        <varRef name='Q{}element' slot='13'/>
+                        <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
+                       </slash>
+                      </fn>
+                      <cvUntyped line='3058' to='xs:string' diag='3|0|XTTE0570|class'>
+                       <cast as='xs:untypedAtomic' emptiable='0'>
+                        <fn name='string'>
+                         <convert from='xs:untypedAtomic' to='xs:string'>
+                          <data>
+                           <slash simple='1'>
+                            <varRef name='Q{}element' slot='13'/>
+                            <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
+                           </slash>
+                          </data>
+                         </convert>
+                        </fn>
+                       </cast>
+                      </cvUntyped>
+                     </choose>
+                     <let line='3061' var='Q{}class-mod' as='xs:string?' slot='15' eval='7'>
+                      <choose line='3063'>
+                       <fn name='exists'>
+                        <slash simple='1'>
+                         <varRef name='Q{}element' slot='13'/>
+                         <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
+                        </slash>
+                       </fn>
+                       <cvUntyped line='3064' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                        <cast as='xs:untypedAtomic' emptiable='0'>
+                         <fn name='string-join'>
+                          <sequence>
+                           <varRef name='Q{}class' slot='14'/>
+                           <str val='incremental'/>
+                          </sequence>
+                          <str val=' '/>
+                         </fn>
+                        </cast>
+                       </cvUntyped>
+                       <true/>
+                       <varRef line='3067' name='Q{}class' slot='14'/>
+                      </choose>
+                      <choose line='3071'>
+                       <fn name='exists'>
+                        <varRef name='Q{}class-mod' slot='15'/>
+                       </fn>
+                       <treat line='3072' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                        <att name='class' flags='l'>
+                         <varRef name='Q{}class-mod' slot='15'/>
+                        </att>
+                       </treat>
+                      </choose>
+                     </let>
+                    </let>
+                   </let>
+                   <att line='1346' name='id' flags='l'>
+                    <varRef name='Q{}myid' slot='3'/>
+                   </att>
+                   <att line='1348' name='data-ref' flags='l'>
+                    <varRef name='Q{}refi' slot='7'/>
+                   </att>
+                   <att line='1349' name='data-element' flags='l'>
+                    <lastOf line='1342'>
+                     <fn name='tokenize'>
+                      <varRef name='Q{}refi' slot='7'/>
+                      <str val='/'/>
+                      <str val=''/>
+                     </fn>
+                    </lastOf>
+                   </att>
+                   <choose line='1351'>
+                    <and op='and'>
+                     <fn name='exists'>
+                      <varRef name='Q{}bindingi' slot='6'/>
+                     </fn>
+                     <fn name='exists'>
+                      <slash simple='1'>
+                       <varRef name='Q{}bindingi' slot='6'/>
+                       <axis name='attribute' nodeTest='attribute(Q{}required)' jsTest='return item.name===&#39;required&#39;'/>
+                      </slash>
+                     </fn>
+                    </and>
+                    <att line='1352' name='data-required' flags='l'>
+                     <convert from='xs:untypedAtomic' to='xs:string'>
+                      <data>
+                       <slash simple='1'>
+                        <varRef name='Q{}bindingi' slot='6'/>
+                        <axis name='attribute' nodeTest='attribute(Q{}required)' jsTest='return item.name===&#39;required&#39;'/>
+                       </slash>
+                      </data>
+                     </convert>
+                    </att>
+                   </choose>
+                   <choose line='1354'>
+                    <and op='and'>
+                     <fn name='exists'>
+                      <varRef name='Q{}bindingi' slot='6'/>
+                     </fn>
+                     <fn name='exists'>
+                      <slash simple='1'>
+                       <varRef name='Q{}bindingi' slot='6'/>
+                       <axis name='attribute' nodeTest='attribute(Q{}constraint)' jsTest='return item.name===&#39;constraint&#39;'/>
+                      </slash>
+                     </fn>
+                    </and>
+                    <att line='1355' name='data-constraint' flags='l'>
+                     <convert from='xs:untypedAtomic' to='xs:string'>
+                      <data>
+                       <slash simple='1'>
+                        <varRef name='Q{}bindingi' slot='6'/>
+                        <axis name='attribute' nodeTest='attribute(Q{}constraint)' jsTest='return item.name===&#39;constraint&#39;'/>
+                       </slash>
+                      </data>
+                     </convert>
+                    </att>
+                   </choose>
+                   <choose line='1357'>
+                    <fn name='exists'>
+                     <varRef name='Q{}actions' slot='11'/>
+                    </fn>
+                    <att line='1358' name='data-action' flags='l'>
+                     <varRef name='Q{}myid' slot='3'/>
+                    </att>
+                   </choose>
+                   <choose line='1361'>
+                    <and op='and'>
+                     <fn name='exists'>
+                      <varRef name='Q{}bindingi' slot='6'/>
+                     </fn>
+                     <fn name='exists'>
+                      <slash simple='1'>
+                       <varRef name='Q{}bindingi' slot='6'/>
+                       <axis name='attribute' nodeTest='attribute(Q{}relevant)' jsTest='return item.name===&#39;relevant&#39;'/>
+                      </slash>
+                     </fn>
+                    </and>
+                    <att line='1362' name='data-relevant' flags='l'>
+                     <convert from='xs:untypedAtomic' to='xs:string'>
+                      <data>
+                       <slash simple='1'>
+                        <varRef name='Q{}bindingi' slot='6'/>
+                        <axis name='attribute' nodeTest='attribute(Q{}relevant)' jsTest='return item.name===&#39;relevant&#39;'/>
+                       </slash>
+                      </data>
+                     </convert>
+                    </att>
+                   </choose>
+                   <let line='1365' var='Q{}input-value' as='xs:string' slot='16' eval='16'>
+                    <choose line='1367'>
+                     <fn name='exists'>
+                      <varRef name='Q{}instanceField' slot='8'/>
+                     </fn>
+                     <cvUntyped line='1368' to='xs:string' diag='3|0|XTTE0570|input-value'>
+                      <cast as='xs:untypedAtomic' emptiable='0'>
+                       <fn name='string'>
+                        <convert from='xs:anyAtomicType' to='xs:string'>
+                         <data>
+                          <varRef name='Q{}instanceField' slot='8'/>
+                         </data>
+                        </convert>
+                       </fn>
+                      </cast>
+                     </cvUntyped>
+                     <true/>
+                     <str val=''/>
+                    </choose>
+                    <sequence line='1382'>
+                     <choose>
+                      <choose>
+                       <fn name='exists'>
+                        <varRef name='Q{}bindingi' slot='6'/>
+                       </fn>
+                       <vc op='eq' comp='EQC'>
+                        <cast as='xs:QName' emptiable='1'>
+                         <data>
+                          <slash simple='1'>
+                           <varRef name='Q{}bindingi' slot='6'/>
+                           <axis name='attribute' nodeTest='attribute(Q{}type)' jsTest='return item.name===&#39;type&#39;'/>
+                          </slash>
+                         </data>
+                        </cast>
+                        <qName pre='xs' uri='http://www.w3.org/2001/XMLSchema' loc='date'/>
+                       </vc>
+                       <true/>
+                       <false/>
+                      </choose>
+                      <sequence line='1383'>
+                       <att name='data-type' flags='l'>
+                        <str val='date'/>
+                       </att>
+                       <att line='1385' name='type' flags='l'>
+                        <str val='date'/>
+                       </att>
+                       <att line='1387' name='value' flags='l'>
+                        <varRef name='Q{}input-value' slot='16'/>
+                       </att>
+                      </sequence>
+                      <choose line='1394'>
+                       <fn name='exists'>
+                        <varRef name='Q{}bindingi' slot='6'/>
+                       </fn>
+                       <vc op='eq' comp='EQC'>
+                        <cast as='xs:QName' emptiable='1'>
+                         <data>
+                          <slash simple='1'>
+                           <varRef name='Q{}bindingi' slot='6'/>
+                           <axis name='attribute' nodeTest='attribute(Q{}type)' jsTest='return item.name===&#39;type&#39;'/>
+                          </slash>
+                         </data>
+                        </cast>
+                        <qName pre='xs' uri='http://www.w3.org/2001/XMLSchema' loc='time'/>
+                       </vc>
+                       <true/>
+                       <false/>
+                      </choose>
+                      <sequence line='1395'>
+                       <att name='data-type' flags='l'>
+                        <str val='time'/>
+                       </att>
+                       <att line='1397' name='type' flags='l'>
+                        <str val='time'/>
+                       </att>
+                       <att line='1400' name='value' flags='l'>
+                        <varRef name='Q{}input-value' slot='16'/>
+                       </att>
+                      </sequence>
+                      <choose line='1407'>
+                       <fn name='exists'>
+                        <varRef name='Q{}bindingi' slot='6'/>
+                       </fn>
+                       <vc op='eq' comp='EQC'>
+                        <cast as='xs:QName' emptiable='1'>
+                         <data>
+                          <slash simple='1'>
+                           <varRef name='Q{}bindingi' slot='6'/>
+                           <axis name='attribute' nodeTest='attribute(Q{}type)' jsTest='return item.name===&#39;type&#39;'/>
+                          </slash>
+                         </data>
+                        </cast>
+                        <qName pre='xs' uri='http://www.w3.org/2001/XMLSchema' loc='boolean'/>
+                       </vc>
+                       <true/>
+                       <false/>
+                      </choose>
+                      <sequence line='1408'>
+                       <att name='data-type' flags='l'>
+                        <str val='checkbox'/>
+                       </att>
+                       <att line='1410' name='type' flags='l'>
+                        <str val='checkbox'/>
+                       </att>
+                       <choose line='1415'>
+                        <fn name='exists'>
+                         <varRef name='Q{}instanceField' slot='8'/>
+                        </fn>
+                        <choose line='1416'>
+                         <and op='and'>
+                          <varRef name='Q{}input-value' slot='16'/>
+                          <cast as='xs:boolean' emptiable='0'>
+                           <varRef name='Q{}input-value' slot='16'/>
+                          </cast>
+                         </and>
+                         <att line='1417' name='checked' flags='l'>
+                          <varRef name='Q{}input-value' slot='16'/>
+                         </att>
+                        </choose>
+                       </choose>
+                      </sequence>
+                      <true/>
+                      <sequence line='1423'>
+                       <choose>
+                        <varRef name='Q{}relevantVar' slot='9'/>
+                        <att line='1424' name='type' flags='l'>
+                         <str val='text'/>
+                        </att>
+                       </choose>
+                       <att line='1426' name='value' flags='l'>
+                        <varRef name='Q{}input-value' slot='16'/>
+                       </att>
+                      </sequence>
+                     </choose>
+                     <choose line='1430'>
+                      <fn name='exists'>
+                       <varRef name='Q{}hints' slot='12'/>
+                      </fn>
+                      <att line='1431' name='title' flags='l'>
+                       <fn name='string-join'>
+                        <convert from='xs:untypedAtomic' to='xs:string'>
+                         <data>
+                          <mergeAdj>
+                           <varRef name='Q{}hints' slot='12'/>
+                          </mergeAdj>
+                         </data>
+                        </convert>
+                        <str val=' '/>
+                       </fn>
+                      </att>
+                     </choose>
+                     <choose line='1433'>
+                      <fn name='exists'>
+                       <axis name='attribute' nodeTest='attribute(Q{}size)' jsTest='return item.name===&#39;size&#39;'/>
+                      </fn>
+                      <att line='1434' name='size' flags='l'>
+                       <convert from='xs:untypedAtomic' to='xs:string'>
+                        <attVal name='Q{}size' chk='0'/>
+                       </convert>
+                      </att>
+                     </choose>
+                    </sequence>
+                   </let>
+                  </sequence>
+                 </elem>
+                </let>
+               </sequence>
+              </elem>
+             </sequence>
+            </let>
+           </let>
+          </let>
+         </let>
+        </let>
+       </sequence>
+      </let>
+     </let>
+    </sequence>
+   </templateRule>
+   <templateRule prec='0' prio='2.0' seq='11' rank='3' minImp='0' slots='10' flags='s' line='1452' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}textarea)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;textarea&#39;;'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1453'>
+     <param name='Q{}position' slot='0' as='xs:integer'>
+      <int role='select' val='0'/>
+      <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
+       <check card='1' diag='8|0|XTTE0590|position'>
+        <cvUntyped to='xs:integer' diag='8|0|XTTE0590|position'>
+         <data>
+          <supplied slot='0'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <param line='1454' name='Q{}context-position' slot='1' as='xs:string'>
+      <str role='select' val=''/>
+      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
+       <check card='1' diag='8|0|XTTE0590|context-position'>
+        <cvUntyped to='xs:string' diag='8|0|XTTE0590|context-position'>
+         <data>
+          <supplied slot='1'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <let line='1458' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+      <choose>
+       <fn name='exists'>
+        <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+       </fn>
+       <check card='1' diag='3|0|XTTE0570|myid'>
+        <cvUntyped to='xs:string' diag='3|0|XTTE0570|myid'>
+         <attVal name='Q{}id' chk='0'/>
+        </cvUntyped>
+       </check>
+       <true/>
+       <fn name='concat'>
+        <fn name='generate-id'>
+         <dot type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
+        </fn>
+        <str val='-'/>
+        <choose line='1456'>
+         <varRef name='Q{}context-position' slot='1'/>
+         <varRef name='Q{}context-position' slot='1'/>
+         <true/>
+         <fn name='string'>
+          <varRef name='Q{}position' slot='0'/>
+         </fn>
+        </choose>
+       </fn>
+      </choose>
+      <sequence line='1460'>
+       <choose>
+        <and op='and'>
+         <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}textarea)' slot='3' eval='16'>
+          <dot type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
+          <fn line='2990' name='exists'>
+           <sequence line='2965'>
+            <analyzeString>
+             <cvUntyped role='select' to='xs:string'>
+              <data>
+               <slash simple='1'>
+                <varRef name='Q{}this' slot='3'/>
+                <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+               </slash>
+              </data>
+             </cvUntyped>
+             <str role='regex' val='\i\c*\('/>
+             <str role='flags' val=''/>
+             <choose role='matching' line='2968'>
+              <vc op='eq' onEmpty='0' comp='CCC'>
+               <fn name='substring-before'>
+                <dot type='xs:string'/>
+                <str val='('/>
+               </fn>
+               <str val='index'/>
+              </vc>
+              <str val='i'/>
+             </choose>
+             <empty role='nonMatching'/>
+            </analyzeString>
+            <analyzeString line='2977'>
+             <cvUntyped role='select' to='xs:string'>
+              <data>
+               <slash simple='1'>
+                <varRef name='Q{}this' slot='3'/>
+                <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+               </slash>
+              </data>
+             </cvUntyped>
+             <str role='regex' val='\i\c*\('/>
+             <str role='flags' val=''/>
+             <choose role='matching' line='2980'>
+              <vc op='eq' onEmpty='0' comp='CCC'>
+               <fn name='substring-before'>
+                <dot type='xs:string'/>
+                <str val='('/>
+               </fn>
+               <str val='index'/>
+              </vc>
+              <str val='i'/>
+             </choose>
+             <empty role='nonMatching'/>
+            </analyzeString>
+           </sequence>
+          </fn>
+         </let>
+         <fn name='empty'>
+          <filter flags='b'>
+           <slash simple='1'>
+            <dot type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
+            <axis name='ancestor' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+           </slash>
+           <let var='Q{}this' as='element()' slot='4' eval='16'>
+            <dot type='element()'/>
+            <fn line='2990' name='exists'>
+             <sequence line='2965'>
+              <analyzeString>
+               <cvUntyped role='select' to='xs:string'>
+                <data>
+                 <slash simple='1'>
+                  <varRef name='Q{}this' slot='4'/>
+                  <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+                 </slash>
+                </data>
+               </cvUntyped>
+               <str role='regex' val='\i\c*\('/>
+               <str role='flags' val=''/>
+               <choose role='matching' line='2968'>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <fn name='substring-before'>
+                  <dot type='xs:string'/>
+                  <str val='('/>
+                 </fn>
+                 <str val='index'/>
+                </vc>
+                <str val='i'/>
+               </choose>
+               <empty role='nonMatching'/>
+              </analyzeString>
+              <analyzeString line='2977'>
+               <cvUntyped role='select' to='xs:string'>
+                <data>
+                 <slash simple='1'>
+                  <varRef name='Q{}this' slot='4'/>
+                  <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+                 </slash>
+                </data>
+               </cvUntyped>
+               <str role='regex' val='\i\c*\('/>
+               <str role='flags' val=''/>
+               <choose role='matching' line='2980'>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <fn name='substring-before'>
+                  <dot type='xs:string'/>
+                  <str val='('/>
+                 </fn>
+                 <str val='index'/>
+                </vc>
+                <str val='i'/>
+               </choose>
+               <empty role='nonMatching'/>
+              </analyzeString>
+             </sequence>
+            </fn>
+           </let>
+          </filter>
+         </fn>
+        </and>
+        <ifCall line='1461' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+         <check card='1' diag='0|0||ixsl:call'>
+          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+         </check>
+         <str val='setElementUsingIndexFunction'/>
+         <arrayBlock>
+          <varRef name='Q{}myid' slot='2'/>
+          <dot type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
+         </arrayBlock>
+        </ifCall>
+       </choose>
+       <let line='1465' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1466' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+         <check card='?' diag='3|0|XTTE0570|bindingi'>
+          <callT name='Q{}getBinding' bSlot='30'>
+           <withParam name='Q{}this' flags='c' as='element()'>
+            <dot line='1467' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
+           </withParam>
+          </callT>
+         </check>
+        </treat>
+        <let line='1472' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1473' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+          <check card='1' diag='3|0|XTTE0570|refi'>
+           <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
+            <data>
+             <callT name='Q{}getDataRef' bSlot='31'>
+              <withParam name='Q{}this' flags='c' as='element()'>
+               <dot line='1474' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
+              </withParam>
+              <withParam name='Q{}bindingi' flags='c' as='node()?'>
+               <varRef line='1475' name='Q{}bindingi' slot='5'/>
+              </withParam>
+             </callT>
+            </data>
+           </cvUntyped>
+          </check>
+         </treat>
+         <let line='1480' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
+          <treat line='1481' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+           <check card='?' diag='3|0|XTTE0570|instanceField'>
+            <callT name='Q{}getReferencedInstanceField' bSlot='32'>
+             <withParam name='Q{}refi' flags='c' as='xs:string'>
+              <varRef line='1482' name='Q{}refi' slot='6'/>
+             </withParam>
+            </callT>
+           </check>
+          </treat>
+          <let line='1487' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
+           <treat line='1488' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+            <callT name='Q{}setActions' bSlot='33'>
+             <withParam name='Q{}this' flags='c' as='element()'>
+              <dot line='1489' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
+             </withParam>
+             <withParam name='Q{}nodeset' flags='t' as='xs:string'>
+              <varRef line='1490' name='Q{}refi' slot='6'/>
+             </withParam>
+            </callT>
+           </treat>
+           <sequence line='1494'>
+            <choose>
+             <fn name='exists'>
+              <varRef name='Q{}actions' slot='8'/>
+             </fn>
+             <ifCall line='1495' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+              <check card='1' diag='0|0||ixsl:call'>
+               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+              </check>
+              <str val='addAction'/>
+              <arrayBlock>
+               <varRef name='Q{}myid' slot='2'/>
+               <varRef name='Q{}actions' slot='8'/>
+              </arrayBlock>
+             </ifCall>
+            </choose>
+            <let line='1500' var='Q{}hints' as='text()*' slot='9' eval='4'>
+             <slash simple='2'>
+              <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}hint)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;hint&#39;;'/>
+              <axis name='child' nodeTest='text()' jsTest='return item.nodeType===3;'/>
+             </slash>
+             <elem line='1502' name='textarea' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+              <sequence line='1503'>
+               <copyOf flags='vc'>
+                <filter flags='b'>
+                 <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+                 <vc op='ne' onEmpty='0' comp='CCC'>
+                  <fn name='local-name'>
+                   <dot type='attribute()'/>
+                  </fn>
+                  <str val='ref'/>
+                 </vc>
+                </filter>
+               </copyOf>
+               <att line='1504' name='data-element' flags='l'>
+                <lastOf line='1498'>
+                 <fn name='tokenize'>
+                  <varRef name='Q{}refi' slot='6'/>
+                  <str val='/'/>
+                  <str val=''/>
+                 </fn>
+                </lastOf>
+               </att>
+               <att line='1505' name='data-ref' flags='l'>
+                <varRef name='Q{}refi' slot='6'/>
+               </att>
+               <choose line='1507'>
+                <fn name='exists'>
+                 <varRef name='Q{}instanceField' slot='7'/>
+                </fn>
+                <valueOf line='1508' flags='l'>
+                 <convert from='xs:anyAtomicType' to='xs:string'>
+                  <data>
+                   <varRef name='Q{}instanceField' slot='7'/>
+                  </data>
+                 </convert>
+                </valueOf>
+                <true/>
+                <sequence line='1510'>
+                 <valueOf flags='Sl'>
+                  <str val=''/>
+                 </valueOf>
+                 <valueOf flags='l'>
+                  <str val='  '/>
+                 </valueOf>
+                </sequence>
+               </choose>
+               <choose line='1513'>
+                <fn name='exists'>
+                 <varRef name='Q{}hints' slot='9'/>
+                </fn>
+                <att line='1514' name='title' flags='l'>
+                 <fn name='string-join'>
+                  <convert from='xs:untypedAtomic' to='xs:string'>
+                   <data>
+                    <mergeAdj>
+                     <varRef name='Q{}hints' slot='9'/>
+                    </mergeAdj>
+                   </data>
+                  </convert>
+                  <str val=' '/>
+                 </fn>
+                </att>
+               </choose>
+              </sequence>
+             </elem>
+            </let>
+           </sequence>
+          </let>
+         </let>
+        </let>
+       </let>
+      </sequence>
+     </let>
+    </sequence>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='24' rank='1' minImp='0' slots='9' flags='s' line='2029' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}trigger)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;trigger&#39;;'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2030'>
+     <param name='Q{}position' slot='0' as='xs:integer'>
+      <int role='select' val='0'/>
+      <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
+       <check card='1' diag='8|0|XTTE0590|position'>
+        <cvUntyped to='xs:integer' diag='8|0|XTTE0590|position'>
+         <data>
+          <supplied slot='0'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <param line='2031' name='Q{}context-position' slot='1' as='xs:string'>
+      <str role='select' val=''/>
+      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
+       <check card='1' diag='8|0|XTTE0590|context-position'>
+        <cvUntyped to='xs:string' diag='8|0|XTTE0590|context-position'>
+         <data>
+          <supplied slot='1'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <let line='2035' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+      <choose>
+       <fn name='exists'>
+        <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+       </fn>
+       <check card='1' diag='3|0|XTTE0570|myid'>
+        <cvUntyped to='xs:string' diag='3|0|XTTE0570|myid'>
+         <attVal name='Q{}id' chk='0'/>
+        </cvUntyped>
+       </check>
+       <true/>
+       <fn name='concat'>
+        <fn name='generate-id'>
+         <dot type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
+        </fn>
+        <str val='-'/>
+        <choose line='2033'>
+         <varRef name='Q{}context-position' slot='1'/>
+         <varRef name='Q{}context-position' slot='1'/>
+         <true/>
+         <fn name='string'>
+          <varRef name='Q{}position' slot='0'/>
+         </fn>
+        </choose>
+       </fn>
+      </choose>
+      <sequence line='2037'>
+       <choose>
+        <and op='and'>
+         <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}trigger)' slot='3' eval='16'>
+          <dot type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
+          <fn line='2990' name='exists'>
+           <sequence line='2965'>
+            <analyzeString>
+             <cvUntyped role='select' to='xs:string'>
+              <data>
+               <slash simple='1'>
+                <varRef name='Q{}this' slot='3'/>
+                <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+               </slash>
+              </data>
+             </cvUntyped>
+             <str role='regex' val='\i\c*\('/>
+             <str role='flags' val=''/>
+             <choose role='matching' line='2968'>
+              <vc op='eq' onEmpty='0' comp='CCC'>
+               <fn name='substring-before'>
+                <dot type='xs:string'/>
+                <str val='('/>
+               </fn>
+               <str val='index'/>
+              </vc>
+              <str val='i'/>
+             </choose>
+             <empty role='nonMatching'/>
+            </analyzeString>
+            <analyzeString line='2977'>
+             <cvUntyped role='select' to='xs:string'>
+              <data>
+               <slash simple='1'>
+                <varRef name='Q{}this' slot='3'/>
+                <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+               </slash>
+              </data>
+             </cvUntyped>
+             <str role='regex' val='\i\c*\('/>
+             <str role='flags' val=''/>
+             <choose role='matching' line='2980'>
+              <vc op='eq' onEmpty='0' comp='CCC'>
+               <fn name='substring-before'>
+                <dot type='xs:string'/>
+                <str val='('/>
+               </fn>
+               <str val='index'/>
+              </vc>
+              <str val='i'/>
+             </choose>
+             <empty role='nonMatching'/>
+            </analyzeString>
+           </sequence>
+          </fn>
+         </let>
+         <fn name='empty'>
+          <filter flags='b'>
+           <slash simple='1'>
+            <dot type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
+            <axis name='ancestor' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+           </slash>
+           <let var='Q{}this' as='element()' slot='4' eval='16'>
+            <dot type='element()'/>
+            <fn line='2990' name='exists'>
+             <sequence line='2965'>
+              <analyzeString>
+               <cvUntyped role='select' to='xs:string'>
+                <data>
+                 <slash simple='1'>
+                  <varRef name='Q{}this' slot='4'/>
+                  <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+                 </slash>
+                </data>
+               </cvUntyped>
+               <str role='regex' val='\i\c*\('/>
+               <str role='flags' val=''/>
+               <choose role='matching' line='2968'>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <fn name='substring-before'>
+                  <dot type='xs:string'/>
+                  <str val='('/>
+                 </fn>
+                 <str val='index'/>
+                </vc>
+                <str val='i'/>
+               </choose>
+               <empty role='nonMatching'/>
+              </analyzeString>
+              <analyzeString line='2977'>
+               <cvUntyped role='select' to='xs:string'>
+                <data>
+                 <slash simple='1'>
+                  <varRef name='Q{}this' slot='4'/>
+                  <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+                 </slash>
+                </data>
+               </cvUntyped>
+               <str role='regex' val='\i\c*\('/>
+               <str role='flags' val=''/>
+               <choose role='matching' line='2980'>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <fn name='substring-before'>
+                  <dot type='xs:string'/>
+                  <str val='('/>
+                 </fn>
+                 <str val='index'/>
+                </vc>
+                <str val='i'/>
+               </choose>
+               <empty role='nonMatching'/>
+              </analyzeString>
+             </sequence>
+            </fn>
+           </let>
+          </filter>
+         </fn>
+        </and>
+        <ifCall line='2038' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+         <check card='1' diag='0|0||ixsl:call'>
+          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+         </check>
+         <str val='setElementUsingIndexFunction'/>
+         <arrayBlock>
+          <varRef name='Q{}myid' slot='2'/>
+          <dot type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
+         </arrayBlock>
+        </ifCall>
+       </choose>
+       <let line='2042' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='2043' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+         <check card='?' diag='3|0|XTTE0570|bindingi'>
+          <callT name='Q{}getBinding' bSlot='34'>
+           <withParam name='Q{}this' flags='c' as='element()'>
+            <dot line='2044' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
+           </withParam>
+          </callT>
+         </check>
+        </treat>
+        <let line='2049' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='2050' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+          <check card='1' diag='3|0|XTTE0570|refi'>
+           <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
+            <data>
+             <callT name='Q{}getDataRef' bSlot='35'>
+              <withParam name='Q{}this' flags='c' as='element()'>
+               <dot line='2051' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
+              </withParam>
+              <withParam name='Q{}bindingi' flags='c' as='node()?'>
+               <varRef line='2052' name='Q{}bindingi' slot='5'/>
+              </withParam>
+             </callT>
+            </data>
+           </cvUntyped>
+          </check>
+         </treat>
+         <let line='2059' var='Q{}actions' as='map(*)*' slot='7' eval='8'>
+          <treat line='2060' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+           <callT name='Q{}setActions' bSlot='36'>
+            <withParam name='Q{}this' flags='c' as='element()'>
+             <dot line='2061' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
+            </withParam>
+            <withParam name='Q{}nodeset' flags='t' as='xs:string'>
+             <varRef line='2062' name='Q{}refi' slot='6'/>
+            </withParam>
+           </callT>
+          </treat>
+          <sequence line='2066'>
+           <choose>
+            <fn name='exists'>
+             <varRef name='Q{}actions' slot='7'/>
+            </fn>
+            <ifCall line='2067' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+             <check card='1' diag='0|0||ixsl:call'>
+              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+             </check>
+             <str val='addAction'/>
+             <arrayBlock>
+              <varRef name='Q{}myid' slot='2'/>
+              <varRef name='Q{}actions' slot='7'/>
+             </arrayBlock>
+            </ifCall>
+           </choose>
+           <let line='2070' var='Q{}innerbody' as='document-node()' slot='8' eval='16'>
+            <doc line='2072' validation='preserve'>
+             <choose>
+              <fn name='exists'>
+               <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
+              </fn>
+              <applyT line='2073' bSlot='37'>
+               <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
+              </applyT>
+              <true/>
+              <valueOf line='2075' flags='l'>
+               <str val=' '/>
+              </valueOf>
+             </choose>
+            </doc>
+            <elem line='2079' name='span' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+             <sequence>
+              <att name='style' flags='l'>
+               <str val='display:&#39;inline&#39;'/>
+              </att>
+              <compElem line='2090' flags='l'>
+               <choose role='name' line='2082'>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <cast as='xs:string' emptiable='1'>
+                  <attVal name='Q{}appearance' chk='0'/>
+                 </cast>
+                 <str val='minimal'/>
+                </vc>
+                <str val='a'/>
+                <true/>
+                <str val='button'/>
+               </choose>
+               <sequence role='content' line='2091'>
+                <choose>
+                 <vc op='eq' onEmpty='0' comp='CCC'>
+                  <cast as='xs:string' emptiable='1'>
+                   <attVal name='Q{}appearance' chk='0'/>
+                  </cast>
+                  <str val='minimal'/>
+                 </vc>
+                 <att line='2092' name='type' flags='l'>
+                  <str val='button'/>
+                 </att>
+                </choose>
+                <att line='2095' name='data-ref' flags='l'>
+                 <varRef name='Q{}refi' slot='6'/>
+                </att>
+                <att line='2096' name='data-action' flags='l'>
+                 <varRef name='Q{}myid' slot='2'/>
+                </att>
+                <copyOf line='2097' flags='vc'>
+                 <varRef name='Q{}innerbody' slot='8'/>
+                </copyOf>
+               </sequence>
+              </compElem>
+             </sequence>
+            </elem>
+           </let>
+          </sequence>
+         </let>
+        </let>
+       </let>
+      </sequence>
+     </let>
+    </sequence>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='6' rank='1' minImp='0' slots='0' flags='s' line='1079' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
+    <empty role='action'/>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='17' rank='1' minImp='0' slots='1' flags='s' line='1680' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1681'>
+     <param name='Q{}selectedValue' slot='0' as='xs:string'>
+      <str role='select' val=''/>
+      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|selectedValue'>
+       <check card='1' diag='8|0|XTTE0590|selectedValue'>
+        <cvUntyped to='xs:string' diag='8|0|XTTE0590|selectedValue'>
+         <data>
+          <supplied slot='0'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <elem line='1683' name='option' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+      <sequence>
+       <att name='value' flags='l'>
+        <fn name='string-join'>
+         <convert from='xs:untypedAtomic' to='xs:string'>
+          <data>
+           <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}value)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;value&#39;;'/>
+          </data>
+         </convert>
+         <str val=' '/>
+        </fn>
+       </att>
+       <choose line='1684'>
+        <vc op='eq' onEmpty='0' comp='CCC'>
+         <varRef name='Q{}selectedValue' slot='0'/>
+         <cast as='xs:string' emptiable='1'>
+          <atomSing card='?' diag='2|0||cast as'>
+           <slash simple='2'>
+            <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}value)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;value&#39;;'/>
+            <axis name='child' nodeTest='text()' jsTest='return item.nodeType===3;'/>
+           </slash>
+          </atomSing>
+         </cast>
+        </vc>
+        <att line='1685' name='selected' flags='l'>
+         <varRef name='Q{}selectedValue' slot='0'/>
+        </att>
+       </choose>
+       <valueOf line='1688' flags='l'>
+        <fn name='string-join'>
+         <convert from='xs:untypedAtomic' to='xs:string'>
+          <data>
+           <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
+          </data>
+         </convert>
+         <str val=' '/>
+        </fn>
+       </valueOf>
+      </sequence>
+     </elem>
+    </sequence>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='25' part='4' rank='1' minImp='0' slots='1' flags='s' line='2111' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}script)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;script&#39;;'/>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2117' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2118' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+      <check card='1' diag='3|0|XTTE0570|action-map'>
+       <callT name='Q{}setAction' bSlot='2'>
+        <withParam name='Q{}this' flags='c' as='element()'>
+         <dot line='2119' type='element()'/>
+        </withParam>
+       </callT>
+      </check>
+     </treat>
+     <varRef line='2132' name='Q{}action-map' slot='0'/>
+    </let>
+   </templateRule>
+   <templateRule prec='0' prio='-0.5' seq='14' part='1' rank='0' minImp='0' slots='0' flags='s' line='1641' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+    <copy role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1643' flags='cin'>
+     <applyT role='content' bSlot='38'>
+      <sequence role='select'>
+       <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+       <axis name='child' nodeTest='( element() | text() | comment() | processing-instruction() )' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);'/>
+      </sequence>
+     </applyT>
+    </copy>
+   </templateRule>
+   <templateRule prec='0' prio='0.5' seq='15' rank='2' minImp='0' slots='0' flags='s' line='1652' module='saxon-xforms.xsl'>
+    <p.withPredicate role='match'>
+     <p.nodeTest test='text()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===3;'/>
+     <axis ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1652' name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
+    </p.withPredicate>
+    <empty role='action'/>
+   </templateRule>
+   <templateRule prec='0' prio='-0.5' seq='14' rank='0' minImp='0' slots='0' flags='s' line='1641' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='( element() | text() | comment() | processing-instruction() )' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);'/>
+    <copy role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1643' flags='cin'>
+     <applyT role='content' bSlot='38'>
+      <sequence role='select'>
+       <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+       <axis name='child' nodeTest='( element() | text() | comment() | processing-instruction() )' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);'/>
+      </sequence>
+     </applyT>
+    </copy>
+   </templateRule>
+  </mode>
+ </co>
+ <co id='63' binds='62'>
+  <template name='Q{}getDataRef' flags='os' line='3321' module='saxon-xforms.xsl' slots='11'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3322'>
+    <param name='Q{}this' slot='0' flags='r' as='element()'>
+     <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+      <check card='1' diag='8|0|XTTE0590|this'>
+       <supplied slot='0'/>
+      </check>
+     </treat>
+    </param>
+    <param line='3323' name='Q{}nodeset' slot='1' flags='t' as='xs:string'>
+     <str role='select' val=''/>
+     <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
+      <check card='1' diag='8|0|XTTE0590|nodeset'>
+       <cvUntyped to='xs:string' diag='8|0|XTTE0590|nodeset'>
+        <data>
+         <supplied slot='1'/>
+        </data>
+       </cvUntyped>
+      </check>
+     </treat>
+    </param>
+    <param line='3324' name='Q{}bindingi' slot='2' as='node()?'>
+     <empty role='select'/>
+     <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|bindingi'>
+      <check card='?' diag='8|0|XTTE0590|bindingi'>
+       <supplied slot='2'/>
+      </check>
+     </treat>
+    </param>
+    <let line='3332' var='Q{}this-ref' as='xs:string?' slot='3' eval='7'>
+     <choose>
+      <fn name='exists'>
+       <slash simple='1'>
+        <varRef name='Q{}this' slot='0'/>
+        <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+       </slash>
+      </fn>
+      <fn name='normalize-space'>
+       <cast as='xs:string' emptiable='1'>
+        <data>
+         <slash simple='1'>
+          <varRef name='Q{}this' slot='0'/>
+          <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+         </slash>
+        </data>
+       </cast>
+      </fn>
+      <fn name='exists'>
+       <slash simple='1'>
+        <varRef name='Q{}this' slot='0'/>
+        <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+       </slash>
+      </fn>
+      <fn name='normalize-space'>
+       <cast as='xs:string' emptiable='1'>
+        <data>
+         <slash simple='1'>
+          <varRef name='Q{}this' slot='0'/>
+          <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+         </slash>
+        </data>
+       </cast>
+      </fn>
+     </choose>
+     <let line='3335' var='Q{}this-binding-ref' as='xs:string?' slot='4' eval='7'>
+      <choose line='3337'>
+       <fn name='exists'>
+        <varRef name='Q{}bindingi' slot='2'/>
+       </fn>
+       <cvUntyped line='3348' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
+        <cast as='xs:untypedAtomic' emptiable='0'>
+         <choose>
+          <fn name='exists'>
+           <slash simple='1'>
+            <varRef name='Q{}bindingi' slot='2'/>
+            <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+           </slash>
+          </fn>
+          <fn name='normalize-space'>
+           <cast as='xs:string' emptiable='1'>
+            <data>
+             <slash simple='1'>
+              <varRef name='Q{}bindingi' slot='2'/>
+              <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+             </slash>
+            </data>
+           </cast>
+          </fn>
+          <true/>
+          <fn name='normalize-space'>
+           <cast as='xs:string' emptiable='1'>
+            <data>
+             <slash simple='1'>
+              <varRef name='Q{}bindingi' slot='2'/>
+              <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+             </slash>
+            </data>
+           </cast>
+          </fn>
+         </choose>
+        </cast>
+       </cvUntyped>
+       <true/>
+       <let line='3352' var='Q{}this-binding' as='node()?' slot='5' eval='7'>
+        <treat line='3353' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|this-binding'>
+         <check card='?' diag='3|0|XTTE0570|this-binding'>
+          <callT name='Q{}getBinding' bSlot='0'>
+           <withParam name='Q{}this' flags='c' as='element()'>
+            <treat line='3354' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+             <dot flags='a'/>
+            </treat>
+           </withParam>
+          </callT>
+         </check>
+        </treat>
+        <choose line='3357'>
+         <fn name='exists'>
+          <varRef name='Q{}this-binding' slot='5'/>
+         </fn>
+         <cvUntyped line='3364' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
+          <cast as='xs:untypedAtomic' emptiable='0'>
+           <choose>
+            <fn name='exists'>
+             <slash simple='1'>
+              <varRef name='Q{}this-binding' slot='5'/>
+              <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+             </slash>
+            </fn>
+            <fn name='normalize-space'>
+             <cast as='xs:string' emptiable='1'>
+              <data>
+               <slash simple='1'>
+                <varRef name='Q{}this-binding' slot='5'/>
+                <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+               </slash>
+              </data>
+             </cast>
+            </fn>
+            <true/>
+            <fn name='normalize-space'>
+             <cast as='xs:string' emptiable='1'>
+              <data>
+               <slash simple='1'>
+                <varRef name='Q{}this-binding' slot='5'/>
+                <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+               </slash>
+              </data>
+             </cast>
+            </fn>
+           </choose>
+          </cast>
+         </cvUntyped>
+        </choose>
+       </let>
+      </choose>
+      <choose line='3374'>
+       <fn name='exists'>
+        <varRef name='Q{}bindingi' slot='2'/>
+       </fn>
+       <let line='3376' var='Q{}relative' as='xs:string' slot='6' eval='16'>
+        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
+         <varRef name='Q{}this-binding-ref' slot='4'/>
+        </check>
+        <choose line='835'>
+         <fn name='starts-with'>
+          <varRef name='Q{}relative' slot='6'/>
+          <str val='/'/>
+         </fn>
+         <varRef line='836' name='Q{}relative' slot='6'/>
+         <fn line='838' name='starts-with'>
+          <varRef name='Q{}relative' slot='6'/>
+          <str val='instance('/>
+         </fn>
+         <varRef line='839' name='Q{}relative' slot='6'/>
+         <true/>
+         <varRef line='842' name='Q{}relative' slot='6'/>
+        </choose>
+       </let>
+       <fn line='3378' name='exists'>
+        <varRef name='Q{}this-ref' slot='3'/>
+       </fn>
+       <let line='3380' var='Q{}relative' as='xs:string' slot='7' eval='16'>
+        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
+         <varRef name='Q{}this-ref' slot='3'/>
+        </check>
+        <choose line='835'>
+         <fn name='starts-with'>
+          <varRef name='Q{}relative' slot='7'/>
+          <str val='/'/>
+         </fn>
+         <varRef line='836' name='Q{}relative' slot='7'/>
+         <fn line='838' name='starts-with'>
+          <varRef name='Q{}relative' slot='7'/>
+          <str val='instance('/>
+         </fn>
+         <varRef line='839' name='Q{}relative' slot='7'/>
+         <fn line='3380' name='not'>
+          <varRef name='Q{}nodeset' slot='1'/>
+         </fn>
+         <varRef line='842' name='Q{}relative' slot='7'/>
+         <or line='844' op='or'>
+          <fn name='not'>
+           <varRef name='Q{}relative' slot='7'/>
+          </fn>
+          <vc op='eq' onEmpty='0' comp='CCC'>
+           <varRef name='Q{}relative' slot='7'/>
+           <str val='.'/>
+          </vc>
+         </or>
+         <varRef line='3380' name='Q{}nodeset' slot='1'/>
+         <true/>
+         <let line='849' var='Q{}parentCallCount' as='xs:integer' slot='8' eval='16'>
+          <choose>
+           <fn name='contains'>
+            <varRef name='Q{}relative' slot='7'/>
+            <str val='/'/>
+           </fn>
+           <fn name='count'>
+            <filter flags='b'>
+             <fn name='tokenize'>
+              <varRef name='Q{}relative' slot='7'/>
+              <str val='/'/>
+              <str val=''/>
+             </fn>
+             <vc op='eq' onEmpty='0' comp='CCC'>
+              <dot type='xs:string'/>
+              <str val='..'/>
+             </vc>
+            </filter>
+           </fn>
+           <fn name='contains'>
+            <varRef name='Q{}relative' slot='7'/>
+            <str val='..'/>
+           </fn>
+           <int val='1'/>
+           <true/>
+           <int val='0'/>
+          </choose>
+          <let line='852' var='Q{}slashes' as='xs:integer*' slot='9' eval='4'>
+           <choose>
+            <fn line='3380' name='contains'>
+             <varRef name='Q{}nodeset' slot='1'/>
+             <str val='/'/>
+            </fn>
+            <fn name='index-of'>
+             <fn name='string-to-codepoints'>
+              <varRef line='3380' name='Q{}nodeset' slot='1'/>
+             </fn>
+             <int val='47'/>
+            </fn>
+            <true/>
+            <int val='0'/>
+           </choose>
+           <choose line='884'>
+            <compareToInt op='gt' val='0'>
+             <varRef name='Q{}parentCallCount' slot='8'/>
+            </compareToInt>
+            <fn line='888' name='concat'>
+             <fn name='substring'>
+              <varRef line='3380' name='Q{}nodeset' slot='1'/>
+              <int val='1'/>
+              <choose line='863'>
+               <and op='and'>
+                <vc op='ge' onEmpty='0' comp='CAVC'>
+                 <fn name='count'>
+                  <varRef name='Q{}slashes' slot='9'/>
+                 </fn>
+                 <varRef name='Q{}parentCallCount' slot='8'/>
+                </vc>
+                <compareToInt op='gt' val='0'>
+                 <varRef name='Q{}parentCallCount' slot='8'/>
+                </compareToInt>
+               </and>
+               <let line='864' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='10' eval='13'>
+                <arith op='-' calc='i-i'>
+                 <varRef name='Q{}parentCallCount' slot='8'/>
+                 <int val='1'/>
+                </arith>
+                <check card='1' diag='3|0|XTTE0570|parentSlash'>
+                 <filter flags='p'>
+                  <varRef name='Q{}slashes' slot='9'/>
+                  <arith op='-' calc='i-i'>
+                   <fn name='last'/>
+                   <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='10'/>
+                  </arith>
+                 </filter>
+                </check>
+               </let>
+               <true/>
+               <check line='867' card='1' diag='3|0|XTTE0570|parentSlash'>
+                <lastOf>
+                 <varRef name='Q{}slashes' slot='9'/>
+                </lastOf>
+               </check>
+              </choose>
+             </fn>
+             <fn name='replace'>
+              <varRef name='Q{}relative' slot='7'/>
+              <str val='\.\./'/>
+              <str val=''/>
+              <str val=''/>
+             </fn>
+            </fn>
+            <true/>
+            <fn line='3380' name='concat'>
+             <varRef name='Q{}nodeset' slot='1'/>
+             <str val='/'/>
+             <varRef line='891' name='Q{}relative' slot='7'/>
+            </fn>
+           </choose>
+          </let>
+         </let>
+        </choose>
+       </let>
+       <varRef line='3382' name='Q{}nodeset' slot='1'/>
+       <choose line='3385'>
+        <fn name='starts-with'>
+         <varRef name='Q{}nodeset' slot='1'/>
+         <str val='/'/>
+        </fn>
+        <varRef name='Q{}nodeset' slot='1'/>
+        <fn name='starts-with'>
+         <varRef name='Q{}nodeset' slot='1'/>
+         <str val='instance('/>
+        </fn>
+        <varRef name='Q{}nodeset' slot='1'/>
+        <true/>
+        <varRef name='Q{}nodeset' slot='1'/>
+       </choose>
+       <true/>
+       <cvUntyped line='3389' to='xs:string' diag='3|0|XTTE0570|data-ref'>
+        <cast as='xs:untypedAtomic' emptiable='0'>
+         <varRef name='Q{}nodeset' slot='1'/>
+        </cast>
+       </cvUntyped>
+      </choose>
+     </let>
+    </let>
+   </sequence>
+  </template>
+ </co>
+ <co id='5' binds='22'>
+  <function name='Q{http://www.w3.org/2002/xforms}setInstance-JS' line='3230' module='saxon-xforms.xsl' eval='7' flags='pU' as='empty-sequence()' slots='2'>
+   <arg name='Q{}ref' as='xs:string'/>
+   <arg name='Q{}updatedInstance' as='element()'/>
+   <check role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3238' card='°' diag='5|0|XTTE0780|xforms:setInstance-JS#2'>
+    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+     <check card='1' diag='0|0||ixsl:call'>
+      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+     </check>
+     <str val='setInstance'/>
+     <arrayBlock>
+      <check line='3236' card='1' diag='3|0|XTTE0570|this-instance-id'>
+       <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+        <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='0' eval='6'>
+         <varRef name='Q{}ref' slot='0'/>
+        </ufCall>
+        <str val='instance-id'/>
+       </ifCall>
+      </check>
+      <varRef name='Q{}updatedInstance' slot='1'/>
+     </arrayBlock>
+    </ifCall>
+   </check>
+  </function>
+ </co>
+ <co id='2' binds='41 22'>
+  <function name='Q{http://www.w3.org/2002/xforms}getInstance-JS' line='3203' module='saxon-xforms.xsl' eval='7' flags='pU' as='element()?' slots='1'>
+   <arg name='Q{}ref' as='xs:string'/>
+   <tailCallLoop role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3207'>
+    <choose>
+     <fn name='not'>
+      <varRef name='Q{}ref' slot='0'/>
+     </fn>
+     <treat line='3208' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='5|0|XTTE0780|xforms:getInstance-JS#1'>
+      <message>
+       <valueOf role='select'>
+        <str val='[xforms:getInstance-JS] Empty ref supplied, no instance will be returned'/>
+       </valueOf>
+       <str role='terminate' val='no'/>
+       <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+      </message>
+     </treat>
+     <true/>
+     <ufCall line='3213' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='foreign' bSlot='0' eval='16'>
+      <check line='3211' card='1' diag='3|0|XTTE0570|this-instance-id'>
+       <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+        <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='1' eval='6'>
+         <varRef name='Q{}ref' slot='0'/>
+        </ufCall>
+        <str val='instance-id'/>
+       </ifCall>
+      </check>
+     </ufCall>
+    </choose>
+   </tailCallLoop>
+  </function>
+ </co>
+ <co id='22' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}getInstanceMap' line='3097' module='saxon-xforms.xsl' eval='8' flags='pU' as='map(xs:string, xs:string)' slots='3'>
+   <arg name='Q{}nodeset' as='xs:string'/>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3121' var='Q{http://saxon.sf.net/generated-variable}v0' as='map(xs:string, xs:string)+' slot='1' eval='4'>
+    <sequence>
+     <map size='1'>
+      <str val='instance-id'/>
+      <str val='saxon-forms-default'/>
+     </map>
+     <ifCall line='3122' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+      <str val='xpath'/>
+      <fn name='normalize-space'>
+       <varRef name='Q{}nodeset' slot='0'/>
+      </fn>
+     </ifCall>
+    </sequence>
+    <ifCall line='3102' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+     <analyzeString>
+      <fn role='select' name='normalize-space'>
+       <varRef name='Q{}nodeset' slot='0'/>
+      </fn>
+      <str role='regex' val='^instance\s*\(\s*&#39;([^&#39;]+)&#39;\s*\)\s*(/\s*(.*)|)$'/>
+      <str role='flags' val=''/>
+      <let role='matching' line='3104' var='Q{}xpath' as='xs:string' slot='2' eval='16'>
+       <choose line='3106'>
+        <fn name='regex-group'>
+         <int val='2'/>
+        </fn>
+        <fn line='3107' name='regex-group'>
+         <int val='3'/>
+        </fn>
+        <true/>
+        <str val='.'/>
+       </choose>
+       <sequence line='3114'>
+        <message>
+         <sequence role='select'>
+          <valueOf>
+           <str val='[xforms:getInstanceMap] From $nodeset = &#39;'/>
+          </valueOf>
+          <varRef name='Q{}nodeset' slot='0'/>
+          <valueOf flags='S'>
+           <str val='&#39;'/>
+          </valueOf>
+         </sequence>
+         <str role='terminate' val='no'/>
+         <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+        </message>
+        <message line='3115'>
+         <sequence role='select'>
+          <valueOf>
+           <str val='[xforms:getInstanceMap] &#39;instance-id&#39; = &#39;'/>
+          </valueOf>
+          <fn name='regex-group'>
+           <int val='1'/>
+          </fn>
+          <valueOf flags='S'>
+           <str val='&#39;'/>
+          </valueOf>
+         </sequence>
+         <str role='terminate' val='no'/>
+         <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+        </message>
+        <message line='3116'>
+         <sequence role='select'>
+          <valueOf>
+           <str val='[xforms:getInstanceMap] &#39;xpath&#39; = &#39;'/>
+          </valueOf>
+          <varRef name='Q{}xpath' slot='2'/>
+          <valueOf flags='S'>
+           <str val='&#39;'/>
+          </valueOf>
+         </sequence>
+         <str role='terminate' val='no'/>
+         <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+        </message>
+        <ifCall line='3117' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <str val='instance-id'/>
+         <fn name='regex-group'>
+          <int val='1'/>
+         </fn>
+        </ifCall>
+        <ifCall line='3118' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <str val='xpath'/>
+         <varRef name='Q{}xpath' slot='2'/>
+        </ifCall>
+       </sequence>
+      </let>
+      <varRef role='nonMatching' line='3121' name='Q{http://saxon.sf.net/generated-variable}v0' slot='1'/>
+     </analyzeString>
+     <map size='2'>
+      <str val='duplicates'/>
+      <str val='reject'/>
+      <str val='duplicates-error-code'/>
+      <str val='XTDE3365'/>
+     </map>
+    </ifCall>
+   </let>
+  </function>
+ </co>
+ <co id='1' binds='22'>
+  <function name='Q{http://www.w3.org/2002/xforms}getInstanceId' line='3084' module='saxon-xforms.xsl' eval='8' flags='pU' as='xs:string' slots='1'>
+   <arg name='Q{}nodeset' as='xs:string'/>
+   <cvUntyped role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3087' to='xs:string' diag='5|0|XTTE0780|xforms:getInstanceId#1'>
+    <cast as='xs:untypedAtomic' emptiable='0'>
+     <fn name='string'>
+      <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+       <ufCall line='3086' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='0' eval='6'>
+        <varRef name='Q{}nodeset' slot='0'/>
+       </ufCall>
+       <str val='instance-id'/>
+      </ifCall>
+     </fn>
+    </cast>
+   </cvUntyped>
+  </function>
+ </co>
+ <co id='65' binds=''>
+  <globalVariable name='Q{}debugMode' type='xs:boolean' line='73' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.boolean.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
+   <true/>
+  </globalVariable>
+ </co>
+ <co id='66' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}getWhileStatement' line='806' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
+   <arg name='Q{}map' as='map(*)'/>
+   <choose role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='809'>
+    <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+     <varRef name='Q{}map' slot='0'/>
+     <str val='@while'/>
+    </ifCall>
+    <treat line='810' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
+     <check card='?' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
+      <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
+       <data>
+        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+         <varRef name='Q{}map' slot='0'/>
+         <str val='@while'/>
+        </ifCall>
+       </data>
+      </cvUntyped>
+     </check>
+    </treat>
+    <true/>
+    <treat line='813' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
+     <check card='?' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
+      <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
+       <data>
+        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+         <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:get'>
+          <check card='1' diag='0|0||map:get'>
+           <lookupAll>
+            <varRef name='Q{}map' slot='0'/>
+           </lookupAll>
+          </check>
+         </treat>
+         <str val='@while'/>
+        </ifCall>
+       </data>
+      </cvUntyped>
+     </check>
+    </treat>
+   </choose>
+  </function>
+ </co>
+ <co id='67' binds='2 16 1 19'>
+  <template name='Q{}DOMActivate' flags='os' line='4364' module='saxon-xforms.xsl' slots='6'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4365'>
+    <param name='Q{}form-control' slot='0' flags='i' as='node()'>
+     <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|form-control'>
+      <check card='1' diag='8|0|XTTE0590|form-control'>
+       <supplied slot='0'/>
+      </check>
+     </treat>
+    </param>
+    <let line='4367' var='Q{}actions' as='map(*)?' slot='1' eval='7'>
+     <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+       <check card='1' diag='0|0||ixsl:call'>
+        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+       </check>
+       <str val='getAction'/>
+       <arrayBlock>
+        <fn name='string'>
+         <slash simple='1'>
+          <varRef name='Q{}form-control' slot='0'/>
+          <axis name='attribute' nodeTest='attribute(Q{}data-action)' jsTest='return item.name===&#39;data-action&#39;'/>
+         </slash>
+        </fn>
+       </arrayBlock>
+      </ifCall>
+     </treat>
+     <let line='4369' var='Q{}refi' as='attribute(Q{}data-ref)?' slot='2' eval='8'>
+      <slash simple='1'>
+       <varRef name='Q{}form-control' slot='0'/>
+       <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
+      </slash>
+      <let line='4373' var='Q{}instanceXML' as='element()?' slot='3' eval='7'>
+       <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='0' eval='16'>
+        <check card='1' diag='0|0||xforms:getInstance-JS'>
+         <cvUntyped to='xs:string'>
+          <data>
+           <varRef name='Q{}refi' slot='2'/>
+          </data>
+         </cvUntyped>
+        </check>
+       </ufCall>
+       <let line='4375' var='Q{}updatedInstanceXML' as='element()?' slot='4' eval='7'>
+        <choose line='4376'>
+         <fn name='exists'>
+          <varRef name='Q{}instanceXML' slot='3'/>
+         </fn>
+         <treat line='4377' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+          <check card='?' diag='3|0|XTTE0570|updatedInstanceXML'>
+           <applyT mode='Q{}form-check-initial' bSlot='1'>
+            <varRef role='select' name='Q{}instanceXML' slot='3'/>
+            <withParam name='Q{}instance-id' as='xs:string'>
+             <ufCall line='4371' name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='2' eval='16'>
+              <check card='1' diag='0|0||xforms:getInstanceId'>
+               <cvUntyped to='xs:string'>
+                <data>
+                 <varRef name='Q{}refi' slot='2'/>
+                </data>
+               </cvUntyped>
+              </check>
+             </ufCall>
+            </withParam>
+           </applyT>
+          </check>
+         </treat>
+        </choose>
+        <forEach line='4383'>
+         <varRef name='Q{}actions' slot='1'/>
+         <let line='4384' var='Q{}action-map' as='map(*)' slot='5' eval='16'>
+          <dot type='map(*)'/>
+          <choose line='4387'>
+           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+            <varRef name='Q{}action-map' slot='5'/>
+            <str val='@event'/>
+           </ifCall>
+           <choose line='4388'>
+            <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+             <data>
+              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+               <varRef name='Q{}action-map' slot='5'/>
+               <str val='@event'/>
+              </ifCall>
+             </data>
+             <str val='DOMActivate'/>
+            </gc>
+            <callT line='4389' name='Q{}applyActions' bSlot='3' flags='t'>
+             <withParam name='Q{}action-map' flags='t' as='item()'>
+              <varRef line='4390' name='Q{}action-map' slot='5'/>
+             </withParam>
+             <withParam name='Q{}instanceXML' flags='t' as='element()?'>
+              <varRef line='4391' name='Q{}updatedInstanceXML' slot='4'/>
+             </withParam>
+            </callT>
+           </choose>
+          </choose>
+         </let>
+        </forEach>
+       </let>
+      </let>
+     </let>
+    </let>
+   </sequence>
+  </template>
+ </co>
+ <co id='64' binds='42'>
+  <template name='Q{}setActions' flags='os' line='3638' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3639'>
+    <param name='Q{}this' slot='0' flags='i' as='element()'>
+     <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+      <check card='1' diag='8|0|XTTE0590|this'>
+       <supplied slot='0'/>
+      </check>
+     </treat>
+    </param>
+    <applyT line='3641' flags='t' bSlot='0'>
+     <union role='select' op='|'>
+      <union op='|'>
+       <union op='|'>
+        <union op='|'>
+         <union op='|'>
+          <slash simple='1'>
+           <varRef name='Q{}this' slot='0'/>
+           <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}action)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;action&#39;;'/>
+          </slash>
+          <filter flags='b'>
+           <slash simple='1'>
+            <varRef name='Q{}this' slot='0'/>
+            <axis name='child' nodeTest='Q{http://www.w3.org/2002/xforms}*' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.uri===&#39;http://www.w3.org/2002/xforms&#39;'/>
+           </slash>
+           <gc op='=' card='N:1' comp='CCC'>
+            <literal count='15'>
+             <str val='setvalue'/>
+             <str val='insert'/>
+             <str val='delete'/>
+             <str val='setindex'/>
+             <str val='toggle'/>
+             <str val='setfocus'/>
+             <str val='dispatch'/>
+             <str val='rebuild'/>
+             <str val='recalculate'/>
+             <str val='revalidate'/>
+             <str val='refresh'/>
+             <str val='reset'/>
+             <str val='load'/>
+             <str val='send'/>
+             <str val='message'/>
+            </literal>
+            <fn name='local-name'>
+             <dot type='Q{http://www.w3.org/2002/xforms}*'/>
+            </fn>
+           </gc>
+          </filter>
+         </union>
+         <slash simple='1'>
+          <varRef name='Q{}this' slot='0'/>
+          <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}show)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;show&#39;;'/>
+         </slash>
+        </union>
+        <slash simple='1'>
+         <varRef name='Q{}this' slot='0'/>
+         <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}hide)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;hide&#39;;'/>
+        </slash>
+       </union>
+       <slash simple='1'>
+        <varRef name='Q{}this' slot='0'/>
+        <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}script)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;script&#39;;'/>
+       </slash>
+      </union>
+      <slash simple='1'>
+       <varRef name='Q{}this' slot='0'/>
+       <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}unload)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;unload&#39;;'/>
+      </slash>
+     </union>
+    </applyT>
+   </sequence>
+  </template>
+ </co>
+ <co id='68' binds=''>
+  <template name='Q{}serverError' flags='os' line='1058' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1059'>
+    <param name='Q{}responseMap' slot='0' flags='i' as='map(*)'>
+     <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|responseMap'>
+      <check card='1' diag='8|0|XTTE0590|responseMap'>
+       <supplied slot='0'/>
+      </check>
+     </treat>
+    </param>
+    <message line='1060'>
+     <sequence role='select'>
+      <valueOf>
+       <str val='Server side error HTTP response - '/>
+      </valueOf>
+      <valueOf>
+       <fn name='concat'>
+        <atomSing card='?' diag='0|0||fn:concat'>
+         <lookup>
+          <varRef name='Q{}responseMap' slot='0'/>
+          <str val='status'/>
+         </lookup>
+        </atomSing>
+        <str val=' '/>
+        <atomSing card='?' diag='0|2||fn:concat'>
+         <lookup>
+          <varRef name='Q{}responseMap' slot='0'/>
+          <str val='message'/>
+         </lookup>
+        </atomSing>
+       </fn>
+      </valueOf>
+     </sequence>
+     <str role='terminate' val='no'/>
+     <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+    </message>
+   </sequence>
+  </template>
+ </co>
+ <co id='61' binds='62 63 42'>
+  <template name='Q{}setAction' flags='os' line='3805' module='saxon-xforms.xsl' slots='15'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3806'>
+    <param name='Q{}this' slot='0' flags='i' as='element()'>
+     <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+      <check card='1' diag='8|0|XTTE0590|this'>
+       <supplied slot='0'/>
+      </check>
+     </treat>
+    </param>
+    <param line='3807' name='Q{}nodeset' slot='1' flags='t'>
+     <str role='select' val=''/>
+     <supplied role='conversion' slot='1'/>
+    </param>
+    <let line='3810' var='Q{}bindingi' as='node()?' slot='2' eval='7'>
+     <treat line='3811' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+      <check card='?' diag='3|0|XTTE0570|bindingi'>
+       <callT name='Q{}getBinding' bSlot='0'>
+        <withParam name='Q{}this' flags='c' as='element()'>
+         <treat line='3812' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+          <dot flags='a'/>
+         </treat>
+        </withParam>
+       </callT>
+      </check>
+     </treat>
+     <let line='3817' var='Q{}refi' as='xs:string' slot='3' eval='16'>
+      <treat line='3818' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+       <check card='1' diag='3|0|XTTE0570|refi'>
+        <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
+         <data>
+          <callT name='Q{}getDataRef' bSlot='1'>
+           <withParam name='Q{}this' flags='c' as='element()'>
+            <treat line='3819' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+             <dot flags='a'/>
+            </treat>
+           </withParam>
+           <withParam name='Q{}bindingi' flags='c' as='node()?'>
+            <varRef line='3820' name='Q{}bindingi' slot='2'/>
+           </withParam>
+          </callT>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+      <ifCall line='3828' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+       <sequence>
+        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <str val='name'/>
+         <fn name='local-name'>
+          <treat as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='0|0||fn:local-name'>
+           <dot flags='a'/>
+          </treat>
+         </fn>
+        </ifCall>
+        <choose line='3830'>
+         <fn name='exists'>
+          <slash simple='1'>
+           <varRef name='Q{}this' slot='0'/>
+           <axis name='attribute' nodeTest='attribute(Q{}value)' jsTest='return item.name===&#39;value&#39;'/>
+          </slash>
+         </fn>
+         <ifCall line='3831' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <str val='@value'/>
+          <fn name='string'>
+           <slash simple='1'>
+            <varRef name='Q{}this' slot='0'/>
+            <axis name='attribute' nodeTest='attribute(Q{}value)' jsTest='return item.name===&#39;value&#39;'/>
+           </slash>
+          </fn>
+         </ifCall>
+        </choose>
+        <choose line='3833'>
+         <and op='and'>
+          <fn name='empty'>
+           <slash simple='1'>
+            <varRef name='Q{}this' slot='0'/>
+            <axis name='attribute' nodeTest='attribute(Q{}value)' jsTest='return item.name===&#39;value&#39;'/>
+           </slash>
+          </fn>
+          <fn name='exists'>
+           <slash simple='1'>
+            <treat as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='1|0|XPTY0019|/'>
+             <dot flags='a'/>
+            </treat>
+            <axis name='child' nodeTest='text()' jsTest='return item.nodeType===3;'/>
+           </slash>
+          </fn>
+         </and>
+         <ifCall line='3834' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <str val='value'/>
+          <fn name='string'>
+           <dot flags='a'/>
+          </fn>
+         </ifCall>
+        </choose>
+        <ifCall line='3837' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <str val='@ref'/>
+         <varRef name='Q{}refi' slot='3'/>
+        </ifCall>
+        <choose line='3843'>
+         <fn name='exists'>
+          <slash simple='1'>
+           <varRef name='Q{}this' slot='0'/>
+           <axis name='attribute' nodeTest='attribute(Q{}position)' jsTest='return item.name===&#39;position&#39;'/>
+          </slash>
+         </fn>
+         <ifCall line='3844' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <str val='@position'/>
+          <fn name='string'>
+           <slash simple='1'>
+            <varRef name='Q{}this' slot='0'/>
+            <axis name='attribute' nodeTest='attribute(Q{}position)' jsTest='return item.name===&#39;position&#39;'/>
+           </slash>
+          </fn>
+         </ifCall>
+        </choose>
+        <choose line='3846'>
+         <fn name='exists'>
+          <slash simple='1'>
+           <varRef name='Q{}this' slot='0'/>
+           <axis name='attribute' nodeTest='attribute(Q{}at)' jsTest='return item.name===&#39;at&#39;'/>
+          </slash>
+         </fn>
+         <ifCall line='3847' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <str val='@at'/>
+          <fn name='string'>
+           <slash simple='1'>
+            <varRef name='Q{}this' slot='0'/>
+            <axis name='attribute' nodeTest='attribute(Q{}at)' jsTest='return item.name===&#39;at&#39;'/>
+           </slash>
+          </fn>
+         </ifCall>
+        </choose>
+        <choose line='3851'>
+         <fn name='exists'>
+          <slash simple='1'>
+           <varRef name='Q{}this' slot='0'/>
+           <axis name='attribute' nodeTest='attribute(Q{}if)' jsTest='return item.name===&#39;if&#39;'/>
+          </slash>
+         </fn>
+         <ifCall line='3852' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <str val='@if'/>
+          <fn name='string'>
+           <slash simple='1'>
+            <varRef name='Q{}this' slot='0'/>
+            <axis name='attribute' nodeTest='attribute(Q{}if)' jsTest='return item.name===&#39;if&#39;'/>
+           </slash>
+          </fn>
+         </ifCall>
+        </choose>
+        <choose line='3856'>
+         <fn name='exists'>
+          <slash simple='1'>
+           <varRef name='Q{}this' slot='0'/>
+           <axis name='attribute' nodeTest='attribute(Q{}while)' jsTest='return item.name===&#39;while&#39;'/>
+          </slash>
+         </fn>
+         <ifCall line='3857' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <str val='@while'/>
+          <fn name='string'>
+           <slash simple='1'>
+            <varRef name='Q{}this' slot='0'/>
+            <axis name='attribute' nodeTest='attribute(Q{}while)' jsTest='return item.name===&#39;while&#39;'/>
+           </slash>
+          </fn>
+         </ifCall>
+        </choose>
+        <choose line='3860'>
+         <fn name='exists'>
+          <slash simple='1'>
+           <varRef name='Q{}this' slot='0'/>
+           <axis name='attribute' nodeTest='@*:event' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===2&amp;&amp;q.local===&#39;event&#39;'/>
+          </slash>
+         </fn>
+         <ifCall line='3861' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <str val='@event'/>
+          <fn name='string'>
+           <check card='?' diag='0|0||fn:string'>
+            <slash simple='1'>
+             <varRef name='Q{}this' slot='0'/>
+             <axis name='attribute' nodeTest='@*:event' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===2&amp;&amp;q.local===&#39;event&#39;'/>
+            </slash>
+           </check>
+          </fn>
+         </ifCall>
+        </choose>
+        <choose line='3863'>
+         <fn name='exists'>
+          <slash simple='1'>
+           <varRef name='Q{}this' slot='0'/>
+           <axis name='attribute' nodeTest='attribute(Q{}submission)' jsTest='return item.name===&#39;submission&#39;'/>
+          </slash>
+         </fn>
+         <ifCall line='3864' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <str val='@submission'/>
+          <fn name='string'>
+           <slash simple='1'>
+            <varRef name='Q{}this' slot='0'/>
+            <axis name='attribute' nodeTest='attribute(Q{}submission)' jsTest='return item.name===&#39;submission&#39;'/>
+           </slash>
+          </fn>
+         </ifCall>
+        </choose>
+        <choose line='3867'>
+         <fn name='exists'>
+          <slash simple='1'>
+           <varRef name='Q{}this' slot='0'/>
+           <axis name='attribute' nodeTest='attribute(Q{}model)' jsTest='return item.name===&#39;model&#39;'/>
+          </slash>
+         </fn>
+         <ifCall line='3868' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <str val='@model'/>
+          <fn name='string'>
+           <slash simple='1'>
+            <varRef name='Q{}this' slot='0'/>
+            <axis name='attribute' nodeTest='attribute(Q{}model)' jsTest='return item.name===&#39;model&#39;'/>
+           </slash>
+          </fn>
+         </ifCall>
+        </choose>
+        <choose line='3871'>
+         <fn name='exists'>
+          <slash simple='1'>
+           <varRef name='Q{}this' slot='0'/>
+           <axis name='attribute' nodeTest='attribute(Q{}control)' jsTest='return item.name===&#39;control&#39;'/>
+          </slash>
+         </fn>
+         <ifCall line='3872' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <str val='@control'/>
+          <fn name='string'>
+           <slash simple='1'>
+            <varRef name='Q{}this' slot='0'/>
+            <axis name='attribute' nodeTest='attribute(Q{}control)' jsTest='return item.name===&#39;control&#39;'/>
+           </slash>
+          </fn>
+         </ifCall>
+        </choose>
+        <choose line='3875'>
+         <fn name='exists'>
+          <slash simple='1'>
+           <varRef name='Q{}this' slot='0'/>
+           <axis name='attribute' nodeTest='attribute(Q{}repeat)' jsTest='return item.name===&#39;repeat&#39;'/>
+          </slash>
+         </fn>
+         <ifCall line='3876' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <str val='@repeat'/>
+          <fn name='string'>
+           <slash simple='1'>
+            <varRef name='Q{}this' slot='0'/>
+            <axis name='attribute' nodeTest='attribute(Q{}repeat)' jsTest='return item.name===&#39;repeat&#39;'/>
+           </slash>
+          </fn>
+         </ifCall>
+        </choose>
+        <choose line='3879'>
+         <fn name='exists'>
+          <slash simple='1'>
+           <varRef name='Q{}this' slot='0'/>
+           <axis name='attribute' nodeTest='attribute(Q{}index)' jsTest='return item.name===&#39;index&#39;'/>
+          </slash>
+         </fn>
+         <ifCall line='3880' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <str val='@index'/>
+          <fn name='string'>
+           <slash simple='1'>
+            <varRef name='Q{}this' slot='0'/>
+            <axis name='attribute' nodeTest='attribute(Q{}index)' jsTest='return item.name===&#39;index&#39;'/>
+           </slash>
+          </fn>
+         </ifCall>
+        </choose>
+        <choose line='3885'>
+         <fn name='exists'>
+          <slash simple='1'>
+           <varRef name='Q{}this' slot='0'/>
+           <axis name='attribute' nodeTest='attribute(Q{}origin)' jsTest='return item.name===&#39;origin&#39;'/>
+          </slash>
+         </fn>
+         <ifCall line='3893' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <str val='@origin'/>
+          <let line='3889' var='Q{}base' as='xs:string' slot='4' eval='16'>
+           <choose>
+            <fn name='exists'>
+             <slash simple='1'>
+              <varRef name='Q{}this' slot='0'/>
+              <axis name='attribute' nodeTest='attribute(Q{}context)' jsTest='return item.name===&#39;context&#39;'/>
+             </slash>
+            </fn>
+            <let var='Q{}base' as='xs:string' slot='5' eval='16'>
+             <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:resolveXPathStrings'>
+              <check card='1' diag='0|0||xforms:resolveXPathStrings'>
+               <cvUntyped to='xs:string'>
+                <data>
+                 <varRef name='Q{}nodeset' slot='1'/>
+                </data>
+               </cvUntyped>
+              </check>
+             </treat>
+             <let var='Q{}relative' as='xs:string' slot='6' eval='16'>
+              <check card='1' diag='0|1||xforms:resolveXPathStrings'>
+               <cvUntyped to='xs:string'>
+                <data>
+                 <slash simple='1'>
+                  <varRef name='Q{}this' slot='0'/>
+                  <axis name='attribute' nodeTest='attribute(Q{}context)' jsTest='return item.name===&#39;context&#39;'/>
+                 </slash>
+                </data>
+               </cvUntyped>
+              </check>
+              <choose line='835'>
+               <fn name='starts-with'>
+                <varRef name='Q{}relative' slot='6'/>
+                <str val='/'/>
+               </fn>
+               <varRef line='836' name='Q{}relative' slot='6'/>
+               <fn line='838' name='starts-with'>
+                <varRef name='Q{}relative' slot='6'/>
+                <str val='instance('/>
+               </fn>
+               <varRef line='839' name='Q{}relative' slot='6'/>
+               <fn line='841' name='not'>
+                <varRef name='Q{}base' slot='5'/>
+               </fn>
+               <varRef line='842' name='Q{}relative' slot='6'/>
+               <or line='844' op='or'>
+                <fn name='not'>
+                 <varRef name='Q{}relative' slot='6'/>
+                </fn>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <varRef name='Q{}relative' slot='6'/>
+                 <str val='.'/>
+                </vc>
+               </or>
+               <varRef line='845' name='Q{}base' slot='5'/>
+               <true/>
+               <let line='849' var='Q{}parentCallCount' as='xs:integer' slot='7' eval='16'>
+                <choose>
+                 <fn name='contains'>
+                  <varRef name='Q{}relative' slot='6'/>
+                  <str val='/'/>
+                 </fn>
+                 <fn name='count'>
+                  <filter flags='b'>
+                   <fn name='tokenize'>
+                    <varRef name='Q{}relative' slot='6'/>
+                    <str val='/'/>
+                    <str val=''/>
+                   </fn>
+                   <vc op='eq' onEmpty='0' comp='CCC'>
+                    <dot type='xs:string'/>
+                    <str val='..'/>
+                   </vc>
+                  </filter>
+                 </fn>
+                 <fn name='contains'>
+                  <varRef name='Q{}relative' slot='6'/>
+                  <str val='..'/>
+                 </fn>
+                 <int val='1'/>
+                 <true/>
+                 <int val='0'/>
+                </choose>
+                <let line='852' var='Q{}slashes' as='xs:integer*' slot='8' eval='4'>
+                 <choose>
+                  <fn name='contains'>
+                   <varRef name='Q{}base' slot='5'/>
+                   <str val='/'/>
+                  </fn>
+                  <fn name='index-of'>
+                   <fn name='string-to-codepoints'>
+                    <varRef name='Q{}base' slot='5'/>
+                   </fn>
+                   <int val='47'/>
+                  </fn>
+                  <true/>
+                  <int val='0'/>
+                 </choose>
+                 <choose line='884'>
+                  <compareToInt op='gt' val='0'>
+                   <varRef name='Q{}parentCallCount' slot='7'/>
+                  </compareToInt>
+                  <fn line='888' name='concat'>
+                   <fn name='substring'>
+                    <varRef name='Q{}base' slot='5'/>
+                    <int val='1'/>
+                    <choose line='863'>
+                     <and op='and'>
+                      <vc op='ge' onEmpty='0' comp='CAVC'>
+                       <fn name='count'>
+                        <varRef name='Q{}slashes' slot='8'/>
+                       </fn>
+                       <varRef name='Q{}parentCallCount' slot='7'/>
+                      </vc>
+                      <compareToInt op='gt' val='0'>
+                       <varRef name='Q{}parentCallCount' slot='7'/>
+                      </compareToInt>
+                     </and>
+                     <let line='864' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='9' eval='16'>
+                      <arith op='-' calc='i-i'>
+                       <varRef name='Q{}parentCallCount' slot='7'/>
+                       <int val='1'/>
+                      </arith>
+                      <check card='1' diag='3|0|XTTE0570|parentSlash'>
+                       <filter flags='p'>
+                        <varRef name='Q{}slashes' slot='8'/>
+                        <arith op='-' calc='i-i'>
+                         <fn name='last'/>
+                         <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='9'/>
+                        </arith>
+                       </filter>
+                      </check>
+                     </let>
+                     <true/>
+                     <check line='867' card='1' diag='3|0|XTTE0570|parentSlash'>
+                      <lastOf>
+                       <varRef name='Q{}slashes' slot='8'/>
+                      </lastOf>
+                     </check>
+                    </choose>
+                   </fn>
+                   <fn name='replace'>
+                    <varRef name='Q{}relative' slot='6'/>
+                    <str val='\.\./'/>
+                    <str val=''/>
+                    <str val=''/>
+                   </fn>
+                  </fn>
+                  <true/>
+                  <fn line='891' name='concat'>
+                   <varRef name='Q{}base' slot='5'/>
+                   <str val='/'/>
+                   <varRef name='Q{}relative' slot='6'/>
+                  </fn>
+                 </choose>
+                </let>
+               </let>
+              </choose>
+             </let>
+            </let>
+            <true/>
+            <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|origin-context'>
+             <check card='1' diag='3|0|XTTE0570|origin-context'>
+              <cvUntyped to='xs:string' diag='3|0|XTTE0570|origin-context'>
+               <data>
+                <varRef name='Q{}nodeset' slot='1'/>
+               </data>
+              </cvUntyped>
+             </check>
+            </treat>
+           </choose>
+           <let line='3891' var='Q{}relative' as='xs:string' slot='10' eval='16'>
+            <check card='1' diag='0|1||xforms:resolveXPathStrings'>
+             <cvUntyped to='xs:string'>
+              <data>
+               <slash simple='1'>
+                <varRef name='Q{}this' slot='0'/>
+                <axis name='attribute' nodeTest='attribute(Q{}origin)' jsTest='return item.name===&#39;origin&#39;'/>
+               </slash>
+              </data>
+             </cvUntyped>
+            </check>
+            <choose line='835'>
+             <fn name='starts-with'>
+              <varRef name='Q{}relative' slot='10'/>
+              <str val='/'/>
+             </fn>
+             <varRef line='836' name='Q{}relative' slot='10'/>
+             <fn line='838' name='starts-with'>
+              <varRef name='Q{}relative' slot='10'/>
+              <str val='instance('/>
+             </fn>
+             <varRef line='839' name='Q{}relative' slot='10'/>
+             <fn line='841' name='not'>
+              <varRef name='Q{}base' slot='4'/>
+             </fn>
+             <varRef line='842' name='Q{}relative' slot='10'/>
+             <or line='844' op='or'>
+              <fn name='not'>
+               <varRef name='Q{}relative' slot='10'/>
+              </fn>
+              <vc op='eq' onEmpty='0' comp='CCC'>
+               <varRef name='Q{}relative' slot='10'/>
+               <str val='.'/>
+              </vc>
+             </or>
+             <varRef line='845' name='Q{}base' slot='4'/>
+             <true/>
+             <let line='849' var='Q{}parentCallCount' as='xs:integer' slot='11' eval='16'>
+              <choose>
+               <fn name='contains'>
+                <varRef name='Q{}relative' slot='10'/>
+                <str val='/'/>
+               </fn>
+               <fn name='count'>
+                <filter flags='b'>
+                 <fn name='tokenize'>
+                  <varRef name='Q{}relative' slot='10'/>
+                  <str val='/'/>
+                  <str val=''/>
+                 </fn>
+                 <vc op='eq' onEmpty='0' comp='CCC'>
+                  <dot type='xs:string'/>
+                  <str val='..'/>
+                 </vc>
+                </filter>
+               </fn>
+               <fn name='contains'>
+                <varRef name='Q{}relative' slot='10'/>
+                <str val='..'/>
+               </fn>
+               <int val='1'/>
+               <true/>
+               <int val='0'/>
+              </choose>
+              <let line='852' var='Q{}slashes' as='xs:integer*' slot='12' eval='4'>
+               <choose>
+                <fn name='contains'>
+                 <varRef name='Q{}base' slot='4'/>
+                 <str val='/'/>
+                </fn>
+                <fn name='index-of'>
+                 <fn name='string-to-codepoints'>
+                  <varRef name='Q{}base' slot='4'/>
+                 </fn>
+                 <int val='47'/>
+                </fn>
+                <true/>
+                <int val='0'/>
+               </choose>
+               <choose line='884'>
+                <compareToInt op='gt' val='0'>
+                 <varRef name='Q{}parentCallCount' slot='11'/>
+                </compareToInt>
+                <fn line='888' name='concat'>
+                 <fn name='substring'>
+                  <varRef name='Q{}base' slot='4'/>
+                  <int val='1'/>
+                  <choose line='863'>
+                   <and op='and'>
+                    <vc op='ge' onEmpty='0' comp='CAVC'>
+                     <fn name='count'>
+                      <varRef name='Q{}slashes' slot='12'/>
+                     </fn>
+                     <varRef name='Q{}parentCallCount' slot='11'/>
+                    </vc>
+                    <compareToInt op='gt' val='0'>
+                     <varRef name='Q{}parentCallCount' slot='11'/>
+                    </compareToInt>
+                   </and>
+                   <let line='864' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='13' eval='13'>
+                    <arith op='-' calc='i-i'>
+                     <varRef name='Q{}parentCallCount' slot='11'/>
+                     <int val='1'/>
+                    </arith>
+                    <check card='1' diag='3|0|XTTE0570|parentSlash'>
+                     <filter flags='p'>
+                      <varRef name='Q{}slashes' slot='12'/>
+                      <arith op='-' calc='i-i'>
+                       <fn name='last'/>
+                       <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='13'/>
+                      </arith>
+                     </filter>
+                    </check>
+                   </let>
+                   <true/>
+                   <check line='867' card='1' diag='3|0|XTTE0570|parentSlash'>
+                    <lastOf>
+                     <varRef name='Q{}slashes' slot='12'/>
+                    </lastOf>
+                   </check>
+                  </choose>
+                 </fn>
+                 <fn name='replace'>
+                  <varRef name='Q{}relative' slot='10'/>
+                  <str val='\.\./'/>
+                  <str val=''/>
+                  <str val=''/>
+                 </fn>
+                </fn>
+                <true/>
+                <fn line='891' name='concat'>
+                 <varRef name='Q{}base' slot='4'/>
+                 <str val='/'/>
+                 <varRef name='Q{}relative' slot='10'/>
+                </fn>
+               </choose>
+              </let>
+             </let>
+            </choose>
+           </let>
+          </let>
+         </ifCall>
+        </choose>
+        <choose line='3897'>
+         <fn name='exists'>
+          <slash simple='1'>
+           <varRef name='Q{}this' slot='0'/>
+           <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+          </slash>
+         </fn>
+         <ifCall line='3898' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <str val='nested-actions'/>
+          <let line='3899' var='Q{}array' as='map(*)*' slot='14' eval='3'>
+           <treat line='3900' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|array'>
+            <forEach>
+             <slash simple='1'>
+              <varRef name='Q{}this' slot='0'/>
+              <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+             </slash>
+             <applyT line='3901' bSlot='2'>
+              <dot role='select' type='element()'/>
+             </applyT>
+            </forEach>
+           </treat>
+           <ifCall line='3904' name='Q{http://www.w3.org/2005/xpath-functions/array}_from-sequence' type='array(*)'>
+            <varRef name='Q{}array' slot='14'/>
+           </ifCall>
+          </let>
+         </ifCall>
+        </choose>
+       </sequence>
+       <map size='2'>
+        <str val='duplicates'/>
+        <str val='reject'/>
+        <str val='duplicates-error-code'/>
+        <str val='XTDE3365'/>
+       </map>
+      </ifCall>
+     </let>
+    </let>
+   </sequence>
+  </template>
+ </co>
+ <co id='69' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}check-constraints-on-fields' line='956' module='saxon-xforms.xsl' eval='8' flags='pU' as='item()*' slots='4'>
+   <arg name='Q{}updatedInstanceXML' as='document-node()'/>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='959' var='Q{}constraint-fieldsi' as='element()*' slot='1' eval='8'>
+    <filter flags='b'>
+     <slash simple='1'>
+      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
+      <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+     </slash>
+     <fn name='exists'>
+      <axis name='attribute' nodeTest='attribute(Q{}data-constraint)' jsTest='return item.name===&#39;data-constraint&#39;'/>
+     </fn>
+    </filter>
+    <forEach line='963'>
+     <varRef name='Q{}constraint-fieldsi' slot='1'/>
+     <let line='964' var='Q{}contexti' as='node()' slot='2' eval='16'>
+      <treat line='965' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|contexti'>
+       <check card='1' diag='3|0|XTTE0570|contexti'>
+        <evaluate dxns=''>
+         <check role='xpath' card='1' diag='4|0||xsl:evaluate/xpath'>
+          <cvUntyped to='xs:string'>
+           <attVal name='Q{}data-ref' chk='0'/>
+          </cvUntyped>
+         </check>
+         <varRef role='cxt' name='Q{}updatedInstanceXML' slot='0'/>
+         <varRef role='nsCxt' name='Q{}updatedInstanceXML' slot='0'/>
+         <str role='sa' val='no'/>
+         <map role='options' size='0'/>
+         <map role='wp' size='0'/>
+        </evaluate>
+       </check>
+      </treat>
+      <let line='968' var='Q{}resulti' as='xs:boolean' slot='3' eval='16'>
+       <treat line='971' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|resulti'>
+        <check card='1' diag='3|0|XTTE0570|resulti'>
+         <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|resulti'>
+          <data>
+           <evaluate dxns=''>
+            <check role='xpath' card='1' diag='4|0||xsl:evaluate/xpath'>
+             <cvUntyped to='xs:string'>
+              <attVal name='Q{}data-constraint' chk='0'/>
+             </cvUntyped>
+            </check>
+            <varRef role='cxt' name='Q{}contexti' slot='2'/>
+            <varRef role='nsCxt' name='Q{}contexti' slot='2'/>
+            <str role='sa' val='no'/>
+            <map role='options' size='0'/>
+            <map role='wp' size='0'/>
+           </evaluate>
+          </data>
+         </cvUntyped>
+        </check>
+       </treat>
+       <choose line='979'>
+        <fn name='not'>
+         <varRef name='Q{}resulti' slot='3'/>
+        </fn>
+        <dot type='element()'/>
+       </choose>
+      </let>
+     </let>
+    </forEach>
+   </let>
+  </function>
+ </co>
+ <co id='48' binds='57'>
+  <mode name='Q{}binding-calculation-initial' onNo='TC' flags='W' patternSlots='0'>
+   <templateRule prec='0' prio='-0.5' seq='28' rank='0' minImp='0' slots='2' flags='s' line='2709' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2710'>
+     <param name='Q{}instance-id' slot='0' as='xs:string'>
+      <str role='select' val='saxon-forms-default'/>
+      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|instance-id'>
+       <check card='1' diag='8|0|XTTE0590|instance-id'>
+        <cvUntyped to='xs:string' diag='8|0|XTTE0590|instance-id'>
+         <data>
+          <supplied slot='0'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <let line='2712' var='Q{}calculationMap' as='map(xs:string, xs:string)' slot='1' eval='16'>
+      <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|calculationMap'>
+       <check card='1' diag='3|0|XTTE0570|calculationMap'>
+        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+         <check card='1' diag='0|0||ixsl:call'>
+          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+         </check>
+         <str val='getCalculationMap'/>
+         <array size='0'/>
+        </ifCall>
+       </check>
+      </treat>
+      <copy line='2726' flags='cin'>
+       <applyT role='content' mode='Q{}binding-calculation' bSlot='0'>
+        <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+        <withParam name='Q{}curPath' as='xs:string'>
+         <choose line='2716'>
+          <vc op='eq' onEmpty='0' comp='CCC'>
+           <varRef name='Q{}instance-id' slot='0'/>
+           <str val='saxon-forms-default'/>
+          </vc>
+          <str val=''/>
+          <true/>
+          <cvUntyped line='2720' to='xs:string' diag='3|0|XTTE0570|curPath'>
+           <cast as='xs:untypedAtomic' emptiable='0'>
+            <fn name='concat'>
+             <str val='instance(&#39;'/>
+             <varRef name='Q{}instance-id' slot='0'/>
+             <str val='&#39;)/'/>
+            </fn>
+           </cast>
+          </cvUntyped>
+         </choose>
+        </withParam>
+        <withParam name='Q{}calculationMap' flags='t' as='map(xs:string, xs:string)'>
+         <varRef line='2728' name='Q{}calculationMap' slot='1'/>
+        </withParam>
+       </applyT>
+      </copy>
+     </let>
+    </sequence>
+   </templateRule>
+  </mode>
+ </co>
+ <co id='70' binds='18 18'>
+  <mode name='Q{http://saxonica.com/ns/interactiveXSLT}onchange' onNo='TC' flags='W' patternSlots='0'>
+   <templateRule prec='0' prio='0.0' seq='1' rank='0' minImp='0' slots='0' flags='s' line='709' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='710' name='Q{}xforms-value-changed' bSlot='0' flags='t'>
+     <withParam name='Q{}form-control' flags='c' as='node()'>
+      <dot line='711' type='element(Q{}input)'/>
+     </withParam>
+    </callT>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='2' rank='0' minImp='0' slots='0' flags='s' line='719' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{}select)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;select&#39;;'/>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='720' name='Q{}xforms-value-changed' bSlot='1' flags='t'>
+     <withParam name='Q{}form-control' flags='c' as='node()'>
+      <dot line='721' type='element(Q{}select)'/>
+     </withParam>
+    </callT>
+   </templateRule>
+  </mode>
+ </co>
+ <co id='54' binds='46 71 58 58 72 42'>
+  <template name='Q{}xformsjs-main' flags='os' line='111' module='saxon-xforms.xsl' slots='23'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='607' var='Q{http://saxon.sf.net/generated-variable}v1' as='item()' slot='5' eval='13'>
+    <check card='1' diag='0|0||ixsl:call'>
+     <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+    </check>
+    <let line='577' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='6' eval='13'>
+     <check card='1' diag='0|0||ixsl:call'>
+      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+     </check>
+     <sequence line='112'>
+      <param name='Q{}xforms-doc' slot='0' as='document-node()?'>
+       <empty role='select'/>
+       <treat role='conversion' as='document-node()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);' diag='8|0|XTTE0590|xforms-doc'>
+        <check card='?' diag='8|0|XTTE0590|xforms-doc'>
+         <supplied slot='0'/>
+        </check>
+       </treat>
+      </param>
+      <param line='113' name='Q{}xforms-file' slot='1' as='xs:string?'>
+       <empty role='select'/>
+       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|xforms-file'>
+        <check card='?' diag='8|0|XTTE0590|xforms-file'>
+         <cvUntyped to='xs:string' diag='8|0|XTTE0590|xforms-file'>
+          <data>
+           <supplied slot='1'/>
+          </data>
+         </cvUntyped>
+        </check>
+       </treat>
+      </param>
+      <param line='122' name='Q{}instance-xml' slot='2' as='document-node()*'>
+       <empty role='select'/>
+       <treat role='conversion' as='document-node()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);' diag='8|0|XTTE0590|instance-xml'>
+        <supplied slot='2'/>
+       </treat>
+      </param>
+      <param line='123' name='Q{}instance-docs' slot='3' as='map(*)?'>
+       <empty role='select'/>
+       <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|instance-docs'>
+        <check card='?' diag='8|0|XTTE0590|instance-docs'>
+         <supplied slot='3'/>
+        </check>
+       </treat>
+      </param>
+      <param line='125' name='Q{}xFormsId' slot='4' as='xs:string'>
+       <gVarRef role='select' name='Q{}xform-html-id' bSlot='0'/>
+       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|xFormsId'>
+        <check card='1' diag='8|0|XTTE0590|xFormsId'>
+         <cvUntyped to='xs:string' diag='8|0|XTTE0590|xFormsId'>
+          <data>
+           <supplied slot='4'/>
+          </data>
+         </cvUntyped>
+        </check>
+       </treat>
+      </param>
+      <message line='127'>
+       <valueOf role='select'>
+        <str val='[xformsjs-main] START'/>
+       </valueOf>
+       <str role='terminate' val='no'/>
+       <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+      </message>
+      <let line='135' var='Q{}xforms-doci' as='document-node()?' slot='7' eval='7'>
+       <choose>
+        <fn name='empty'>
+         <varRef name='Q{}xforms-doc' slot='0'/>
+        </fn>
+        <fn name='doc'>
+         <varRef name='Q{}xforms-file' slot='1'/>
+        </fn>
+        <true/>
+        <varRef name='Q{}xforms-doc' slot='0'/>
+       </choose>
+       <let line='137' var='Q{}xform' as='element(Q{http://www.w3.org/2002/xforms}xform, Q{http://www.w3.org/2001/XMLSchema}untyped)' slot='8' eval='16'>
+        <treat as='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;' diag='3|0|XTTE0570|xform'>
+         <let var='Q{}this' as='element()' slot='9' eval='16'>
+          <check card='1' diag='0|0||xforms:addNamespaceDeclarations'>
+           <slash simple='1'>
+            <varRef name='Q{}xforms-doci' slot='7'/>
+            <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+           </slash>
+          </check>
+          <compElem line='3000'>
+           <fn role='name' name='name'>
+            <varRef name='Q{}this' slot='9'/>
+           </fn>
+           <sequence role='content' line='3001'>
+            <namespace flags='l'>
+             <str role='name' val='xforms'/>
+             <str role='select' val='http://www.w3.org/2002/xforms'/>
+            </namespace>
+            <forEach line='3002'>
+             <filter flags='b'>
+              <filter flags='b'>
+               <slash simple='1'>
+                <varRef name='Q{}this' slot='9'/>
+                <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+               </slash>
+               <fn name='boolean'>
+                <fn name='namespace-uri'>
+                 <dot type='element()'/>
+                </fn>
+               </fn>
+              </filter>
+              <fn name='not'>
+               <gc op='=' card='N:1' comp='CCC'>
+                <sequence>
+                 <slash>
+                  <fn name='reverse'>
+                   <axis name='ancestor' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+                  </fn>
+                  <fn name='namespace-uri'>
+                   <dot type='element()'/>
+                  </fn>
+                 </slash>
+                 <slash>
+                  <fn name='reverse'>
+                   <axis name='preceding' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+                  </fn>
+                  <fn name='namespace-uri'>
+                   <dot type='element()'/>
+                  </fn>
+                 </slash>
+                </sequence>
+                <fn name='namespace-uri'>
+                 <dot type='element()'/>
+                </fn>
+               </gc>
+              </fn>
+             </filter>
+             <namespace line='3005' flags='l'>
+              <fn role='name' line='3004' name='substring-before'>
+               <fn name='name'>
+                <dot type='element()'/>
+               </fn>
+               <str val=':'/>
+              </fn>
+              <convert role='select' from='xs:anyURI' to='xs:string'>
+               <fn line='3003' name='namespace-uri'>
+                <dot type='element()'/>
+               </fn>
+              </convert>
+             </namespace>
+            </forEach>
+            <copyOf line='3007' flags='vc'>
+             <sequence>
+              <slash simple='1'>
+               <varRef name='Q{}this' slot='9'/>
+               <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+              </slash>
+              <slash simple='1'>
+               <varRef name='Q{}this' slot='9'/>
+               <axis name='child' nodeTest='( element() | text() | comment() | processing-instruction() )' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);'/>
+              </slash>
+             </sequence>
+            </copyOf>
+           </sequence>
+          </compElem>
+         </let>
+        </treat>
+        <let line='141' var='Q{}xforms-instances' as='map(xs:string, element())' slot='10' eval='16'>
+         <choose line='143'>
+          <fn name='empty'>
+           <varRef name='Q{}instance-docs' slot='3'/>
+          </fn>
+          <treat line='146' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|xforms-instances'>
+           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+            <choose>
+             <fn name='empty'>
+              <varRef name='Q{}instance-xml' slot='2'/>
+             </fn>
+             <let line='147' var='Q{}instances' as='element(Q{http://www.w3.org/2002/xforms}instance)*' slot='11' eval='4'>
+              <slash simple='2'>
+               <slash simple='2'>
+                <slash simple='1'>
+                 <varRef name='Q{}xforms-doci' slot='7'/>
+                 <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
+                </slash>
+                <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
+               </slash>
+               <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}instance)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;instance&#39;;'/>
+              </slash>
+              <sequence line='148'>
+               <choose>
+                <fn name='exists'>
+                 <filter flags='b'>
+                  <varRef name='Q{}instances' slot='11'/>
+                  <fn name='empty'>
+                   <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+                  </fn>
+                 </filter>
+                </fn>
+                <treat line='150' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='20|0|XTTE3375|xsl:map sequence constructor'>
+                 <message>
+                  <str role='select' val='[xformsjs-main] FATAL ERROR: The XForm contains more than one instance with no ID. At most one instance may have no ID.'/>
+                  <str role='terminate' val='yes'/>
+                  <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+                 </message>
+                </treat>
+               </choose>
+               <forEach line='153'>
+                <varRef name='Q{}instances' slot='11'/>
+                <let line='154' var='Q{}instance-with-explicit-namespaces' as='element()' slot='12' eval='16'>
+                 <treat line='155' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-explicit-namespaces'>
+                  <check card='1' diag='3|0|XTTE0570|instance-with-explicit-namespaces'>
+                   <applyT mode='Q{}namespace-fix' bSlot='1'>
+                    <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+                   </applyT>
+                  </check>
+                 </treat>
+                 <ifCall line='164' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                  <check card='1' diag='0|0||map:entry'>
+                   <cast as='xs:string' emptiable='1'>
+                    <choose>
+                     <fn name='exists'>
+                      <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+                     </fn>
+                     <attVal name='Q{}id' chk='0'/>
+                     <true/>
+                     <str val='saxon-forms-default'/>
+                    </choose>
+                   </cast>
+                  </check>
+                  <varRef name='Q{}instance-with-explicit-namespaces' slot='12'/>
+                 </ifCall>
+                </let>
+               </forEach>
+              </sequence>
+             </let>
+             <true/>
+             <ifCall line='174' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+              <check card='1' diag='0|0||map:entry'>
+               <cast as='xs:string' emptiable='1'>
+                <choose>
+                 <fn name='exists'>
+                  <slash simple='2'>
+                   <slash simple='2'>
+                    <varRef name='Q{}instance-xml' slot='2'/>
+                    <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+                   </slash>
+                   <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+                  </slash>
+                 </fn>
+                 <atomSing card='?' diag='2|0||cast as'>
+                  <slash simple='2'>
+                   <conditionalSort>
+                    <fn name='exists'>
+                     <tail start='2'>
+                      <varRef name='Q{}instance-xml' slot='2'/>
+                     </tail>
+                    </fn>
+                    <docOrder intra='0'>
+                     <slash simple='2'>
+                      <varRef name='Q{}instance-xml' slot='2'/>
+                      <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+                     </slash>
+                    </docOrder>
+                   </conditionalSort>
+                   <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+                  </slash>
+                 </atomSing>
+                 <true/>
+                 <str val='saxon-forms-default'/>
+                </choose>
+               </cast>
+              </check>
+              <conditionalSort>
+               <fn name='exists'>
+                <tail start='2'>
+                 <varRef name='Q{}instance-xml' slot='2'/>
+                </tail>
+               </fn>
+               <docOrder intra='0'>
+                <slash simple='2'>
+                 <varRef name='Q{}instance-xml' slot='2'/>
+                 <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+                </slash>
+               </docOrder>
+              </conditionalSort>
+             </ifCall>
+            </choose>
+            <map size='2'>
+             <str val='duplicates'/>
+             <str val='reject'/>
+             <str val='duplicates-error-code'/>
+             <str val='XTDE3365'/>
+            </map>
+           </ifCall>
+          </treat>
+          <true/>
+          <treat line='180' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|xforms-instances'>
+           <check card='1' diag='3|0|XTTE0570|xforms-instances'>
+            <varRef name='Q{}instance-docs' slot='3'/>
+           </check>
+          </treat>
+         </choose>
+         <let line='187' var='Q{}default-instance' as='element()' slot='13' eval='16'>
+          <choose line='189'>
+           <fn name='empty'>
+            <varRef name='Q{}instance-docs' slot='3'/>
+           </fn>
+           <choose line='191'>
+            <fn name='exists'>
+             <filter flags='b'>
+              <slash simple='2'>
+               <slash simple='2'>
+                <slash simple='1'>
+                 <varRef name='Q{}xforms-doci' slot='7'/>
+                 <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
+                </slash>
+                <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
+               </slash>
+               <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}instance)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;instance&#39;;'/>
+              </slash>
+              <fn name='empty'>
+               <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+              </fn>
+             </filter>
+            </fn>
+            <check line='192' card='1' diag='3|0|XTTE0570|default-instance'>
+             <slash simple='2'>
+              <slash>
+               <slash simple='2'>
+                <slash simple='1'>
+                 <varRef name='Q{}xforms-doci' slot='7'/>
+                 <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
+                </slash>
+                <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
+               </slash>
+               <first>
+                <filter flags='b'>
+                 <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}instance)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;instance&#39;;'/>
+                 <fn name='empty'>
+                  <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+                 </fn>
+                </filter>
+               </first>
+              </slash>
+              <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+             </slash>
+            </check>
+            <true/>
+            <check line='195' card='1' diag='3|0|XTTE0570|default-instance'>
+             <slash simple='2'>
+              <slash>
+               <slash simple='2'>
+                <slash simple='1'>
+                 <varRef name='Q{}xforms-doci' slot='7'/>
+                 <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
+                </slash>
+                <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
+               </slash>
+               <first>
+                <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}instance)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;instance&#39;;'/>
+               </first>
+              </slash>
+              <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+             </slash>
+            </check>
+           </choose>
+           <true/>
+           <treat line='201' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|default-instance'>
+            <check card='1' diag='3|0|XTTE0570|default-instance'>
+             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+              <check card='1' diag='0|0||ixsl:call'>
+               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+              </check>
+              <str val='getDefaultInstance'/>
+              <array size='0'/>
+             </ifCall>
+            </check>
+           </treat>
+          </choose>
+          <let line='207' var='Q{}bindings' as='map(xs:string, element(Q{http://www.w3.org/2002/xforms}bind))' slot='14' eval='8'>
+           <ifCall line='209' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+            <forEach>
+             <slash simple='2'>
+              <slash simple='2'>
+               <slash simple='1'>
+                <varRef name='Q{}xforms-doci' slot='7'/>
+                <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
+               </slash>
+               <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
+              </slash>
+              <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}bind)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;bind&#39;;'/>
+             </slash>
+             <ifCall line='217' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+              <check card='1' diag='0|0||map:entry'>
+               <cast as='xs:string' emptiable='1'>
+                <choose>
+                 <fn name='exists'>
+                  <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+                 </fn>
+                 <attVal name='Q{}id' chk='0'/>
+                 <true/>
+                 <attVal name='Q{}nodeset' chk='0'/>
+                </choose>
+               </cast>
+              </check>
+              <dot type='element(Q{http://www.w3.org/2002/xforms}bind)'/>
+             </ifCall>
+            </forEach>
+            <map size='2'>
+             <str val='duplicates'/>
+             <str val='reject'/>
+             <str val='duplicates-error-code'/>
+             <str val='XTDE3365'/>
+            </map>
+           </ifCall>
+           <let line='231' var='Q{}bindingKeys' as='xs:anyAtomicType*' slot='15' eval='3'>
+            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
+             <varRef name='Q{}bindings' slot='14'/>
+            </ifCall>
+            <let line='233' var='Q{}RelevantBindings' as='map(xs:string, xs:string)' slot='16' eval='16'>
+             <treat line='235' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|RelevantBindings'>
+              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+               <forEach>
+                <varRef name='Q{}bindingKeys' slot='15'/>
+                <let line='236' var='Q{}bindingNode' as='element(Q{http://www.w3.org/2002/xforms}bind)' slot='17' eval='16'>
+                 <check card='1' diag='3|0|XTTE0570|bindingNode'>
+                  <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                   <varRef name='Q{}bindings' slot='14'/>
+                   <cast as='xs:string' emptiable='0'>
+                    <dot type='xs:anyAtomicType'/>
+                   </cast>
+                  </ifCall>
+                 </check>
+                 <choose line='238'>
+                  <fn name='exists'>
+                   <filter flags='b'>
+                    <varRef name='Q{}bindingNode' slot='17'/>
+                    <fn name='exists'>
+                     <axis name='attribute' nodeTest='attribute(Q{}relevant)' jsTest='return item.name===&#39;relevant&#39;'/>
+                    </fn>
+                   </filter>
+                  </fn>
+                  <ifCall line='240' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                   <check line='239' card='1' diag='3|0|XTTE0570|keyi'>
+                    <cast as='xs:string' emptiable='1'>
+                     <data>
+                      <slash simple='1'>
+                       <varRef name='Q{}bindingNode' slot='17'/>
+                       <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+                      </slash>
+                     </data>
+                    </cast>
+                   </check>
+                   <cast as='xs:string' emptiable='1'>
+                    <data>
+                     <slash simple='1'>
+                      <varRef name='Q{}bindingNode' slot='17'/>
+                      <axis name='attribute' nodeTest='attribute(Q{}relevant)' jsTest='return item.name===&#39;relevant&#39;'/>
+                     </slash>
+                    </data>
+                   </cast>
+                  </ifCall>
+                 </choose>
+                </let>
+               </forEach>
+               <map size='2'>
+                <str val='duplicates'/>
+                <str val='reject'/>
+                <str val='duplicates-error-code'/>
+                <str val='XTDE3365'/>
+               </map>
+              </ifCall>
+             </treat>
+             <let line='249' var='Q{}CalculationBindings' as='map(xs:string, xs:string)' slot='18' eval='16'>
+              <treat line='251' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|CalculationBindings'>
+               <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+                <forEach>
+                 <varRef name='Q{}bindingKeys' slot='15'/>
+                 <let line='252' var='Q{}bindingNode' as='element(Q{http://www.w3.org/2002/xforms}bind)' slot='19' eval='16'>
+                  <check card='1' diag='3|0|XTTE0570|bindingNode'>
+                   <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                    <varRef name='Q{}bindings' slot='14'/>
+                    <cast as='xs:string' emptiable='0'>
+                     <dot type='xs:anyAtomicType'/>
+                    </cast>
+                   </ifCall>
+                  </check>
+                  <choose line='254'>
+                   <fn name='exists'>
+                    <filter flags='b'>
+                     <varRef name='Q{}bindingNode' slot='19'/>
+                     <fn name='exists'>
+                      <axis name='attribute' nodeTest='attribute(Q{}calculate)' jsTest='return item.name===&#39;calculate&#39;'/>
+                     </fn>
+                    </filter>
+                   </fn>
+                   <ifCall line='256' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                    <check line='255' card='1' diag='3|0|XTTE0570|keyi'>
+                     <cast as='xs:string' emptiable='1'>
+                      <data>
+                       <slash simple='1'>
+                        <varRef name='Q{}bindingNode' slot='19'/>
+                        <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+                       </slash>
+                      </data>
+                     </cast>
+                    </check>
+                    <cast as='xs:string' emptiable='1'>
+                     <data>
+                      <slash simple='1'>
+                       <varRef name='Q{}bindingNode' slot='19'/>
+                       <axis name='attribute' nodeTest='attribute(Q{}calculate)' jsTest='return item.name===&#39;calculate&#39;'/>
+                      </slash>
+                     </data>
+                    </cast>
+                   </ifCall>
+                  </choose>
+                 </let>
+                </forEach>
+                <map size='2'>
+                 <str val='duplicates'/>
+                 <str val='reject'/>
+                 <str val='duplicates-error-code'/>
+                 <str val='XTDE3365'/>
+                </map>
+               </ifCall>
+              </treat>
+              <sequence line='268'>
+               <choose>
+                <gc op='=' card='M:N' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+                 <data>
+                  <slash simple='2'>
+                   <slash simple='1'>
+                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
+                    <axis name='descendant' nodeTest='element(Q{}script)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;script&#39;;'/>
+                   </slash>
+                   <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+                  </slash>
+                 </data>
+                 <data>
+                  <gVarRef name='Q{}xforms-cache-id' bSlot='2'/>
+                 </data>
+                </gc>
+                <sequence line='269'>
+                 <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                  <check card='1' diag='0|0||ixsl:call'>
+                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                  </check>
+                  <str val='setXFormsDoc'/>
+                  <arrayBlock>
+                   <varRef name='Q{}xforms-doc' slot='0'/>
+                  </arrayBlock>
+                 </ifCall>
+                 <ifCall line='270' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                  <check card='1' diag='0|0||ixsl:call'>
+                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                  </check>
+                  <str val='setXForm'/>
+                  <arrayBlock>
+                   <varRef name='Q{}xform' slot='8'/>
+                  </arrayBlock>
+                 </ifCall>
+                 <ifCall line='271' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                  <check card='1' diag='0|0||ixsl:call'>
+                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                  </check>
+                  <str val='setXFormsID'/>
+                  <arrayBlock>
+                   <varRef name='Q{}xFormsId' slot='4'/>
+                  </arrayBlock>
+                 </ifCall>
+                 <ifCall line='272' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                  <check card='1' diag='0|0||ixsl:call'>
+                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                  </check>
+                  <str val='setRelevantMap'/>
+                  <arrayBlock>
+                   <varRef name='Q{}RelevantBindings' slot='16'/>
+                  </arrayBlock>
+                 </ifCall>
+                 <ifCall line='273' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                  <check card='1' diag='0|0||ixsl:call'>
+                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                  </check>
+                  <str val='setCalculationMap'/>
+                  <arrayBlock>
+                   <varRef name='Q{}CalculationBindings' slot='18'/>
+                  </arrayBlock>
+                 </ifCall>
+                </sequence>
+                <true/>
+                <sequence line='284'>
+                 <forEach>
+                  <slash simple='1'>
+                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
+                   <axis name='descendant' nodeTest='element(Q{}head)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;head&#39;;'/>
+                  </slash>
+                  <resultDoc line='293' global='#&#xA;#Sat Feb 22 17:48:53 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sat Feb 22 17:48:53 GMT 2020&#xA;'>
+                   <str role='href' val='?.'/>
+                   <elem role='content' line='294' name='script' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+                    <sequence>
+                     <att name='type' flags='l'>
+                      <str val='text/javascript'/>
+                     </att>
+                     <att name='id' flags='l'>
+                      <fn name='string-join'>
+                       <convert from='xs:anyAtomicType' to='xs:string'>
+                        <data>
+                         <mergeAdj>
+                          <gVarRef name='Q{}xforms-cache-id' bSlot='3'/>
+                         </mergeAdj>
+                        </data>
+                       </convert>
+                       <str val=' '/>
+                      </fn>
+                     </att>
+                     <valueOf flags='l'>
+                      <str val='                &#xA;                            var XFormsDoc = null;&#xA;                            var XForm = null;&#xA;                            var defaultInstanceDoc = null;&#xA;                            &#xA;                            // MD 2018: OND&#39;s suggestion for multiple instances&#xA;                            var instanceDocs = {};&#xA;                            &#xA;                            var pendingUpdatesMap = null;&#xA;                            var updatesMap = null;&#xA;                            var XFormsID = &#39;'/>
+                     </valueOf>
+                     <valueOf line='304' flags='l'>
+                      <varRef name='Q{}xFormsId' slot='4'/>
+                     </valueOf>
+                     <valueOf flags='l'>
+                      <str val='&#39;;&#xA;                            var actions = {};&#xA;                            var submissions = {};&#xA;                            var outputs = {};&#xA;                            var repeats = {};&#xA;                            var relevantMap = {};&#xA;                            var calculationMap = {};&#xA;                            var repeatIndexMap = {};&#xA;                            var repeatSizeMap = {};&#xA;                            var elementsUsingIndexFunction = {};&#xA;                            &#xA;                            var getCurrentDate = function(){&#xA;                                var today = new Date();&#xA;                                var dd = today.getDate();&#xA;                                var mm = today.getMonth()+1; //January is 0!&#xA;                                var yyyy = today.getFullYear();&#xA;                            &#xA;                                if(dd &lt; 10) {&#xA;                                    dd = &#39;0&#39; + dd;&#xA;                                } &#xA;                            &#xA;                                if(mm &lt; 10) {&#xA;                                    mm = &#39;0&#39; + mm;&#xA;                                } &#xA;                            &#xA;                                today = yyyy + &#39;-&#39; + mm + &#39;-&#39; + dd;&#xA;                                return today;&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var setXFormsDoc = function(doc) {&#xA;                                XFormsDoc = doc;&#xA;                            }&#xA;                            &#xA;                            var getXFormsDoc = function() {&#xA;                                return XFormsDoc;&#xA;                            }&#xA;                            &#xA;                            var setXForm = function(element) {&#xA;                                XForm = element;&#xA;                            }&#xA;                            &#xA;                            var getXForm = function() {&#xA;                                return XForm;&#xA;                            }&#xA;                            &#xA;                            var setXFormsID = function(id) {&#xA;                                XFormsID = id;&#xA;                            }&#xA;                            &#xA;                            var getXFormsID = function() {&#xA;                                return XFormsID;&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var setInstance = function(name, value) {&#xA;                                instanceDocs[name] = value;&#xA;                            } &#xA;                            &#xA;                            var getInstance = function(name) {&#xA;                                return instanceDocs[name];&#xA;                            }&#xA;                            &#xA;                            &#xA;                            //[OND] Maybe we can just set the key-&gt; value without having to copy the entire instanceDocs object.&#xA;                            var updateInstance = function(instanceDocs, key, value){&#xA;                                instanceDocs[key] = value;&#xA;                                return instanceDocs;&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var setDefaultInstance = function(doc) {&#xA;                                defaultInstanceDoc = doc;&#xA;                            }&#xA;                            &#xA;                            var getDefaultInstance = function() {&#xA;                                return defaultInstanceDoc;&#xA;                            }&#xA;                            &#xA;                           &#xA;                            var getInstanceKeys = function() {&#xA;                                return Object.keys(instanceDocs);&#xA;                            }&#xA;                            &#xA;                            var getInstances = function() {&#xA;                                return instanceDocs;&#xA;                            }&#xA;                            &#xA;                            var setPendingUpdates = function(map1) {&#xA;                                pendingUpdatesMap = map1;&#xA;                            }&#xA;                            &#xA;                            var clearPendingUpdates = function() {&#xA;                                pendingUpdatesMap = null;&#xA;                            }&#xA;                            &#xA;                            var getPendingUpdates = function() {&#xA;                                return pendingUpdatesMap;&#xA;                            }&#xA;                            &#xA;                            var setUpdates = function(map1) {&#xA;                                updatesMap = map1;&#xA;                            }&#xA;                            &#xA;                            var clearUpdates = function() {&#xA;                                updatesMap = null;&#xA;                            }&#xA;                            &#xA;                            var getUpdates = function() {&#xA;                                return updatesMap;&#xA;                            }&#xA;                            &#xA;                            var addAction = function(name, value){&#xA;                                actions[name] = value;&#xA;                            }&#xA;&#xA;                            var getAction = function(name){&#xA;                                return actions[name];&#xA;                            }&#xA;                            &#xA;                            var updateAction = function(actioni, key, value){&#xA;                                actioni[key] = value;&#xA;                                return actioni;&#xA;                            }&#xA;                            &#xA;                            var addSubmission = function(name, value){&#xA;                                submissions[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getSubmission = function(name){&#xA;                                return submissions[name];&#xA;                            }     &#xA;                            &#xA;                            var addOutput = function(name, value){&#xA;                                outputs[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getOutput = function(name){&#xA;                                return outputs[name];&#xA;                            }&#xA;                            &#xA;                            var getOutputKeys = function() {&#xA;                                return Object.keys(outputs);&#xA;                            }&#xA;                            &#xA;                            // repeats is a map of HTML IDs to (parsed) xf:repeat/@nodeset values&#xA;                            var addRepeat = function(name, value){&#xA;                                repeats[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getRepeat = function(name){&#xA;                                return repeats[name];&#xA;                            }&#xA;                            &#xA;                            var getRepeatKeys = function() {&#xA;                                return Object.keys(repeats);&#xA;                            }&#xA;                            &#xA;                            var setRelevantMap = function(map1) {&#xA;                                relevantMap = map1;                            &#xA;                            }&#xA;                            &#xA;                            var getRelevantMap = function() {&#xA;                                return relevantMap;&#xA;                            }&#xA;                            &#xA;  &#xA;                            var setCalculationMap = function(map1) {&#xA;                                calculationMap = map1;                            &#xA;                            }&#xA;  &#xA;                            var getCalculationMap = function() {&#xA;                                return calculationMap;&#xA;                            }&#xA;  &#xA;                            &#xA;                            var setRepeatIndex = function(name, value) {&#xA;                                repeatIndexMap[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getRepeatIndex = function(name) {&#xA;                                if ( typeof(repeatIndexMap[name]) != &#39;undefined&#39; ) {&#xA;                                    return repeatIndexMap[name];&#xA;                                }&#xA;                                else {&#xA;                                    return 0;&#xA;                                }&#xA;                            } &#xA;                            &#xA;                            var setRepeatSize = function(name, value) {&#xA;                                repeatSizeMap[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getRepeatSize = function(name) {&#xA;                                if ( typeof(repeatSizeMap[name]) != &#39;undefined&#39; ) {&#xA;                                    return repeatSizeMap[name];&#xA;                                }&#xA;                                else {&#xA;                                    return 0;&#xA;                                }&#xA;                            } &#xA;                            &#xA;                            var setElementUsingIndexFunction = function(name, value) {&#xA;                                elementsUsingIndexFunction[name] = value;&#xA;                            } &#xA;                            &#xA;                            var getElementUsingIndexFunction = function(name) {&#xA;                                return elementsUsingIndexFunction[name];&#xA;                            }&#xA;                            &#xA;                            var getElementsUsingIndexFunctionKeys = function() {&#xA;                            return Object.keys(elementsUsingIndexFunction);&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var startTime = function(name) {&#xA;                                console.time(name);&#xA;                            }&#xA;                            &#xA;                            var endTime = function(name) {&#xA;                                console.timeEnd(name);&#xA;                            }&#xA;                            &#xA;                            var highlightClicked = function(id) {&#xA;                                var item = document.getElementById(id);&#xA;                                toggleClass(item);&#xA;                            }&#xA;                            &#xA;                            var toggleClass = function(element) {&#xA;                                if (element.className == &#39;selected&#39;) {&#xA;                                    element.classList.remove(&#39;selected&#39;);&#xA;                                }&#xA;                                else {&#xA;                                    var x = document.getElementsByClassName(&#39;selected&#39;);&#xA;                                    var i;&#xA;                                    for (i = 0; i &lt; x.length; i++) {&#xA;                                        x[i].classList.remove(&#39;selected&#39;);&#xA;                                    } &#xA;                                    element.classList.add(&#39;selected&#39;);&#xA;                                }&#xA;                            }&#xA;                            &#xA;                            var setFocus = function(id) {&#xA;                                var item = document.getElementById(id);&#xA;                                item.focus();&#xA;                                // alert(&#39;setFocus on &#39; + id);&#xA;                            }&#xA;                            &#xA;                        '/>
+                     </valueOf>
+                    </sequence>
+                   </elem>
+                  </resultDoc>
+                 </forEach>
+                 <ifCall line='556' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                  <check card='1' diag='0|0||ixsl:call'>
+                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                  </check>
+                  <str val='setXFormsDoc'/>
+                  <arrayBlock>
+                   <varRef name='Q{}xforms-doc' slot='0'/>
+                  </arrayBlock>
+                 </ifCall>
+                 <ifCall line='557' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                  <check card='1' diag='0|0||ixsl:call'>
+                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                  </check>
+                  <str val='setXForm'/>
+                  <arrayBlock>
+                   <varRef name='Q{}xform' slot='8'/>
+                  </arrayBlock>
+                 </ifCall>
+                 <ifCall line='558' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                  <check card='1' diag='0|0||ixsl:call'>
+                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                  </check>
+                  <str val='setDefaultInstance'/>
+                  <arrayBlock>
+                   <varRef name='Q{}default-instance' slot='13'/>
+                  </arrayBlock>
+                 </ifCall>
+                 <ifCall line='559' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                  <check card='1' diag='0|0||ixsl:call'>
+                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                  </check>
+                  <str val='setRelevantMap'/>
+                  <arrayBlock>
+                   <varRef name='Q{}RelevantBindings' slot='16'/>
+                  </arrayBlock>
+                 </ifCall>
+                 <ifCall line='560' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                  <check card='1' diag='0|0||ixsl:call'>
+                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                  </check>
+                  <str val='setCalculationMap'/>
+                  <arrayBlock>
+                   <varRef name='Q{}CalculationBindings' slot='18'/>
+                  </arrayBlock>
+                 </ifCall>
+                 <ifCall line='565' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                  <check card='1' diag='0|0||ixsl:call'>
+                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                  </check>
+                  <str val='setPendingUpdates'/>
+                  <arrayBlock>
+                   <treat line='562' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||pendingInstanceUpdates'>
+                    <map size='0'/>
+                   </treat>
+                  </arrayBlock>
+                 </ifCall>
+                 <ifCall line='566' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                  <check card='1' diag='0|0||ixsl:call'>
+                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                  </check>
+                  <str val='setUpdates'/>
+                  <arrayBlock>
+                   <treat line='563' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||instanceUpdates'>
+                    <map size='0'/>
+                   </treat>
+                  </arrayBlock>
+                 </ifCall>
+                </sequence>
+               </choose>
+               <forEach line='575'>
+                <treat line='573' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|instanceKeys'>
+                 <cvUntyped to='xs:string' diag='3|0|XTTE0570|instanceKeys'>
+                  <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
+                   <varRef name='Q{}xforms-instances' slot='10'/>
+                  </ifCall>
+                 </cvUntyped>
+                </treat>
+                <ifCall line='577' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='6'/>
+                 <str val='setInstance'/>
+                 <arrayBlock>
+                  <dot type='xs:string'/>
+                  <check line='576' card='1' diag='3|0|XTTE0570|instance'>
+                   <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                    <varRef name='Q{}xforms-instances' slot='10'/>
+                    <dot type='xs:string'/>
+                   </ifCall>
+                  </check>
+                 </arrayBlock>
+                </ifCall>
+               </forEach>
+               <let line='582' var='Q{}submissions' as='map(xs:string, map(*))' slot='20' eval='8'>
+                <ifCall line='584' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+                 <forEach>
+                  <slash simple='2'>
+                   <slash simple='2'>
+                    <slash simple='1'>
+                     <varRef name='Q{}xforms-doci' slot='7'/>
+                     <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
+                    </slash>
+                    <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
+                   </slash>
+                   <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}submission)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;submission&#39;;'/>
+                  </slash>
+                  <let line='588' var='Q{}map-key' as='xs:string' slot='21' eval='16'>
+                   <choose>
+                    <fn name='exists'>
+                     <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+                    </fn>
+                    <check card='1' diag='3|0|XTTE0570|map-key'>
+                     <cast as='xs:string' emptiable='1'>
+                      <attVal name='Q{}id' chk='0'/>
+                     </cast>
+                    </check>
+                    <true/>
+                    <str val='saxon-forms-default-submission'/>
+                   </choose>
+                   <let line='589' var='Q{}map-value' as='map(*)' slot='22' eval='16'>
+                    <treat line='590' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|map-value'>
+                     <check card='1' diag='3|0|XTTE0570|map-value'>
+                      <callT name='Q{}setSubmission' bSlot='4'>
+                       <withParam name='Q{}this' flags='c' as='element()'>
+                        <dot line='591' type='element(Q{http://www.w3.org/2002/xforms}submission)'/>
+                       </withParam>
+                       <withParam name='Q{}submission-id' flags='c' as='xs:string'>
+                        <varRef line='592' name='Q{}map-key' slot='21'/>
+                       </withParam>
+                      </callT>
+                     </check>
+                    </treat>
+                    <ifCall line='595' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                     <varRef name='Q{}map-key' slot='21'/>
+                     <varRef name='Q{}map-value' slot='22'/>
+                    </ifCall>
+                   </let>
+                  </let>
+                 </forEach>
+                 <map size='2'>
+                  <str val='duplicates'/>
+                  <str val='reject'/>
+                  <str val='duplicates-error-code'/>
+                  <str val='XTDE3365'/>
+                 </map>
+                </ifCall>
+                <sequence line='604'>
+                 <forEach>
+                  <treat line='602' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|submissionKeys'>
+                   <cvUntyped to='xs:string' diag='3|0|XTTE0570|submissionKeys'>
+                    <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
+                     <varRef name='Q{}submissions' slot='20'/>
+                    </ifCall>
+                   </cvUntyped>
+                  </treat>
+                  <sequence line='606'>
+                   <message>
+                    <sequence role='select'>
+                     <valueOf>
+                      <str val='Setting submission with ID &#39;'/>
+                     </valueOf>
+                     <valueOf>
+                      <dot type='xs:string'/>
+                     </valueOf>
+                     <valueOf flags='S'>
+                      <str val='&#39;'/>
+                     </valueOf>
+                    </sequence>
+                    <str role='terminate' val='no'/>
+                    <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+                   </message>
+                   <ifCall line='607' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                    <varRef name='Q{http://saxon.sf.net/generated-variable}v1' slot='5'/>
+                    <str val='addSubmission'/>
+                    <arrayBlock>
+                     <dot type='xs:string'/>
+                     <check line='605' card='1' diag='3|0|XTTE0570|submission'>
+                      <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                       <varRef name='Q{}submissions' slot='20'/>
+                       <dot type='xs:string'/>
+                      </ifCall>
+                     </check>
+                    </arrayBlock>
+                   </ifCall>
+                  </sequence>
+                 </forEach>
+                 <resultDoc line='616' global='#&#xA;#Sat Feb 22 17:48:53 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sat Feb 22 17:48:53 GMT 2020&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xA;'>
+                  <fn role='href' name='concat'>
+                   <str val='#'/>
+                   <varRef name='Q{}xFormsId' slot='4'/>
+                  </fn>
+                  <applyT role='content' line='617' bSlot='5'>
+                   <slash role='select' simple='1'>
+                    <varRef name='Q{}xforms-doci' slot='7'/>
+                    <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
+                   </slash>
+                   <withParam name='Q{}instances' flags='t' as='map(xs:string, element())'>
+                    <varRef line='618' name='Q{}xforms-instances' slot='10'/>
+                   </withParam>
+                   <withParam name='Q{}bindings' flags='t' as='map(xs:string, node())'>
+                    <varRef line='619' name='Q{}bindings' slot='14'/>
+                   </withParam>
+                   <withParam name='Q{}submissions' flags='t' as='map(xs:string, map(*))'>
+                    <varRef line='620' name='Q{}submissions' slot='20'/>
+                   </withParam>
+                   <withParam name='Q{}nodeset' flags='t' as='xs:string'>
+                    <str val=''/>
+                   </withParam>
+                  </applyT>
+                 </resultDoc>
+                </sequence>
+               </let>
+              </sequence>
+             </let>
+            </let>
+           </let>
+          </let>
+         </let>
+        </let>
+       </let>
+      </let>
+     </sequence>
+    </let>
+   </let>
+  </template>
+ </co>
+ <co id='71' binds='71'>
+  <mode name='Q{}namespace-fix' onNo='TC' flags='W' patternSlots='0'>
+   <templateRule prec='0' prio='-0.5' seq='31' rank='0' minImp='0' slots='1' flags='s' line='2864' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2865' var='Q{}current-namespace' as='xs:anyURI' slot='0' eval='8'>
+     <fn name='namespace-uri'>
+      <dot type='element()'/>
+     </fn>
+     <compElem line='2867'>
+      <convert role='name' from='xs:QName' to='xs:string'>
+       <fn line='2866' name='QName'>
+        <convert from='xs:anyURI' to='xs:string'>
+         <varRef name='Q{}current-namespace' slot='0'/>
+        </convert>
+        <fn name='name'>
+         <dot type='element()'/>
+        </fn>
+       </fn>
+      </convert>
+      <convert role='namespace' from='xs:anyURI' to='xs:string'>
+       <varRef name='Q{}current-namespace' slot='0'/>
+      </convert>
+      <sequence role='content' line='2868'>
+       <namespace flags='l'>
+        <str role='name' val='xforms'/>
+        <str role='select' val='http://www.w3.org/2002/xforms'/>
+       </namespace>
+       <applyT line='2870' mode='Q{}namespace-fix' bSlot='0'>
+        <sequence role='select'>
+         <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+         <axis name='child' nodeTest='( element() | text() | comment() | processing-instruction() )' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);'/>
+        </sequence>
+       </applyT>
+      </sequence>
+     </compElem>
+    </let>
+   </templateRule>
+  </mode>
+ </co>
+ <co id='53' binds='68 5 35'>
+  <template name='Q{}HTTPsubmit' cxt='map(*)' jsTest='return SaxonJS.U.isMap(item)' flags='s' line='1008' module='saxon-xforms.xsl' slots='5'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1014'>
+    <param name='Q{}instance-id' slot='0' as='xs:string'>
+     <str role='select' val='saxon-forms-default'/>
+     <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|instance-id'>
+      <check card='1' diag='8|0|XTTE0590|instance-id'>
+       <cvUntyped to='xs:string' diag='8|0|XTTE0590|instance-id'>
+        <data>
+         <supplied slot='0'/>
+        </data>
+       </cvUntyped>
+      </check>
+     </treat>
+    </param>
+    <param line='1015' name='Q{}targetref' slot='1' as='xs:string?'>
+     <empty role='select'/>
+     <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|targetref'>
+      <check card='?' diag='8|0|XTTE0590|targetref'>
+       <cvUntyped to='xs:string' diag='8|0|XTTE0590|targetref'>
+        <data>
+         <supplied slot='1'/>
+        </data>
+       </cvUntyped>
+      </check>
+     </treat>
+    </param>
+    <param line='1016' name='Q{}replace' slot='2' as='xs:string?'>
+     <empty role='select'/>
+     <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|replace'>
+      <check card='?' diag='8|0|XTTE0590|replace'>
+       <cvUntyped to='xs:string' diag='8|0|XTTE0590|replace'>
+        <data>
+         <supplied slot='2'/>
+        </data>
+       </cvUntyped>
+      </check>
+     </treat>
+    </param>
+    <let line='1018' var='Q{}refi' as='xs:string' slot='3' eval='8'>
+     <fn name='concat'>
+      <str val='instance(&#39;'/>
+      <varRef name='Q{}instance-id' slot='0'/>
+      <str val='&#39;)/'/>
+     </fn>
+     <let line='1020' var='Q{}responseXML' as='document-node()' slot='4' eval='16'>
+      <treat as='document-node()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);' diag='3|0|XTTE0570|responseXML'>
+       <check card='1' diag='3|0|XTTE0570|responseXML'>
+        <lookup>
+         <dot type='map(*)'/>
+         <str val='body'/>
+        </lookup>
+       </check>
+      </treat>
+      <choose line='1023'>
+       <fn name='empty'>
+        <varRef name='Q{}responseXML' slot='4'/>
+       </fn>
+       <callT line='1024' name='Q{}serverError' bSlot='0' flags='t'>
+        <withParam name='Q{}responseMap' flags='c' as='map(*)'>
+         <dot line='1025' type='map(*)'/>
+        </withParam>
+       </callT>
+       <vc line='1037' op='eq' onEmpty='0' comp='CCC'>
+        <varRef name='Q{}replace' slot='2'/>
+        <str val='instance'/>
+       </vc>
+       <sequence line='1038'>
+        <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='1' eval='6 16'>
+         <varRef name='Q{}refi' slot='3'/>
+         <check card='1' diag='0|1||xforms:setInstance-JS'>
+          <slash simple='1'>
+           <varRef name='Q{}responseXML' slot='4'/>
+           <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+          </slash>
+         </check>
+        </ufCall>
+        <callT line='1040' name='Q{}xforms-rebuild' bSlot='2' flags='t'/>
+       </sequence>
+      </choose>
+     </let>
+    </let>
+   </sequence>
+  </template>
+ </co>
+ <co id='41' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}instance' line='126' module='xforms-function-library.xsl' eval='7' flags='pU' as='element()?' slots='1'>
+   <arg name='Q{}instance-id' as='xs:string'/>
+   <treat role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='128' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='5|0|XTTE0780|xforms:instance#1'>
+    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+     <check card='1' diag='0|0||ixsl:call'>
+      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+     </check>
+     <str val='getInstance'/>
+     <arrayBlock>
+      <varRef name='Q{}instance-id' slot='0'/>
+     </arrayBlock>
+    </ifCall>
+   </treat>
+  </function>
+ </co>
+ <co id='73' binds='49 67 11'>
+  <mode name='Q{http://saxonica.com/ns/interactiveXSLT}onclick' onNo='TC' flags='W' patternSlots='0'>
+   <templateRule prec='0' prio='0.5' seq='3' rank='0' minImp='0' slots='3' flags='s' line='731' module='saxon-xforms.xsl'>
+    <p.withUpper role='match' axis='ancestor' upFirst='false'>
+     <p.withPredicate>
+      <p.nodeTest test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
+      <or ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='731' op='or'>
+       <axis name='self' nodeTest='element(Q{}span)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;span&#39;;'/>
+       <axis name='self' nodeTest='element(Q{}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
+      </or>
+     </p.withPredicate>
+     <p.withPredicate>
+      <p.nodeTest test='element(Q{}div)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;div&#39;;'/>
+      <vc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='731' op='eq' onEmpty='0' comp='CCC'>
+       <cast as='xs:string' emptiable='1'>
+        <data>
+         <axis name='attribute' nodeTest='attribute(Q{}data-repeat-item)' jsTest='return item.name===&#39;data-repeat-item&#39;'/>
+        </data>
+       </cast>
+       <str val='true'/>
+      </vc>
+     </p.withPredicate>
+    </p.withUpper>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='740' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='0' eval='13'>
+     <check card='1' diag='0|0||ixsl:call'>
+      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+     </check>
+     <sequence line='732'>
+      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+       <check card='1' diag='0|0||ixsl:call'>
+        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+       </check>
+       <str val='highlightClicked'/>
+       <arrayBlock>
+        <fn name='string'>
+         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+        </fn>
+       </arrayBlock>
+      </ifCall>
+      <forEach line='735'>
+       <fn name='reverse'>
+        <filter flags='b'>
+         <axis name='ancestor' nodeTest='element(Q{}div)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;div&#39;;'/>
+         <vc op='eq' onEmpty='0' comp='CCC'>
+          <cast as='xs:string' emptiable='1'>
+           <attVal name='Q{}data-repeat-item' chk='0'/>
+          </cast>
+          <str val='true'/>
+         </vc>
+        </filter>
+       </fn>
+       <let line='736' var='Q{}repeat-id' as='xs:string' slot='1' eval='16'>
+        <check card='1' diag='3|0|XTTE0570|repeat-id'>
+         <cvUntyped to='xs:string' diag='3|0|XTTE0570|repeat-id'>
+          <data>
+           <slash simple='1'>
+            <first>
+             <filter flags='b'>
+              <axis name='ancestor' nodeTest='element(Q{}div)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;div&#39;;'/>
+              <fn name='exists'>
+               <axis name='attribute' nodeTest='attribute(Q{}data-repeatable-context)' jsTest='return item.name===&#39;data-repeatable-context&#39;'/>
+              </fn>
+             </filter>
+            </first>
+            <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+           </slash>
+          </data>
+         </cvUntyped>
+        </check>
+        <let line='737' var='Q{}item-position' as='xs:integer' slot='2' eval='16'>
+         <arith op='+' calc='i+i'>
+          <fn name='count'>
+           <filter flags='b'>
+            <axis name='preceding-sibling' nodeTest='element(Q{}div)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;div&#39;;'/>
+            <vc op='eq' onEmpty='0' comp='CCC'>
+             <cast as='xs:string' emptiable='1'>
+              <attVal name='Q{}data-repeat-item' chk='0'/>
+             </cast>
+             <str val='true'/>
+            </vc>
+           </filter>
+          </fn>
+          <int val='1'/>
+         </arith>
+         <sequence line='739'>
+          <message>
+           <sequence role='select'>
+            <valueOf>
+             <str val='[div onclick] Setting repeat index &#39;'/>
+            </valueOf>
+            <valueOf>
+             <varRef name='Q{}repeat-id' slot='1'/>
+            </valueOf>
+            <valueOf>
+             <str val='&#39; to value &#39;'/>
+            </valueOf>
+            <valueOf>
+             <convert from='xs:integer' to='xs:string'>
+              <varRef name='Q{}item-position' slot='2'/>
+             </convert>
+            </valueOf>
+            <valueOf flags='S'>
+             <str val='&#39;'/>
+            </valueOf>
+           </sequence>
+           <str role='terminate' val='no'/>
+           <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+          </message>
+          <ifCall line='740' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+           <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='0'/>
+           <str val='setRepeatIndex'/>
+           <arrayBlock>
+            <varRef name='Q{}repeat-id' slot='1'/>
+            <varRef name='Q{}item-position' slot='2'/>
+           </arrayBlock>
+          </ifCall>
+         </sequence>
+        </let>
+       </let>
+      </forEach>
+      <choose line='743'>
+       <fn name='exists'>
+        <axis name='self' nodeTest='element(Q{}span)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;span&#39;;'/>
+       </fn>
+       <callT line='744' name='Q{}refreshElementsUsingIndexFunction-JS' bSlot='0' flags='t'/>
+      </choose>
+     </sequence>
+    </let>
+   </templateRule>
+   <templateRule prec='0' prio='0.5' seq='23' rank='0' minImp='0' slots='0' flags='s' line='2011' module='saxon-xforms.xsl'>
+    <p.withPredicate role='match'>
+     <p.nodeTest test='element(Q{}button)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;button&#39;;'/>
+     <fn ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2011' name='exists'>
+      <axis name='attribute' nodeTest='attribute(Q{}data-action)' jsTest='return item.name===&#39;data-action&#39;'/>
+     </fn>
+    </p.withPredicate>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2013' name='Q{}DOMActivate' bSlot='1' flags='t'>
+     <withParam name='Q{}form-control' flags='c' as='node()'>
+      <dot line='2014' type='element(Q{}button)'/>
+     </withParam>
+    </callT>
+   </templateRule>
+   <templateRule prec='0' prio='0.5' seq='4' rank='0' minImp='0' slots='0' flags='s' line='991' module='saxon-xforms.xsl'>
+    <p.withPredicate role='match'>
+     <p.nodeTest test='element(Q{}button)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;button&#39;;'/>
+     <fn ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='991' name='exists'>
+      <axis name='attribute' nodeTest='attribute(Q{}data-submit)' jsTest='return item.name===&#39;data-submit&#39;'/>
+     </fn>
+    </p.withPredicate>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='993' name='Q{}xforms-submit' bSlot='2' flags='t'>
+     <withParam name='Q{}submission' flags='c' as='xs:string'>
+      <fn line='994' name='string'>
+       <axis name='attribute' nodeTest='attribute(Q{}data-submit)' jsTest='return item.name===&#39;data-submit&#39;'/>
+      </fn>
+     </withParam>
+    </callT>
+   </templateRule>
+  </mode>
+ </co>
+ <co id='72' binds='62 63 64'>
+  <template name='Q{}setSubmission' flags='os' line='3922' module='saxon-xforms.xsl' slots='5'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3923'>
+    <param name='Q{}this' slot='0' flags='i' as='element()'>
+     <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+      <check card='1' diag='8|0|XTTE0590|this'>
+       <supplied slot='0'/>
+      </check>
+     </treat>
+    </param>
+    <param line='3924' name='Q{}submission-id' slot='1' flags='i' as='xs:string'>
+     <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|submission-id'>
+      <check card='1' diag='8|0|XTTE0590|submission-id'>
+       <cvUntyped to='xs:string' diag='8|0|XTTE0590|submission-id'>
+        <data>
+         <supplied slot='1'/>
+        </data>
+       </cvUntyped>
+      </check>
+     </treat>
+    </param>
+    <let line='3927' var='Q{}bindingi' as='node()?' slot='2' eval='7'>
+     <treat line='3928' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+      <check card='?' diag='3|0|XTTE0570|bindingi'>
+       <callT name='Q{}getBinding' bSlot='0'>
+        <withParam name='Q{}this' flags='c' as='element()'>
+         <varRef line='3929' name='Q{}this' slot='0'/>
+        </withParam>
+       </callT>
+      </check>
+     </treat>
+     <let line='3934' var='Q{}refi' as='xs:string' slot='3' eval='16'>
+      <treat line='3935' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+       <check card='1' diag='3|0|XTTE0570|refi'>
+        <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
+         <data>
+          <callT name='Q{}getDataRef' bSlot='1'>
+           <withParam name='Q{}this' flags='c' as='element()'>
+            <varRef line='3936' name='Q{}this' slot='0'/>
+           </withParam>
+           <withParam name='Q{}bindingi' flags='c' as='node()?'>
+            <varRef line='3937' name='Q{}bindingi' slot='2'/>
+           </withParam>
+          </callT>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+      <let line='3942' var='Q{}actions' as='map(*)*' slot='4' eval='8'>
+       <treat line='3943' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+        <callT name='Q{}setActions' bSlot='2'>
+         <withParam name='Q{}this' flags='c' as='element()'>
+          <treat line='3944' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+           <dot flags='a'/>
+          </treat>
+         </withParam>
+         <withParam name='Q{}nodeset' flags='t' as='xs:string'>
+          <varRef line='3945' name='Q{}refi' slot='3'/>
+         </withParam>
+        </callT>
+       </treat>
+       <sequence line='3949'>
+        <choose>
+         <fn name='exists'>
+          <varRef name='Q{}actions' slot='4'/>
+         </fn>
+         <ifCall line='3950' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+          <check card='1' diag='0|0||ixsl:call'>
+           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+          </check>
+          <str val='addAction'/>
+          <arrayBlock>
+           <varRef name='Q{}submission-id' slot='1'/>
+           <varRef name='Q{}actions' slot='4'/>
+          </arrayBlock>
+         </ifCall>
+        </choose>
+        <ifCall line='3955' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+         <sequence>
+          <ifCall line='3956' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <str val='@ref'/>
+           <varRef name='Q{}refi' slot='3'/>
+          </ifCall>
+          <choose line='3959'>
+           <fn name='exists'>
+            <slash simple='1'>
+             <varRef name='Q{}this' slot='0'/>
+             <axis name='attribute' nodeTest='attribute(Q{}resource)' jsTest='return item.name===&#39;resource&#39;'/>
+            </slash>
+           </fn>
+           <ifCall line='3960' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+            <str val='@resource'/>
+            <cast as='xs:string' emptiable='1'>
+             <data>
+              <slash simple='1'>
+               <varRef name='Q{}this' slot='0'/>
+               <axis name='attribute' nodeTest='attribute(Q{}resource)' jsTest='return item.name===&#39;resource&#39;'/>
+              </slash>
+             </data>
+            </cast>
+           </ifCall>
+          </choose>
+          <choose line='3962'>
+           <fn name='exists'>
+            <slash simple='1'>
+             <varRef name='Q{}this' slot='0'/>
+             <axis name='attribute' nodeTest='attribute(Q{}mode)' jsTest='return item.name===&#39;mode&#39;'/>
+            </slash>
+           </fn>
+           <ifCall line='3963' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+            <str val='@mode'/>
+            <cast as='xs:string' emptiable='1'>
+             <data>
+              <slash simple='1'>
+               <varRef name='Q{}this' slot='0'/>
+               <axis name='attribute' nodeTest='attribute(Q{}mode)' jsTest='return item.name===&#39;mode&#39;'/>
+              </slash>
+             </data>
+            </cast>
+           </ifCall>
+          </choose>
+          <ifCall line='3966' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <str val='@method'/>
+           <choose line='3968'>
+            <fn name='exists'>
+             <slash simple='1'>
+              <varRef name='Q{}this' slot='0'/>
+              <axis name='attribute' nodeTest='attribute(Q{}method)' jsTest='return item.name===&#39;method&#39;'/>
+             </slash>
+            </fn>
+            <fn line='3969' name='string'>
+             <slash simple='1'>
+              <varRef name='Q{}this' slot='0'/>
+              <axis name='attribute' nodeTest='attribute(Q{}method)' jsTest='return item.name===&#39;method&#39;'/>
+             </slash>
+            </fn>
+            <true/>
+            <str val='POST'/>
+           </choose>
+          </ifCall>
+          <choose line='3978'>
+           <fn name='exists'>
+            <slash simple='1'>
+             <varRef name='Q{}this' slot='0'/>
+             <axis name='attribute' nodeTest='attribute(Q{}validate)' jsTest='return item.name===&#39;validate&#39;'/>
+            </slash>
+           </fn>
+           <ifCall line='3979' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+            <str val='@validate'/>
+            <fn name='string'>
+             <slash simple='1'>
+              <varRef name='Q{}this' slot='0'/>
+              <axis name='attribute' nodeTest='attribute(Q{}validate)' jsTest='return item.name===&#39;validate&#39;'/>
+             </slash>
+            </fn>
+           </ifCall>
+          </choose>
+          <choose line='3981'>
+           <fn name='exists'>
+            <slash simple='1'>
+             <varRef name='Q{}this' slot='0'/>
+             <axis name='attribute' nodeTest='attribute(Q{}relevant)' jsTest='return item.name===&#39;relevant&#39;'/>
+            </slash>
+           </fn>
+           <ifCall line='3982' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+            <str val='@relevant'/>
+            <fn name='string'>
+             <slash simple='1'>
+              <varRef name='Q{}this' slot='0'/>
+              <axis name='attribute' nodeTest='attribute(Q{}relevant)' jsTest='return item.name===&#39;relevant&#39;'/>
+             </slash>
+            </fn>
+           </ifCall>
+          </choose>
+          <choose line='3984'>
+           <fn name='exists'>
+            <slash simple='1'>
+             <varRef name='Q{}this' slot='0'/>
+             <axis name='attribute' nodeTest='attribute(Q{}serialization)' jsTest='return item.name===&#39;serialization&#39;'/>
+            </slash>
+           </fn>
+           <ifCall line='3985' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+            <str val='@serialization'/>
+            <fn name='string'>
+             <slash simple='1'>
+              <varRef name='Q{}this' slot='0'/>
+              <axis name='attribute' nodeTest='attribute(Q{}serialization)' jsTest='return item.name===&#39;serialization&#39;'/>
+             </slash>
+            </fn>
+           </ifCall>
+          </choose>
+          <choose line='3987'>
+           <fn name='exists'>
+            <slash simple='1'>
+             <varRef name='Q{}this' slot='0'/>
+             <axis name='attribute' nodeTest='attribute(Q{}version)' jsTest='return item.name===&#39;version&#39;'/>
+            </slash>
+           </fn>
+           <ifCall line='3988' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+            <str val='@version'/>
+            <fn name='string'>
+             <slash simple='1'>
+              <varRef name='Q{}this' slot='0'/>
+              <axis name='attribute' nodeTest='attribute(Q{}version)' jsTest='return item.name===&#39;version&#39;'/>
+             </slash>
+            </fn>
+           </ifCall>
+          </choose>
+          <choose line='3990'>
+           <fn name='exists'>
+            <slash simple='1'>
+             <varRef name='Q{}this' slot='0'/>
+             <axis name='attribute' nodeTest='attribute(Q{}indent)' jsTest='return item.name===&#39;indent&#39;'/>
+            </slash>
+           </fn>
+           <ifCall line='3991' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+            <str val='@indent'/>
+            <fn name='string'>
+             <slash simple='1'>
+              <varRef name='Q{}this' slot='0'/>
+              <axis name='attribute' nodeTest='attribute(Q{}indent)' jsTest='return item.name===&#39;indent&#39;'/>
+             </slash>
+            </fn>
+           </ifCall>
+          </choose>
+          <ifCall line='3995' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <str val='@mediatype'/>
+           <choose line='3997'>
+            <fn name='exists'>
+             <slash simple='1'>
+              <varRef name='Q{}this' slot='0'/>
+              <axis name='attribute' nodeTest='attribute(Q{}mediatype)' jsTest='return item.name===&#39;mediatype&#39;'/>
+             </slash>
+            </fn>
+            <fn line='3998' name='string'>
+             <slash simple='1'>
+              <varRef name='Q{}this' slot='0'/>
+              <axis name='attribute' nodeTest='attribute(Q{}mediatype)' jsTest='return item.name===&#39;mediatype&#39;'/>
+             </slash>
+            </fn>
+            <true/>
+            <str val='text/plain'/>
+           </choose>
+          </ifCall>
+          <choose line='4008'>
+           <fn name='exists'>
+            <slash simple='1'>
+             <varRef name='Q{}this' slot='0'/>
+             <axis name='attribute' nodeTest='attribute(Q{}encoding)' jsTest='return item.name===&#39;encoding&#39;'/>
+            </slash>
+           </fn>
+           <ifCall line='4009' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+            <str val='@encoding'/>
+            <fn name='string'>
+             <slash simple='1'>
+              <varRef name='Q{}this' slot='0'/>
+              <axis name='attribute' nodeTest='attribute(Q{}encoding)' jsTest='return item.name===&#39;encoding&#39;'/>
+             </slash>
+            </fn>
+           </ifCall>
+          </choose>
+          <choose line='4011'>
+           <fn name='exists'>
+            <slash simple='1'>
+             <varRef name='Q{}this' slot='0'/>
+             <axis name='attribute' nodeTest='attribute(Q{}omit-xml-declaration)' jsTest='return item.name===&#39;omit-xml-declaration&#39;'/>
+            </slash>
+           </fn>
+           <ifCall line='4012' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+            <str val='@omit-xml-declaration'/>
+            <fn name='string'>
+             <slash simple='1'>
+              <varRef name='Q{}this' slot='0'/>
+              <axis name='attribute' nodeTest='attribute(Q{}omit-xml-declaration)' jsTest='return item.name===&#39;omit-xml-declaration&#39;'/>
+             </slash>
+            </fn>
+           </ifCall>
+          </choose>
+          <choose line='4014'>
+           <fn name='exists'>
+            <slash simple='1'>
+             <varRef name='Q{}this' slot='0'/>
+             <axis name='attribute' nodeTest='attribute(Q{}standalone)' jsTest='return item.name===&#39;standalone&#39;'/>
+            </slash>
+           </fn>
+           <ifCall line='4015' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+            <str val='@standalone'/>
+            <fn name='string'>
+             <slash simple='1'>
+              <varRef name='Q{}this' slot='0'/>
+              <axis name='attribute' nodeTest='attribute(Q{}standalone)' jsTest='return item.name===&#39;standalone&#39;'/>
+             </slash>
+            </fn>
+           </ifCall>
+          </choose>
+          <choose line='4017'>
+           <fn name='exists'>
+            <slash simple='1'>
+             <varRef name='Q{}this' slot='0'/>
+             <axis name='attribute' nodeTest='attribute(Q{}cdata-section-elements)' jsTest='return item.name===&#39;cdata-section-elements&#39;'/>
+            </slash>
+           </fn>
+           <ifCall line='4018' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+            <str val='@cdata-section-elements'/>
+            <fn name='string'>
+             <slash simple='1'>
+              <varRef name='Q{}this' slot='0'/>
+              <axis name='attribute' nodeTest='attribute(Q{}cdata-section-elements)' jsTest='return item.name===&#39;cdata-section-elements&#39;'/>
+             </slash>
+            </fn>
+           </ifCall>
+          </choose>
+          <ifCall line='4021' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <str val='@replace'/>
+           <choose line='4023'>
+            <fn name='exists'>
+             <slash simple='1'>
+              <varRef name='Q{}this' slot='0'/>
+              <axis name='attribute' nodeTest='attribute(Q{}replace)' jsTest='return item.name===&#39;replace&#39;'/>
+             </slash>
+            </fn>
+            <fn line='4024' name='string'>
+             <slash simple='1'>
+              <varRef name='Q{}this' slot='0'/>
+              <axis name='attribute' nodeTest='attribute(Q{}replace)' jsTest='return item.name===&#39;replace&#39;'/>
+             </slash>
+            </fn>
+            <true/>
+            <str val='all'/>
+           </choose>
+          </ifCall>
+          <choose line='4035'>
+           <fn name='exists'>
+            <slash simple='1'>
+             <varRef name='Q{}this' slot='0'/>
+             <axis name='attribute' nodeTest='attribute(Q{}instance)' jsTest='return item.name===&#39;instance&#39;'/>
+            </slash>
+           </fn>
+           <ifCall line='4036' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+            <str val='@instance'/>
+            <fn name='string'>
+             <slash simple='1'>
+              <varRef name='Q{}this' slot='0'/>
+              <axis name='attribute' nodeTest='attribute(Q{}instance)' jsTest='return item.name===&#39;instance&#39;'/>
+             </slash>
+            </fn>
+           </ifCall>
+          </choose>
+          <choose line='4038'>
+           <fn name='exists'>
+            <slash simple='1'>
+             <varRef name='Q{}this' slot='0'/>
+             <axis name='attribute' nodeTest='attribute(Q{}targetref)' jsTest='return item.name===&#39;targetref&#39;'/>
+            </slash>
+           </fn>
+           <ifCall line='4039' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+            <str val='@targetref'/>
+            <fn name='string'>
+             <slash simple='1'>
+              <varRef name='Q{}this' slot='0'/>
+              <axis name='attribute' nodeTest='attribute(Q{}targetref)' jsTest='return item.name===&#39;targetref&#39;'/>
+             </slash>
+            </fn>
+           </ifCall>
+          </choose>
+          <choose line='4041'>
+           <fn name='exists'>
+            <slash simple='1'>
+             <varRef name='Q{}this' slot='0'/>
+             <axis name='attribute' nodeTest='attribute(Q{}separator)' jsTest='return item.name===&#39;separator&#39;'/>
+            </slash>
+           </fn>
+           <ifCall line='4042' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+            <str val='@separator'/>
+            <fn name='string'>
+             <slash simple='1'>
+              <varRef name='Q{}this' slot='0'/>
+              <axis name='attribute' nodeTest='attribute(Q{}separator)' jsTest='return item.name===&#39;separator&#39;'/>
+             </slash>
+            </fn>
+           </ifCall>
+          </choose>
+          <choose line='4044'>
+           <fn name='exists'>
+            <slash simple='1'>
+             <varRef name='Q{}this' slot='0'/>
+             <axis name='attribute' nodeTest='attribute(Q{}includenamespaceprefixes)' jsTest='return item.name===&#39;includenamespaceprefixes&#39;'/>
+            </slash>
+           </fn>
+           <ifCall line='4045' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+            <str val='@includenamespaceprefixes'/>
+            <fn name='string'>
+             <slash simple='1'>
+              <varRef name='Q{}this' slot='0'/>
+              <axis name='attribute' nodeTest='attribute(Q{}includenamespaceprefixes)' jsTest='return item.name===&#39;includenamespaceprefixes&#39;'/>
+             </slash>
+            </fn>
+           </ifCall>
+          </choose>
+         </sequence>
+         <map size='2'>
+          <str val='duplicates'/>
+          <str val='reject'/>
+          <str val='duplicates-error-code'/>
+          <str val='XTDE3365'/>
+         </map>
+        </ifCall>
+       </sequence>
+      </let>
+     </let>
+    </let>
+   </sequence>
+  </template>
+ </co>
+ <co id='74' binds='18'>
+  <mode name='Q{http://saxonica.com/ns/interactiveXSLT}onkeyup' onNo='TC' flags='W' patternSlots='0'>
+   <templateRule prec='0' prio='0.5' seq='0' rank='0' minImp='0' slots='0' flags='s' line='698' module='saxon-xforms.xsl'>
+    <p.withPredicate role='match'>
+     <p.nodeTest test='element(Q{}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
+     <gc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='698' op='=' card='N:1' comp='CCC'>
+      <fn name='tokenize'>
+       <cvUntyped to='xs:string' diag='3|0|XTTE0570|class'>
+        <data>
+         <slash simple='1'>
+          <dot type='element(Q{}input)'/>
+          <axis line='3036' name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
+         </slash>
+        </data>
+       </cvUntyped>
+      </fn>
+      <str val='incremental'/>
+     </gc>
+    </p.withPredicate>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='700' name='Q{}xforms-value-changed' bSlot='0' flags='t'>
+     <withParam name='Q{}form-control' flags='c' as='node()'>
+      <dot line='701' type='element(Q{}input)'/>
+     </withParam>
+    </callT>
+   </templateRule>
+  </mode>
+ </co>
+ <co id='62' binds=''>
+  <template name='Q{}getBinding' flags='os' line='3277' module='saxon-xforms.xsl' slots='4'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3278'>
+    <param name='Q{}this' slot='0' flags='r' as='element()'>
+     <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+      <check card='1' diag='8|0|XTTE0590|this'>
+       <supplied slot='0'/>
+      </check>
+     </treat>
+    </param>
+    <param line='3279' name='Q{}bindings' slot='1' flags='t' as='map(xs:string, node())'>
+     <map role='select' size='0'/>
+     <treat role='conversion' as='map(xs:string, node())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|bindings'>
+      <check card='1' diag='8|0|XTTE0590|bindings'>
+       <supplied slot='1'/>
+      </check>
+     </treat>
+    </param>
+    <let line='3288' var='Q{}ref-binding' as='xs:string' slot='2' eval='16'>
+     <choose>
+      <fn name='exists'>
+       <slash simple='1'>
+        <varRef name='Q{}this' slot='0'/>
+        <axis name='attribute' nodeTest='attribute(Q{}bind)' jsTest='return item.name===&#39;bind&#39;'/>
+       </slash>
+      </fn>
+      <check card='1' diag='3|0|XTTE0570|ref-binding'>
+       <cast as='xs:string' emptiable='1'>
+        <data>
+         <slash simple='1'>
+          <varRef name='Q{}this' slot='0'/>
+          <axis name='attribute' nodeTest='attribute(Q{}bind)' jsTest='return item.name===&#39;bind&#39;'/>
+         </slash>
+        </data>
+       </cast>
+      </check>
+      <fn name='exists'>
+       <slash simple='1'>
+        <varRef name='Q{}this' slot='0'/>
+        <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+       </slash>
+      </fn>
+      <check card='1' diag='3|0|XTTE0570|ref-binding'>
+       <cast as='xs:string' emptiable='1'>
+        <data>
+         <slash simple='1'>
+          <varRef name='Q{}this' slot='0'/>
+          <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+         </slash>
+        </data>
+       </cast>
+      </check>
+      <true/>
+      <str val=''/>
+     </choose>
+     <let line='3290' var='Q{}binding' as='element()?' slot='3' eval='7'>
+      <choose line='3295'>
+       <fn name='empty'>
+        <varRef name='Q{}ref-binding' slot='2'/>
+       </fn>
+       <empty/>
+       <true/>
+       <treat as='element()' jsTest='return item.nodeType===1;' diag='3|0|XTTE0570|binding'>
+        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+         <varRef name='Q{}bindings' slot='1'/>
+         <varRef name='Q{}ref-binding' slot='2'/>
+        </ifCall>
+       </treat>
+      </choose>
+      <sequence line='3298'>
+       <choose>
+        <fn name='exists'>
+         <varRef name='Q{}binding' slot='3'/>
+        </fn>
+        <message line='3304'>
+         <sequence role='select'>
+          <valueOf>
+           <str val='[getBinding for '/>
+          </valueOf>
+          <valueOf>
+           <fn name='name'>
+            <varRef name='Q{}this' slot='0'/>
+           </fn>
+          </valueOf>
+          <valueOf>
+           <str val='] Binding found: '/>
+          </valueOf>
+          <valueOf>
+           <fn name='serialize'>
+            <varRef name='Q{}binding' slot='3'/>
+           </fn>
+          </valueOf>
+         </sequence>
+         <str role='terminate' val='no'/>
+         <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+        </message>
+       </choose>
+       <varRef line='3308' name='Q{}binding' slot='3'/>
+      </sequence>
+     </let>
+    </let>
+   </sequence>
+  </template>
+ </co>
+ <co id='75' binds=''>
+  <globalVariable name='Q{}default-instance-id' type='xs:string' line='75' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
+   <str val='saxon-forms-default'/>
+  </globalVariable>
+ </co>
+ <co id='76' binds=''>
+  <globalVariable name='Q{}debugTiming' type='xs:boolean' line='74' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.boolean.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
+   <false/>
+  </globalVariable>
+ </co>
+ <co id='44' binds='62'>
+  <function name='Q{http://www.w3.org/2002/xforms}getDataRef' line='3136' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:string' slots='11'>
+   <arg name='Q{}this' as='element()'/>
+   <arg name='Q{}nodeset' as='xs:string?'/>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3145' var='Q{}this-ref' as='xs:string?' slot='2' eval='7'>
+    <choose>
+     <fn name='exists'>
+      <slash simple='1'>
+       <varRef name='Q{}this' slot='0'/>
+       <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+      </slash>
+     </fn>
+     <fn name='normalize-space'>
+      <cast as='xs:string' emptiable='1'>
+       <data>
+        <slash simple='1'>
+         <varRef name='Q{}this' slot='0'/>
+         <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+        </slash>
+       </data>
+      </cast>
+     </fn>
+     <fn name='exists'>
+      <slash simple='1'>
+       <varRef name='Q{}this' slot='0'/>
+       <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+      </slash>
+     </fn>
+     <fn name='normalize-space'>
+      <cast as='xs:string' emptiable='1'>
+       <data>
+        <slash simple='1'>
+         <varRef name='Q{}this' slot='0'/>
+         <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+        </slash>
+       </data>
+      </cast>
+     </fn>
+    </choose>
+    <let line='3148' var='Q{}this-binding' as='node()?' slot='3' eval='7'>
+     <treat line='3149' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|this-binding'>
+      <check card='?' diag='3|0|XTTE0570|this-binding'>
+       <callT name='Q{}getBinding' bSlot='0'>
+        <withParam name='Q{}this' flags='c' as='element()'>
+         <varRef line='3150' name='Q{}this' slot='0'/>
+        </withParam>
+       </callT>
+      </check>
+     </treat>
+     <choose line='3175'>
+      <fn name='exists'>
+       <varRef name='Q{}this-binding' slot='3'/>
+      </fn>
+      <let line='3156' var='Q{}relative' as='xs:string' slot='4' eval='16'>
+       <check card='1' diag='0|1||xforms:resolveXPathStrings'>
+        <choose>
+         <fn name='exists'>
+          <varRef name='Q{}this-binding' slot='3'/>
+         </fn>
+         <cvUntyped line='3167' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
+          <cast as='xs:untypedAtomic' emptiable='0'>
+           <choose>
+            <fn name='exists'>
+             <slash simple='1'>
+              <varRef name='Q{}this-binding' slot='3'/>
+              <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+             </slash>
+            </fn>
+            <fn name='normalize-space'>
+             <cast as='xs:string' emptiable='1'>
+              <data>
+               <slash simple='1'>
+                <varRef name='Q{}this-binding' slot='3'/>
+                <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+               </slash>
+              </data>
+             </cast>
+            </fn>
+            <true/>
+            <fn name='normalize-space'>
+             <cast as='xs:string' emptiable='1'>
+              <data>
+               <slash simple='1'>
+                <varRef name='Q{}this-binding' slot='3'/>
+                <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+               </slash>
+              </data>
+             </cast>
+            </fn>
+           </choose>
+          </cast>
+         </cvUntyped>
+        </choose>
+       </check>
+       <choose line='835'>
+        <fn name='starts-with'>
+         <varRef name='Q{}relative' slot='4'/>
+         <str val='/'/>
+        </fn>
+        <varRef line='836' name='Q{}relative' slot='4'/>
+        <fn line='838' name='starts-with'>
+         <varRef name='Q{}relative' slot='4'/>
+         <str val='instance('/>
+        </fn>
+        <varRef line='839' name='Q{}relative' slot='4'/>
+        <true/>
+        <varRef line='842' name='Q{}relative' slot='4'/>
+       </choose>
+      </let>
+      <fn line='3178' name='exists'>
+       <varRef name='Q{}this-ref' slot='2'/>
+      </fn>
+      <let line='3179' var='Q{}base' as='xs:string' slot='5' eval='16'>
+       <check card='1' diag='0|0||xforms:resolveXPathStrings'>
+        <varRef name='Q{}nodeset' slot='1'/>
+       </check>
+       <let var='Q{}relative' as='xs:string' slot='6' eval='16'>
+        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
+         <varRef name='Q{}this-ref' slot='2'/>
+        </check>
+        <choose line='835'>
+         <fn name='starts-with'>
+          <varRef name='Q{}relative' slot='6'/>
+          <str val='/'/>
+         </fn>
+         <varRef line='836' name='Q{}relative' slot='6'/>
+         <fn line='838' name='starts-with'>
+          <varRef name='Q{}relative' slot='6'/>
+          <str val='instance('/>
+         </fn>
+         <varRef line='839' name='Q{}relative' slot='6'/>
+         <fn line='841' name='not'>
+          <varRef name='Q{}base' slot='5'/>
+         </fn>
+         <varRef line='842' name='Q{}relative' slot='6'/>
+         <or line='844' op='or'>
+          <fn name='not'>
+           <varRef name='Q{}relative' slot='6'/>
+          </fn>
+          <vc op='eq' onEmpty='0' comp='CCC'>
+           <varRef name='Q{}relative' slot='6'/>
+           <str val='.'/>
+          </vc>
+         </or>
+         <varRef line='845' name='Q{}base' slot='5'/>
+         <true/>
+         <let line='849' var='Q{}parentCallCount' as='xs:integer' slot='7' eval='16'>
+          <choose>
+           <fn name='contains'>
+            <varRef name='Q{}relative' slot='6'/>
+            <str val='/'/>
+           </fn>
+           <fn name='count'>
+            <filter flags='b'>
+             <fn name='tokenize'>
+              <varRef name='Q{}relative' slot='6'/>
+              <str val='/'/>
+              <str val=''/>
+             </fn>
+             <vc op='eq' onEmpty='0' comp='CCC'>
+              <dot type='xs:string'/>
+              <str val='..'/>
+             </vc>
+            </filter>
+           </fn>
+           <fn name='contains'>
+            <varRef name='Q{}relative' slot='6'/>
+            <str val='..'/>
+           </fn>
+           <int val='1'/>
+           <true/>
+           <int val='0'/>
+          </choose>
+          <let line='852' var='Q{}slashes' as='xs:integer*' slot='8' eval='4'>
+           <choose>
+            <fn name='contains'>
+             <varRef name='Q{}base' slot='5'/>
+             <str val='/'/>
+            </fn>
+            <fn name='index-of'>
+             <fn name='string-to-codepoints'>
+              <varRef name='Q{}base' slot='5'/>
+             </fn>
+             <int val='47'/>
+            </fn>
+            <true/>
+            <int val='0'/>
+           </choose>
+           <choose line='884'>
+            <compareToInt op='gt' val='0'>
+             <varRef name='Q{}parentCallCount' slot='7'/>
+            </compareToInt>
+            <fn line='888' name='concat'>
+             <fn name='substring'>
+              <varRef name='Q{}base' slot='5'/>
+              <int val='1'/>
+              <choose line='863'>
+               <and op='and'>
+                <vc op='ge' onEmpty='0' comp='CAVC'>
+                 <fn name='count'>
+                  <varRef name='Q{}slashes' slot='8'/>
+                 </fn>
+                 <varRef name='Q{}parentCallCount' slot='7'/>
+                </vc>
+                <compareToInt op='gt' val='0'>
+                 <varRef name='Q{}parentCallCount' slot='7'/>
+                </compareToInt>
+               </and>
+               <let line='864' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='9' eval='16'>
+                <arith op='-' calc='i-i'>
+                 <varRef name='Q{}parentCallCount' slot='7'/>
+                 <int val='1'/>
+                </arith>
+                <check card='1' diag='3|0|XTTE0570|parentSlash'>
+                 <filter flags='p'>
+                  <varRef name='Q{}slashes' slot='8'/>
+                  <arith op='-' calc='i-i'>
+                   <fn name='last'/>
+                   <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='9'/>
+                  </arith>
+                 </filter>
+                </check>
+               </let>
+               <true/>
+               <check line='867' card='1' diag='3|0|XTTE0570|parentSlash'>
+                <lastOf>
+                 <varRef name='Q{}slashes' slot='8'/>
+                </lastOf>
+               </check>
+              </choose>
+             </fn>
+             <fn name='replace'>
+              <varRef name='Q{}relative' slot='6'/>
+              <str val='\.\./'/>
+              <str val=''/>
+              <str val=''/>
+             </fn>
+            </fn>
+            <true/>
+            <fn line='891' name='concat'>
+             <varRef name='Q{}base' slot='5'/>
+             <str val='/'/>
+             <varRef name='Q{}relative' slot='6'/>
+            </fn>
+           </choose>
+          </let>
+         </let>
+        </choose>
+       </let>
+      </let>
+      <varRef line='3181' name='Q{}nodeset' slot='1'/>
+      <let line='3182' var='Q{}relative' as='xs:string' slot='10' eval='16'>
+       <check card='1' diag='0|1||xforms:resolveXPathStrings'>
+        <varRef name='Q{}nodeset' slot='1'/>
+       </check>
+       <choose line='835'>
+        <fn name='starts-with'>
+         <varRef name='Q{}relative' slot='10'/>
+         <str val='/'/>
+        </fn>
+        <varRef line='836' name='Q{}relative' slot='10'/>
+        <fn line='838' name='starts-with'>
+         <varRef name='Q{}relative' slot='10'/>
+         <str val='instance('/>
+        </fn>
+        <varRef line='839' name='Q{}relative' slot='10'/>
+        <true/>
+        <varRef line='842' name='Q{}relative' slot='10'/>
+       </choose>
+      </let>
+      <true/>
+      <str val=''/>
+     </choose>
+    </let>
+   </let>
+  </function>
+ </co>
+ <co id='23' binds=''>
+  <template name='Q{}getInstance' flags='os' as='element()?' line='3251' module='saxon-xforms.xsl' slots='2'>
+   <check role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3252' card='?' diag='7|0|XTTE0505|getInstance'>
+    <sequence>
+     <param name='Q{}instance-id' slot='0' as='xs:string'>
+      <str role='select' val=''/>
+      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|instance-id'>
+       <check card='1' diag='8|0|XTTE0590|instance-id'>
+        <cvUntyped to='xs:string' diag='8|0|XTTE0590|instance-id'>
+         <data>
+          <supplied slot='0'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <param line='3253' name='Q{}instances' slot='1' flags='ti' as='map(xs:string, element())'>
+      <treat role='conversion' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|instances'>
+       <check card='1' diag='8|0|XTTE0590|instances'>
+        <supplied slot='1'/>
+       </check>
+      </treat>
+     </param>
+     <choose line='3257'>
+      <varRef name='Q{}instance-id' slot='0'/>
+      <ifCall line='3258' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+       <varRef name='Q{}instances' slot='1'/>
+       <varRef name='Q{}instance-id' slot='0'/>
+      </ifCall>
+      <true/>
+      <copyOf line='3262' flags='vc'>
+       <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+        <varRef name='Q{}instances' slot='1'/>
+        <str val='saxon-forms-default'/>
+       </ifCall>
+      </copyOf>
+     </choose>
+    </sequence>
+   </check>
+  </template>
+ </co>
+ <overridden/>
+ <output>
+  <property name='indent' value='no'/>
+  <property name='doctype-system' value='http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd'/>
+  <property name='encoding' value='utf-8'/>
+  <property name='doctype-public' value='-//W3C//DTD XHTML 1.0 Transitional//EN'/>
+  <property name='omit-xml-declaration' value='no'/>
+  <property name='{http://saxon.sf.net/}stylesheet-version' value='30'/>
+  <property name='method' value='html'/>
+ </output>
+ <decimalFormat/>
+</package>
+<?Σ c2e05e34?>

--- a/sef/saxon-xforms.sef.xml
+++ b/sef/saxon-xforms.sef.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns='http://ns.saxonica.com/xslt/export' xmlns:fn='http://www.w3.org/2005/xpath-functions' xmlns:xs='http://www.w3.org/2001/XMLSchema' xmlns:vv='http://saxon.sf.net/generated-variable' xmlns:java-type='http://saxon.sf.net/java-type' when='2020-02-22T17:48:53.047Z' id='0' version='30' packageVersion='1' saxonVersion='9.9.1.5' target='JS' targetVersion='1' relocatable='true' implicit='true'>
+<package xmlns='http://ns.saxonica.com/xslt/export' xmlns:fn='http://www.w3.org/2005/xpath-functions' xmlns:xs='http://www.w3.org/2001/XMLSchema' xmlns:vv='http://saxon.sf.net/generated-variable' xmlns:java-type='http://saxon.sf.net/java-type' when='2020-02-22T22:54:41.392Z' id='0' version='30' packageVersion='1' saxonVersion='9.9.1.5' target='JS' targetVersion='1' relocatable='true' implicit='true'>
  <co id='0' binds='1 2 1 2 3 3 4 5 6 3 7'>
-  <template name='Q{}action-insert' flags='os' line='4496' module='saxon-xforms.xsl' slots='18'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4497'>
+  <template name='Q{}action-insert' flags='os' line='4553' module='saxon-xforms.xsl' slots='18'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4554'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -10,7 +10,7 @@
       </check>
      </treat>
     </param>
-    <param line='4498' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
+    <param line='4555' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
      <empty role='select'/>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|instanceXML'>
       <check card='?' diag='8|0|XTTE0590|instanceXML'>
@@ -18,7 +18,7 @@
       </check>
      </treat>
     </param>
-    <param line='4499' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
+    <param line='4556' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -30,7 +30,7 @@
       </check>
      </treat>
     </param>
-    <let line='4501' var='Q{}ref' as='xs:string' slot='3' eval='16'>
+    <let line='4558' var='Q{}ref' as='xs:string' slot='3' eval='16'>
      <let var='Q{}relative' as='xs:string' slot='4' eval='16'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|1||xforms:resolveXPathStrings'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
@@ -44,22 +44,22 @@
         </cvUntyped>
        </check>
       </treat>
-      <choose line='835'>
+      <choose line='836'>
        <fn name='starts-with'>
         <varRef name='Q{}relative' slot='4'/>
         <str val='/'/>
        </fn>
-       <varRef line='836' name='Q{}relative' slot='4'/>
-       <fn line='838' name='starts-with'>
+       <varRef line='837' name='Q{}relative' slot='4'/>
+       <fn line='839' name='starts-with'>
         <varRef name='Q{}relative' slot='4'/>
         <str val='instance('/>
        </fn>
-       <varRef line='839' name='Q{}relative' slot='4'/>
-       <fn line='4501' name='not'>
+       <varRef line='840' name='Q{}relative' slot='4'/>
+       <fn line='4558' name='not'>
         <varRef name='Q{}nodeset' slot='2'/>
        </fn>
-       <varRef line='842' name='Q{}relative' slot='4'/>
-       <or line='844' op='or'>
+       <varRef line='843' name='Q{}relative' slot='4'/>
+       <or line='845' op='or'>
         <fn name='not'>
          <varRef name='Q{}relative' slot='4'/>
         </fn>
@@ -68,9 +68,9 @@
          <str val='.'/>
         </vc>
        </or>
-       <varRef line='4501' name='Q{}nodeset' slot='2'/>
+       <varRef line='4558' name='Q{}nodeset' slot='2'/>
        <true/>
-       <let line='849' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
+       <let line='850' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
         <choose>
          <fn name='contains'>
           <varRef name='Q{}relative' slot='4'/>
@@ -97,30 +97,30 @@
          <true/>
          <int val='0'/>
         </choose>
-        <let line='852' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
+        <let line='853' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
          <choose>
-          <fn line='4501' name='contains'>
+          <fn line='4558' name='contains'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
           </fn>
           <fn name='index-of'>
            <fn name='string-to-codepoints'>
-            <varRef line='4501' name='Q{}nodeset' slot='2'/>
+            <varRef line='4558' name='Q{}nodeset' slot='2'/>
            </fn>
            <int val='47'/>
           </fn>
           <true/>
           <int val='0'/>
          </choose>
-         <choose line='884'>
+         <choose line='885'>
           <compareToInt op='gt' val='0'>
            <varRef name='Q{}parentCallCount' slot='5'/>
           </compareToInt>
-          <fn line='888' name='concat'>
+          <fn line='889' name='concat'>
            <fn name='substring'>
-            <varRef line='4501' name='Q{}nodeset' slot='2'/>
+            <varRef line='4558' name='Q{}nodeset' slot='2'/>
             <int val='1'/>
-            <choose line='863'>
+            <choose line='864'>
              <and op='and'>
               <vc op='ge' onEmpty='0' comp='CAVC'>
                <fn name='count'>
@@ -132,7 +132,7 @@
                <varRef name='Q{}parentCallCount' slot='5'/>
               </compareToInt>
              </and>
-             <let line='864' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='7' eval='13'>
+             <let line='865' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='7' eval='13'>
               <arith op='-' calc='i-i'>
                <varRef name='Q{}parentCallCount' slot='5'/>
                <int val='1'/>
@@ -148,7 +148,7 @@
               </check>
              </let>
              <true/>
-             <check line='867' card='1' diag='3|0|XTTE0570|parentSlash'>
+             <check line='868' card='1' diag='3|0|XTTE0570|parentSlash'>
               <lastOf>
                <varRef name='Q{}slashes' slot='6'/>
               </lastOf>
@@ -163,17 +163,17 @@
            </fn>
           </fn>
           <true/>
-          <fn line='4501' name='concat'>
+          <fn line='4558' name='concat'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
-           <varRef line='891' name='Q{}relative' slot='4'/>
+           <varRef line='892' name='Q{}relative' slot='4'/>
           </fn>
          </choose>
         </let>
        </let>
       </choose>
      </let>
-     <let line='4502' var='Q{}at' as='xs:string?' slot='8' eval='7'>
+     <let line='4559' var='Q{}at' as='xs:string?' slot='8' eval='7'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|at'>
        <check card='?' diag='3|0|XTTE0570|at'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|at'>
@@ -186,7 +186,7 @@
         </cvUntyped>
        </check>
       </treat>
-      <let line='4503' var='Q{}position' as='xs:string?' slot='9' eval='7'>
+      <let line='4560' var='Q{}position' as='xs:string?' slot='9' eval='7'>
        <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|position'>
         <check card='?' diag='3|0|XTTE0570|position'>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|position'>
@@ -199,7 +199,7 @@
          </cvUntyped>
         </check>
        </treat>
-       <let line='4504' var='Q{}origin-ref' as='xs:string?' slot='10' eval='7'>
+       <let line='4561' var='Q{}origin-ref' as='xs:string?' slot='10' eval='7'>
         <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|origin-ref'>
          <check card='?' diag='3|0|XTTE0570|origin-ref'>
           <cvUntyped to='xs:string' diag='3|0|XTTE0570|origin-ref'>
@@ -212,11 +212,11 @@
           </cvUntyped>
          </check>
         </treat>
-        <let line='4519' var='Q{}instanceXML2' as='element()' slot='11' eval='16'>
-         <choose line='4521'>
+        <let line='4576' var='Q{}instanceXML2' as='element()' slot='11' eval='16'>
+         <choose line='4578'>
           <and op='and'>
            <vc op='eq' onEmpty='0' comp='CCC'>
-            <ufCall line='4517' name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='6'>
+            <ufCall line='4574' name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='6'>
              <varRef name='Q{}ref' slot='3'/>
             </ufCall>
             <str val='saxon-forms-default'/>
@@ -225,21 +225,21 @@
             <varRef name='Q{}instanceXML' slot='1'/>
            </fn>
           </and>
-          <check line='4522' card='1' diag='3|0|XTTE0570|instanceXML2'>
+          <check line='4579' card='1' diag='3|0|XTTE0570|instanceXML2'>
            <varRef name='Q{}instanceXML' slot='1'/>
           </check>
           <true/>
-          <check line='4525' card='1' diag='3|0|XTTE0570|instanceXML2'>
+          <check line='4582' card='1' diag='3|0|XTTE0570|instanceXML2'>
            <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='1' eval='6'>
             <varRef name='Q{}ref' slot='3'/>
            </ufCall>
           </check>
          </choose>
-         <let line='4532' var='Q{}instanceXML-origin' as='element()' slot='12' eval='16'>
-          <choose line='4534'>
+         <let line='4589' var='Q{}instanceXML-origin' as='element()' slot='12' eval='16'>
+          <choose line='4591'>
            <and op='and'>
             <vc op='eq' onEmpty='0' comp='CCC'>
-             <ufCall line='4530' name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='2' eval='16'>
+             <ufCall line='4587' name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='2' eval='16'>
               <check card='1' diag='0|0||xforms:getInstanceId'>
                <varRef name='Q{}origin-ref' slot='10'/>
               </check>
@@ -250,11 +250,11 @@
              <varRef name='Q{}instanceXML' slot='1'/>
             </fn>
            </and>
-           <check line='4535' card='1' diag='3|0|XTTE0570|instanceXML-origin'>
+           <check line='4592' card='1' diag='3|0|XTTE0570|instanceXML-origin'>
             <varRef name='Q{}instanceXML' slot='1'/>
            </check>
            <true/>
-           <check line='4538' card='1' diag='3|0|XTTE0570|instanceXML-origin'>
+           <check line='4595' card='1' diag='3|0|XTTE0570|instanceXML-origin'>
             <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='3' eval='16'>
              <check card='1' diag='0|0||xforms:getInstance-JS'>
               <varRef name='Q{}origin-ref' slot='10'/>
@@ -262,8 +262,8 @@
             </ufCall>
            </check>
           </choose>
-          <let line='4549' var='Q{}origin-node' as='node()?' slot='13' eval='7'>
-           <treat line='4550' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|origin-node'>
+          <let line='4606' var='Q{}origin-node' as='node()?' slot='13' eval='7'>
+           <treat line='4607' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|origin-node'>
             <check card='?' diag='3|0|XTTE0570|origin-node'>
              <evaluate dxns=''>
               <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='4' eval='16'>
@@ -279,13 +279,13 @@
              </evaluate>
             </check>
            </treat>
-           <let line='4553' var='Q{}insert-node-location' as='node()' slot='14' eval='16'>
-            <treat line='4554' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|insert-node-location'>
+           <let line='4610' var='Q{}insert-node-location' as='node()' slot='14' eval='16'>
+            <treat line='4611' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|insert-node-location'>
              <check card='1' diag='3|0|XTTE0570|insert-node-location'>
               <evaluate dxns=''>
                <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='5' eval='16'>
                 <check card='1' diag='0|0||xforms:impose'>
-                 <choose line='4515'>
+                 <choose line='4572'>
                   <vc op='ne' onEmpty='0' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
                    <varRef name='Q{}ref' slot='3'/>
                    <str val=''/>
@@ -314,7 +314,7 @@
               </evaluate>
              </check>
             </treat>
-            <sequence line='4557'>
+            <sequence line='4614'>
              <message>
               <sequence role='select'>
                <valueOf>
@@ -329,7 +329,7 @@
               <str role='terminate' val='no'/>
               <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
              </message>
-             <message line='4558'>
+             <message line='4615'>
               <sequence role='select'>
                <valueOf>
                 <str val='[action-insert] $origin-node = '/>
@@ -343,53 +343,53 @@
               <str role='terminate' val='no'/>
               <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
              </message>
-             <let line='4575' var='Q{}instance-with-insert' as='element()' slot='15' eval='16'>
-              <treat line='4576' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-insert'>
+             <let line='4632' var='Q{}instance-with-insert' as='element()' slot='15' eval='16'>
+              <treat line='4633' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-insert'>
                <check card='1' diag='3|0|XTTE0570|instance-with-insert'>
                 <applyT mode='Q{}insert-node' bSlot='6'>
                  <varRef role='select' name='Q{}instanceXML2' slot='11'/>
                  <withParam name='Q{}insert-node-location' flags='t' as='node()'>
-                  <varRef line='4577' name='Q{}insert-node-location' slot='14'/>
+                  <varRef line='4634' name='Q{}insert-node-location' slot='14'/>
                  </withParam>
                  <withParam name='Q{}node-to-insert' flags='t' as='node()?'>
-                  <choose line='4564'>
+                  <choose line='4621'>
                    <fn name='exists'>
                     <varRef name='Q{}origin-node' slot='13'/>
                    </fn>
-                   <copyOf line='4565' flags='vc'>
+                   <copyOf line='4622' flags='vc'>
                     <varRef name='Q{}origin-node' slot='13'/>
                    </copyOf>
                    <true/>
-                   <copyOf line='4568' flags='vc'>
+                   <copyOf line='4625' flags='vc'>
                     <varRef name='Q{}insert-node-location' slot='14'/>
                    </copyOf>
                   </choose>
                  </withParam>
                  <withParam name='Q{}position-relative' flags='t' as='xs:string?'>
-                  <varRef line='4579' name='Q{}position' slot='9'/>
+                  <varRef line='4636' name='Q{}position' slot='9'/>
                  </withParam>
                 </applyT>
                </check>
               </treat>
-              <sequence line='4583'>
+              <sequence line='4640'>
                <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='7' eval='6 6'>
                 <varRef name='Q{}ref' slot='3'/>
                 <varRef name='Q{}instance-with-insert' slot='15'/>
                </ufCall>
-               <choose line='4587'>
+               <choose line='4644'>
                 <fn name='matches'>
                  <varRef name='Q{}at' slot='8'/>
                  <str val='index\s*\('/>
                  <str val=''/>
                 </fn>
-                <let line='4588' var='Q{}repeat-id' as='xs:string?' slot='16' eval='7'>
+                <let line='4645' var='Q{}repeat-id' as='xs:string?' slot='16' eval='7'>
                  <ufCall name='Q{http://www.w3.org/2002/xforms}getRepeatID' tailCall='false' bSlot='8' eval='16'>
                   <check card='1' diag='0|0||xforms:getRepeatID'>
                    <varRef name='Q{}at' slot='8'/>
                   </check>
                  </ufCall>
-                 <let line='4589' var='Q{}at-position' as='xs:integer' slot='17' eval='16'>
-                  <treat line='4590' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|at-position'>
+                 <let line='4646' var='Q{}at-position' as='xs:integer' slot='17' eval='16'>
+                  <treat line='4647' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|at-position'>
                    <check card='1' diag='3|0|XTTE0570|at-position'>
                     <cvUntyped to='xs:integer' diag='3|0|XTTE0570|at-position'>
                      <data>
@@ -408,7 +408,7 @@
                     </cvUntyped>
                    </check>
                   </treat>
-                  <sequence line='4592'>
+                  <sequence line='4649'>
                    <message>
                     <sequence role='select'>
                      <valueOf>
@@ -421,7 +421,7 @@
                     <str role='terminate' val='no'/>
                     <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
                    </message>
-                   <message line='4593'>
+                   <message line='4650'>
                     <sequence role='select'>
                      <valueOf>
                       <str val='[action-insert] $at-position evaluated as '/>
@@ -435,16 +435,16 @@
                     <str role='terminate' val='no'/>
                     <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
                    </message>
-                   <choose line='4595'>
+                   <choose line='4652'>
                     <fn name='exists'>
                      <varRef name='Q{}repeat-id' slot='16'/>
                     </fn>
-                    <choose line='4597'>
+                    <choose line='4654'>
                      <vc op='eq' onEmpty='0' comp='CCC'>
                       <varRef name='Q{}position' slot='9'/>
                       <str val='before'/>
                      </vc>
-                     <ifCall line='4598' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                     <ifCall line='4655' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                       <check card='1' diag='0|0||ixsl:call'>
                        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                       </check>
@@ -455,7 +455,7 @@
                       </arrayBlock>
                      </ifCall>
                      <true/>
-                     <ifCall line='4601' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                     <ifCall line='4658' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                       <check card='1' diag='0|0||ixsl:call'>
                        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                       </check>
@@ -474,7 +474,7 @@
                  </let>
                 </let>
                </choose>
-               <callT line='4611' name='Q{}xforms-recalculate' bSlot='10' flags='t'/>
+               <callT line='4668' name='Q{}xforms-recalculate' bSlot='10' flags='t'/>
               </sequence>
              </let>
             </sequence>
@@ -490,8 +490,8 @@
   </template>
  </co>
  <co id='8' binds='1 2 3 3 9 5 6 3 7'>
-  <template name='Q{}action-delete' flags='os' line='4624' module='saxon-xforms.xsl' slots='18'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4625'>
+  <template name='Q{}action-delete' flags='os' line='4681' module='saxon-xforms.xsl' slots='18'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4682'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -499,14 +499,14 @@
       </check>
      </treat>
     </param>
-    <param line='4626' name='Q{}instanceXML' slot='1' flags='ti' as='element()'>
+    <param line='4683' name='Q{}instanceXML' slot='1' flags='ti' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|instanceXML'>
       <check card='1' diag='8|0|XTTE0590|instanceXML'>
        <supplied slot='1'/>
       </check>
      </treat>
     </param>
-    <param line='4627' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
+    <param line='4684' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -518,7 +518,7 @@
       </check>
      </treat>
     </param>
-    <let line='4629' var='Q{}ref' as='xs:string' slot='3' eval='16'>
+    <let line='4686' var='Q{}ref' as='xs:string' slot='3' eval='16'>
      <let var='Q{}relative' as='xs:string' slot='4' eval='16'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|1||xforms:resolveXPathStrings'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
@@ -532,22 +532,22 @@
         </cvUntyped>
        </check>
       </treat>
-      <choose line='835'>
+      <choose line='836'>
        <fn name='starts-with'>
         <varRef name='Q{}relative' slot='4'/>
         <str val='/'/>
        </fn>
-       <varRef line='836' name='Q{}relative' slot='4'/>
-       <fn line='838' name='starts-with'>
+       <varRef line='837' name='Q{}relative' slot='4'/>
+       <fn line='839' name='starts-with'>
         <varRef name='Q{}relative' slot='4'/>
         <str val='instance('/>
        </fn>
-       <varRef line='839' name='Q{}relative' slot='4'/>
-       <fn line='4629' name='not'>
+       <varRef line='840' name='Q{}relative' slot='4'/>
+       <fn line='4686' name='not'>
         <varRef name='Q{}nodeset' slot='2'/>
        </fn>
-       <varRef line='842' name='Q{}relative' slot='4'/>
-       <or line='844' op='or'>
+       <varRef line='843' name='Q{}relative' slot='4'/>
+       <or line='845' op='or'>
         <fn name='not'>
          <varRef name='Q{}relative' slot='4'/>
         </fn>
@@ -556,9 +556,9 @@
          <str val='.'/>
         </vc>
        </or>
-       <varRef line='4629' name='Q{}nodeset' slot='2'/>
+       <varRef line='4686' name='Q{}nodeset' slot='2'/>
        <true/>
-       <let line='849' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
+       <let line='850' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
         <choose>
          <fn name='contains'>
           <varRef name='Q{}relative' slot='4'/>
@@ -585,30 +585,30 @@
          <true/>
          <int val='0'/>
         </choose>
-        <let line='852' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
+        <let line='853' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
          <choose>
-          <fn line='4629' name='contains'>
+          <fn line='4686' name='contains'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
           </fn>
           <fn name='index-of'>
            <fn name='string-to-codepoints'>
-            <varRef line='4629' name='Q{}nodeset' slot='2'/>
+            <varRef line='4686' name='Q{}nodeset' slot='2'/>
            </fn>
            <int val='47'/>
           </fn>
           <true/>
           <int val='0'/>
          </choose>
-         <choose line='884'>
+         <choose line='885'>
           <compareToInt op='gt' val='0'>
            <varRef name='Q{}parentCallCount' slot='5'/>
           </compareToInt>
-          <fn line='888' name='concat'>
+          <fn line='889' name='concat'>
            <fn name='substring'>
-            <varRef line='4629' name='Q{}nodeset' slot='2'/>
+            <varRef line='4686' name='Q{}nodeset' slot='2'/>
             <int val='1'/>
-            <choose line='863'>
+            <choose line='864'>
              <and op='and'>
               <vc op='ge' onEmpty='0' comp='CAVC'>
                <fn name='count'>
@@ -620,7 +620,7 @@
                <varRef name='Q{}parentCallCount' slot='5'/>
               </compareToInt>
              </and>
-             <let line='864' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='7' eval='13'>
+             <let line='865' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='7' eval='13'>
               <arith op='-' calc='i-i'>
                <varRef name='Q{}parentCallCount' slot='5'/>
                <int val='1'/>
@@ -636,7 +636,7 @@
               </check>
              </let>
              <true/>
-             <check line='867' card='1' diag='3|0|XTTE0570|parentSlash'>
+             <check line='868' card='1' diag='3|0|XTTE0570|parentSlash'>
               <lastOf>
                <varRef name='Q{}slashes' slot='6'/>
               </lastOf>
@@ -651,17 +651,17 @@
            </fn>
           </fn>
           <true/>
-          <fn line='4629' name='concat'>
+          <fn line='4686' name='concat'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
-           <varRef line='891' name='Q{}relative' slot='4'/>
+           <varRef line='892' name='Q{}relative' slot='4'/>
           </fn>
          </choose>
         </let>
        </let>
       </choose>
      </let>
-     <let line='4630' var='Q{}at' as='xs:string?' slot='8' eval='7'>
+     <let line='4687' var='Q{}at' as='xs:string?' slot='8' eval='7'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|at'>
        <check card='?' diag='3|0|XTTE0570|at'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|at'>
@@ -674,7 +674,7 @@
         </cvUntyped>
        </check>
       </treat>
-      <let line='4640' var='Q{}ref-qualified' as='xs:string' slot='9' eval='16'>
+      <let line='4697' var='Q{}ref-qualified' as='xs:string' slot='9' eval='16'>
        <choose>
         <fn name='exists'>
          <varRef name='Q{}at' slot='8'/>
@@ -688,34 +688,34 @@
         <true/>
         <varRef name='Q{}ref' slot='3'/>
        </choose>
-       <let line='4644' var='Q{}instanceXML2' as='element()' slot='10' eval='16'>
-        <choose line='4646'>
+       <let line='4701' var='Q{}instanceXML2' as='element()' slot='10' eval='16'>
+        <choose line='4703'>
          <vc op='eq' onEmpty='0' comp='CCC'>
-          <ufCall line='4642' name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='6'>
+          <ufCall line='4699' name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='6'>
            <varRef name='Q{}ref' slot='3'/>
           </ufCall>
           <str val='saxon-forms-default'/>
          </vc>
-         <varRef line='4647' name='Q{}instanceXML' slot='1'/>
+         <varRef line='4704' name='Q{}instanceXML' slot='1'/>
          <true/>
-         <check line='4650' card='1' diag='3|0|XTTE0570|instanceXML2'>
+         <check line='4707' card='1' diag='3|0|XTTE0570|instanceXML2'>
           <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='1' eval='6'>
            <varRef name='Q{}ref' slot='3'/>
           </ufCall>
          </check>
         </choose>
-        <let line='4655' var='Q{}ifVar' as='xs:string?' slot='11' eval='7'>
-         <choose line='790'>
+        <let line='4712' var='Q{}ifVar' as='xs:string?' slot='11' eval='7'>
+         <choose line='791'>
           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
-           <varRef line='4655' name='Q{}action-map' slot='0'/>
+           <varRef line='4712' name='Q{}action-map' slot='0'/>
            <str val='@if'/>
           </ifCall>
-          <treat line='791' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
+          <treat line='792' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
            <check card='?' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
             <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
              <data>
               <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-               <varRef line='4655' name='Q{}action-map' slot='0'/>
+               <varRef line='4712' name='Q{}action-map' slot='0'/>
                <str val='@if'/>
               </ifCall>
              </data>
@@ -723,8 +723,8 @@
            </check>
           </treat>
          </choose>
-         <let line='4658' var='Q{}delete-node' as='node()?' slot='12' eval='7'>
-          <choose line='4660'>
+         <let line='4715' var='Q{}delete-node' as='node()?' slot='12' eval='7'>
+          <choose line='4717'>
            <and op='and'>
             <fn name='exists'>
              <varRef name='Q{}ref-qualified' slot='9'/>
@@ -734,7 +734,7 @@
              <str val=''/>
             </vc>
            </and>
-           <treat line='4661' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|delete-node'>
+           <treat line='4718' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|delete-node'>
             <check card='?' diag='3|0|XTTE0570|delete-node'>
              <evaluate dxns=''>
               <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
@@ -751,12 +751,12 @@
             </check>
            </treat>
           </choose>
-          <let line='4666' var='Q{}ifExecuted' as='xs:boolean' slot='13' eval='16'>
-           <choose line='4668'>
+          <let line='4723' var='Q{}ifExecuted' as='xs:boolean' slot='13' eval='16'>
+           <choose line='4725'>
             <fn name='exists'>
              <varRef name='Q{}ifVar' slot='11'/>
             </fn>
-            <treat line='4669' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|ifExecuted'>
+            <treat line='4726' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|ifExecuted'>
              <check card='1' diag='3|0|XTTE0570|ifExecuted'>
               <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|ifExecuted'>
                <data>
@@ -781,38 +781,38 @@
             <true/>
             <true/>
            </choose>
-           <choose line='4677'>
+           <choose line='4734'>
             <varRef name='Q{}ifExecuted' slot='13'/>
-            <let line='4678' var='Q{}instance-with-delete' as='element()' slot='14' eval='16'>
-             <treat line='4679' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-delete'>
+            <let line='4735' var='Q{}instance-with-delete' as='element()' slot='14' eval='16'>
+             <treat line='4736' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-delete'>
               <check card='1' diag='3|0|XTTE0570|instance-with-delete'>
                <applyT mode='Q{}delete-node' bSlot='4'>
                 <varRef role='select' name='Q{}instanceXML2' slot='10'/>
                 <withParam name='Q{}delete-node' flags='t' as='node()?'>
-                 <varRef line='4680' name='Q{}delete-node' slot='12'/>
+                 <varRef line='4737' name='Q{}delete-node' slot='12'/>
                 </withParam>
                </applyT>
               </check>
              </treat>
-             <sequence line='4684'>
+             <sequence line='4741'>
               <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='5' eval='6 6'>
                <varRef name='Q{}ref' slot='3'/>
                <varRef name='Q{}instance-with-delete' slot='14'/>
               </ufCall>
-              <choose line='4687'>
+              <choose line='4744'>
                <fn name='matches'>
                 <varRef name='Q{}at' slot='8'/>
                 <str val='index\s*\('/>
                 <str val=''/>
                </fn>
-               <let line='4688' var='Q{}repeat-id' as='xs:string?' slot='15' eval='7'>
+               <let line='4745' var='Q{}repeat-id' as='xs:string?' slot='15' eval='7'>
                 <ufCall name='Q{http://www.w3.org/2002/xforms}getRepeatID' tailCall='false' bSlot='6' eval='16'>
                  <check card='1' diag='0|0||xforms:getRepeatID'>
                   <varRef name='Q{}at' slot='8'/>
                  </check>
                 </ufCall>
-                <let line='4689' var='Q{}at-position' as='xs:integer' slot='16' eval='16'>
-                 <treat line='4690' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|at-position'>
+                <let line='4746' var='Q{}at-position' as='xs:integer' slot='16' eval='16'>
+                 <treat line='4747' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|at-position'>
                   <check card='1' diag='3|0|XTTE0570|at-position'>
                    <cvUntyped to='xs:integer' diag='3|0|XTTE0570|at-position'>
                     <data>
@@ -831,11 +831,11 @@
                    </cvUntyped>
                   </check>
                  </treat>
-                 <choose line='4693'>
+                 <choose line='4750'>
                   <fn name='exists'>
                    <varRef name='Q{}repeat-id' slot='15'/>
                   </fn>
-                  <let line='4694' var='Q{}repeat-size' as='xs:double' slot='17' eval='16'>
+                  <let line='4751' var='Q{}repeat-size' as='xs:double' slot='17' eval='16'>
                    <check card='1' diag='3|0|XTTE0570|repeat-size'>
                     <convert from='xs:anyAtomicType' to='xs:double' flags='p' diag='3|0|XTTE0570|repeat-size'>
                      <cvUntyped to='xs:double' diag='3|0|XTTE0570|repeat-size'>
@@ -853,7 +853,7 @@
                      </cvUntyped>
                     </convert>
                    </check>
-                   <sequence line='4696'>
+                   <sequence line='4753'>
                     <message>
                      <sequence role='select'>
                       <valueOf>
@@ -882,12 +882,12 @@
                      <str role='terminate' val='no'/>
                      <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
                     </message>
-                    <choose line='4699'>
+                    <choose line='4756'>
                      <vc op='eq' onEmpty='0' comp='CAVC'>
                       <varRef name='Q{}at-position' slot='16'/>
                       <varRef name='Q{}repeat-size' slot='17'/>
                      </vc>
-                     <ifCall line='4701' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                     <ifCall line='4758' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                       <check card='1' diag='0|0||ixsl:call'>
                        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                       </check>
@@ -907,7 +907,7 @@
                 </let>
                </let>
               </choose>
-              <callT line='4710' name='Q{}xforms-recalculate' bSlot='8' flags='t'/>
+              <callT line='4767' name='Q{}xforms-recalculate' bSlot='8' flags='t'/>
              </sequence>
             </let>
            </choose>
@@ -922,8 +922,8 @@
   </template>
  </co>
  <co id='10' binds='11'>
-  <template name='Q{}action-send' flags='os' line='4755' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4756'>
+  <template name='Q{}action-send' flags='os' line='4812' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4813'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -931,9 +931,9 @@
       </check>
      </treat>
     </param>
-    <callT line='4762' name='Q{}xforms-submit' bSlot='0' flags='t'>
+    <callT line='4819' name='Q{}xforms-submit' bSlot='0' flags='t'>
      <withParam name='Q{}submission' flags='c' as='xs:string'>
-      <treat line='4760' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|submission'>
+      <treat line='4817' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|submission'>
        <check card='1' diag='3|0|XTTE0570|submission'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|submission'>
          <data>
@@ -951,10 +951,10 @@
   </template>
  </co>
  <co id='12' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}usesIndexFunction' line='2954' module='saxon-xforms.xsl' eval='8' flags='pU' as='xs:boolean' slots='1'>
+  <function name='Q{http://www.w3.org/2002/xforms}usesIndexFunction' line='2989' module='saxon-xforms.xsl' eval='8' flags='pU' as='xs:boolean' slots='1'>
    <arg name='Q{}this' as='element()'/>
-   <fn role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2990' name='exists'>
-    <sequence line='2965'>
+   <fn role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3025' name='exists'>
+    <sequence line='3000'>
      <analyzeString>
       <cvUntyped role='select' to='xs:string'>
        <data>
@@ -966,7 +966,7 @@
       </cvUntyped>
       <str role='regex' val='\i\c*\('/>
       <str role='flags' val=''/>
-      <choose role='matching' line='2968'>
+      <choose role='matching' line='3003'>
        <vc op='eq' onEmpty='0' comp='CCC'>
         <fn name='substring-before'>
          <dot type='xs:string'/>
@@ -978,7 +978,7 @@
       </choose>
       <empty role='nonMatching'/>
      </analyzeString>
-     <analyzeString line='2977'>
+     <analyzeString line='3012'>
       <cvUntyped role='select' to='xs:string'>
        <data>
         <slash simple='1'>
@@ -989,7 +989,7 @@
       </cvUntyped>
       <str role='regex' val='\i\c*\('/>
       <str role='flags' val=''/>
-      <choose role='matching' line='2980'>
+      <choose role='matching' line='3015'>
        <vc op='eq' onEmpty='0' comp='CCC'>
         <fn name='substring-before'>
          <dot type='xs:string'/>
@@ -1005,20 +1005,20 @@
    </fn>
   </function>
  </co>
- <co id='13' binds='13 14 15 13 13 15'>
+ <co id='13' binds='14 13 14 15 13 13 15'>
   <mode name='Q{}form-check' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='27' rank='0' minImp='0' slots='10' flags='s' line='2606' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='27' rank='0' minImp='0' slots='12' flags='s' line='2612' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2607'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2613'>
      <param name='Q{}curPath' slot='0'>
       <str role='select' val=''/>
       <supplied role='conversion' slot='0'/>
      </param>
-     <param line='2608' name='Q{}position' slot='1'>
+     <param line='2614' name='Q{}position' slot='1'>
       <int role='select' val='0'/>
       <supplied role='conversion' slot='1'/>
      </param>
-     <param line='2609' name='Q{}pendingUpdates' slot='2' flags='t' as='map(xs:string, xs:string)?'>
+     <param line='2615' name='Q{}pendingUpdates' slot='2' flags='t' as='map(xs:string, xs:string)?'>
       <empty role='select'/>
       <treat role='conversion' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|pendingUpdates'>
        <check card='?' diag='8|0|XTTE0590|pendingUpdates'>
@@ -1026,7 +1026,27 @@
        </check>
       </treat>
      </param>
-     <let line='2615' var='Q{}updatedPath' as='xs:string' slot='3' eval='16'>
+     <param line='2616' name='Q{}updated-node' slot='3' flags='t' as='node()?'>
+      <empty role='select'/>
+      <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|updated-node'>
+       <check card='?' diag='8|0|XTTE0590|updated-node'>
+        <supplied slot='3'/>
+       </check>
+      </treat>
+     </param>
+     <param line='2617' name='Q{}value' slot='4' flags='t' as='xs:string?'>
+      <empty role='select'/>
+      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|value'>
+       <check card='?' diag='8|0|XTTE0590|value'>
+        <cvUntyped to='xs:string' diag='8|0|XTTE0590|value'>
+         <data>
+          <supplied slot='4'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <let line='2638' var='Q{}updatedPath' as='xs:string' slot='5' eval='16'>
       <choose>
        <gc op='&gt;' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
         <data>
@@ -1057,220 +1077,312 @@
         </fn>
        </fn>
       </choose>
-      <copy line='2623' flags='cin'>
-       <sequence role='content'>
-        <applyT mode='Q{}form-check' bSlot='0'>
-         <axis role='select' name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
-         <withParam name='Q{}curPath' as='xs:string'>
-          <fn line='2624' name='concat'>
-           <varRef name='Q{}updatedPath' slot='3'/>
-           <str val='/'/>
+      <sequence line='2644'>
+       <message>
+        <sequence role='select'>
+         <valueOf>
+          <str val='[form-check] looking for form control for XPath &#39;'/>
+         </valueOf>
+         <varRef name='Q{}updatedPath' slot='5'/>
+         <valueOf flags='S'>
+          <str val='&#39;'/>
+         </valueOf>
+        </sequence>
+        <str role='terminate' val='no'/>
+        <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+       </message>
+       <forEach line='2645'>
+        <filter flags='b'>
+         <slash simple='1'>
+          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
+          <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+         </slash>
+         <or op='or'>
+          <or op='or'>
+           <fn name='exists'>
+            <axis name='self' nodeTest='element(Q{}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
+           </fn>
+           <fn name='exists'>
+            <axis name='self' nodeTest='element(Q{}select)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;select&#39;;'/>
+           </fn>
+          </or>
+          <fn name='exists'>
+           <axis name='self' nodeTest='element(Q{}textarea)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;textarea&#39;;'/>
           </fn>
-         </withParam>
-        </applyT>
-        <let line='2630' var='Q{}associated-form-control' as='element()*' slot='4' eval='8'>
-         <filter flags='b'>
-          <filter flags='b'>
-           <slash simple='1'>
-            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
-            <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-           </slash>
-           <or op='or'>
-            <or op='or'>
-             <fn name='exists'>
-              <axis name='self' nodeTest='element(Q{}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
-             </fn>
-             <fn name='exists'>
-              <axis name='self' nodeTest='element(Q{}select)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;select&#39;;'/>
-             </fn>
-            </or>
-            <fn name='exists'>
-             <axis name='self' nodeTest='element(Q{}textarea)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;textarea&#39;;'/>
-            </fn>
-           </or>
-          </filter>
-          <vc op='eq' onEmpty='0' comp='CCC'>
-           <ufCall name='Q{http://www.w3.org/2002/xforms}resolve-index' tailCall='false' bSlot='1' eval='16'>
+         </or>
+        </filter>
+        <sequence line='2646'>
+         <message>
+          <sequence role='select'>
+           <valueOf>
+            <str val='[form-check] checking '/>
+           </valueOf>
+           <fn name='name'>
+            <dot type='element()'/>
+           </fn>
+           <valueOf>
+            <str val=', @data-ref = &#39;'/>
+           </valueOf>
+           <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
+           <valueOf flags='S'>
+            <str val='&#39;'/>
+           </valueOf>
+          </sequence>
+          <str role='terminate' val='no'/>
+          <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+         </message>
+         <message line='2647'>
+          <sequence role='select'>
+           <valueOf>
+            <str val='[form-check] resolved @data-ref = &#39;'/>
+           </valueOf>
+           <ufCall name='Q{http://www.w3.org/2002/xforms}resolve-index' tailCall='false' bSlot='0' eval='16'>
             <check card='1' diag='0|0||xforms:resolve-index'>
              <cvUntyped to='xs:string'>
               <attVal name='Q{}data-ref' chk='0'/>
              </cvUntyped>
             </check>
            </ufCall>
-           <varRef name='Q{}updatedPath' slot='3'/>
-          </vc>
-         </filter>
-         <sequence line='2632'>
-          <choose>
-           <fn name='exists'>
-            <tail start='2'>
-             <varRef name='Q{}associated-form-control' slot='4'/>
-            </tail>
+           <valueOf flags='S'>
+            <str val='&#39;'/>
+           </valueOf>
+          </sequence>
+          <str role='terminate' val='no'/>
+          <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+         </message>
+        </sequence>
+       </forEach>
+       <copy line='2652' flags='cin'>
+        <sequence role='content'>
+         <applyT mode='Q{}form-check' bSlot='1'>
+          <axis role='select' name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+          <withParam name='Q{}curPath' as='xs:string'>
+           <fn line='2653' name='concat'>
+            <varRef name='Q{}updatedPath' slot='5'/>
+            <str val='/'/>
            </fn>
-           <message line='2633'>
-            <sequence role='select'>
-             <valueOf>
-              <str val='[form-check] More than one form element controls the value of XForm node at '/>
-             </valueOf>
-             <valueOf>
-              <varRef name='Q{}updatedPath' slot='3'/>
-             </valueOf>
-             <valueOf>
-              <str val='; Saxon-Forms will apply the value of the first'/>
+          </withParam>
+         </applyT>
+         <let line='2659' var='Q{}associated-form-control' as='element()*' slot='6' eval='8'>
+          <filter flags='b'>
+           <filter flags='b'>
+            <slash simple='1'>
+             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
+             <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+            </slash>
+            <or op='or'>
+             <or op='or'>
+              <fn name='exists'>
+               <axis name='self' nodeTest='element(Q{}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
+              </fn>
+              <fn name='exists'>
+               <axis name='self' nodeTest='element(Q{}select)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;select&#39;;'/>
+              </fn>
+             </or>
+             <fn name='exists'>
+              <axis name='self' nodeTest='element(Q{}textarea)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;textarea&#39;;'/>
+             </fn>
+            </or>
+           </filter>
+           <vc op='eq' onEmpty='0' comp='CCC'>
+            <ufCall name='Q{http://www.w3.org/2002/xforms}resolve-index' tailCall='false' bSlot='2' eval='16'>
+             <check card='1' diag='0|0||xforms:resolve-index'>
+              <cvUntyped to='xs:string'>
+               <attVal name='Q{}data-ref' chk='0'/>
+              </cvUntyped>
+             </check>
+            </ufCall>
+            <varRef name='Q{}updatedPath' slot='5'/>
+           </vc>
+          </filter>
+          <sequence line='2661'>
+           <choose>
+            <fn name='exists'>
+             <tail start='2'>
+              <varRef name='Q{}associated-form-control' slot='6'/>
+             </tail>
+            </fn>
+            <message line='2662'>
+             <sequence role='select'>
+              <valueOf>
+               <str val='[form-check] More than one form element controls the value of XForm node at '/>
+              </valueOf>
+              <valueOf>
+               <varRef name='Q{}updatedPath' slot='5'/>
+              </valueOf>
+              <valueOf>
+               <str val='; Saxon-Forms will apply the value of the first'/>
+              </valueOf>
+             </sequence>
+             <str role='terminate' val='no'/>
+             <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+            </message>
+           </choose>
+           <choose line='2666'>
+            <is op='is'>
+             <varRef name='Q{}updated-node' slot='3'/>
+             <dot type='element()'/>
+            </is>
+            <sequence line='2667'>
+             <message>
+              <valueOf role='select'>
+               <str val='&#xA;                        [form-check] Matched node!!&#xA;                    '/>
+              </valueOf>
+              <str role='terminate' val='no'/>
+              <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+             </message>
+             <valueOf line='2670' flags='l'>
+              <varRef name='Q{}value' slot='4'/>
              </valueOf>
             </sequence>
-            <str role='terminate' val='no'/>
-            <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-           </message>
-          </choose>
-          <choose line='2637'>
-           <fn name='exists'>
-            <varRef name='Q{}associated-form-control' slot='4'/>
-           </fn>
-           <valueOf line='2641' flags='l'>
-            <fn name='string-join'>
-             <convert from='xs:anyAtomicType' to='xs:string'>
-              <data>
-               <mergeAdj>
-                <applyT mode='Q{}get-field' bSlot='2'>
-                 <first role='select'>
-                  <varRef name='Q{}associated-form-control' slot='4'/>
-                 </first>
-                </applyT>
-               </mergeAdj>
-              </data>
-             </convert>
-             <str val=''/>
+            <fn line='2672' name='exists'>
+             <varRef name='Q{}associated-form-control' slot='6'/>
             </fn>
-           </valueOf>
-           <and line='2644' op='and'>
-            <fn name='exists'>
-             <varRef name='Q{}pendingUpdates' slot='2'/>
-            </fn>
-            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
-             <check card='1' diag='0|0||map:contains'>
-              <varRef name='Q{}pendingUpdates' slot='2'/>
-             </check>
-             <varRef name='Q{}updatedPath' slot='3'/>
-            </ifCall>
-           </and>
-           <valueOf line='2652' flags='l'>
-            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-             <check card='1' diag='0|0||map:get'>
-              <varRef name='Q{}pendingUpdates' slot='2'/>
-             </check>
-             <varRef name='Q{}updatedPath' slot='3'/>
-            </ifCall>
-           </valueOf>
-           <true/>
-           <valueOf line='2661' flags='l'>
-            <fn name='normalize-space'>
+            <valueOf line='2676' flags='l'>
              <fn name='string-join'>
-              <data>
-               <axis name='child' nodeTest='text()' jsTest='return item.nodeType===3;'/>
-              </data>
+              <convert from='xs:anyAtomicType' to='xs:string'>
+               <data>
+                <mergeAdj>
+                 <applyT mode='Q{}get-field' bSlot='3'>
+                  <first role='select'>
+                   <varRef name='Q{}associated-form-control' slot='6'/>
+                  </first>
+                 </applyT>
+                </mergeAdj>
+               </data>
+              </convert>
               <str val=''/>
              </fn>
-            </fn>
-           </valueOf>
-          </choose>
-          <forEachGroup line='2666' algorithm='by'>
-           <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-           <fn role='key' name='local-name'>
-            <dot type='element()'/>
-           </fn>
-           <str role='collation' val='http://www.w3.org/2005/xpath-functions/collation/codepoint'/>
-           <let role='content' line='2668' var='Q{}updatedChildPath' as='xs:string' slot='5' eval='8'>
-            <fn name='concat'>
-             <varRef name='Q{}updatedPath' slot='3'/>
-             <str val='/'/>
-             <check card='?' diag='0|2||fn:concat'>
-              <currentGroupingKey/>
-             </check>
-            </fn>
-            <let line='2673' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='6' eval='13'>
-             <fn name='concat'>
-              <varRef name='Q{}updatedChildPath' slot='5'/>
-              <str val='['/>
+            </valueOf>
+            <and line='2679' op='and'>
+             <fn name='exists'>
+              <varRef name='Q{}pendingUpdates' slot='2'/>
              </fn>
-             <let var='Q{}dataRefWithFilter' as='element()*' slot='7' eval='8'>
-              <filter flags='b'>
-               <slash simple='1'>
-                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
-                <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-               </slash>
-               <fn name='starts-with'>
-                <cvUntyped to='xs:string'>
-                 <attVal name='Q{}data-ref' chk='0'/>
-                </cvUntyped>
-                <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='6'/>
-               </fn>
-              </filter>
-              <choose line='2676'>
-               <or op='or'>
-                <fn name='exists'>
-                 <tail start='2'>
+             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+              <check card='1' diag='0|0||map:contains'>
+               <varRef name='Q{}pendingUpdates' slot='2'/>
+              </check>
+              <varRef name='Q{}updatedPath' slot='5'/>
+             </ifCall>
+            </and>
+            <valueOf line='2687' flags='l'>
+             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+              <check card='1' diag='0|0||map:get'>
+               <varRef name='Q{}pendingUpdates' slot='2'/>
+              </check>
+              <varRef name='Q{}updatedPath' slot='5'/>
+             </ifCall>
+            </valueOf>
+            <true/>
+            <valueOf line='2696' flags='l'>
+             <fn name='normalize-space'>
+              <fn name='string-join'>
+               <data>
+                <axis name='child' nodeTest='text()' jsTest='return item.nodeType===3;'/>
+               </data>
+               <str val=''/>
+              </fn>
+             </fn>
+            </valueOf>
+           </choose>
+           <forEachGroup line='2701' algorithm='by'>
+            <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+            <fn role='key' name='local-name'>
+             <dot type='element()'/>
+            </fn>
+            <str role='collation' val='http://www.w3.org/2005/xpath-functions/collation/codepoint'/>
+            <let role='content' line='2703' var='Q{}updatedChildPath' as='xs:string' slot='7' eval='8'>
+             <fn name='concat'>
+              <varRef name='Q{}updatedPath' slot='5'/>
+              <str val='/'/>
+              <check card='?' diag='0|2||fn:concat'>
+               <currentGroupingKey/>
+              </check>
+             </fn>
+             <let line='2708' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='8' eval='13'>
+              <fn name='concat'>
+               <varRef name='Q{}updatedChildPath' slot='7'/>
+               <str val='['/>
+              </fn>
+              <let var='Q{}dataRefWithFilter' as='element()*' slot='9' eval='8'>
+               <filter flags='b'>
+                <slash simple='1'>
+                 <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
+                 <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+                </slash>
+                <fn name='starts-with'>
+                 <cvUntyped to='xs:string'>
+                  <attVal name='Q{}data-ref' chk='0'/>
+                 </cvUntyped>
+                 <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='8'/>
+                </fn>
+               </filter>
+               <choose line='2711'>
+                <or op='or'>
+                 <fn name='exists'>
+                  <tail start='2'>
+                   <currentGroup/>
+                  </tail>
+                 </fn>
+                 <fn name='exists'>
+                  <varRef name='Q{}dataRefWithFilter' slot='9'/>
+                 </fn>
+                </or>
+                <let line='2714' var='Q{http://saxon.sf.net/generated-variable}v1' as='xs:string' slot='10' eval='13'>
+                 <fn name='concat'>
+                  <varRef name='Q{}updatedPath' slot='5'/>
+                  <str val='/'/>
+                 </fn>
+                 <forEach line='2712'>
                   <currentGroup/>
-                 </tail>
-                </fn>
-                <fn name='exists'>
-                 <varRef name='Q{}dataRefWithFilter' slot='7'/>
-                </fn>
-               </or>
-               <let line='2679' var='Q{http://saxon.sf.net/generated-variable}v1' as='xs:string' slot='8' eval='13'>
-                <fn name='concat'>
-                 <varRef name='Q{}updatedPath' slot='3'/>
-                 <str val='/'/>
-                </fn>
-                <forEach line='2677'>
-                 <currentGroup/>
-                 <applyT line='2678' mode='Q{}form-check' bSlot='3'>
-                  <dot role='select'/>
-                  <withParam name='Q{}curPath' as='xs:string'>
-                   <varRef line='2679' name='Q{http://saxon.sf.net/generated-variable}v1' slot='8'/>
-                  </withParam>
-                  <withParam name='Q{}position' as='xs:integer'>
-                   <fn line='2680' name='position'/>
-                  </withParam>
-                 </applyT>
-                </forEach>
-               </let>
-               <true/>
-               <let line='2688' var='Q{http://saxon.sf.net/generated-variable}v2' as='xs:string' slot='9' eval='13'>
-                <fn name='concat'>
-                 <varRef name='Q{}updatedPath' slot='3'/>
-                 <str val='/'/>
-                </fn>
-                <forEach line='2686'>
-                 <currentGroup/>
-                 <applyT line='2687' mode='Q{}form-check' bSlot='4'>
-                  <dot role='select'/>
-                  <withParam name='Q{}curPath' as='xs:string'>
-                   <varRef line='2688' name='Q{http://saxon.sf.net/generated-variable}v2' slot='9'/>
-                  </withParam>
-                 </applyT>
-                </forEach>
-               </let>
-              </choose>
+                  <applyT line='2713' mode='Q{}form-check' bSlot='4'>
+                   <dot role='select'/>
+                   <withParam name='Q{}curPath' as='xs:string'>
+                    <varRef line='2714' name='Q{http://saxon.sf.net/generated-variable}v1' slot='10'/>
+                   </withParam>
+                   <withParam name='Q{}position' as='xs:integer'>
+                    <fn line='2715' name='position'/>
+                   </withParam>
+                  </applyT>
+                 </forEach>
+                </let>
+                <true/>
+                <let line='2723' var='Q{http://saxon.sf.net/generated-variable}v2' as='xs:string' slot='11' eval='13'>
+                 <fn name='concat'>
+                  <varRef name='Q{}updatedPath' slot='5'/>
+                  <str val='/'/>
+                 </fn>
+                 <forEach line='2721'>
+                  <currentGroup/>
+                  <applyT line='2722' mode='Q{}form-check' bSlot='5'>
+                   <dot role='select'/>
+                   <withParam name='Q{}curPath' as='xs:string'>
+                    <varRef line='2723' name='Q{http://saxon.sf.net/generated-variable}v2' slot='11'/>
+                   </withParam>
+                  </applyT>
+                 </forEach>
+                </let>
+               </choose>
+              </let>
              </let>
             </let>
-           </let>
-          </forEachGroup>
-         </sequence>
-        </let>
-       </sequence>
-      </copy>
+           </forEachGroup>
+          </sequence>
+         </let>
+        </sequence>
+       </copy>
+      </sequence>
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='-0.5' seq='30' rank='0' minImp='0' slots='4' flags='s' line='2826' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='30' rank='0' minImp='0' slots='4' flags='s' line='2861' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2827'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2862'>
      <param name='Q{}curPath' slot='0'>
       <str role='select' val=''/>
       <supplied role='conversion' slot='0'/>
      </param>
-     <param line='2828' name='Q{}pendingUpdates' slot='1' flags='t' as='map(xs:string, xs:string)?'>
+     <param line='2863' name='Q{}pendingUpdates' slot='1' flags='t' as='map(xs:string, xs:string)?'>
       <empty role='select'/>
       <treat role='conversion' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|pendingUpdates'>
        <check card='?' diag='8|0|XTTE0590|pendingUpdates'>
@@ -1278,7 +1390,7 @@
        </check>
       </treat>
      </param>
-     <let line='2829' var='Q{}updatedPath' as='xs:string' slot='2' eval='8'>
+     <let line='2864' var='Q{}updatedPath' as='xs:string' slot='2' eval='8'>
       <fn name='concat'>
        <atomSing card='?' diag='0|0||fn:concat'>
         <varRef name='Q{}curPath' slot='0'/>
@@ -1288,7 +1400,7 @@
         <dot type='attribute()'/>
        </fn>
       </fn>
-      <let line='2838' var='Q{}associated-form-control' as='element()*' slot='3' eval='8'>
+      <let line='2873' var='Q{}associated-form-control' as='element()*' slot='3' eval='8'>
        <filter flags='b'>
         <slash simple='1'>
          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
@@ -1301,19 +1413,19 @@
          <varRef name='Q{}updatedPath' slot='2'/>
         </vc>
        </filter>
-       <choose line='2841'>
+       <choose line='2876'>
         <fn name='exists'>
          <varRef name='Q{}associated-form-control' slot='3'/>
         </fn>
-        <compAtt line='2844'>
+        <compAtt line='2879'>
          <fn role='name' name='local-name'>
           <dot type='attribute()'/>
          </fn>
-         <fn role='select' line='2845' name='string-join'>
+         <fn role='select' line='2880' name='string-join'>
           <convert from='xs:anyAtomicType' to='xs:string'>
            <data>
             <mergeAdj>
-             <applyT mode='Q{}get-field' bSlot='5'>
+             <applyT mode='Q{}get-field' bSlot='6'>
               <varRef role='select' name='Q{}associated-form-control' slot='3'/>
              </applyT>
             </mergeAdj>
@@ -1322,7 +1434,7 @@
           <str val=''/>
          </fn>
         </compAtt>
-        <and line='2848' op='and'>
+        <and line='2883' op='and'>
          <fn name='exists'>
           <varRef name='Q{}pendingUpdates' slot='1'/>
          </fn>
@@ -1333,11 +1445,11 @@
           <varRef name='Q{}updatedPath' slot='2'/>
          </ifCall>
         </and>
-        <compAtt line='2849'>
+        <compAtt line='2884'>
          <fn role='name' name='local-name'>
           <dot type='attribute()'/>
          </fn>
-         <ifCall role='select' line='2850' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+         <ifCall role='select' line='2885' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
           <check card='1' diag='0|0||map:get'>
            <varRef name='Q{}pendingUpdates' slot='1'/>
           </check>
@@ -1345,7 +1457,7 @@
          </ifCall>
         </compAtt>
         <true/>
-        <forEach line='2854'>
+        <forEach line='2889'>
          <dot type='attribute()'/>
          <copyOf flags='vsc'>
           <dot type='attribute()'/>
@@ -1360,9 +1472,9 @@
  </co>
  <co id='16' binds='13 13'>
   <mode name='Q{}form-check-initial' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='26' rank='0' minImp='0' slots='6' flags='s' line='2544' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='26' rank='0' minImp='0' slots='6' flags='s' line='2550' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2545'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2551'>
      <param name='Q{}instance-id' slot='0' as='xs:string'>
       <str role='select' val='saxon-forms-default'/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|instance-id'>
@@ -1375,7 +1487,7 @@
        </check>
       </treat>
      </param>
-     <param line='2546' name='Q{}pendingUpdates' slot='1' flags='t' as='map(xs:string, xs:string)?'>
+     <param line='2552' name='Q{}pendingUpdates' slot='1' flags='t' as='map(xs:string, xs:string)?'>
       <empty role='select'/>
       <treat role='conversion' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|pendingUpdates'>
        <check card='?' diag='8|0|XTTE0590|pendingUpdates'>
@@ -1383,15 +1495,15 @@
        </check>
       </treat>
      </param>
-     <let line='2552' var='Q{}curPath' as='xs:string' slot='2' eval='16'>
-      <choose line='2554'>
+     <let line='2558' var='Q{}curPath' as='xs:string' slot='2' eval='16'>
+      <choose line='2560'>
        <vc op='eq' onEmpty='0' comp='CCC'>
         <varRef name='Q{}instance-id' slot='0'/>
         <str val='saxon-forms-default'/>
        </vc>
        <str val=''/>
        <true/>
-       <cvUntyped line='2558' to='xs:string' diag='3|0|XTTE0570|curPath'>
+       <cvUntyped line='2564' to='xs:string' diag='3|0|XTTE0570|curPath'>
         <cast as='xs:untypedAtomic' emptiable='0'>
          <fn name='concat'>
           <str val='instance(&#39;'/>
@@ -1401,21 +1513,21 @@
         </cast>
        </cvUntyped>
       </choose>
-      <copy line='2565' flags='cin'>
+      <copy line='2571' flags='cin'>
        <forEachGroup role='content' algorithm='by'>
         <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
         <fn role='key' name='local-name'>
          <dot type='element()'/>
         </fn>
         <str role='collation' val='http://www.w3.org/2005/xpath-functions/collation/codepoint'/>
-        <let role='content' line='2567' var='Q{}updatedChildPath' as='xs:string' slot='3' eval='8'>
+        <let role='content' line='2573' var='Q{}updatedChildPath' as='xs:string' slot='3' eval='8'>
          <fn name='concat'>
           <varRef name='Q{}curPath' slot='2'/>
           <check card='?' diag='0|1||fn:concat'>
            <currentGroupingKey/>
           </check>
          </fn>
-         <let line='2572' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='4' eval='13'>
+         <let line='2578' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='4' eval='13'>
           <fn name='concat'>
            <varRef name='Q{}updatedChildPath' slot='3'/>
            <str val='['/>
@@ -1433,7 +1545,7 @@
              <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='4'/>
             </fn>
            </filter>
-           <choose line='2574'>
+           <choose line='2580'>
             <or op='or'>
              <fn name='exists'>
               <tail start='2'>
@@ -1444,25 +1556,25 @@
               <varRef name='Q{}dataRefWithFilter' slot='5'/>
              </fn>
             </or>
-            <forEach line='2575'>
+            <forEach line='2581'>
              <currentGroup/>
-             <applyT line='2576' mode='Q{}form-check' bSlot='0'>
+             <applyT line='2582' mode='Q{}form-check' bSlot='0'>
               <dot role='select'/>
               <withParam name='Q{}curPath' as='xs:string'>
-               <varRef line='2577' name='Q{}curPath' slot='2'/>
+               <varRef line='2583' name='Q{}curPath' slot='2'/>
               </withParam>
               <withParam name='Q{}position' as='xs:integer'>
-               <fn line='2578' name='position'/>
+               <fn line='2584' name='position'/>
               </withParam>
              </applyT>
             </forEach>
             <true/>
-            <forEach line='2584'>
+            <forEach line='2590'>
              <currentGroup/>
-             <applyT line='2585' mode='Q{}form-check' bSlot='1'>
+             <applyT line='2591' mode='Q{}form-check' bSlot='1'>
               <dot role='select'/>
               <withParam name='Q{}curPath' as='xs:string'>
-               <varRef line='2586' name='Q{}curPath' slot='2'/>
+               <varRef line='2592' name='Q{}curPath' slot='2'/>
               </withParam>
              </applyT>
             </forEach>
@@ -1478,9 +1590,9 @@
   </mode>
  </co>
  <co id='6' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}getRepeatID' line='763' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
+  <function name='Q{http://www.w3.org/2002/xforms}getRepeatID' line='764' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
    <arg name='Q{}string-to-parse' as='xs:string'/>
-   <treat role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='766' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getRepeatID#1'>
+   <treat role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='767' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getRepeatID#1'>
     <check card='?' diag='5|0|XTTE0780|xforms:getRepeatID#1'>
      <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getRepeatID#1'>
       <data>
@@ -1488,10 +1600,10 @@
         <varRef role='select' name='Q{}string-to-parse' slot='0'/>
         <str role='regex' val='^.*index\s*\(\s*&#39;([^&#39;]+)&#39;\s*\).*$'/>
         <str role='flags' val=''/>
-        <fn role='matching' line='768' name='regex-group'>
+        <fn role='matching' line='769' name='regex-group'>
          <int val='1'/>
         </fn>
-        <message role='nonMatching' line='771'>
+        <message role='nonMatching' line='772'>
          <sequence role='select'>
           <valueOf>
            <str val='[xforms:getRepeatID] No repeat identifiable from value &#39;'/>
@@ -1514,8 +1626,8 @@
   </function>
  </co>
  <co id='17' binds=''>
-  <template name='Q{}action-reset' flags='os' line='4802' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4803'>
+  <template name='Q{}action-reset' flags='os' line='4859' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4860'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -1523,7 +1635,7 @@
       </check>
      </treat>
     </param>
-    <message line='4805'>
+    <message line='4862'>
      <valueOf role='select'>
       <str val='[action-reset] Reset triggered!'/>
      </valueOf>
@@ -1533,9 +1645,17 @@
    </sequence>
   </template>
  </co>
- <co id='18' binds='16 2 1 5 19 7 20'>
-  <template name='Q{}xforms-value-changed' flags='os' line='4121' module='saxon-xforms.xsl' slots='5'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4122'>
+ <co id='18' binds='19'>
+  <globalVariable name='Q{http://saxon.sf.net/generated-variable}gg99297450' type='element()*' line='4232' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='function test(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};if (test(val)) {return val;} else {throw SaxonJS.XError(&#39;Conversion failed&#39;, &#39;XTTE0590&#39;);}' jsCardCheck='function c() {return true;};'>
+   <slash ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4232' simple='1'>
+    <gVarRef name='Q{}xforms-doc' bSlot='0'/>
+    <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+   </slash>
+  </globalVariable>
+ </co>
+ <co id='20' binds='2 3 15 16 1 5 21 7 22'>
+  <template name='Q{}xforms-value-changed' flags='os' line='4157' module='saxon-xforms.xsl' slots='8'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4158'>
     <param name='Q{}form-control' slot='0' flags='i' as='node()'>
      <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|form-control'>
       <check card='1' diag='8|0|XTTE0590|form-control'>
@@ -1543,12 +1663,12 @@
       </check>
      </treat>
     </param>
-    <let line='4124' var='Q{}refi' as='attribute(Q{}data-ref)?' slot='1' eval='8'>
+    <let line='4160' var='Q{}refi' as='attribute(Q{}data-ref)?' slot='1' eval='8'>
      <slash simple='1'>
       <varRef name='Q{}form-control' slot='0'/>
       <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
      </slash>
-     <let line='4128' var='Q{}actions' as='item()?' slot='2' eval='8'>
+     <let line='4164' var='Q{}actions' as='item()?' slot='2' eval='8'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -1563,135 +1683,191 @@
         </fn>
        </arrayBlock>
       </ifCall>
-      <let line='4132' var='Q{}updatedInstanceXML' as='element()' slot='3' eval='16'>
-       <treat line='4133' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
-        <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
-         <applyT mode='Q{}form-check-initial' bSlot='0'>
-          <check role='select' line='4131' card='1' diag='3|0|XTTE0570|instanceXML'>
-           <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='1' eval='16'>
-            <check card='1' diag='0|0||xforms:getInstance-JS'>
-             <cvUntyped to='xs:string'>
-              <data>
-               <varRef name='Q{}refi' slot='1'/>
-              </data>
-             </cvUntyped>
-            </check>
-           </ufCall>
-          </check>
-          <withParam name='Q{}instance-id' as='xs:string'>
-           <ufCall line='4127' name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='2' eval='16'>
-            <check card='1' diag='0|0||xforms:getInstanceId'>
-             <cvUntyped to='xs:string'>
-              <data>
-               <varRef name='Q{}refi' slot='1'/>
-              </data>
-             </cvUntyped>
-            </check>
-           </ufCall>
-          </withParam>
-         </applyT>
-        </check>
-       </treat>
-       <sequence line='4139'>
-        <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='3' eval='16 6'>
-         <check card='1' diag='0|0||xforms:setInstance-JS'>
+      <let line='4167' var='Q{}instanceXML' as='element()' slot='3' eval='16'>
+       <check card='1' diag='3|0|XTTE0570|instanceXML'>
+        <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='0' eval='16'>
+         <check card='1' diag='0|0||xforms:getInstance-JS'>
           <cvUntyped to='xs:string'>
            <data>
             <varRef name='Q{}refi' slot='1'/>
            </data>
           </cvUntyped>
          </check>
-         <varRef name='Q{}updatedInstanceXML' slot='3'/>
         </ufCall>
-        <ifCall line='4146' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-         <check card='1' diag='0|0||ixsl:call'>
-          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+       </check>
+       <let line='4175' var='Q{}updatedNode' as='node()' slot='4' eval='16'>
+        <treat line='4176' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|updatedNode'>
+         <check card='1' diag='3|0|XTTE0570|updatedNode'>
+          <evaluate dxns=''>
+           <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='1' eval='16'>
+            <check card='1' diag='0|0||xforms:impose'>
+             <cvUntyped to='xs:string'>
+              <data>
+               <varRef name='Q{}refi' slot='1'/>
+              </data>
+             </cvUntyped>
+            </check>
+           </ufCall>
+           <varRef role='cxt' name='Q{}instanceXML' slot='3'/>
+           <varRef role='nsCxt' name='Q{}instanceXML' slot='3'/>
+           <str role='sa' val='no'/>
+           <map role='options' size='0'/>
+           <map role='wp' size='0'/>
+          </evaluate>
          </check>
-         <str val='setPendingUpdates'/>
-         <arrayBlock>
-          <treat line='4143' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||pendingInstanceUpdates'>
-           <map size='0'/>
+        </treat>
+        <let line='4178' var='Q{}new-value' as='xs:string' slot='5' eval='16'>
+         <treat line='4179' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-value'>
+          <check card='1' diag='3|0|XTTE0570|new-value'>
+           <cvUntyped to='xs:string' diag='3|0|XTTE0570|new-value'>
+            <data>
+             <applyT mode='Q{}get-field' bSlot='2'>
+              <varRef role='select' name='Q{}form-control' slot='0'/>
+             </applyT>
+            </data>
+           </cvUntyped>
+          </check>
+         </treat>
+         <let line='4181' var='Q{}updatedInstanceXML' as='element()' slot='6' eval='16'>
+          <treat line='4182' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+           <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
+            <applyT mode='Q{}form-check-initial' bSlot='3'>
+             <varRef role='select' name='Q{}instanceXML' slot='3'/>
+             <withParam name='Q{}instance-id' as='xs:string'>
+              <ufCall line='4163' name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='4' eval='16'>
+               <check card='1' diag='0|0||xforms:getInstanceId'>
+                <cvUntyped to='xs:string'>
+                 <data>
+                  <varRef name='Q{}refi' slot='1'/>
+                 </data>
+                </cvUntyped>
+               </check>
+              </ufCall>
+             </withParam>
+             <withParam name='Q{}updated-node' flags='t' as='node()'>
+              <varRef line='4184' name='Q{}updatedNode' slot='4'/>
+             </withParam>
+             <withParam name='Q{}value' flags='t' as='xs:string'>
+              <varRef line='4185' name='Q{}new-value' slot='5'/>
+             </withParam>
+            </applyT>
+           </check>
           </treat>
-         </arrayBlock>
-        </ifCall>
-        <ifCall line='4147' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-         <check card='1' diag='0|0||ixsl:call'>
-          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-         </check>
-         <str val='setUpdates'/>
-         <arrayBlock>
-          <treat line='4144' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||instanceUpdates'>
-           <map size='0'/>
-          </treat>
-         </arrayBlock>
-        </ifCall>
-        <forEach line='4149'>
-         <varRef name='Q{}actions' slot='2'/>
-         <let line='4150' var='Q{}action-map' as='item()' slot='4' eval='16'>
-          <dot/>
-          <choose line='4152'>
-           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
-            <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:contains'>
-             <varRef name='Q{}action-map' slot='4'/>
-            </treat>
-            <str val='@event'/>
+          <sequence line='4189'>
+           <message>
+            <sequence role='select'>
+             <valueOf>
+              <str val='[xforms-value-changed] Updated XML: '/>
+             </valueOf>
+             <fn name='serialize'>
+              <varRef name='Q{}updatedInstanceXML' slot='6'/>
+             </fn>
+            </sequence>
+            <str role='terminate' val='no'/>
+            <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+           </message>
+           <ufCall line='4192' name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='5' eval='16 6'>
+            <check card='1' diag='0|0||xforms:setInstance-JS'>
+             <cvUntyped to='xs:string'>
+              <data>
+               <varRef name='Q{}refi' slot='1'/>
+              </data>
+             </cvUntyped>
+            </check>
+            <varRef name='Q{}updatedInstanceXML' slot='6'/>
+           </ufCall>
+           <ifCall line='4199' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+            <check card='1' diag='0|0||ixsl:call'>
+             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+            </check>
+            <str val='setPendingUpdates'/>
+            <arrayBlock>
+             <treat line='4196' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||pendingInstanceUpdates'>
+              <map size='0'/>
+             </treat>
+            </arrayBlock>
            </ifCall>
-           <choose line='4153'>
-            <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
-             <data>
-              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-               <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:get'>
-                <varRef name='Q{}action-map' slot='4'/>
+           <ifCall line='4200' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+            <check card='1' diag='0|0||ixsl:call'>
+             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+            </check>
+            <str val='setUpdates'/>
+            <arrayBlock>
+             <treat line='4197' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||instanceUpdates'>
+              <map size='0'/>
+             </treat>
+            </arrayBlock>
+           </ifCall>
+           <forEach line='4202'>
+            <varRef name='Q{}actions' slot='2'/>
+            <let line='4203' var='Q{}action-map' as='item()' slot='7' eval='16'>
+             <dot/>
+             <choose line='4205'>
+              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+               <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:contains'>
+                <varRef name='Q{}action-map' slot='7'/>
                </treat>
                <str val='@event'/>
               </ifCall>
-             </data>
-             <str val='xforms-value-changed'/>
-            </gc>
-            <callT line='4155' name='Q{}applyActions' bSlot='4'>
-             <withParam name='Q{}action-map' flags='t' as='item()'>
-              <varRef line='4156' name='Q{}action-map' slot='4'/>
-             </withParam>
-             <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-              <check line='4157' card='1' diag='8|0|XTTE0590|nodeset'>
-               <cvUntyped to='xs:string' diag='8|0|XTTE0590|nodeset'>
+              <choose line='4206'>
+               <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
                 <data>
-                 <varRef name='Q{}refi' slot='1'/>
+                 <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                  <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:get'>
+                   <varRef name='Q{}action-map' slot='7'/>
+                  </treat>
+                  <str val='@event'/>
+                 </ifCall>
                 </data>
-               </cvUntyped>
-              </check>
-             </withParam>
-             <withParam name='Q{}instanceXML' flags='t' as='element()'>
-              <varRef line='4158' name='Q{}updatedInstanceXML' slot='3'/>
-             </withParam>
-            </callT>
-           </choose>
-          </choose>
+                <str val='xforms-value-changed'/>
+               </gc>
+               <callT line='4208' name='Q{}applyActions' bSlot='6'>
+                <withParam name='Q{}action-map' flags='t' as='item()'>
+                 <varRef line='4209' name='Q{}action-map' slot='7'/>
+                </withParam>
+                <withParam name='Q{}nodeset' flags='t' as='xs:string'>
+                 <check line='4210' card='1' diag='8|0|XTTE0590|nodeset'>
+                  <cvUntyped to='xs:string' diag='8|0|XTTE0590|nodeset'>
+                   <data>
+                    <varRef name='Q{}refi' slot='1'/>
+                   </data>
+                  </cvUntyped>
+                 </check>
+                </withParam>
+                <withParam name='Q{}instanceXML' flags='t' as='element()'>
+                 <varRef line='4211' name='Q{}updatedInstanceXML' slot='6'/>
+                </withParam>
+               </callT>
+              </choose>
+             </choose>
+            </let>
+           </forEach>
+           <callT line='4217' name='Q{}xforms-recalculate' bSlot='7'/>
+           <ufCall line='4219' name='Q{http://www.w3.org/2002/xforms}checkRelevantFields' tailCall='false' bSlot='8' eval='16'>
+            <check card='1' diag='0|0||xforms:checkRelevantFields'>
+             <cvUntyped to='xs:string'>
+              <data>
+               <slash line='4161' simple='1'>
+                <varRef name='Q{}form-control' slot='0'/>
+                <axis name='attribute' nodeTest='attribute(Q{}data-element)' jsTest='return item.name===&#39;data-element&#39;'/>
+               </slash>
+              </data>
+             </cvUntyped>
+            </check>
+           </ufCall>
+          </sequence>
          </let>
-        </forEach>
-        <callT line='4164' name='Q{}xforms-recalculate' bSlot='5'/>
-        <ufCall line='4166' name='Q{http://www.w3.org/2002/xforms}checkRelevantFields' tailCall='false' bSlot='6' eval='16'>
-         <check card='1' diag='0|0||xforms:checkRelevantFields'>
-          <cvUntyped to='xs:string'>
-           <data>
-            <slash line='4125' simple='1'>
-             <varRef name='Q{}form-control' slot='0'/>
-             <axis name='attribute' nodeTest='attribute(Q{}data-element)' jsTest='return item.name===&#39;data-element&#39;'/>
-            </slash>
-           </data>
-          </cvUntyped>
-         </check>
-        </ufCall>
-       </sequence>
+        </let>
+       </let>
       </let>
      </let>
     </let>
    </sequence>
   </template>
  </co>
- <co id='21' binds='22 23 3 23'>
-  <template name='Q{}getReferencedInstanceField' flags='os' line='3405' module='saxon-xforms.xsl' slots='5'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3406'>
+ <co id='23' binds='24 25 3 25'>
+  <template name='Q{}getReferencedInstanceField' flags='os' line='3437' module='saxon-xforms.xsl' slots='5'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3438'>
     <param name='Q{}refi' slot='0' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|refi'>
@@ -1704,32 +1880,17 @@
       </check>
      </treat>
     </param>
-    <message line='3408'>
-     <sequence role='select'>
-      <valueOf>
-       <str val='[getReferencedInstanceField] $refi = &#39;'/>
-      </valueOf>
-      <valueOf>
-       <varRef name='Q{}refi' slot='0'/>
-      </valueOf>
-      <valueOf flags='S'>
-       <str val='&#39;'/>
-      </valueOf>
-     </sequence>
-     <str role='terminate' val='no'/>
-     <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-    </message>
-    <let line='3410' var='Q{}field' as='node()*' slot='1' eval='8'>
-     <choose line='3412'>
+    <let line='3442' var='Q{}field' as='node()*' slot='1' eval='8'>
+     <choose line='3444'>
       <varRef name='Q{}refi' slot='0'/>
-      <let line='3413' var='Q{}instance-map' as='map(xs:string, xs:string)' slot='2' eval='16'>
+      <let line='3445' var='Q{}instance-map' as='map(xs:string, xs:string)' slot='2' eval='16'>
        <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='0' eval='6'>
         <varRef name='Q{}refi' slot='0'/>
        </ufCall>
-       <let line='3420' var='Q{}this-instance' as='element()?' slot='3' eval='9'>
-        <callT line='3421' name='Q{}getInstance' bSlot='1'>
+       <let line='3452' var='Q{}this-instance' as='element()?' slot='3' eval='9'>
+        <callT line='3453' name='Q{}getInstance' bSlot='1'>
          <withParam name='Q{}instance-id' flags='c' as='xs:string'>
-          <check line='3422' card='1' diag='8|0|XTTE0590|instance-id'>
+          <check line='3454' card='1' diag='8|0|XTTE0590|instance-id'>
            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
             <varRef name='Q{}instance-map' slot='2'/>
             <str val='instance-id'/>
@@ -1737,9 +1898,9 @@
           </check>
          </withParam>
         </callT>
-        <treat line='3430' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|field'>
+        <treat line='3462' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|field'>
          <evaluate dxns=''>
-          <ufCall role='xpath' line='3426' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
+          <ufCall role='xpath' line='3458' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
            <check card='1' diag='0|0||xforms:impose'>
             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
              <varRef name='Q{}instance-map' slot='2'/>
@@ -1759,23 +1920,23 @@
        </let>
       </let>
       <true/>
-      <let line='3435' var='Q{}default-instance' as='element()?' slot='4' eval='9'>
-       <callT line='3436' name='Q{}getInstance' bSlot='3'>
+      <let line='3467' var='Q{}default-instance' as='element()?' slot='4' eval='9'>
+       <callT line='3468' name='Q{}getInstance' bSlot='3'>
         <withParam name='Q{}instance-id' flags='c' as='xs:string'>
          <str val='saxon-forms-default'/>
         </withParam>
        </callT>
-       <varRef line='3440' name='Q{}default-instance' slot='4'/>
+       <varRef line='3472' name='Q{}default-instance' slot='4'/>
       </let>
      </choose>
-     <varRef line='3445' name='Q{}field' slot='1'/>
+     <varRef line='3477' name='Q{}field' slot='1'/>
     </let>
    </sequence>
   </template>
  </co>
- <co id='24' binds=''>
-  <template name='Q{}action-message' flags='os' line='4722' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4723'>
+ <co id='26' binds=''>
+  <template name='Q{}action-message' flags='os' line='4779' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4780'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -1783,13 +1944,13 @@
       </check>
      </treat>
     </param>
-    <message line='4727'>
+    <message line='4784'>
      <sequence role='select'>
       <valueOf>
        <str val='[action-message] Message reads "'/>
       </valueOf>
       <valueOf>
-       <treat line='4725' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|message-value'>
+       <treat line='4782' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|message-value'>
         <check card='1' diag='3|0|XTTE0570|message-value'>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|message-value'>
           <data>
@@ -1812,26 +1973,26 @@
    </sequence>
   </template>
  </co>
- <co id='25' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}resolveXPathStrings' line='828' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:string' slots='5'>
+ <co id='27' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}resolveXPathStrings' line='829' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:string' slots='5'>
    <arg name='Q{}base' as='xs:string'/>
    <arg name='Q{}relative' as='xs:string'/>
-   <choose role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='835'>
+   <choose role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='836'>
     <fn name='starts-with'>
      <varRef name='Q{}relative' slot='1'/>
      <str val='/'/>
     </fn>
-    <varRef line='836' name='Q{}relative' slot='1'/>
-    <fn line='838' name='starts-with'>
+    <varRef line='837' name='Q{}relative' slot='1'/>
+    <fn line='839' name='starts-with'>
      <varRef name='Q{}relative' slot='1'/>
      <str val='instance('/>
     </fn>
-    <varRef line='839' name='Q{}relative' slot='1'/>
-    <fn line='841' name='not'>
+    <varRef line='840' name='Q{}relative' slot='1'/>
+    <fn line='842' name='not'>
      <varRef name='Q{}base' slot='0'/>
     </fn>
-    <varRef line='842' name='Q{}relative' slot='1'/>
-    <or line='844' op='or'>
+    <varRef line='843' name='Q{}relative' slot='1'/>
+    <or line='845' op='or'>
      <fn name='not'>
       <varRef name='Q{}relative' slot='1'/>
      </fn>
@@ -1840,9 +2001,9 @@
       <str val='.'/>
      </vc>
     </or>
-    <varRef line='845' name='Q{}base' slot='0'/>
+    <varRef line='846' name='Q{}base' slot='0'/>
     <true/>
-    <let line='849' var='Q{}parentCallCount' as='xs:integer' slot='2' eval='16'>
+    <let line='850' var='Q{}parentCallCount' as='xs:integer' slot='2' eval='16'>
      <choose>
       <fn name='contains'>
        <varRef name='Q{}relative' slot='1'/>
@@ -1869,7 +2030,7 @@
       <true/>
       <int val='0'/>
      </choose>
-     <let line='852' var='Q{}slashes' as='xs:integer*' slot='3' eval='4'>
+     <let line='853' var='Q{}slashes' as='xs:integer*' slot='3' eval='4'>
       <choose>
        <fn name='contains'>
         <varRef name='Q{}base' slot='0'/>
@@ -1884,15 +2045,15 @@
        <true/>
        <int val='0'/>
       </choose>
-      <choose line='884'>
+      <choose line='885'>
        <compareToInt op='gt' val='0'>
         <varRef name='Q{}parentCallCount' slot='2'/>
        </compareToInt>
-       <fn line='888' name='concat'>
+       <fn line='889' name='concat'>
         <fn name='substring'>
          <varRef name='Q{}base' slot='0'/>
          <int val='1'/>
-         <choose line='863'>
+         <choose line='864'>
           <and op='and'>
            <vc op='ge' onEmpty='0' comp='CAVC'>
             <fn name='count'>
@@ -1904,7 +2065,7 @@
             <varRef name='Q{}parentCallCount' slot='2'/>
            </compareToInt>
           </and>
-          <let line='864' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='4' eval='13'>
+          <let line='865' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='4' eval='13'>
            <arith op='-' calc='i-i'>
             <varRef name='Q{}parentCallCount' slot='2'/>
             <int val='1'/>
@@ -1920,7 +2081,7 @@
            </check>
           </let>
           <true/>
-          <check line='867' card='1' diag='3|0|XTTE0570|parentSlash'>
+          <check line='868' card='1' diag='3|0|XTTE0570|parentSlash'>
            <lastOf>
             <varRef name='Q{}slashes' slot='3'/>
            </lastOf>
@@ -1935,7 +2096,7 @@
         </fn>
        </fn>
        <true/>
-       <fn line='891' name='concat'>
+       <fn line='892' name='concat'>
         <varRef name='Q{}base' slot='0'/>
         <str val='/'/>
         <varRef name='Q{}relative' slot='1'/>
@@ -1946,7 +2107,7 @@
    </choose>
   </function>
  </co>
- <co id='26' binds=''>
+ <co id='28' binds=''>
   <function name='Q{http://saxonica.com/ns/forms-local}current-date' line='118' module='xforms-function-library.xsl' eval='16' flags='pU' as='xs:string' slots='0'>
    <treat role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='119' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|today'>
     <check card='1' diag='3|0|XTTE0570|today'>
@@ -1965,7 +2126,7 @@
    </treat>
   </function>
  </co>
- <co id='14' binds='27'>
+ <co id='14' binds='29'>
   <function name='Q{http://www.w3.org/2002/xforms}resolve-index' line='72' module='xforms-function-library.xsl' eval='8' flags='pU' as='xs:string' slots='2'>
    <arg name='Q{}input' as='xs:string'/>
    <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='74' var='Q{}parts' as='xs:string*' slot='1' eval='8'>
@@ -1988,9 +2149,9 @@
    </let>
   </function>
  </co>
- <co id='28' binds='3'>
-  <template name='Q{}action-setindex' flags='os' line='4775' module='saxon-xforms.xsl' slots='2'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4776'>
+ <co id='30' binds='3'>
+  <template name='Q{}action-setindex' flags='os' line='4832' module='saxon-xforms.xsl' slots='2'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4833'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -1998,14 +2159,14 @@
       </check>
      </treat>
     </param>
-    <let line='4782' var='Q{}new-index' as='xs:integer' slot='1' eval='16'>
-     <treat line='4783' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|new-index'>
+    <let line='4839' var='Q{}new-index' as='xs:integer' slot='1' eval='16'>
+     <treat line='4840' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|new-index'>
       <check card='1' diag='3|0|XTTE0570|new-index'>
        <cvUntyped to='xs:integer' diag='3|0|XTTE0570|new-index'>
         <data>
          <evaluate dxns=''>
           <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='0' eval='16'>
-           <treat line='4779' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-index-ref'>
+           <treat line='4836' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-index-ref'>
             <check card='1' diag='3|0|XTTE0570|new-index-ref'>
              <cvUntyped to='xs:string' diag='3|0|XTTE0570|new-index-ref'>
               <data>
@@ -2027,7 +2188,7 @@
        </cvUntyped>
       </check>
      </treat>
-     <sequence line='4786'>
+     <sequence line='4843'>
       <message>
        <sequence role='select'>
         <valueOf>
@@ -2042,13 +2203,13 @@
        <str role='terminate' val='no'/>
        <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
       </message>
-      <ifCall line='4788' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+      <ifCall line='4845' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
        </check>
        <str val='setRepeatIndex'/>
        <arrayBlock>
-        <treat line='4778' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|repeatID'>
+        <treat line='4835' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|repeatID'>
          <check card='1' diag='3|0|XTTE0570|repeatID'>
           <cvUntyped to='xs:string' diag='3|0|XTTE0570|repeatID'>
            <data>
@@ -2068,9 +2229,9 @@
    </sequence>
   </template>
  </co>
- <co id='29' binds='30'>
-  <template name='Q{}action-setfocus' flags='os' line='4737' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4738'>
+ <co id='31' binds='32'>
+  <template name='Q{}action-setfocus' flags='os' line='4794' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4795'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -2078,9 +2239,9 @@
       </check>
      </treat>
     </param>
-    <callT line='4742' name='Q{}xforms-focus' bSlot='0' flags='t'>
+    <callT line='4799' name='Q{}xforms-focus' bSlot='0' flags='t'>
      <withParam name='Q{}control' flags='c' as='xs:string'>
-      <treat line='4740' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|control'>
+      <treat line='4797' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|control'>
        <check card='1' diag='3|0|XTTE0570|control'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|control'>
          <data>
@@ -2097,9 +2258,9 @@
    </sequence>
   </template>
  </co>
- <co id='31' binds='1 3 3 32 16 2 5 33'>
-  <template name='Q{}action-setvalue' flags='os' line='4408' module='saxon-xforms.xsl' slots='14'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4409'>
+ <co id='33' binds='1 3 3 34 16 2 5 35'>
+  <template name='Q{}action-setvalue' flags='os' line='4465' module='saxon-xforms.xsl' slots='14'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4466'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -2107,7 +2268,7 @@
       </check>
      </treat>
     </param>
-    <param line='4410' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
+    <param line='4467' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
      <empty role='select'/>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|instanceXML'>
       <check card='?' diag='8|0|XTTE0590|instanceXML'>
@@ -2115,7 +2276,7 @@
       </check>
      </treat>
     </param>
-    <param line='4411' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
+    <param line='4468' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -2127,7 +2288,7 @@
       </check>
      </treat>
     </param>
-    <let line='4415' var='Q{}refz' as='xs:string' slot='3' eval='16'>
+    <let line='4472' var='Q{}refz' as='xs:string' slot='3' eval='16'>
      <let var='Q{}relative' as='xs:string' slot='4' eval='16'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|1||xforms:resolveXPathStrings'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
@@ -2141,22 +2302,22 @@
         </cvUntyped>
        </check>
       </treat>
-      <choose line='835'>
+      <choose line='836'>
        <fn name='starts-with'>
         <varRef name='Q{}relative' slot='4'/>
         <str val='/'/>
        </fn>
-       <varRef line='836' name='Q{}relative' slot='4'/>
-       <fn line='838' name='starts-with'>
+       <varRef line='837' name='Q{}relative' slot='4'/>
+       <fn line='839' name='starts-with'>
         <varRef name='Q{}relative' slot='4'/>
         <str val='instance('/>
        </fn>
-       <varRef line='839' name='Q{}relative' slot='4'/>
-       <fn line='4415' name='not'>
+       <varRef line='840' name='Q{}relative' slot='4'/>
+       <fn line='4472' name='not'>
         <varRef name='Q{}nodeset' slot='2'/>
        </fn>
-       <varRef line='842' name='Q{}relative' slot='4'/>
-       <or line='844' op='or'>
+       <varRef line='843' name='Q{}relative' slot='4'/>
+       <or line='845' op='or'>
         <fn name='not'>
          <varRef name='Q{}relative' slot='4'/>
         </fn>
@@ -2165,9 +2326,9 @@
          <str val='.'/>
         </vc>
        </or>
-       <varRef line='4415' name='Q{}nodeset' slot='2'/>
+       <varRef line='4472' name='Q{}nodeset' slot='2'/>
        <true/>
-       <let line='849' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
+       <let line='850' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
         <choose>
          <fn name='contains'>
           <varRef name='Q{}relative' slot='4'/>
@@ -2194,30 +2355,30 @@
          <true/>
          <int val='0'/>
         </choose>
-        <let line='852' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
+        <let line='853' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
          <choose>
-          <fn line='4415' name='contains'>
+          <fn line='4472' name='contains'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
           </fn>
           <fn name='index-of'>
            <fn name='string-to-codepoints'>
-            <varRef line='4415' name='Q{}nodeset' slot='2'/>
+            <varRef line='4472' name='Q{}nodeset' slot='2'/>
            </fn>
            <int val='47'/>
           </fn>
           <true/>
           <int val='0'/>
          </choose>
-         <choose line='884'>
+         <choose line='885'>
           <compareToInt op='gt' val='0'>
            <varRef name='Q{}parentCallCount' slot='5'/>
           </compareToInt>
-          <fn line='888' name='concat'>
+          <fn line='889' name='concat'>
            <fn name='substring'>
-            <varRef line='4415' name='Q{}nodeset' slot='2'/>
+            <varRef line='4472' name='Q{}nodeset' slot='2'/>
             <int val='1'/>
-            <choose line='863'>
+            <choose line='864'>
              <and op='and'>
               <vc op='ge' onEmpty='0' comp='CAVC'>
                <fn name='count'>
@@ -2229,7 +2390,7 @@
                <varRef name='Q{}parentCallCount' slot='5'/>
               </compareToInt>
              </and>
-             <let line='864' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='7' eval='13'>
+             <let line='865' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='7' eval='13'>
               <arith op='-' calc='i-i'>
                <varRef name='Q{}parentCallCount' slot='5'/>
                <int val='1'/>
@@ -2245,7 +2406,7 @@
               </check>
              </let>
              <true/>
-             <check line='867' card='1' diag='3|0|XTTE0570|parentSlash'>
+             <check line='868' card='1' diag='3|0|XTTE0570|parentSlash'>
               <lastOf>
                <varRef name='Q{}slashes' slot='6'/>
               </lastOf>
@@ -2260,29 +2421,29 @@
            </fn>
           </fn>
           <true/>
-          <fn line='4415' name='concat'>
+          <fn line='4472' name='concat'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
-           <varRef line='891' name='Q{}relative' slot='4'/>
+           <varRef line='892' name='Q{}relative' slot='4'/>
           </fn>
          </choose>
         </let>
        </let>
       </choose>
      </let>
-     <let line='4417' var='Q{}instance-id' as='xs:string' slot='8' eval='16'>
+     <let line='4474' var='Q{}instance-id' as='xs:string' slot='8' eval='16'>
       <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='6'>
        <varRef name='Q{}refz' slot='3'/>
       </ufCall>
-      <let line='4430' var='Q{}valuez' as='document-node()' slot='9' eval='16'>
-       <doc line='4432' validation='preserve'>
+      <let line='4487' var='Q{}valuez' as='document-node()' slot='9' eval='16'>
+       <doc line='4489' validation='preserve'>
         <choose>
          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
           <varRef name='Q{}action-map' slot='0'/>
           <str val='@value'/>
          </ifCall>
-         <let line='4433' var='Q{}contexti' as='node()' slot='10' eval='8'>
-          <evaluate line='4434' as='node()' dxns=''>
+         <let line='4490' var='Q{}contexti' as='node()' slot='10' eval='8'>
+          <evaluate line='4491' as='node()' dxns=''>
            <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='1' eval='6'>
             <varRef name='Q{}nodeset' slot='2'/>
            </ufCall>
@@ -2294,7 +2455,7 @@
            <map role='options' size='0'/>
            <map role='wp' size='0'/>
           </evaluate>
-          <evaluate line='4437' dxns=''>
+          <evaluate line='4494' dxns=''>
            <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
             <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:impose'>
              <check card='1' diag='0|0||xforms:impose'>
@@ -2316,13 +2477,13 @@
            <map role='wp' size='0'/>
           </evaluate>
          </let>
-         <ifCall line='4440' name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+         <ifCall line='4497' name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
           <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:contains'>
            <dot flags='a'/>
           </treat>
           <str val='value'/>
          </ifCall>
-         <ifCall line='4441' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+         <ifCall line='4498' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
           <varRef name='Q{}action-map' slot='0'/>
           <str val='value'/>
          </ifCall>
@@ -2330,8 +2491,8 @@
          <str val=''/>
         </choose>
        </doc>
-       <sequence line='4451'>
-        <let line='4453' var='Q{}associated-form-control' as='element()?' slot='11' eval='7'>
+       <sequence line='4508'>
+        <let line='4510' var='Q{}associated-form-control' as='element()?' slot='11' eval='7'>
          <check card='?' diag='3|0|XTTE0570|associated-form-control'>
           <filter flags='b'>
            <slash simple='1'>
@@ -2346,22 +2507,22 @@
            </vc>
           </filter>
          </check>
-         <choose line='4455'>
+         <choose line='4512'>
           <fn name='exists'>
            <varRef name='Q{}associated-form-control' slot='11'/>
           </fn>
-          <sequence line='4456'>
+          <sequence line='4513'>
            <applyT mode='Q{}set-field' bSlot='3'>
             <varRef role='select' name='Q{}associated-form-control' slot='11'/>
             <withParam name='Q{}value' flags='t' as='xs:string'>
-             <cast line='4457' as='xs:string' emptiable='0'>
+             <cast line='4514' as='xs:string' emptiable='0'>
               <data>
                <varRef name='Q{}valuez' slot='9'/>
               </data>
              </cast>
             </withParam>
            </applyT>
-           <ifCall line='4459' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+           <ifCall line='4516' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
             <check card='1' diag='0|0||ixsl:call'>
              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
             </check>
@@ -2390,7 +2551,7 @@
            </ifCall>
           </sequence>
           <true/>
-          <ifCall line='4462' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+          <ifCall line='4519' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
            <check card='1' diag='0|0||ixsl:call'>
             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
            </check>
@@ -2419,12 +2580,12 @@
           </ifCall>
          </choose>
         </let>
-        <choose line='4468'>
+        <choose line='4525'>
          <vc op='ne' onEmpty='1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
           <varRef name='Q{}refz' slot='3'/>
           <str val=''/>
          </vc>
-         <let line='4470' var='Q{}pendingUpdates' as='map(xs:string, xs:string)?' slot='12' eval='7'>
+         <let line='4527' var='Q{}pendingUpdates' as='map(xs:string, xs:string)?' slot='12' eval='7'>
           <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|pendingUpdates'>
            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
             <check card='1' diag='0|0||ixsl:call'>
@@ -2434,11 +2595,11 @@
             <array size='0'/>
            </ifCall>
           </treat>
-          <let line='4472' var='Q{}updatedInstanceXML' as='element()' slot='13' eval='16'>
-           <treat line='4473' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+          <let line='4529' var='Q{}updatedInstanceXML' as='element()' slot='13' eval='16'>
+           <treat line='4530' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
             <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
              <applyT mode='Q{}form-check-initial' bSlot='4'>
-              <choose role='select' line='4421'>
+              <choose role='select' line='4478'>
                <and op='and'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <varRef name='Q{}instance-id' slot='8'/>
@@ -2448,31 +2609,31 @@
                  <varRef name='Q{}instanceXML' slot='1'/>
                 </fn>
                </and>
-               <check line='4422' card='1' diag='3|0|XTTE0570|instanceXML2'>
+               <check line='4479' card='1' diag='3|0|XTTE0570|instanceXML2'>
                 <varRef name='Q{}instanceXML' slot='1'/>
                </check>
                <true/>
-               <check line='4425' card='1' diag='3|0|XTTE0570|instanceXML2'>
+               <check line='4482' card='1' diag='3|0|XTTE0570|instanceXML2'>
                 <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='5' eval='6'>
                  <varRef name='Q{}refz' slot='3'/>
                 </ufCall>
                </check>
               </choose>
               <withParam name='Q{}instance-id' as='xs:string'>
-               <varRef line='4474' name='Q{}instance-id' slot='8'/>
+               <varRef line='4531' name='Q{}instance-id' slot='8'/>
               </withParam>
               <withParam name='Q{}pendingUpdates' flags='t' as='map(xs:string, xs:string)?'>
-               <varRef line='4475' name='Q{}pendingUpdates' slot='12'/>
+               <varRef line='4532' name='Q{}pendingUpdates' slot='12'/>
               </withParam>
              </applyT>
             </check>
            </treat>
-           <sequence line='4480'>
+           <sequence line='4537'>
             <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='6' eval='6 6'>
              <varRef name='Q{}refz' slot='3'/>
              <varRef name='Q{}updatedInstanceXML' slot='13'/>
             </ufCall>
-            <callT line='4481' name='Q{}refreshOutputs-JS' bSlot='7' flags='t'/>
+            <callT line='4538' name='Q{}refreshOutputs-JS' bSlot='7' flags='t'/>
            </sequence>
           </let>
          </let>
@@ -2484,14 +2645,14 @@
    </sequence>
   </template>
  </co>
- <co id='34' binds=''>
+ <co id='36' binds=''>
   <globalVariable name='Q{}default-submission-id' type='xs:string' line='76' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
    <str val='saxon-forms-default-submission'/>
   </globalVariable>
  </co>
- <co id='19' binds='1 2 3 3 31 0 8 28 29 35 7 17 10 24 19'>
-  <template name='Q{}applyActions' flags='os' line='3653' module='saxon-xforms.xsl' slots='12'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3654'>
+ <co id='21' binds='1 2 3 3 33 0 8 30 31 37 7 17 10 26 21'>
+  <template name='Q{}applyActions' flags='os' line='3689' module='saxon-xforms.xsl' slots='12'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3690'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -2499,7 +2660,7 @@
       </check>
      </treat>
     </param>
-    <param line='3655' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
+    <param line='3691' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
      <empty role='select'/>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|instanceXML'>
       <check card='?' diag='8|0|XTTE0590|instanceXML'>
@@ -2507,7 +2668,7 @@
       </check>
      </treat>
     </param>
-    <param line='3656' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
+    <param line='3692' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -2519,7 +2680,7 @@
       </check>
      </treat>
     </param>
-    <let line='3658' var='Q{}ref' as='xs:string?' slot='3' eval='7'>
+    <let line='3694' var='Q{}ref' as='xs:string?' slot='3' eval='7'>
      <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|ref'>
       <check card='?' diag='3|0|XTTE0570|ref'>
        <cvUntyped to='xs:string' diag='3|0|XTTE0570|ref'>
@@ -2532,7 +2693,7 @@
        </cvUntyped>
       </check>
      </treat>
-     <let line='3659' var='Q{}at' as='xs:string?' slot='4' eval='7'>
+     <let line='3695' var='Q{}at' as='xs:string?' slot='4' eval='7'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|at'>
        <check card='?' diag='3|0|XTTE0570|at'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|at'>
@@ -2545,7 +2706,7 @@
         </cvUntyped>
        </check>
       </treat>
-      <let line='3671' var='Q{}ref-qualified' as='xs:string?' slot='5' eval='7'>
+      <let line='3707' var='Q{}ref-qualified' as='xs:string?' slot='5' eval='7'>
        <choose>
         <and op='and'>
          <fn name='exists'>
@@ -2567,14 +2728,14 @@
          <varRef name='Q{}ref' slot='3'/>
         </choose>
        </choose>
-       <let line='3673' var='Q{}instance-id' as='xs:string' slot='6' eval='16'>
+       <let line='3709' var='Q{}instance-id' as='xs:string' slot='6' eval='16'>
         <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='16'>
          <check card='1' diag='0|0||xforms:getInstanceId'>
           <varRef name='Q{}ref' slot='3'/>
          </check>
         </ufCall>
-        <let line='3675' var='Q{}instanceXML2' as='element()?' slot='7' eval='7'>
-         <choose line='3677'>
+        <let line='3711' var='Q{}instanceXML2' as='element()?' slot='7' eval='7'>
+         <choose line='3713'>
           <and op='and'>
            <vc op='eq' onEmpty='0' comp='CCC'>
             <varRef name='Q{}instance-id' slot='6'/>
@@ -2584,18 +2745,18 @@
             <varRef name='Q{}instanceXML' slot='1'/>
            </fn>
           </and>
-          <varRef line='3678' name='Q{}instanceXML' slot='1'/>
-          <fn line='3680' name='exists'>
+          <varRef line='3714' name='Q{}instanceXML' slot='1'/>
+          <fn line='3716' name='exists'>
            <varRef name='Q{}ref-qualified' slot='5'/>
           </fn>
-          <ufCall line='3681' name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='1' eval='16'>
+          <ufCall line='3717' name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='1' eval='16'>
            <check card='1' diag='0|0||xforms:getInstance-JS'>
             <varRef name='Q{}ref-qualified' slot='5'/>
            </check>
           </ufCall>
          </choose>
-         <let line='3689' var='Q{}context' as='node()?' slot='8' eval='7'>
-          <choose line='3691'>
+         <let line='3725' var='Q{}context' as='node()?' slot='8' eval='7'>
+          <choose line='3727'>
            <and op='and'>
             <and op='and'>
              <fn name='exists'>
@@ -2610,7 +2771,7 @@
              <varRef name='Q{}instanceXML2' slot='7'/>
             </fn>
            </and>
-           <treat line='3692' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|context'>
+           <treat line='3728' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|context'>
             <check card='?' diag='3|0|XTTE0570|context'>
              <evaluate dxns=''>
               <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
@@ -2629,18 +2790,18 @@
             </check>
            </treat>
           </choose>
-          <let line='3699' var='Q{}ifVar' as='xs:string?' slot='9' eval='7'>
-           <choose line='790'>
+          <let line='3735' var='Q{}ifVar' as='xs:string?' slot='9' eval='7'>
+           <choose line='791'>
             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
-             <varRef line='3699' name='Q{}action-map' slot='0'/>
+             <varRef line='3735' name='Q{}action-map' slot='0'/>
              <str val='@if'/>
             </ifCall>
-            <treat line='791' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
+            <treat line='792' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
              <check card='?' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
               <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
                <data>
                 <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                 <varRef line='3699' name='Q{}action-map' slot='0'/>
+                 <varRef line='3735' name='Q{}action-map' slot='0'/>
                  <str val='@if'/>
                 </ifCall>
                </data>
@@ -2648,8 +2809,8 @@
              </check>
             </treat>
            </choose>
-           <let line='3703' var='Q{}ifExecuted' as='xs:boolean' slot='10' eval='16'>
-            <choose line='3705'>
+           <let line='3739' var='Q{}ifExecuted' as='xs:boolean' slot='10' eval='16'>
+            <choose line='3741'>
              <and op='and'>
               <fn name='exists'>
                <varRef name='Q{}ifVar' slot='9'/>
@@ -2658,7 +2819,7 @@
                <varRef name='Q{}context' slot='8'/>
               </fn>
              </and>
-             <treat line='3706' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|ifExecuted'>
+             <treat line='3742' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|ifExecuted'>
               <check card='1' diag='3|0|XTTE0570|ifExecuted'>
                <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|ifExecuted'>
                 <data>
@@ -2683,9 +2844,9 @@
              <true/>
              <true/>
             </choose>
-            <choose line='3716'>
+            <choose line='3752'>
              <varRef name='Q{}ifExecuted' slot='10'/>
-             <let line='3717' var='Q{}action-name' as='xs:string' slot='11' eval='16'>
+             <let line='3753' var='Q{}action-name' as='xs:string' slot='11' eval='16'>
               <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|action-name'>
                <check card='1' diag='3|0|XTTE0570|action-name'>
                 <cvUntyped to='xs:string' diag='3|0|XTTE0570|action-name'>
@@ -2698,98 +2859,98 @@
                 </cvUntyped>
                </check>
               </treat>
-              <sequence line='3720'>
+              <sequence line='3756'>
                <choose>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <varRef name='Q{}action-name' slot='11'/>
                  <str val='action'/>
                 </vc>
                 <empty/>
-                <vc line='3723' op='eq' onEmpty='0' comp='CCC'>
+                <vc line='3759' op='eq' onEmpty='0' comp='CCC'>
                  <varRef name='Q{}action-name' slot='11'/>
                  <str val='setvalue'/>
                 </vc>
-                <callT line='3724' name='Q{}action-setvalue' bSlot='4'>
+                <callT line='3760' name='Q{}action-setvalue' bSlot='4'>
                  <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                  <check line='3725' card='1' diag='8|0|XTTE0590|nodeset'>
+                  <check line='3761' card='1' diag='8|0|XTTE0590|nodeset'>
                    <varRef name='Q{}ref' slot='3'/>
                   </check>
                  </withParam>
                  <withParam name='Q{}instanceXML' flags='t' as='element()'>
-                  <check line='3726' card='1' diag='8|0|XTTE0590|instanceXML'>
+                  <check line='3762' card='1' diag='8|0|XTTE0590|instanceXML'>
                    <varRef name='Q{}instanceXML2' slot='7'/>
                   </check>
                  </withParam>
                 </callT>
-                <vc line='3729' op='eq' onEmpty='0' comp='CCC'>
+                <vc line='3765' op='eq' onEmpty='0' comp='CCC'>
                  <varRef name='Q{}action-name' slot='11'/>
                  <str val='insert'/>
                 </vc>
-                <callT line='3730' name='Q{}action-insert' bSlot='5'>
+                <callT line='3766' name='Q{}action-insert' bSlot='5'>
                  <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                  <check line='3731' card='1' diag='8|0|XTTE0590|nodeset'>
+                  <check line='3767' card='1' diag='8|0|XTTE0590|nodeset'>
                    <varRef name='Q{}ref-qualified' slot='5'/>
                   </check>
                  </withParam>
                  <withParam name='Q{}instanceXML' flags='t' as='element()'>
-                  <check line='3732' card='1' diag='8|0|XTTE0590|instanceXML'>
+                  <check line='3768' card='1' diag='8|0|XTTE0590|instanceXML'>
                    <varRef name='Q{}instanceXML2' slot='7'/>
                   </check>
                  </withParam>
                 </callT>
-                <vc line='3735' op='eq' onEmpty='0' comp='CCC'>
+                <vc line='3771' op='eq' onEmpty='0' comp='CCC'>
                  <varRef name='Q{}action-name' slot='11'/>
                  <str val='delete'/>
                 </vc>
-                <callT line='3736' name='Q{}action-delete' bSlot='6'>
+                <callT line='3772' name='Q{}action-delete' bSlot='6'>
                  <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                  <check line='3737' card='1' diag='8|0|XTTE0590|nodeset'>
+                  <check line='3773' card='1' diag='8|0|XTTE0590|nodeset'>
                    <varRef name='Q{}ref-qualified' slot='5'/>
                   </check>
                  </withParam>
                  <withParam name='Q{}instanceXML' flags='t' as='element()'>
-                  <check line='3738' card='1' diag='8|0|XTTE0590|instanceXML'>
+                  <check line='3774' card='1' diag='8|0|XTTE0590|instanceXML'>
                    <varRef name='Q{}instanceXML2' slot='7'/>
                   </check>
                  </withParam>
                 </callT>
-                <vc line='3741' op='eq' onEmpty='0' comp='CCC'>
+                <vc line='3777' op='eq' onEmpty='0' comp='CCC'>
                  <varRef name='Q{}action-name' slot='11'/>
                  <str val='setindex'/>
                 </vc>
-                <callT line='3742' name='Q{}action-setindex' bSlot='7'/>
-                <vc line='3747' op='eq' onEmpty='0' comp='CCC'>
+                <callT line='3778' name='Q{}action-setindex' bSlot='7'/>
+                <vc line='3783' op='eq' onEmpty='0' comp='CCC'>
                  <varRef name='Q{}action-name' slot='11'/>
                  <str val='setfocus'/>
                 </vc>
-                <callT line='3748' name='Q{}action-setfocus' bSlot='8'/>
-                <vc line='3753' op='eq' onEmpty='0' comp='CCC'>
+                <callT line='3784' name='Q{}action-setfocus' bSlot='8'/>
+                <vc line='3789' op='eq' onEmpty='0' comp='CCC'>
                  <varRef name='Q{}action-name' slot='11'/>
                  <str val='rebuild'/>
                 </vc>
-                <callT line='3754' name='Q{}xforms-rebuild' bSlot='9'/>
-                <vc line='3756' op='eq' onEmpty='0' comp='CCC'>
+                <callT line='3790' name='Q{}xforms-rebuild' bSlot='9'/>
+                <vc line='3792' op='eq' onEmpty='0' comp='CCC'>
                  <varRef name='Q{}action-name' slot='11'/>
                  <str val='recalculate'/>
                 </vc>
-                <callT line='3757' name='Q{}xforms-recalculate' bSlot='10'/>
-                <vc line='3765' op='eq' onEmpty='0' comp='CCC'>
+                <callT line='3793' name='Q{}xforms-recalculate' bSlot='10'/>
+                <vc line='3801' op='eq' onEmpty='0' comp='CCC'>
                  <varRef name='Q{}action-name' slot='11'/>
                  <str val='reset'/>
                 </vc>
-                <callT line='3766' name='Q{}action-reset' bSlot='11'/>
-                <vc line='3771' op='eq' onEmpty='0' comp='CCC'>
+                <callT line='3802' name='Q{}action-reset' bSlot='11'/>
+                <vc line='3807' op='eq' onEmpty='0' comp='CCC'>
                  <varRef name='Q{}action-name' slot='11'/>
                  <str val='send'/>
                 </vc>
-                <callT line='3772' name='Q{}action-send' bSlot='12'/>
-                <vc line='3774' op='eq' onEmpty='0' comp='CCC'>
+                <callT line='3808' name='Q{}action-send' bSlot='12'/>
+                <vc line='3810' op='eq' onEmpty='0' comp='CCC'>
                  <varRef name='Q{}action-name' slot='11'/>
                  <str val='message'/>
                 </vc>
-                <callT line='3775' name='Q{}action-message' bSlot='13'/>
+                <callT line='3811' name='Q{}action-message' bSlot='13'/>
                 <true/>
-                <message line='3778'>
+                <message line='3814'>
                  <sequence role='select'>
                   <valueOf>
                    <str val='[applyActions] action &#39;'/>
@@ -2805,8 +2966,8 @@
                  <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
                 </message>
                </choose>
-               <forEach line='3787'>
-                <ifCall line='3783' name='Q{http://www.w3.org/2005/xpath-functions/array}flatten' type='item()*'>
+               <forEach line='3823'>
+                <ifCall line='3819' name='Q{http://www.w3.org/2005/xpath-functions/array}flatten' type='item()*'>
                  <treat as='array(map(*))' jsTest='function v(item) {return SaxonJS.U.isMap(item)};function c(n) {return n==1;};return SaxonJS.U.isArray(item) &amp;&amp; SaxonJS.U.ForArray(item.value).every(function(seq){return c(seq.length) &amp;&amp; SaxonJS.U.ForArray(seq).every(v)});' diag='3|0|XTTE0570|nested-actions-array'>
                   <check card='?' diag='3|0|XTTE0570|nested-actions-array'>
                    <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
@@ -2816,9 +2977,9 @@
                   </check>
                  </treat>
                 </ifCall>
-                <callT line='3788' name='Q{}applyActions' bSlot='14'>
+                <callT line='3824' name='Q{}applyActions' bSlot='14'>
                  <withParam name='Q{}action-map' flags='t' as='item()'>
-                  <dot line='3789'/>
+                  <dot line='3825'/>
                  </withParam>
                 </callT>
                </forEach>
@@ -2838,9 +2999,9 @@
  </co>
  <co id='4' binds='4'>
   <mode name='Q{}insert-node' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='21' rank='0' minImp='0' slots='3' flags='s' line='1909' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='21' rank='0' minImp='0' slots='3' flags='s' line='1915' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1910'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1916'>
      <param name='Q{}insert-node-location' slot='0' flags='ti' as='node()'>
       <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|insert-node-location'>
        <check card='1' diag='8|0|XTTE0590|insert-node-location'>
@@ -2848,14 +3009,14 @@
        </check>
       </treat>
      </param>
-     <param line='1911' name='Q{}node-to-insert' slot='1' flags='ti' as='node()'>
+     <param line='1917' name='Q{}node-to-insert' slot='1' flags='ti' as='node()'>
       <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|node-to-insert'>
        <check card='1' diag='8|0|XTTE0590|node-to-insert'>
         <supplied slot='1'/>
        </check>
       </treat>
      </param>
-     <param line='1912' name='Q{}position-relative' slot='2' flags='t' as='xs:string?'>
+     <param line='1918' name='Q{}position-relative' slot='2' flags='t' as='xs:string?'>
       <str role='select' val='after'/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|position-relative'>
        <check card='?' diag='8|0|XTTE0590|position-relative'>
@@ -2867,7 +3028,7 @@
        </check>
       </treat>
      </param>
-     <choose line='1915'>
+     <choose line='1921'>
       <and op='and'>
        <is op='is'>
         <dot type='element()'/>
@@ -2878,21 +3039,21 @@
         <str val='before'/>
        </vc>
       </and>
-      <copyOf line='1917' flags='vc'>
+      <copyOf line='1923' flags='vc'>
        <varRef name='Q{}node-to-insert' slot='1'/>
       </copyOf>
      </choose>
-     <copy line='1920' flags='cin'>
+     <copy line='1926' flags='cin'>
       <sequence role='content'>
        <copyOf flags='vc'>
         <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
        </copyOf>
-       <applyT line='1921' mode='Q{}insert-node' bSlot='0'>
+       <applyT line='1927' mode='Q{}insert-node' bSlot='0'>
         <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
        </applyT>
       </sequence>
      </copy>
-     <choose line='1923'>
+     <choose line='1929'>
       <and op='and'>
        <is op='is'>
         <dot type='element()'/>
@@ -2903,7 +3064,7 @@
         <str val='after'/>
        </vc>
       </and>
-      <copyOf line='1924' flags='vc'>
+      <copyOf line='1930' flags='vc'>
        <varRef name='Q{}node-to-insert' slot='1'/>
       </copyOf>
      </choose>
@@ -2911,11 +3072,11 @@
    </templateRule>
   </mode>
  </co>
- <co id='36' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}hasClass' line='3032' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:boolean' slots='2'>
+ <co id='38' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}hasClass' line='3067' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:boolean' slots='2'>
    <arg name='Q{}element' as='element()'/>
    <arg name='Q{}string' as='xs:string'/>
-   <gc role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3036' op='=' card='N:1' comp='CCC'>
+   <gc role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3071' op='=' card='N:1' comp='CCC'>
     <fn name='tokenize'>
      <cvUntyped to='xs:string' diag='3|0|XTTE0570|class'>
       <data>
@@ -2926,24 +3087,24 @@
       </data>
      </cvUntyped>
     </fn>
-    <varRef line='3039' name='Q{}string' slot='1'/>
+    <varRef line='3074' name='Q{}string' slot='1'/>
    </gc>
   </function>
  </co>
- <co id='37' binds=''>
+ <co id='39' binds=''>
   <globalParam name='Q{}xforms-instance-id' type='item()*' line='63' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return val;' jsCardCheck='function c() {return true;};'>
    <str val='xforms-jinstance'/>
   </globalParam>
  </co>
- <co id='38' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}getIfStatement' line='787' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
+ <co id='40' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}getIfStatement' line='788' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
    <arg name='Q{}map' as='map(*)'/>
-   <choose role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='790'>
+   <choose role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='791'>
     <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
      <varRef name='Q{}map' slot='0'/>
      <str val='@if'/>
     </ifCall>
-    <treat line='791' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
+    <treat line='792' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
      <check card='?' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
       <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
        <data>
@@ -2958,18 +3119,18 @@
    </choose>
   </function>
  </co>
- <co id='39' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}getClass' line='3053' module='saxon-xforms.xsl' eval='7' flags='pU' as='attribute(Q{}class)?' slots='3'>
+ <co id='41' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}getClass' line='3088' module='saxon-xforms.xsl' eval='7' flags='pU' as='attribute(Q{}class)?' slots='3'>
    <arg name='Q{}element' as='element()'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3056' var='Q{}class' as='xs:string?' slot='1' eval='7'>
-    <choose line='3057'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3091' var='Q{}class' as='xs:string?' slot='1' eval='7'>
+    <choose line='3092'>
      <fn name='exists'>
       <slash simple='1'>
        <varRef name='Q{}element' slot='0'/>
        <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
       </slash>
      </fn>
-     <cvUntyped line='3058' to='xs:string' diag='3|0|XTTE0570|class'>
+     <cvUntyped line='3093' to='xs:string' diag='3|0|XTTE0570|class'>
       <cast as='xs:untypedAtomic' emptiable='0'>
        <fn name='string'>
         <convert from='xs:untypedAtomic' to='xs:string'>
@@ -2984,15 +3145,15 @@
       </cast>
      </cvUntyped>
     </choose>
-    <let line='3061' var='Q{}class-mod' as='xs:string?' slot='2' eval='7'>
-     <choose line='3063'>
+    <let line='3096' var='Q{}class-mod' as='xs:string?' slot='2' eval='7'>
+     <choose line='3098'>
       <fn name='exists'>
        <slash simple='1'>
         <varRef name='Q{}element' slot='0'/>
         <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
        </slash>
       </fn>
-      <cvUntyped line='3064' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+      <cvUntyped line='3099' to='xs:string' diag='3|0|XTTE0570|class-mod'>
        <cast as='xs:untypedAtomic' emptiable='0'>
         <fn name='string-join'>
          <sequence>
@@ -3004,13 +3165,13 @@
        </cast>
       </cvUntyped>
       <true/>
-      <varRef line='3067' name='Q{}class' slot='1'/>
+      <varRef line='3102' name='Q{}class' slot='1'/>
      </choose>
-     <choose line='3071'>
+     <choose line='3106'>
       <fn name='exists'>
        <varRef name='Q{}class-mod' slot='2'/>
       </fn>
-      <treat line='3072' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+      <treat line='3107' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
        <att name='class'>
         <varRef name='Q{}class-mod' slot='2'/>
        </att>
@@ -3020,9 +3181,9 @@
    </let>
   </function>
  </co>
- <co id='40' binds='41 22 42 43 44'>
-  <template name='Q{}refreshRepeats-JS' flags='os' line='3533' module='saxon-xforms.xsl' slots='8'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3535'>
+ <co id='42' binds='43 24 44 19 45'>
+  <template name='Q{}refreshRepeats-JS' flags='os' line='3565' module='saxon-xforms.xsl' slots='8'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3567'>
     <message>
      <valueOf role='select'>
       <str val='[refreshRepeats-JS] START refreshRepeats'/>
@@ -3030,7 +3191,7 @@
      <str role='terminate' val='no'/>
      <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
     </message>
-    <let line='3538' var='Q{}repeat-keys' as='item()?' slot='0' eval='8'>
+    <let line='3570' var='Q{}repeat-keys' as='item()?' slot='0' eval='8'>
      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
       <check card='1' diag='0|0||ixsl:call'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -3038,9 +3199,9 @@
       <str val='getRepeatKeys'/>
       <array size='0'/>
      </ifCall>
-     <forEach line='3540'>
+     <forEach line='3572'>
       <varRef name='Q{}repeat-keys' slot='0'/>
-      <let line='3541' var='Q{}this-key' as='xs:string' slot='1' eval='16'>
+      <let line='3573' var='Q{}this-key' as='xs:string' slot='1' eval='16'>
        <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|this-key'>
         <check card='1' diag='3|0|XTTE0570|this-key'>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|this-key'>
@@ -3050,7 +3211,7 @@
          </cvUntyped>
         </check>
        </treat>
-       <let line='3542' var='Q{}this-repeat-nodeset' as='xs:string' slot='2' eval='16'>
+       <let line='3574' var='Q{}this-repeat-nodeset' as='xs:string' slot='2' eval='16'>
         <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|this-repeat-nodeset'>
          <check card='1' diag='3|0|XTTE0570|this-repeat-nodeset'>
           <cvUntyped to='xs:string' diag='3|0|XTTE0570|this-repeat-nodeset'>
@@ -3068,7 +3229,7 @@
           </cvUntyped>
          </check>
         </treat>
-        <sequence line='3544'>
+        <sequence line='3576'>
          <message>
           <sequence role='select'>
            <valueOf>
@@ -3082,9 +3243,9 @@
           <str role='terminate' val='no'/>
           <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
          </message>
-         <let line='3555' var='Q{}contexti' as='element()?' slot='3' eval='7'>
-          <ufCall line='3556' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='0' eval='16'>
-           <check line='3548' card='1' diag='3|0|XTTE0570|this-instance-id'>
+         <let line='3587' var='Q{}contexti' as='element()?' slot='3' eval='7'>
+          <ufCall line='3588' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='0' eval='16'>
+           <check line='3580' card='1' diag='3|0|XTTE0570|this-instance-id'>
             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
              <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='1' eval='6'>
               <varRef name='Q{}this-repeat-nodeset' slot='2'/>
@@ -3093,7 +3254,7 @@
             </ifCall>
            </check>
           </ufCall>
-          <let line='3563' var='Q{}namespace-context-item' as='element()' slot='4' eval='16'>
+          <let line='3595' var='Q{}namespace-context-item' as='element()' slot='4' eval='16'>
            <choose>
             <fn name='exists'>
              <varRef name='Q{}contexti' slot='3'/>
@@ -3114,7 +3275,7 @@
              </check>
             </treat>
            </choose>
-           <let line='3565' var='Q{}page-element' as='element()?' slot='5' eval='7'>
+           <let line='3597' var='Q{}page-element' as='element()?' slot='5' eval='7'>
             <check card='?' diag='3|0|XTTE0570|page-element'>
              <filter flags='b'>
               <slash simple='1'>
@@ -3129,11 +3290,11 @@
               </vc>
              </filter>
             </check>
-            <choose line='3568'>
+            <choose line='3600'>
              <fn name='exists'>
               <varRef name='Q{}page-element' slot='5'/>
              </fn>
-             <let line='3569' var='Q{}instance-keys' as='item()?' slot='6' eval='8'>
+             <let line='3601' var='Q{}instance-keys' as='item()?' slot='6' eval='8'>
               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                <check card='1' diag='0|0||ixsl:call'>
                 <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -3141,12 +3302,12 @@
                <str val='getInstanceKeys'/>
                <array size='0'/>
               </ifCall>
-              <let line='3570' var='Q{}instances' as='map(xs:string, element())' slot='7' eval='16'>
-               <treat line='3572' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances'>
+              <let line='3602' var='Q{}instances' as='map(xs:string, element())' slot='7' eval='16'>
+               <treat line='3604' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances'>
                 <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
                  <forEach>
                   <varRef name='Q{}instance-keys' slot='6'/>
-                  <ifCall line='3573' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                  <ifCall line='3605' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                    <atomSing diag='0|0||map:entry'>
                     <dot/>
                    </atomSing>
@@ -3169,12 +3330,12 @@
                  </map>
                 </ifCall>
                </treat>
-               <resultDoc line='3577' global='#&#xA;#Sat Feb 22 17:48:53 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sat Feb 22 17:48:53 GMT 2020&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xA;'>
+               <resultDoc line='3609' global='#&#xA;#Sat Feb 22 22:54:41 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sat Feb 22 22:54:41 GMT 2020&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xA;'>
                 <fn role='href' name='concat'>
                  <str val='#'/>
                  <varRef name='Q{}this-key' slot='1'/>
                 </fn>
-                <applyT role='content' line='3578' bSlot='2'>
+                <applyT role='content' line='3610' bSlot='2'>
                  <filter role='select' flags='b'>
                   <slash simple='1'>
                    <gVarRef name='Q{}xforms-doc' bSlot='3'/>
@@ -3195,7 +3356,7 @@
                   <true/>
                  </withParam>
                  <withParam name='Q{}instances' flags='t' as='map(xs:string, element())'>
-                  <varRef line='3579' name='Q{}instances' slot='7'/>
+                  <varRef line='3611' name='Q{}instances' slot='7'/>
                  </withParam>
                 </applyT>
                </resultDoc>
@@ -3213,9 +3374,9 @@
    </sequence>
   </template>
  </co>
- <co id='33' binds='3 41 22 22'>
-  <template name='Q{}refreshOutputs-JS' flags='os' line='3454' module='saxon-xforms.xsl' slots='8'>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3461' var='Q{}output-keys' as='item()?' slot='0' eval='8'>
+ <co id='35' binds='3 43 24 24'>
+  <template name='Q{}refreshOutputs-JS' flags='os' line='3486' module='saxon-xforms.xsl' slots='8'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3493' var='Q{}output-keys' as='item()?' slot='0' eval='8'>
     <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
      <check card='1' diag='0|0||ixsl:call'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -3223,9 +3384,9 @@
      <str val='getOutputKeys'/>
      <array size='0'/>
     </ifCall>
-    <forEach line='3463'>
+    <forEach line='3495'>
      <varRef name='Q{}output-keys' slot='0'/>
-     <let line='3464' var='Q{}this-key' as='xs:string' slot='1' eval='16'>
+     <let line='3496' var='Q{}this-key' as='xs:string' slot='1' eval='16'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|this-key'>
        <check card='1' diag='3|0|XTTE0570|this-key'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|this-key'>
@@ -3235,7 +3396,7 @@
         </cvUntyped>
        </check>
       </treat>
-      <let line='3465' var='Q{}this-output' as='map(*)' slot='2' eval='16'>
+      <let line='3497' var='Q{}this-output' as='map(*)' slot='2' eval='16'>
        <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|this-output'>
         <check card='1' diag='3|0|XTTE0570|this-output'>
          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
@@ -3249,7 +3410,7 @@
          </ifCall>
         </check>
        </treat>
-       <sequence line='3467'>
+       <sequence line='3499'>
         <message>
          <sequence role='select'>
           <valueOf>
@@ -3263,14 +3424,14 @@
          <str role='terminate' val='no'/>
          <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
         </message>
-        <let line='3484' var='Q{}xpath-mod' as='xs:string' slot='3' eval='16'>
+        <let line='3516' var='Q{}xpath-mod' as='xs:string' slot='3' eval='16'>
          <ufCall name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='0' eval='16'>
-          <choose line='3472'>
+          <choose line='3504'>
            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
             <varRef name='Q{}this-output' slot='2'/>
             <str val='@value'/>
            </ifCall>
-           <treat line='3473' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|xpath'>
+           <treat line='3505' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|xpath'>
             <check card='1' diag='3|0|XTTE0570|xpath'>
              <cvUntyped to='xs:string' diag='3|0|XTTE0570|xpath'>
               <data>
@@ -3282,11 +3443,11 @@
              </cvUntyped>
             </check>
            </treat>
-           <ifCall line='3475' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+           <ifCall line='3507' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
             <varRef name='Q{}this-output' slot='2'/>
             <str val='@ref'/>
            </ifCall>
-           <treat line='3476' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|xpath'>
+           <treat line='3508' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|xpath'>
             <check card='1' diag='3|0|XTTE0570|xpath'>
              <cvUntyped to='xs:string' diag='3|0|XTTE0570|xpath'>
               <data>
@@ -3302,7 +3463,7 @@
            <str val=''/>
           </choose>
          </ufCall>
-         <sequence line='3486'>
+         <sequence line='3518'>
           <message>
            <sequence role='select'>
             <valueOf>
@@ -3316,21 +3477,21 @@
            <str role='terminate' val='no'/>
            <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
           </message>
-          <let line='3502' var='Q{}contexti' as='element()?' slot='4' eval='7'>
-           <ufCall line='3503' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='16'>
-            <check line='3490' card='1' diag='3|0|XTTE0570|this-instance-id'>
+          <let line='3534' var='Q{}contexti' as='element()?' slot='4' eval='7'>
+           <ufCall line='3535' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='16'>
+            <check line='3522' card='1' diag='3|0|XTTE0570|this-instance-id'>
              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
               <choose>
                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
                 <varRef name='Q{}this-output' slot='2'/>
                 <str val='@ref'/>
                </ifCall>
-               <ufCall line='3492' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='2' eval='16'>
+               <ufCall line='3524' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='2' eval='16'>
                 <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:getInstanceMap'>
                  <check card='1' diag='0|0||xforms:getInstanceMap'>
                   <cvUntyped to='xs:string'>
                    <data>
-                    <ifCall line='3491' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                    <ifCall line='3523' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
                      <varRef name='Q{}this-output' slot='2'/>
                      <str val='@ref'/>
                     </ifCall>
@@ -3340,7 +3501,7 @@
                 </treat>
                </ufCall>
                <true/>
-               <ufCall line='3495' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='3' eval='0'>
+               <ufCall line='3527' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='3' eval='0'>
                 <str val='saxon-forms-default'/>
                </ufCall>
               </choose>
@@ -3348,7 +3509,7 @@
              </ifCall>
             </check>
            </ufCall>
-           <let line='3510' var='Q{}namespace-context-item' as='element()' slot='5' eval='16'>
+           <let line='3542' var='Q{}namespace-context-item' as='element()' slot='5' eval='16'>
             <choose>
              <fn name='exists'>
               <varRef name='Q{}contexti' slot='4'/>
@@ -3369,8 +3530,8 @@
               </check>
              </treat>
             </choose>
-            <let line='3512' var='Q{}value' as='xs:string?' slot='6' eval='7'>
-             <treat line='3513' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|value'>
+            <let line='3544' var='Q{}value' as='xs:string?' slot='6' eval='7'>
+             <treat line='3545' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|value'>
               <check card='?' diag='3|0|XTTE0570|value'>
                <cvUntyped to='xs:string' diag='3|0|XTTE0570|value'>
                 <data>
@@ -3386,7 +3547,7 @@
                </cvUntyped>
               </check>
              </treat>
-             <let line='3516' var='Q{}associated-form-control' as='element()?' slot='7' eval='7'>
+             <let line='3548' var='Q{}associated-form-control' as='element()?' slot='7' eval='7'>
               <check card='?' diag='3|0|XTTE0570|associated-form-control'>
                <filter flags='b'>
                 <slash simple='1'>
@@ -3401,16 +3562,16 @@
                 </vc>
                </filter>
               </check>
-              <choose line='3519'>
+              <choose line='3551'>
                <fn name='exists'>
                 <varRef name='Q{}associated-form-control' slot='7'/>
                </fn>
-               <resultDoc line='3520' global='#&#xA;#Sat Feb 22 17:48:53 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sat Feb 22 17:48:53 GMT 2020&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xA;'>
+               <resultDoc line='3552' global='#&#xA;#Sat Feb 22 22:54:41 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sat Feb 22 22:54:41 GMT 2020&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xA;'>
                 <fn role='href' name='concat'>
                  <str val='#'/>
                  <varRef name='Q{}this-key' slot='1'/>
                 </fn>
-                <valueOf role='content' line='3521'>
+                <valueOf role='content' line='3553'>
                  <varRef name='Q{}value' slot='6'/>
                 </valueOf>
                </resultDoc>
@@ -3428,9 +3589,9 @@
    </let>
   </template>
  </co>
- <co id='30' binds='45'>
-  <template name='Q{}xforms-focus' flags='os' line='4177' module='saxon-xforms.xsl' slots='5'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4178'>
+ <co id='32' binds='18'>
+  <template name='Q{}xforms-focus' flags='os' line='4230' module='saxon-xforms.xsl' slots='5'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4231'>
     <param name='Q{}control' slot='0' flags='i' as='xs:string'>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|control'>
       <check card='1' diag='8|0|XTTE0590|control'>
@@ -3442,10 +3603,10 @@
       </check>
      </treat>
     </param>
-    <let line='4179' var='Q{}xforms-control' as='element()' slot='1' eval='16'>
+    <let line='4232' var='Q{}xforms-control' as='element()' slot='1' eval='16'>
      <check card='1' diag='3|0|XTTE0570|xforms-control'>
       <filter flags='b'>
-       <gVarRef name='Q{http://saxon.sf.net/generated-variable}gg893415836' bSlot='0'/>
+       <gVarRef name='Q{http://saxon.sf.net/generated-variable}gg99297450' bSlot='0'/>
        <vc op='eq' onEmpty='0' comp='CCC'>
         <cast as='xs:string' emptiable='1'>
          <attVal name='Q{}id' chk='0'/>
@@ -3454,19 +3615,19 @@
        </vc>
       </filter>
      </check>
-     <choose line='4184'>
+     <choose line='4237'>
       <fn name='exists'>
        <slash simple='1'>
         <varRef name='Q{}xforms-control' slot='1'/>
         <axis name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
        </slash>
       </fn>
-      <let line='4188' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='2' eval='13'>
+      <let line='4241' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='2' eval='13'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
        </check>
-       <let line='4185' var='Q{}context-indexes' as='xs:double*' slot='3' eval='8'>
-        <convert line='4186' from='xs:anyAtomicType' to='xs:double' flags='p' diag='3|0|XTTE0570|context-indexes'>
+       <let line='4238' var='Q{}context-indexes' as='xs:double*' slot='3' eval='8'>
+        <convert line='4239' from='xs:anyAtomicType' to='xs:double' flags='p' diag='3|0|XTTE0570|context-indexes'>
          <cvUntyped to='xs:double' diag='3|0|XTTE0570|context-indexes'>
           <data>
            <forEach>
@@ -3477,7 +3638,7 @@
                <axis name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
               </fn>
              </slash>
-             <sortKey line='4187' comp='DESC|NC11'>
+             <sortKey line='4240' comp='DESC|NC11'>
               <fn role='select' name='position'/>
               <str role='order' val='descending'/>
               <str role='dataType' val='number'/>
@@ -3487,7 +3648,7 @@
               <str role='collation' val='http://www.w3.org/2005/xpath-functions/collation/codepoint'/>
              </sortKey>
             </sort>
-            <ifCall line='4188' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+            <ifCall line='4241' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
              <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='2'/>
              <str val='getRepeatIndex'/>
              <arrayBlock>
@@ -3500,12 +3661,12 @@
           </data>
          </cvUntyped>
         </convert>
-        <let line='4192' var='Q{}control-index' as='xs:string' slot='4' eval='8'>
+        <let line='4245' var='Q{}control-index' as='xs:string' slot='4' eval='8'>
          <fn name='string-join'>
           <varRef name='Q{}context-indexes' slot='3'/>
           <str val='.'/>
          </fn>
-         <sequence line='4193'>
+         <sequence line='4246'>
           <message>
            <sequence role='select'>
             <valueOf>
@@ -3523,7 +3684,7 @@
            <str role='terminate' val='no'/>
            <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
           </message>
-          <ifCall line='4194' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+          <ifCall line='4247' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
            <check card='1' diag='0|0||ixsl:call'>
             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
            </check>
@@ -3541,7 +3702,7 @@
        </let>
       </let>
       <true/>
-      <ifCall line='4197' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+      <ifCall line='4250' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
        </check>
@@ -3555,10 +3716,10 @@
    </sequence>
   </template>
  </co>
- <co id='20' binds='2'>
-  <function name='Q{http://www.w3.org/2002/xforms}checkRelevantFields' line='630' module='saxon-xforms.xsl' eval='8' flags='pU' as='item()*' slots='13'>
+ <co id='22' binds='2'>
+  <function name='Q{http://www.w3.org/2002/xforms}checkRelevantFields' line='631' module='saxon-xforms.xsl' eval='8' flags='pU' as='item()*' slots='13'>
    <arg name='Q{}refElement' as='xs:string'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='633' var='Q{}pendingUpdatesi' as='map(xs:string, xs:string)?' slot='1' eval='7'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='634' var='Q{}pendingUpdatesi' as='map(xs:string, xs:string)?' slot='1' eval='7'>
     <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|pendingUpdatesi'>
      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
       <check card='1' diag='0|0||ixsl:call'>
@@ -3568,7 +3729,7 @@
       <array size='0'/>
      </ifCall>
     </treat>
-    <let line='636' var='Q{}updatesi' as='map(xs:string, xs:string)?' slot='2' eval='7'>
+    <let line='637' var='Q{}updatesi' as='map(xs:string, xs:string)?' slot='2' eval='7'>
      <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|updatesi'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
@@ -3578,7 +3739,7 @@
        <array size='0'/>
       </ifCall>
      </treat>
-     <let line='639' var='Q{}relevantMap' as='map(xs:string, xs:string)' slot='3' eval='16'>
+     <let line='640' var='Q{}relevantMap' as='map(xs:string, xs:string)' slot='3' eval='16'>
       <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|relevantMap'>
        <check card='1' diag='3|0|XTTE0570|relevantMap'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
@@ -3590,16 +3751,16 @@
         </ifCall>
        </check>
       </treat>
-      <let line='640' var='Q{}mapKeys' as='xs:anyAtomicType*' slot='4' eval='4'>
+      <let line='641' var='Q{}mapKeys' as='xs:anyAtomicType*' slot='4' eval='4'>
        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
         <varRef name='Q{}relevantMap' slot='3'/>
        </ifCall>
-       <sequence line='670'>
+       <sequence line='671'>
         <forEach>
-         <sequence line='643'>
+         <sequence line='644'>
           <forEach>
            <varRef name='Q{}mapKeys' slot='4'/>
-           <choose line='644'>
+           <choose line='645'>
             <fn name='matches'>
              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
               <varRef name='Q{}relevantMap' slot='3'/>
@@ -3608,10 +3769,10 @@
              <varRef name='Q{}refElement' slot='0'/>
              <str val=''/>
             </fn>
-            <dot line='645' type='xs:anyAtomicType'/>
+            <dot line='646' type='xs:anyAtomicType'/>
            </choose>
           </forEach>
-          <forEach line='634'>
+          <forEach line='635'>
            <choose>
             <fn name='exists'>
              <varRef name='Q{}pendingUpdatesi' slot='1'/>
@@ -3622,7 +3783,7 @@
              </check>
             </ifCall>
            </choose>
-           <let line='651' var='Q{}keyi' as='xs:string?' slot='5' eval='7'>
+           <let line='652' var='Q{}keyi' as='xs:string?' slot='5' eval='7'>
             <lastOf>
              <fn name='tokenize'>
               <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||fn:tokenize'>
@@ -3634,13 +3795,13 @@
               <str val=''/>
              </fn>
             </lastOf>
-            <let line='653' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='6' eval='13'>
+            <let line='654' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='6' eval='13'>
              <check card='1' diag='0|1||fn:matches'>
               <varRef name='Q{}keyi' slot='5'/>
              </check>
-             <forEach line='652'>
+             <forEach line='653'>
               <varRef name='Q{}mapKeys' slot='4'/>
-              <choose line='653'>
+              <choose line='654'>
                <fn name='matches'>
                 <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
                  <varRef name='Q{}relevantMap' slot='3'/>
@@ -3649,13 +3810,13 @@
                 <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='6'/>
                 <str val=''/>
                </fn>
-               <dot line='654' type='xs:anyAtomicType'/>
+               <dot line='655' type='xs:anyAtomicType'/>
               </choose>
              </forEach>
             </let>
            </let>
           </forEach>
-          <forEach line='637'>
+          <forEach line='638'>
            <choose>
             <fn name='exists'>
              <varRef name='Q{}updatesi' slot='2'/>
@@ -3666,7 +3827,7 @@
              </check>
             </ifCall>
            </choose>
-           <let line='660' var='Q{}keyi' as='xs:string?' slot='7' eval='7'>
+           <let line='661' var='Q{}keyi' as='xs:string?' slot='7' eval='7'>
             <lastOf>
              <fn name='tokenize'>
               <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||fn:tokenize'>
@@ -3678,13 +3839,13 @@
               <str val=''/>
              </fn>
             </lastOf>
-            <let line='662' var='Q{http://saxon.sf.net/generated-variable}v1' as='xs:string' slot='8' eval='13'>
+            <let line='663' var='Q{http://saxon.sf.net/generated-variable}v1' as='xs:string' slot='8' eval='13'>
              <check card='1' diag='0|1||fn:matches'>
               <varRef name='Q{}keyi' slot='7'/>
              </check>
-             <forEach line='661'>
+             <forEach line='662'>
               <varRef name='Q{}mapKeys' slot='4'/>
-              <choose line='662'>
+              <choose line='663'>
                <fn name='matches'>
                 <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
                  <varRef name='Q{}relevantMap' slot='3'/>
@@ -3693,16 +3854,16 @@
                 <varRef name='Q{http://saxon.sf.net/generated-variable}v1' slot='8'/>
                 <str val=''/>
                </fn>
-               <dot line='663' type='xs:anyAtomicType'/>
+               <dot line='664' type='xs:anyAtomicType'/>
               </choose>
              </forEach>
             </let>
            </let>
           </forEach>
          </sequence>
-         <let line='671' var='Q{}keyi' as='xs:anyAtomicType' slot='9' eval='16'>
+         <let line='672' var='Q{}keyi' as='xs:anyAtomicType' slot='9' eval='16'>
           <dot type='xs:anyAtomicType'/>
-          <let line='672' var='Q{}context' as='element()*' slot='10' eval='8'>
+          <let line='673' var='Q{}context' as='element()*' slot='10' eval='8'>
            <filter flags='b'>
             <slash simple='1'>
              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
@@ -3713,7 +3874,7 @@
              <varRef name='Q{}keyi' slot='9'/>
             </gc>
            </filter>
-           <let line='673' var='Q{}updatedInstanceXML4' as='element()?' slot='11' eval='7'>
+           <let line='674' var='Q{}updatedInstanceXML4' as='element()?' slot='11' eval='7'>
             <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='0' eval='16'>
              <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:getInstance-JS'>
               <cvUntyped to='xs:string'>
@@ -3721,8 +3882,8 @@
               </cvUntyped>
              </treat>
             </ufCall>
-            <let line='675' var='Q{}relevantCheck' as='xs:boolean' slot='12' eval='16'>
-             <treat line='676' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantCheck'>
+            <let line='676' var='Q{}relevantCheck' as='xs:boolean' slot='12' eval='16'>
+             <treat line='677' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantCheck'>
               <check card='1' diag='3|0|XTTE0570|relevantCheck'>
                <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|relevantCheck'>
                 <data>
@@ -3747,9 +3908,9 @@
                </cvUntyped>
               </check>
              </treat>
-             <choose line='679'>
+             <choose line='680'>
               <varRef name='Q{}relevantCheck' slot='12'/>
-              <ifCall line='682' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+              <ifCall line='683' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
                <str val='style.display'/>
                <str val='inline'/>
                <check card='1' diag='0|2||ixsl:set-property'>
@@ -3762,14 +3923,14 @@
                  <docOrder intra='1'>
                   <slash simple='2'>
                    <varRef name='Q{}context' slot='10'/>
-                   <axis name='parent' nodeTest='(document-node()|element())' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11||item.nodeType===1);'/>
+                   <axis name='parent' nodeTest='(element()|document-node())' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11||item.nodeType===1);'/>
                   </slash>
                  </docOrder>
                 </conditionalSort>
                </check>
               </ifCall>
               <true/>
-              <ifCall line='685' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+              <ifCall line='686' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
                <str val='style.display'/>
                <str val='none'/>
                <check card='1' diag='0|2||ixsl:set-property'>
@@ -3782,7 +3943,7 @@
                  <docOrder intra='1'>
                   <slash simple='2'>
                    <varRef name='Q{}context' slot='10'/>
-                   <axis name='parent' nodeTest='(document-node()|element())' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11||item.nodeType===1);'/>
+                   <axis name='parent' nodeTest='(element()|document-node())' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11||item.nodeType===1);'/>
                   </slash>
                  </docOrder>
                 </conditionalSort>
@@ -3794,14 +3955,14 @@
           </let>
          </let>
         </forEach>
-        <ifCall line='690' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='691' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
          <str val='clearPendingUpdates'/>
          <array size='0'/>
         </ifCall>
-        <ifCall line='691' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='692' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -3839,9 +4000,9 @@
    </check>
   </function>
  </co>
- <co id='7' binds='2 48 2 33 40 49'>
-  <template name='Q{}xforms-recalculate' flags='os' line='4089' module='saxon-xforms.xsl' slots='3'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4090'>
+ <co id='7' binds='2 48 2 35 42 49'>
+  <template name='Q{}xforms-recalculate' flags='os' line='4125' module='saxon-xforms.xsl' slots='3'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4126'>
     <message>
      <valueOf role='select'>
       <str val='[xforms-recalculate] START'/>
@@ -3849,7 +4010,7 @@
      <str role='terminate' val='no'/>
      <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
     </message>
-    <let line='4091' var='Q{}instance-keys' as='item()?' slot='0' eval='8'>
+    <let line='4127' var='Q{}instance-keys' as='item()?' slot='0' eval='8'>
      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
       <check card='1' diag='0|0||ixsl:call'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -3857,9 +4018,9 @@
       <str val='getInstanceKeys'/>
       <array size='0'/>
      </ifCall>
-     <forEach line='4092'>
+     <forEach line='4128'>
       <varRef name='Q{}instance-keys' slot='0'/>
-      <let line='4093' var='Q{}refz' as='xs:string' slot='1' eval='8'>
+      <let line='4129' var='Q{}refz' as='xs:string' slot='1' eval='8'>
        <fn name='concat'>
         <str val='instance(&#39;'/>
         <atomSing card='?' diag='0|1||fn:concat'>
@@ -3867,7 +4028,7 @@
         </atomSing>
         <str val='&#39;)/'/>
        </fn>
-       <sequence line='4094'>
+       <sequence line='4130'>
         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
          <atomSing diag='0|0||map:entry'>
           <dot/>
@@ -3876,22 +4037,22 @@
           <varRef name='Q{}refz' slot='1'/>
          </ufCall>
         </ifCall>
-        <let line='4097' var='Q{}updatedInstanceXML' as='element()' slot='2' eval='16'>
-         <treat line='4098' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+        <let line='4133' var='Q{}updatedInstanceXML' as='element()' slot='2' eval='16'>
+         <treat line='4134' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
           <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
            <applyT mode='Q{}binding-calculation-initial' bSlot='1'>
-            <check role='select' line='4096' card='1' diag='3|0|XTTE0570|instanceXML'>
+            <check role='select' line='4132' card='1' diag='3|0|XTTE0570|instanceXML'>
              <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='2' eval='6'>
               <varRef name='Q{}refz' slot='1'/>
              </ufCall>
             </check>
             <withParam name='Q{}instance-id' as='item()'>
-             <dot line='4099'/>
+             <dot line='4135'/>
             </withParam>
            </applyT>
           </check>
          </treat>
-         <sequence line='4105'>
+         <sequence line='4141'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
            <check card='1' diag='0|0||ixsl:call'>
             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -3902,9 +4063,9 @@
             <varRef name='Q{}updatedInstanceXML' slot='2'/>
            </arrayBlock>
           </ifCall>
-          <callT line='4106' name='Q{}refreshOutputs-JS' bSlot='3'/>
-          <callT line='4107' name='Q{}refreshRepeats-JS' bSlot='4'/>
-          <callT line='4108' name='Q{}refreshElementsUsingIndexFunction-JS' bSlot='5' flags='t'/>
+          <callT line='4142' name='Q{}refreshOutputs-JS' bSlot='3'/>
+          <callT line='4143' name='Q{}refreshRepeats-JS' bSlot='4'/>
+          <callT line='4144' name='Q{}refreshElementsUsingIndexFunction-JS' bSlot='5' flags='t'/>
          </sequence>
         </let>
        </sequence>
@@ -3914,7 +4075,7 @@
    </sequence>
   </template>
  </co>
- <co id='43' binds='50 50 50'>
+ <co id='19' binds='50 50 50'>
   <globalVariable name='Q{}xforms-doc' type='document-node()?' line='71' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='function test(item) {return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);};if (test(val)) {return val;} else {throw SaxonJS.XError(&#39;Conversion failed&#39;, &#39;XTTE0590&#39;);}' jsCardCheck='function c(n) {return n&lt;=1;};'>
    <choose ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='71'>
     <and op='and'>
@@ -3937,18 +4098,18 @@
   </globalParam>
  </co>
  <co id='51' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}addNamespaceDeclarations' line='2998' module='saxon-xforms.xsl' eval='16' flags='pU' as='element()' slots='1'>
+  <function name='Q{http://www.w3.org/2002/xforms}addNamespaceDeclarations' line='3033' module='saxon-xforms.xsl' eval='16' flags='pU' as='element()' slots='1'>
    <arg name='Q{}this' as='element()'/>
-   <compElem role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3000'>
+   <compElem role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3035'>
     <fn role='name' name='name'>
      <varRef name='Q{}this' slot='0'/>
     </fn>
-    <sequence role='content' line='3001'>
+    <sequence role='content' line='3036'>
      <namespace flags='l'>
       <str role='name' val='xforms'/>
       <str role='select' val='http://www.w3.org/2002/xforms'/>
      </namespace>
-     <forEach line='3002'>
+     <forEach line='3037'>
       <filter flags='b'>
        <filter flags='b'>
         <slash simple='1'>
@@ -3987,21 +4148,21 @@
         </gc>
        </fn>
       </filter>
-      <namespace line='3005' flags='l'>
-       <fn role='name' line='3004' name='substring-before'>
+      <namespace line='3040' flags='l'>
+       <fn role='name' line='3039' name='substring-before'>
         <fn name='name'>
          <dot type='element()'/>
         </fn>
         <str val=':'/>
        </fn>
        <convert role='select' from='xs:anyURI' to='xs:string'>
-        <fn line='3003' name='namespace-uri'>
+        <fn line='3038' name='namespace-uri'>
          <dot type='element()'/>
         </fn>
        </convert>
       </namespace>
      </forEach>
-     <copyOf line='3007' flags='vc'>
+     <copyOf line='3042' flags='vc'>
       <sequence>
        <slash simple='1'>
         <varRef name='Q{}this' slot='0'/>
@@ -4017,9 +4178,9 @@
    </compElem>
   </function>
  </co>
- <co id='11' binds='2 41 16 52 3 53 19'>
-  <template name='Q{}xforms-submit' flags='os' line='4210' module='saxon-xforms.xsl' slots='16'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4211'>
+ <co id='11' binds='2 43 16 52 3 53 21'>
+  <template name='Q{}xforms-submit' flags='os' line='4263' module='saxon-xforms.xsl' slots='17'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4264'>
     <param name='Q{}submission' slot='0' flags='i' as='xs:string'>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|submission'>
       <check card='1' diag='8|0|XTTE0590|submission'>
@@ -4031,7 +4192,7 @@
       </check>
      </treat>
     </param>
-    <let line='4213' var='Q{}submission-map' as='map(*)' slot='1' eval='16'>
+    <let line='4266' var='Q{}submission-map' as='map(*)' slot='1' eval='16'>
      <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|submission-map'>
       <check card='1' diag='3|0|XTTE0570|submission-map'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
@@ -4045,7 +4206,7 @@
        </ifCall>
       </check>
      </treat>
-     <let line='4214' var='Q{}actions' as='map(*)?' slot='2' eval='7'>
+     <let line='4267' var='Q{}actions' as='map(*)?' slot='2' eval='7'>
       <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
         <check card='1' diag='0|0||ixsl:call'>
@@ -4057,7 +4218,7 @@
         </arrayBlock>
        </ifCall>
       </treat>
-      <sequence line='4216'>
+      <sequence line='4269'>
        <message>
         <sequence role='select'>
          <valueOf>
@@ -4072,7 +4233,7 @@
         <str role='terminate' val='no'/>
         <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
        </message>
-       <let line='4218' var='Q{}refi' as='xs:string?' slot='3' eval='7'>
+       <let line='4271' var='Q{}refi' as='xs:string?' slot='3' eval='7'>
         <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
          <check card='?' diag='3|0|XTTE0570|refi'>
           <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
@@ -4085,13 +4246,13 @@
           </cvUntyped>
          </check>
         </treat>
-        <let line='4220' var='Q{}instance-id' as='xs:string' slot='4' eval='16'>
-         <choose line='4222'>
+        <let line='4273' var='Q{}instance-id' as='xs:string' slot='4' eval='16'>
+         <choose line='4275'>
           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
            <varRef name='Q{}submission-map' slot='1'/>
            <str val='@instance'/>
           </ifCall>
-          <treat line='4223' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|instance-id'>
+          <treat line='4276' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|instance-id'>
            <check card='1' diag='3|0|XTTE0570|instance-id'>
             <cvUntyped to='xs:string' diag='3|0|XTTE0570|instance-id'>
              <data>
@@ -4106,7 +4267,7 @@
           <true/>
           <str val='saxon-forms-default'/>
          </choose>
-         <let line='4234' var='Q{}instanceXML' as='element()' slot='5' eval='16'>
+         <let line='4287' var='Q{}instanceXML' as='element()' slot='5' eval='16'>
           <choose>
            <varRef name='Q{}refi' slot='3'/>
            <check card='1' diag='3|0|XTTE0570|instanceXML'>
@@ -4123,18 +4284,18 @@
             </ufCall>
            </check>
           </choose>
-          <let line='4236' var='Q{}updatedInstanceXML' as='element()' slot='6' eval='16'>
-           <treat line='4237' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+          <let line='4289' var='Q{}updatedInstanceXML' as='element()' slot='6' eval='16'>
+           <treat line='4290' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
             <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
              <applyT mode='Q{}form-check-initial' bSlot='2'>
               <varRef role='select' name='Q{}instanceXML' slot='5'/>
               <withParam name='Q{}instance-id' as='xs:string'>
-               <varRef line='4238' name='Q{}instance-id' slot='4'/>
+               <varRef line='4291' name='Q{}instance-id' slot='4'/>
               </withParam>
              </applyT>
             </check>
            </treat>
-           <let line='4242' var='Q{}required-fieldsi' as='element()*' slot='7' eval='8'>
+           <let line='4297' var='Q{}required-fieldsi' as='element()*' slot='7' eval='8'>
             <filter flags='b'>
              <slash simple='1'>
               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
@@ -4144,160 +4305,153 @@
               <axis name='attribute' nodeTest='attribute(Q{}data-required)' jsTest='return item.name===&#39;data-required&#39;'/>
              </fn>
             </filter>
-            <let line='4244' var='Q{}required-fields-check' as='element()*' slot='8' eval='3'>
+            <let line='4299' var='Q{}required-fields-check' as='element()*' slot='8' eval='3'>
              <ufCall name='Q{http://www.w3.org/2002/xforms}check-required-fields' tailCall='false' bSlot='3' eval='6'>
               <varRef name='Q{}updatedInstanceXML' slot='6'/>
              </ufCall>
-             <choose line='4250'>
-              <fn name='empty'>
-               <varRef name='Q{}required-fields-check' slot='8'/>
-              </fn>
-              <let line='4251' var='Q{}requestBodyXML' as='element()' slot='9' eval='16'>
-               <choose line='4253'>
-                <varRef name='Q{}refi' slot='3'/>
-                <treat line='4254' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|requestBodyXML'>
-                 <check card='1' diag='3|0|XTTE0570|requestBodyXML'>
-                  <evaluate dxns=''>
-                   <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='4' eval='16'>
-                    <check card='1' diag='0|0||xforms:impose'>
-                     <varRef name='Q{}refi' slot='3'/>
-                    </check>
-                   </ufCall>
-                   <varRef role='cxt' name='Q{}instanceXML' slot='5'/>
-                   <varRef role='nsCxt' name='Q{}instanceXML' slot='5'/>
-                   <str role='sa' val='no'/>
-                   <map role='options' size='0'/>
-                   <map role='wp' size='0'/>
-                  </evaluate>
-                 </check>
-                </treat>
-                <true/>
-                <varRef line='4257' name='Q{}instanceXML' slot='5'/>
-               </choose>
-               <let line='4271' var='Q{}method' as='xs:string' slot='10' eval='16'>
-                <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|method'>
-                 <check card='1' diag='3|0|XTTE0570|method'>
-                  <cvUntyped to='xs:string' diag='3|0|XTTE0570|method'>
-                   <data>
-                    <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                     <varRef name='Q{}submission-map' slot='1'/>
-                     <str val='@method'/>
-                    </ifCall>
-                   </data>
-                  </cvUntyped>
-                 </check>
-                </treat>
-                <let line='4273' var='Q{}serialization' as='xs:string?' slot='11' eval='7'>
-                 <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|serialization'>
-                  <check card='?' diag='3|0|XTTE0570|serialization'>
-                   <cvUntyped to='xs:string' diag='3|0|XTTE0570|serialization'>
+             <sequence line='4301'>
+              <message>
+               <sequence role='select'>
+                <valueOf>
+                 <str val='[xforms-submit] Submitting instance XML: '/>
+                </valueOf>
+                <valueOf>
+                 <fn name='serialize'>
+                  <varRef name='Q{}instanceXML' slot='5'/>
+                 </fn>
+                </valueOf>
+               </sequence>
+               <str role='terminate' val='no'/>
+               <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+              </message>
+              <message line='4302'>
+               <sequence role='select'>
+                <valueOf>
+                 <str val='[xforms-submit] Updated instance XML: '/>
+                </valueOf>
+                <valueOf>
+                 <fn name='serialize'>
+                  <varRef name='Q{}updatedInstanceXML' slot='6'/>
+                 </fn>
+                </valueOf>
+               </sequence>
+               <str role='terminate' val='no'/>
+               <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+              </message>
+              <choose line='4305'>
+               <fn name='empty'>
+                <varRef name='Q{}required-fields-check' slot='8'/>
+               </fn>
+               <let line='4306' var='Q{}requestBodyXML' as='element()' slot='9' eval='16'>
+                <choose line='4308'>
+                 <varRef name='Q{}refi' slot='3'/>
+                 <treat line='4309' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|requestBodyXML'>
+                  <check card='1' diag='3|0|XTTE0570|requestBodyXML'>
+                   <evaluate dxns=''>
+                    <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='4' eval='16'>
+                     <check card='1' diag='0|0||xforms:impose'>
+                      <varRef name='Q{}refi' slot='3'/>
+                     </check>
+                    </ufCall>
+                    <varRef role='cxt' name='Q{}instanceXML' slot='5'/>
+                    <varRef role='nsCxt' name='Q{}instanceXML' slot='5'/>
+                    <str role='sa' val='no'/>
+                    <map role='options' size='0'/>
+                    <map role='wp' size='0'/>
+                   </evaluate>
+                  </check>
+                 </treat>
+                 <true/>
+                 <varRef line='4312' name='Q{}instanceXML' slot='5'/>
+                </choose>
+                <let line='4326' var='Q{}method' as='xs:string' slot='10' eval='16'>
+                 <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|method'>
+                  <check card='1' diag='3|0|XTTE0570|method'>
+                   <cvUntyped to='xs:string' diag='3|0|XTTE0570|method'>
                     <data>
                      <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
                       <varRef name='Q{}submission-map' slot='1'/>
-                      <str val='@serialization'/>
+                      <str val='@method'/>
                      </ifCall>
                     </data>
                    </cvUntyped>
                   </check>
                  </treat>
-                 <let line='4275' var='Q{}query-parameters' as='xs:string?' slot='12' eval='7'>
-                  <choose line='4276'>
-                   <and op='and'>
-                    <fn name='exists'>
-                     <varRef name='Q{}serialization' slot='11'/>
+                 <let line='4328' var='Q{}serialization' as='xs:string?' slot='11' eval='7'>
+                  <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|serialization'>
+                   <check card='?' diag='3|0|XTTE0570|serialization'>
+                    <cvUntyped to='xs:string' diag='3|0|XTTE0570|serialization'>
+                     <data>
+                      <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                       <varRef name='Q{}submission-map' slot='1'/>
+                       <str val='@serialization'/>
+                      </ifCall>
+                     </data>
+                    </cvUntyped>
+                   </check>
+                  </treat>
+                  <let line='4330' var='Q{}query-parameters' as='xs:string?' slot='12' eval='7'>
+                   <choose line='4331'>
+                    <and op='and'>
+                     <fn name='exists'>
+                      <varRef name='Q{}serialization' slot='11'/>
+                     </fn>
+                     <vc op='eq' onEmpty='0' comp='CCC'>
+                      <varRef name='Q{}serialization' slot='11'/>
+                      <str val='application/x-www-form-urlencoded'/>
+                     </vc>
+                    </and>
+                    <fn line='4342' name='string-join'>
+                     <forEach line='4333'>
+                      <slash simple='1'>
+                       <varRef name='Q{}requestBodyXML' slot='9'/>
+                       <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+                      </slash>
+                      <let line='4334' var='Q{}query-part' as='xs:string' slot='13' eval='8'>
+                       <fn name='concat'>
+                        <fn name='name'>
+                         <dot type='element()'/>
+                        </fn>
+                        <str val='='/>
+                        <fn name='string'>
+                         <dot type='element()'/>
+                        </fn>
+                       </fn>
+                       <sequence line='4335'>
+                        <varRef name='Q{}query-part' slot='13'/>
+                        <message line='4336'>
+                         <sequence role='select'>
+                          <valueOf>
+                           <str val='[xforms-submit] Query part: '/>
+                          </valueOf>
+                          <valueOf>
+                           <varRef name='Q{}query-part' slot='13'/>
+                          </valueOf>
+                         </sequence>
+                         <str role='terminate' val='no'/>
+                         <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+                        </message>
+                       </sequence>
+                      </let>
+                     </forEach>
+                     <str val='&amp;'/>
                     </fn>
-                    <vc op='eq' onEmpty='0' comp='CCC'>
-                     <varRef name='Q{}serialization' slot='11'/>
-                     <str val='application/x-www-form-urlencoded'/>
-                    </vc>
-                   </and>
-                   <fn line='4287' name='string-join'>
-                    <forEach line='4278'>
-                     <slash simple='1'>
-                      <varRef name='Q{}requestBodyXML' slot='9'/>
-                      <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-                     </slash>
-                     <let line='4279' var='Q{}query-part' as='xs:string' slot='13' eval='8'>
-                      <fn name='concat'>
-                       <fn name='name'>
-                        <dot type='element()'/>
-                       </fn>
-                       <str val='='/>
-                       <fn name='string'>
-                        <dot type='element()'/>
-                       </fn>
-                      </fn>
-                      <sequence line='4280'>
-                       <varRef name='Q{}query-part' slot='13'/>
-                       <message line='4281'>
-                        <sequence role='select'>
-                         <valueOf>
-                          <str val='[xforms-submit] Query part: '/>
-                         </valueOf>
-                         <valueOf>
-                          <varRef name='Q{}query-part' slot='13'/>
-                         </valueOf>
-                        </sequence>
-                        <str role='terminate' val='no'/>
-                        <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-                       </message>
-                      </sequence>
-                     </let>
-                    </forEach>
-                    <str val='&amp;'/>
-                   </fn>
-                  </choose>
-                  <let line='4291' var='Q{}href-base' as='xs:string' slot='14' eval='16'>
-                   <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|href-base'>
-                    <check card='1' diag='3|0|XTTE0570|href-base'>
-                     <cvUntyped to='xs:string' diag='3|0|XTTE0570|href-base'>
-                      <data>
-                       <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                        <varRef name='Q{}submission-map' slot='1'/>
-                        <str val='@resource'/>
-                       </ifCall>
-                      </data>
-                     </cvUntyped>
-                    </check>
-                   </treat>
-                   <sequence line='4322'>
-                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}schedule-action' type='item()*'>
-                     <int val='0'/>
-                     <empty/>
-                     <callT name='Q{}HTTPsubmit' bSlot='5'>
-                      <withParam name='Q{}instance-id' flags='c' as='xs:string'>
-                       <varRef line='4323' name='Q{}instance-id' slot='4'/>
-                      </withParam>
-                      <withParam name='Q{}targetref' flags='c' as='xs:string?'>
-                       <treat line='4324' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|targetref'>
-                        <check card='?' diag='8|0|XTTE0590|targetref'>
-                         <cvUntyped to='xs:string' diag='8|0|XTTE0590|targetref'>
-                          <data>
-                           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                            <varRef name='Q{}submission-map' slot='1'/>
-                            <str val='@targetref'/>
-                           </ifCall>
-                          </data>
-                         </cvUntyped>
-                        </check>
-                       </treat>
-                      </withParam>
-                      <withParam name='Q{}replace' flags='c' as='xs:string?'>
-                       <treat line='4325' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|replace'>
-                        <check card='?' diag='8|0|XTTE0590|replace'>
-                         <cvUntyped to='xs:string' diag='8|0|XTTE0590|replace'>
-                          <data>
-                           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                            <varRef name='Q{}submission-map' slot='1'/>
-                            <str val='@replace'/>
-                           </ifCall>
-                          </data>
-                         </cvUntyped>
-                        </check>
-                       </treat>
-                      </withParam>
-                     </callT>
-                     <ifCall line='4309' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+                   </choose>
+                   <let line='4346' var='Q{}href-base' as='xs:string' slot='14' eval='16'>
+                    <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|href-base'>
+                     <check card='1' diag='3|0|XTTE0570|href-base'>
+                      <cvUntyped to='xs:string' diag='3|0|XTTE0570|href-base'>
+                       <data>
+                        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                         <varRef name='Q{}submission-map' slot='1'/>
+                         <str val='@resource'/>
+                        </ifCall>
+                       </data>
+                      </cvUntyped>
+                     </check>
+                    </treat>
+                    <let line='4362' var='Q{}HTTPrequest' as='map(xs:string, item())' slot='15' eval='8'>
+                     <ifCall line='4364' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
                       <sequence>
                        <choose>
                         <vc op='ne' onEmpty='1' comp='CCC'>
@@ -4306,37 +4460,37 @@
                          </fn>
                          <str val='GET'/>
                         </vc>
-                        <ifCall line='4310' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                        <ifCall line='4365' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                          <str val='body'/>
-                         <doc line='4266' validation='preserve'>
+                         <doc line='4321' validation='preserve'>
                           <doc flags='l'>
-                           <varRef line='4267' name='Q{}requestBodyXML' slot='9'/>
+                           <varRef line='4322' name='Q{}requestBodyXML' slot='9'/>
                           </doc>
                          </doc>
                         </ifCall>
                        </choose>
-                       <ifCall line='4312' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                       <ifCall line='4367' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                         <str val='method'/>
                         <varRef name='Q{}method' slot='10'/>
                        </ifCall>
-                       <ifCall line='4313' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                       <ifCall line='4368' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                         <str val='href'/>
-                        <choose line='4295'>
+                        <choose line='4350'>
                          <fn name='exists'>
                           <varRef name='Q{}query-parameters' slot='12'/>
                          </fn>
-                         <fn line='4296' name='concat'>
+                         <fn line='4351' name='concat'>
                           <varRef name='Q{}href-base' slot='14'/>
                           <str val='?'/>
                           <varRef name='Q{}query-parameters' slot='12'/>
                          </fn>
                          <true/>
-                         <varRef line='4299' name='Q{}href-base' slot='14'/>
+                         <varRef line='4354' name='Q{}href-base' slot='14'/>
                         </choose>
                        </ifCall>
-                       <ifCall line='4314' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                       <ifCall line='4369' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                         <str val='media-type'/>
-                        <treat line='4304' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|mediatype'>
+                        <treat line='4359' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|mediatype'>
                          <check card='1' diag='3|0|XTTE0570|mediatype'>
                           <cvUntyped to='xs:string' diag='3|0|XTTE0570|mediatype'>
                            <data>
@@ -4357,78 +4511,133 @@
                        <str val='XTDE3365'/>
                       </map>
                      </ifCall>
-                    </ifCall>
-                    <forEach line='4329'>
-                     <varRef name='Q{}actions' slot='2'/>
-                     <let line='4330' var='Q{}action-map' as='map(*)' slot='15' eval='16'>
-                      <dot type='map(*)'/>
-                      <choose line='4333'>
-                       <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
-                        <varRef name='Q{}action-map' slot='15'/>
-                        <str val='@event'/>
-                       </ifCall>
-                       <choose line='4334'>
-                        <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
-                         <data>
-                          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                           <varRef name='Q{}action-map' slot='15'/>
-                           <str val='@event'/>
-                          </ifCall>
-                         </data>
-                         <str val='xforms-submit-done'/>
-                        </gc>
-                        <callT line='4335' name='Q{}applyActions' bSlot='6' flags='t'>
-                         <withParam name='Q{}action-map' flags='t' as='item()'>
-                          <varRef line='4336' name='Q{}action-map' slot='15'/>
-                         </withParam>
-                         <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                          <check line='4337' card='1' diag='8|0|XTTE0590|nodeset'>
-                           <varRef name='Q{}refi' slot='3'/>
+                     <sequence line='4373'>
+                      <message>
+                       <sequence role='select'>
+                        <valueOf>
+                         <str val='[xforms-submit] Sending HTTP request &#39;'/>
+                        </valueOf>
+                        <fn name='serialize'>
+                         <varRef name='Q{}HTTPrequest' slot='15'/>
+                        </fn>
+                        <valueOf flags='S'>
+                         <str val='&#39;'/>
+                        </valueOf>
+                       </sequence>
+                       <str role='terminate' val='no'/>
+                       <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+                      </message>
+                      <ifCall line='4379' name='Q{http://saxonica.com/ns/interactiveXSLT}schedule-action' type='item()*'>
+                       <int val='0'/>
+                       <empty/>
+                       <callT name='Q{}HTTPsubmit' bSlot='5'>
+                        <withParam name='Q{}instance-id' flags='c' as='xs:string'>
+                         <varRef line='4380' name='Q{}instance-id' slot='4'/>
+                        </withParam>
+                        <withParam name='Q{}targetref' flags='c' as='xs:string?'>
+                         <treat line='4381' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|targetref'>
+                          <check card='?' diag='8|0|XTTE0590|targetref'>
+                           <cvUntyped to='xs:string' diag='8|0|XTTE0590|targetref'>
+                            <data>
+                             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                              <varRef name='Q{}submission-map' slot='1'/>
+                              <str val='@targetref'/>
+                             </ifCall>
+                            </data>
+                           </cvUntyped>
                           </check>
-                         </withParam>
-                         <withParam name='Q{}instanceXML' flags='t' as='element()'>
-                          <varRef line='4338' name='Q{}instanceXML' slot='5'/>
-                         </withParam>
-                        </callT>
-                       </choose>
-                      </choose>
-                     </let>
-                    </forEach>
-                   </sequence>
+                         </treat>
+                        </withParam>
+                        <withParam name='Q{}replace' flags='c' as='xs:string?'>
+                         <treat line='4382' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|replace'>
+                          <check card='?' diag='8|0|XTTE0590|replace'>
+                           <cvUntyped to='xs:string' diag='8|0|XTTE0590|replace'>
+                            <data>
+                             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                              <varRef name='Q{}submission-map' slot='1'/>
+                              <str val='@replace'/>
+                             </ifCall>
+                            </data>
+                           </cvUntyped>
+                          </check>
+                         </treat>
+                        </withParam>
+                       </callT>
+                       <varRef line='4376' name='Q{}HTTPrequest' slot='15'/>
+                      </ifCall>
+                      <forEach line='4386'>
+                       <varRef name='Q{}actions' slot='2'/>
+                       <let line='4387' var='Q{}action-map' as='map(*)' slot='16' eval='16'>
+                        <dot type='map(*)'/>
+                        <choose line='4390'>
+                         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+                          <varRef name='Q{}action-map' slot='16'/>
+                          <str val='@event'/>
+                         </ifCall>
+                         <choose line='4391'>
+                          <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+                           <data>
+                            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                             <varRef name='Q{}action-map' slot='16'/>
+                             <str val='@event'/>
+                            </ifCall>
+                           </data>
+                           <str val='xforms-submit-done'/>
+                          </gc>
+                          <callT line='4392' name='Q{}applyActions' bSlot='6' flags='t'>
+                           <withParam name='Q{}action-map' flags='t' as='item()'>
+                            <varRef line='4393' name='Q{}action-map' slot='16'/>
+                           </withParam>
+                           <withParam name='Q{}nodeset' flags='t' as='xs:string'>
+                            <check line='4394' card='1' diag='8|0|XTTE0590|nodeset'>
+                             <varRef name='Q{}refi' slot='3'/>
+                            </check>
+                           </withParam>
+                           <withParam name='Q{}instanceXML' flags='t' as='element()'>
+                            <varRef line='4395' name='Q{}instanceXML' slot='5'/>
+                           </withParam>
+                          </callT>
+                         </choose>
+                        </choose>
+                       </let>
+                      </forEach>
+                     </sequence>
+                    </let>
+                   </let>
                   </let>
                  </let>
                 </let>
                </let>
-              </let>
-              <true/>
-              <ifCall line='4351' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-               <check card='1' diag='0|0||ixsl:call'>
-                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-               </check>
-               <str val='alert'/>
-               <arrayBlock>
-                <fn name='serialize'>
-                 <doc line='4346' flags='t' validation='preserve'>
-                  <forEach>
-                   <varRef name='Q{}required-fields-check' slot='8'/>
-                   <valueOf line='4348' flags='l'>
-                    <fn name='concat'>
-                     <str val='Value error see: '/>
-                     <fn name='serialize'>
-                      <slash line='4347' simple='1'>
-                       <dot type='element()'/>
-                       <axis line='4348' name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
-                      </slash>
+               <true/>
+               <ifCall line='4408' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                <check card='1' diag='0|0||ixsl:call'>
+                 <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                </check>
+                <str val='alert'/>
+                <arrayBlock>
+                 <fn name='serialize'>
+                  <doc line='4403' flags='t' validation='preserve'>
+                   <forEach>
+                    <varRef name='Q{}required-fields-check' slot='8'/>
+                    <valueOf line='4405' flags='l'>
+                     <fn name='concat'>
+                      <str val='Value error see: '/>
+                      <fn name='serialize'>
+                       <slash line='4404' simple='1'>
+                        <dot type='element()'/>
+                        <axis line='4405' name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
+                       </slash>
+                      </fn>
+                      <str val='&#xA;'/>
                      </fn>
-                     <str val='&#xA;'/>
-                    </fn>
-                   </valueOf>
-                  </forEach>
-                 </doc>
-                </fn>
-               </arrayBlock>
-              </ifCall>
-             </choose>
+                    </valueOf>
+                   </forEach>
+                  </doc>
+                 </fn>
+                </arrayBlock>
+               </ifCall>
+              </choose>
+             </sequence>
             </let>
            </let>
           </let>
@@ -4441,9 +4650,9 @@
    </sequence>
   </template>
  </co>
- <co id='35' binds='2 54 50'>
-  <template name='Q{}xforms-rebuild' flags='os' line='4064' module='saxon-xforms.xsl' slots='2'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4065'>
+ <co id='37' binds='2 54 50'>
+  <template name='Q{}xforms-rebuild' flags='os' line='4100' module='saxon-xforms.xsl' slots='2'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4101'>
     <message>
      <valueOf role='select'>
       <str val='[xforms-rebuild] START'/>
@@ -4451,8 +4660,8 @@
      <str role='terminate' val='no'/>
      <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
     </message>
-    <let line='4066' var='Q{}instanceDocs' as='map(xs:anyAtomicType, element()?)' slot='0' eval='8'>
-     <let line='4067' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
+    <let line='4102' var='Q{}instanceDocs' as='map(xs:anyAtomicType, element()?)' slot='0' eval='8'>
+     <let line='4103' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -4460,15 +4669,15 @@
        <str val='getInstanceKeys'/>
        <array size='0'/>
       </ifCall>
-      <ifCall line='4069' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+      <ifCall line='4105' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
        <forEach>
         <varRef name='Q{}instance-keys' slot='1'/>
-        <ifCall line='4071' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+        <ifCall line='4107' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
          <atomSing diag='0|0||map:entry'>
           <dot/>
          </atomSing>
          <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='0' eval='16'>
-          <fn line='4070' name='concat'>
+          <fn line='4106' name='concat'>
            <str val='instance(&#39;'/>
            <atomSing card='?' diag='0|1||fn:concat'>
             <dot/>
@@ -4486,41 +4695,41 @@
        </map>
       </ifCall>
      </let>
-     <callT line='4076' name='Q{}xformsjs-main' bSlot='1' flags='t'>
+     <callT line='4112' name='Q{}xformsjs-main' bSlot='1' flags='t'>
       <withParam name='Q{}xforms-file' flags='c' as='xs:string?'>
-       <gVarRef line='4077' name='Q{}xforms-file' bSlot='2'/>
+       <gVarRef line='4113' name='Q{}xforms-file' bSlot='2'/>
       </withParam>
       <withParam name='Q{}instance-docs' flags='c' as='map(*)'>
-       <varRef line='4078' name='Q{}instanceDocs' slot='0'/>
+       <varRef line='4114' name='Q{}instanceDocs' slot='0'/>
       </withParam>
      </callT>
     </let>
    </sequence>
   </template>
  </co>
- <co id='32' binds=''>
+ <co id='34' binds=''>
   <mode name='Q{}set-field' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.25' seq='37' rank='0' minImp='0' slots='1' flags='s' line='2932' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='37' rank='0' minImp='0' slots='1' flags='s' line='2967' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:textarea' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;textarea&#39;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2933'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2968'>
      <param name='Q{}value' slot='0' flags='t'>
       <str role='select' val=''/>
       <supplied role='conversion' slot='0'/>
      </param>
-     <ifCall line='2935' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+     <ifCall line='2970' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
       <dot type='*:textarea'/>
       <str val='value'/>
      </ifCall>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='-0.25' seq='36' rank='0' minImp='0' slots='1' flags='s' line='2924' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='36' rank='0' minImp='0' slots='1' flags='s' line='2959' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:select' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;select&#39;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2925'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2960'>
      <param name='Q{}value' slot='0' flags='t'>
       <str role='select' val=''/>
       <supplied role='conversion' slot='0'/>
      </param>
-     <forEach line='2927'>
+     <forEach line='2962'>
       <filter flags='b'>
        <axis name='child' nodeTest='element(Q{}option)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;option&#39;;'/>
        <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
@@ -4530,7 +4739,7 @@
         <attVal name='Q{}value' chk='0'/>
        </gc>
       </filter>
-      <ifCall line='2928' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+      <ifCall line='2963' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
        <str val='selected'/>
        <true/>
        <dot type='element(Q{}option)'/>
@@ -4538,16 +4747,16 @@
      </forEach>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='-0.25' seq='35' rank='0' minImp='0' slots='1' flags='s' line='2903' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='35' rank='0' minImp='0' slots='1' flags='s' line='2938' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:input' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;input&#39;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2904'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2939'>
      <param name='Q{}value' slot='0' flags='t'>
       <str role='select' val=''/>
       <supplied role='conversion' slot='0'/>
      </param>
-     <forEach line='2907'>
+     <forEach line='2942'>
       <dot type='*:input'/>
-      <choose line='2909'>
+      <choose line='2944'>
        <and op='and'>
         <fn name='exists'>
          <axis name='attribute' nodeTest='attribute(Q{}type)' jsTest='return item.name===&#39;type&#39;'/>
@@ -4559,7 +4768,7 @@
          <str val='checkbox'/>
         </vc>
        </and>
-       <ifCall line='2910' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+       <ifCall line='2945' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
         <str val='checked'/>
         <choose>
          <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
@@ -4577,7 +4786,7 @@
         <dot type='*:input'/>
        </ifCall>
        <true/>
-       <ifCall line='2913' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+       <ifCall line='2948' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
         <str val='value'/>
         <check card='?' diag='0|1||ixsl:set-property'>
          <varRef name='Q{}value' slot='0'/>
@@ -4590,9 +4799,9 @@
    </templateRule>
   </mode>
  </co>
- <co id='49' binds='42'>
-  <template name='Q{}refreshElementsUsingIndexFunction-JS' flags='os' line='3597' module='saxon-xforms.xsl' slots='6'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3598'>
+ <co id='49' binds='44'>
+  <template name='Q{}refreshElementsUsingIndexFunction-JS' flags='os' line='3629' module='saxon-xforms.xsl' slots='6'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3630'>
     <message>
      <valueOf role='select'>
       <str val='[refreshElementsUsingIndexFunction-JS] START'/>
@@ -4600,7 +4809,7 @@
      <str role='terminate' val='no'/>
      <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
     </message>
-    <let line='3599' var='Q{}ElementsUsingIndexFunction-keys' as='item()?' slot='0' eval='8'>
+    <let line='3631' var='Q{}ElementsUsingIndexFunction-keys' as='item()?' slot='0' eval='8'>
      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
       <check card='1' diag='0|0||ixsl:call'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -4608,7 +4817,7 @@
       <str val='getElementsUsingIndexFunctionKeys'/>
       <array size='0'/>
      </ifCall>
-     <let line='3601' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
+     <let line='3633' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -4616,12 +4825,12 @@
        <str val='getInstanceKeys'/>
        <array size='0'/>
       </ifCall>
-      <let line='3602' var='Q{}instances' as='map(xs:string, element())' slot='2' eval='16'>
-       <treat line='3604' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances'>
+      <let line='3634' var='Q{}instances' as='map(xs:string, element())' slot='2' eval='16'>
+       <treat line='3636' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances'>
         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
          <forEach>
           <varRef name='Q{}instance-keys' slot='1'/>
-          <ifCall line='3605' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <ifCall line='3637' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
            <atomSing diag='0|0||map:entry'>
             <dot/>
            </atomSing>
@@ -4644,9 +4853,9 @@
          </map>
         </ifCall>
        </treat>
-       <forEach line='3610'>
+       <forEach line='3643'>
         <varRef name='Q{}ElementsUsingIndexFunction-keys' slot='0'/>
-        <let line='3611' var='Q{}this-key' as='xs:string' slot='3' eval='16'>
+        <let line='3644' var='Q{}this-key' as='xs:string' slot='3' eval='16'>
          <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|this-key'>
           <check card='1' diag='3|0|XTTE0570|this-key'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|this-key'>
@@ -4656,81 +4865,96 @@
            </cvUntyped>
           </check>
          </treat>
-         <let line='3612' var='Q{}this-element' as='element()' slot='4' eval='16'>
-          <treat as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|this-element'>
-           <check card='1' diag='3|0|XTTE0570|this-element'>
-            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-             <check card='1' diag='0|0||ixsl:call'>
-              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-             </check>
-             <str val='getElementUsingIndexFunction'/>
-             <arrayBlock>
-              <varRef name='Q{}this-key' slot='3'/>
-             </arrayBlock>
-            </ifCall>
-           </check>
-          </treat>
-          <let line='3613' var='Q{}this-element-refi' as='xs:string?' slot='5' eval='7'>
-           <choose line='3615'>
-            <fn name='exists'>
-             <slash simple='1'>
-              <varRef name='Q{}this-element' slot='4'/>
-              <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
-             </slash>
-            </fn>
-            <cvUntyped to='xs:string' diag='3|0|XTTE0570|this-element-refi'>
-             <data>
+         <sequence line='3646'>
+          <message>
+           <sequence role='select'>
+            <valueOf>
+             <str val='[refreshElementsUsingIndexFunction-JS] Refreshing item with key &#39;'/>
+            </valueOf>
+            <varRef name='Q{}this-key' slot='3'/>
+            <valueOf flags='S'>
+             <str val='&#39;'/>
+            </valueOf>
+           </sequence>
+           <str role='terminate' val='no'/>
+           <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+          </message>
+          <let line='3648' var='Q{}this-element' as='element()' slot='4' eval='16'>
+           <treat as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|this-element'>
+            <check card='1' diag='3|0|XTTE0570|this-element'>
+             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+              <check card='1' diag='0|0||ixsl:call'>
+               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+              </check>
+              <str val='getElementUsingIndexFunction'/>
+              <arrayBlock>
+               <varRef name='Q{}this-key' slot='3'/>
+              </arrayBlock>
+             </ifCall>
+            </check>
+           </treat>
+           <let line='3649' var='Q{}this-element-refi' as='xs:string?' slot='5' eval='7'>
+            <choose line='3651'>
+             <fn name='exists'>
               <slash simple='1'>
                <varRef name='Q{}this-element' slot='4'/>
                <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
               </slash>
-             </data>
-            </cvUntyped>
-            <fn line='3616' name='exists'>
-             <slash simple='1'>
-              <varRef name='Q{}this-element' slot='4'/>
-              <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
-             </slash>
-            </fn>
-            <cvUntyped line='3616' to='xs:string' diag='3|0|XTTE0570|this-element-refi'>
-             <data>
+             </fn>
+             <cvUntyped to='xs:string' diag='3|0|XTTE0570|this-element-refi'>
+              <data>
+               <slash simple='1'>
+                <varRef name='Q{}this-element' slot='4'/>
+                <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+               </slash>
+              </data>
+             </cvUntyped>
+             <fn line='3652' name='exists'>
               <slash simple='1'>
                <varRef name='Q{}this-element' slot='4'/>
                <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
               </slash>
-             </data>
-            </cvUntyped>
-           </choose>
-           <resultDoc line='3620' global='#&#xA;#Sat Feb 22 17:48:53 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sat Feb 22 17:48:53 GMT 2020&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xA;'>
-            <fn role='href' name='concat'>
-             <str val='#'/>
-             <varRef name='Q{}this-key' slot='3'/>
-            </fn>
-            <applyT role='content' line='3621' bSlot='0'>
-             <slash role='select' simple='1'>
-              <varRef name='Q{}this-element' slot='4'/>
-              <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-             </slash>
-             <withParam name='Q{}recalculate' as='xs:boolean'>
-              <true/>
-             </withParam>
-             <withParam name='Q{}instances' flags='t' as='map(xs:string, element())'>
-              <varRef line='3622' name='Q{}instances' slot='2'/>
-             </withParam>
-             <withParam name='Q{}nodeset' flags='t' as='xs:string?'>
-              <choose line='3623'>
-               <fn name='exists'>
-                <varRef name='Q{}this-element-refi' slot='5'/>
-               </fn>
-               <varRef name='Q{}this-element-refi' slot='5'/>
+             </fn>
+             <cvUntyped line='3652' to='xs:string' diag='3|0|XTTE0570|this-element-refi'>
+              <data>
+               <slash simple='1'>
+                <varRef name='Q{}this-element' slot='4'/>
+                <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+               </slash>
+              </data>
+             </cvUntyped>
+            </choose>
+            <resultDoc line='3656' global='#&#xA;#Sat Feb 22 22:54:41 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sat Feb 22 22:54:41 GMT 2020&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xA;'>
+             <fn role='href' name='concat'>
+              <str val='#'/>
+              <varRef name='Q{}this-key' slot='3'/>
+             </fn>
+             <applyT role='content' line='3657' bSlot='0'>
+              <slash role='select' simple='1'>
+               <varRef name='Q{}this-element' slot='4'/>
+               <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+              </slash>
+              <withParam name='Q{}recalculate' as='xs:boolean'>
                <true/>
-               <str val=''/>
-              </choose>
-             </withParam>
-            </applyT>
-           </resultDoc>
+              </withParam>
+              <withParam name='Q{}instances' flags='t' as='map(xs:string, element())'>
+               <varRef line='3658' name='Q{}instances' slot='2'/>
+              </withParam>
+              <withParam name='Q{}nodeset' flags='t' as='xs:string?'>
+               <choose line='3659'>
+                <fn name='exists'>
+                 <varRef name='Q{}this-element-refi' slot='5'/>
+                </fn>
+                <varRef name='Q{}this-element-refi' slot='5'/>
+                <true/>
+                <str val=''/>
+               </choose>
+              </withParam>
+             </applyT>
+            </resultDoc>
+           </let>
           </let>
-         </let>
+         </sequence>
         </let>
        </forEach>
       </let>
@@ -4770,25 +4994,25 @@
  </co>
  <co id='57' binds='57 3 57 57'>
   <mode name='Q{}binding-calculation' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='29' rank='0' minImp='0' slots='9' flags='s' line='2741' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='29' rank='0' minImp='0' slots='9' flags='s' line='2776' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2742'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2777'>
      <param name='Q{}curPath' slot='0'>
       <str role='select' val=''/>
       <supplied role='conversion' slot='0'/>
      </param>
-     <param line='2743' name='Q{}position' slot='1'>
+     <param line='2778' name='Q{}position' slot='1'>
       <int role='select' val='0'/>
       <supplied role='conversion' slot='1'/>
      </param>
-     <param line='2744' name='Q{}calculationMap' slot='2' flags='ti' as='map(xs:string, xs:string)'>
+     <param line='2779' name='Q{}calculationMap' slot='2' flags='ti' as='map(xs:string, xs:string)'>
       <treat role='conversion' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|calculationMap'>
        <check card='1' diag='8|0|XTTE0590|calculationMap'>
         <supplied slot='2'/>
        </check>
       </treat>
      </param>
-     <let line='2750' var='Q{}updatedPath' as='xs:string' slot='3' eval='16'>
+     <let line='2785' var='Q{}updatedPath' as='xs:string' slot='3' eval='16'>
       <choose>
        <gc op='&gt;' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
         <data>
@@ -4819,27 +5043,27 @@
         </fn>
        </fn>
       </choose>
-      <copy line='2755' flags='cin'>
+      <copy line='2790' flags='cin'>
        <sequence role='content'>
         <applyT mode='Q{}binding-calculation' bSlot='0'>
          <axis role='select' name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
          <withParam name='Q{}curPath' as='xs:string'>
-          <fn line='2756' name='concat'>
+          <fn line='2791' name='concat'>
            <varRef name='Q{}updatedPath' slot='3'/>
            <str val='/'/>
           </fn>
          </withParam>
         </applyT>
-        <choose line='2765'>
+        <choose line='2800'>
          <fn name='exists'>
           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
            <varRef name='Q{}calculationMap' slot='2'/>
            <varRef name='Q{}updatedPath' slot='3'/>
           </ifCall>
          </fn>
-         <evaluate line='2769' dxns=''>
+         <evaluate line='2804' dxns=''>
           <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='1' eval='16'>
-           <check line='2767' card='1' diag='3|0|XTTE0570|calculationXPath'>
+           <check line='2802' card='1' diag='3|0|XTTE0570|calculationXPath'>
             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
              <varRef name='Q{}calculationMap' slot='2'/>
              <varRef name='Q{}updatedPath' slot='3'/>
@@ -4853,7 +5077,7 @@
           <map role='wp' size='0'/>
          </evaluate>
          <true/>
-         <valueOf line='2779' flags='l'>
+         <valueOf line='2814' flags='l'>
           <fn name='normalize-space'>
            <fn name='string-join'>
             <data>
@@ -4864,13 +5088,13 @@
           </fn>
          </valueOf>
         </choose>
-        <forEachGroup line='2784' algorithm='by'>
+        <forEachGroup line='2819' algorithm='by'>
          <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
          <fn role='key' name='local-name'>
           <dot type='element()'/>
          </fn>
          <str role='collation' val='http://www.w3.org/2005/xpath-functions/collation/codepoint'/>
-         <let role='content' line='2786' var='Q{}updatedChildPath' as='xs:string' slot='4' eval='8'>
+         <let role='content' line='2821' var='Q{}updatedChildPath' as='xs:string' slot='4' eval='8'>
           <fn name='concat'>
            <varRef name='Q{}updatedPath' slot='3'/>
            <str val='/'/>
@@ -4878,7 +5102,7 @@
             <currentGroupingKey/>
            </check>
           </fn>
-          <let line='2791' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='5' eval='13'>
+          <let line='2826' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='5' eval='13'>
            <fn name='concat'>
             <varRef name='Q{}updatedChildPath' slot='4'/>
             <str val='['/>
@@ -4896,7 +5120,7 @@
               <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='5'/>
              </fn>
             </filter>
-            <choose line='2794'>
+            <choose line='2829'>
              <or op='or'>
               <fn name='exists'>
                <tail start='2'>
@@ -4907,36 +5131,36 @@
                <varRef name='Q{}dataRefWithFilter' slot='6'/>
               </fn>
              </or>
-             <let line='2797' var='Q{http://saxon.sf.net/generated-variable}v1' as='xs:string' slot='7' eval='13'>
+             <let line='2832' var='Q{http://saxon.sf.net/generated-variable}v1' as='xs:string' slot='7' eval='13'>
               <fn name='concat'>
                <varRef name='Q{}updatedPath' slot='3'/>
                <str val='/'/>
               </fn>
-              <forEach line='2795'>
+              <forEach line='2830'>
                <currentGroup/>
-               <applyT line='2796' mode='Q{}binding-calculation' bSlot='2'>
+               <applyT line='2831' mode='Q{}binding-calculation' bSlot='2'>
                 <dot role='select'/>
                 <withParam name='Q{}curPath' as='xs:string'>
-                 <varRef line='2797' name='Q{http://saxon.sf.net/generated-variable}v1' slot='7'/>
+                 <varRef line='2832' name='Q{http://saxon.sf.net/generated-variable}v1' slot='7'/>
                 </withParam>
                 <withParam name='Q{}position' as='xs:integer'>
-                 <fn line='2798' name='position'/>
+                 <fn line='2833' name='position'/>
                 </withParam>
                </applyT>
               </forEach>
              </let>
              <true/>
-             <let line='2806' var='Q{http://saxon.sf.net/generated-variable}v2' as='xs:string' slot='8' eval='13'>
+             <let line='2841' var='Q{http://saxon.sf.net/generated-variable}v2' as='xs:string' slot='8' eval='13'>
               <fn name='concat'>
                <varRef name='Q{}updatedPath' slot='3'/>
                <str val='/'/>
               </fn>
-              <forEach line='2804'>
+              <forEach line='2839'>
                <currentGroup/>
-               <applyT line='2805' mode='Q{}binding-calculation' bSlot='3'>
+               <applyT line='2840' mode='Q{}binding-calculation' bSlot='3'>
                 <dot role='select'/>
                 <withParam name='Q{}curPath' as='xs:string'>
-                 <varRef line='2806' name='Q{http://saxon.sf.net/generated-variable}v2' slot='8'/>
+                 <varRef line='2841' name='Q{http://saxon.sf.net/generated-variable}v2' slot='8'/>
                 </withParam>
                </applyT>
               </forEach>
@@ -5028,18 +5252,10 @@
    </sequence>
   </globalVariable>
  </co>
- <co id='45' binds='43'>
-  <globalVariable name='Q{http://saxon.sf.net/generated-variable}gg893415836' type='element()*' line='4179' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='function test(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};if (test(val)) {return val;} else {throw SaxonJS.XError(&#39;Conversion failed&#39;, &#39;XTTE0590&#39;);}' jsCardCheck='function c() {return true;};'>
-   <slash ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4179' simple='1'>
-    <gVarRef name='Q{}xforms-doc' bSlot='0'/>
-    <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-   </slash>
-  </globalVariable>
- </co>
  <co id='52' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}check-required-fields' line='934' module='saxon-xforms.xsl' eval='8' flags='pU' as='item()*' slots='3'>
+  <function name='Q{http://www.w3.org/2002/xforms}check-required-fields' line='935' module='saxon-xforms.xsl' eval='8' flags='pU' as='item()*' slots='3'>
    <arg name='Q{}instanceXML' as='element()'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='937' var='Q{}required-fieldsi' as='element()*' slot='1' eval='8'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='938' var='Q{}required-fieldsi' as='element()*' slot='1' eval='8'>
     <filter flags='b'>
      <slash simple='1'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
@@ -5049,10 +5265,10 @@
       <axis name='attribute' nodeTest='attribute(Q{}data-required)' jsTest='return item.name===&#39;data-required&#39;'/>
      </fn>
     </filter>
-    <forEach line='939'>
+    <forEach line='940'>
      <varRef name='Q{}required-fieldsi' slot='1'/>
-     <let line='941' var='Q{}resulti' as='document-node()' slot='2' eval='16'>
-      <doc line='944' validation='preserve'>
+     <let line='942' var='Q{}resulti' as='document-node()' slot='2' eval='16'>
+      <doc line='945' validation='preserve'>
        <evaluate dxns=''>
         <fn role='xpath' name='concat'>
          <str val='boolean(normalize-space('/>
@@ -5070,7 +5286,7 @@
         <map role='wp' size='0'/>
        </evaluate>
       </doc>
-      <choose line='950'>
+      <choose line='951'>
        <vc op='eq' onEmpty='0' comp='CCC'>
         <cast as='xs:string' emptiable='0'>
          <data>
@@ -5087,14 +5303,14 @@
   </function>
  </co>
  <co id='60' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}logToPage' line='3015' module='saxon-xforms.xsl' eval='7' flags='pU' as='empty-sequence()' slots='1'>
+  <function name='Q{http://www.w3.org/2002/xforms}logToPage' line='3050' module='saxon-xforms.xsl' eval='7' flags='pU' as='empty-sequence()' slots='1'>
    <arg name='Q{}message' as='xs:string'/>
    <check role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='-1' card='°' diag='5|0|XTTE0780|xforms:logToPage#1'>
     <error message='Call to xsl:result-document while in temporary output state' code='XTDE1480' isTypeErr='1'/>
    </check>
   </function>
  </co>
- <co id='27' binds=''>
+ <co id='29' binds=''>
   <function name='Q{http://www.w3.org/2002/xforms}index' line='97' module='xforms-function-library.xsl' eval='16' flags='pU' as='xs:integer' slots='2'>
    <arg name='Q{}repeatID' as='xs:string'/>
    <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='101' var='Q{}repeat-index' as='xs:double?' slot='1' eval='7'>
@@ -5132,9 +5348,9 @@
  </co>
  <co id='9' binds='9'>
   <mode name='Q{}delete-node' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='22' rank='0' minImp='0' slots='1' flags='s' line='1936' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='22' rank='0' minImp='0' slots='1' flags='s' line='1942' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1937'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1943'>
      <param name='Q{}delete-node' slot='0' flags='ti' as='node()'>
       <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|delete-node'>
        <check card='1' diag='8|0|XTTE0590|delete-node'>
@@ -5142,19 +5358,19 @@
        </check>
       </treat>
      </param>
-     <choose line='1940'>
+     <choose line='1946'>
       <is op='is'>
        <dot type='element()'/>
        <varRef name='Q{}delete-node' slot='0'/>
       </is>
       <empty/>
       <true/>
-      <copy line='1954' flags='cin'>
+      <copy line='1960' flags='cin'>
        <sequence role='content'>
         <copyOf flags='vc'>
          <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
         </copyOf>
-        <applyT line='1955' mode='Q{}delete-node' bSlot='0'>
+        <applyT line='1961' mode='Q{}delete-node' bSlot='0'>
          <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
         </applyT>
        </sequence>
@@ -5166,16 +5382,16 @@
  </co>
  <co id='15' binds=''>
   <mode name='Q{}get-field' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.25' seq='34' rank='0' minImp='0' slots='0' flags='s' line='2896' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='34' rank='0' minImp='0' slots='0' flags='s' line='2931' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:textarea' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;textarea&#39;'/>
-    <ifCall role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2899' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+    <ifCall role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2934' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
      <dot type='*:textarea'/>
      <str val='value'/>
     </ifCall>
    </templateRule>
-   <templateRule prec='0' prio='-0.25' seq='33' rank='0' minImp='0' slots='0' flags='s' line='2891' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='33' rank='0' minImp='0' slots='0' flags='s' line='2926' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:select' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;select&#39;'/>
-    <ifCall role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2893' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+    <ifCall role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2928' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
      <check card='?' diag='0|0||ixsl:get'>
       <filter flags='b'>
        <axis name='child' nodeTest='element(Q{}option)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;option&#39;;'/>
@@ -5193,9 +5409,9 @@
      <str val='value'/>
     </ifCall>
    </templateRule>
-   <templateRule prec='0' prio='-0.25' seq='32' rank='0' minImp='0' slots='0' flags='s' line='2877' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='32' rank='0' minImp='0' slots='0' flags='s' line='2912' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:input' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;input&#39;'/>
-    <choose role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2881'>
+    <choose role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2916'>
      <and op='and'>
       <fn name='exists'>
        <axis name='attribute' nodeTest='attribute(Q{}type)' jsTest='return item.name===&#39;type&#39;'/>
@@ -5207,12 +5423,12 @@
        <str val='checkbox'/>
       </vc>
      </and>
-     <ifCall line='2882' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+     <ifCall line='2917' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
       <dot type='*:input'/>
       <str val='checked'/>
      </ifCall>
      <true/>
-     <ifCall line='2885' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+     <ifCall line='2920' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
       <dot type='*:input'/>
       <str val='value'/>
      </ifCall>
@@ -5220,23 +5436,23 @@
    </templateRule>
   </mode>
  </co>
- <co id='42' binds='54 46 61 62 63 21 64 42 42 62 63 21 42 42 42 62 63 21 3 3 42 42 42 42 62 63 21 3 64 42 62 63 21 64 62 63 64 42 42'>
+ <co id='44' binds='54 46 61 62 63 23 64 44 44 62 63 23 44 44 44 62 63 23 3 3 44 44 44 44 62 63 23 3 64 44 62 63 23 64 62 63 64 44 44'>
   <mode onNo='TC' flags='dW' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='7' rank='0' minImp='0' slots='0' flags='s' line='1088' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='7' rank='0' minImp='0' slots='0' flags='s' line='1089' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='document-node()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);'/>
-    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1089' name='Q{}xformsjs-main' bSlot='0' flags='t'>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1090' name='Q{}xformsjs-main' bSlot='0' flags='t'>
      <withParam name='Q{}xforms-doc' flags='c' as='document-node()'>
-      <dot line='1090' type='document-node()'/>
+      <dot line='1091' type='document-node()'/>
      </withParam>
      <withParam name='Q{}xFormsId' flags='c' as='xs:string'>
-      <gVarRef line='1091' name='Q{}xform-html-id' bSlot='1'/>
+      <gVarRef line='1092' name='Q{}xform-html-id' bSlot='1'/>
      </withParam>
     </callT>
    </templateRule>
-   <templateRule prec='0' prio='0.5' seq='25' part='1' rank='2' minImp='0' slots='1' flags='s' line='2111' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.5' seq='25' part='1' rank='2' minImp='0' slots='1' flags='s' line='2117' module='saxon-xforms.xsl'>
     <p.withPredicate role='match'>
      <p.nodeTest test='Q{http://www.w3.org/2002/xforms}*' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.uri===&#39;http://www.w3.org/2002/xforms&#39;'/>
-     <gc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2111' op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+     <gc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2117' op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
       <literal count='15'>
        <str val='setvalue'/>
        <str val='insert'/>
@@ -5259,22 +5475,22 @@
       </fn>
      </gc>
     </p.withPredicate>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2117' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2118' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2123' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2124' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
       <check card='1' diag='3|0|XTTE0570|action-map'>
        <callT name='Q{}setAction' bSlot='2'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2119' type='element()'/>
+         <dot line='2125' type='element()'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <varRef line='2132' name='Q{}action-map' slot='0'/>
+     <varRef line='2138' name='Q{}action-map' slot='0'/>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='13' part='1' rank='1' minImp='0' slots='12' flags='s' line='1537' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='13' part='1' rank='1' minImp='0' slots='12' flags='s' line='1538' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}select)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;select&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1538'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1539'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -5287,7 +5503,7 @@
        </check>
       </treat>
      </param>
-     <param line='1539' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1540' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -5299,7 +5515,7 @@
        </check>
       </treat>
      </param>
-     <let line='1543' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='1544' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -5315,7 +5531,7 @@
          <dot type='element()'/>
         </fn>
         <str val='-'/>
-        <choose line='1541'>
+        <choose line='1542'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -5325,13 +5541,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1545'>
+      <sequence line='1546'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element()' slot='3' eval='16'>
           <dot type='element()'/>
-          <fn line='2990' name='exists'>
-           <sequence line='2965'>
+          <fn line='3025' name='exists'>
+           <sequence line='3000'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -5343,7 +5559,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2968'>
+             <choose role='matching' line='3003'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -5355,7 +5571,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='2977'>
+            <analyzeString line='3012'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -5366,7 +5582,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2980'>
+             <choose role='matching' line='3015'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -5389,8 +5605,8 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='2990' name='exists'>
-             <sequence line='2965'>
+            <fn line='3025' name='exists'>
+             <sequence line='3000'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
@@ -5402,7 +5618,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2968'>
+               <choose role='matching' line='3003'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -5414,7 +5630,7 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
-              <analyzeString line='2977'>
+              <analyzeString line='3012'>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
@@ -5425,7 +5641,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2980'>
+               <choose role='matching' line='3015'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -5443,7 +5659,7 @@
           </filter>
          </fn>
         </and>
-        <ifCall line='1546' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1547' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -5454,60 +5670,60 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1553' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='1554' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='1554' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1555' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
           <callT name='Q{}getBinding' bSlot='3'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='1555' type='element()'/>
+            <dot line='1556' type='element()'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='1560' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='1561' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='1561' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1562' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
              <callT name='Q{}getDataRef' bSlot='4'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='1562' type='element()'/>
+               <dot line='1563' type='element()'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='1563' name='Q{}bindingi' slot='5'/>
+               <varRef line='1564' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='1568' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
-          <treat line='1569' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+         <let line='1569' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
+          <treat line='1570' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
            <check card='?' diag='3|0|XTTE0570|instanceField'>
             <callT name='Q{}getReferencedInstanceField' bSlot='5'>
              <withParam name='Q{}refi' flags='c' as='xs:string'>
-              <varRef line='1570' name='Q{}refi' slot='6'/>
+              <varRef line='1571' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </check>
           </treat>
-          <let line='1575' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
-           <treat line='1576' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+          <let line='1576' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
+           <treat line='1577' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
             <callT name='Q{}setActions' bSlot='6'>
              <withParam name='Q{}this' flags='c' as='element()'>
-              <dot line='1577' type='element()'/>
+              <dot line='1578' type='element()'/>
              </withParam>
              <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-              <varRef line='1578' name='Q{}refi' slot='6'/>
+              <varRef line='1579' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </treat>
-           <sequence line='1582'>
+           <sequence line='1583'>
             <choose>
              <fn name='exists'>
               <varRef name='Q{}actions' slot='8'/>
              </fn>
-             <ifCall line='1583' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+             <ifCall line='1584' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
               <check card='1' diag='0|0||ixsl:call'>
                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
               </check>
@@ -5518,27 +5734,27 @@
               </arrayBlock>
              </ifCall>
             </choose>
-            <elem line='1600' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+            <elem line='1601' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
              <sequence>
               <att name='class' flags='l'>
                <str val='xforms-select'/>
               </att>
-              <applyT line='1601' bSlot='7'>
+              <applyT line='1602' bSlot='7'>
                <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
               </applyT>
-              <elem line='1603' name='select' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-               <sequence line='1604'>
+              <elem line='1604' name='select' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+               <sequence line='1605'>
                 <let var='Q{}element' as='element()' slot='9' eval='16'>
                  <dot type='element()'/>
-                 <let line='3056' var='Q{}class' as='xs:string?' slot='10' eval='7'>
-                  <choose line='3057'>
+                 <let line='3091' var='Q{}class' as='xs:string?' slot='10' eval='7'>
+                  <choose line='3092'>
                    <fn name='exists'>
                     <slash simple='1'>
                      <varRef name='Q{}element' slot='9'/>
                      <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
                     </slash>
                    </fn>
-                   <cvUntyped line='3058' to='xs:string' diag='3|0|XTTE0570|class'>
+                   <cvUntyped line='3093' to='xs:string' diag='3|0|XTTE0570|class'>
                     <cast as='xs:untypedAtomic' emptiable='0'>
                      <fn name='string'>
                       <convert from='xs:untypedAtomic' to='xs:string'>
@@ -5553,15 +5769,15 @@
                     </cast>
                    </cvUntyped>
                   </choose>
-                  <let line='3061' var='Q{}class-mod' as='xs:string?' slot='11' eval='7'>
-                   <choose line='3063'>
+                  <let line='3096' var='Q{}class-mod' as='xs:string?' slot='11' eval='7'>
+                   <choose line='3098'>
                     <fn name='exists'>
                      <slash simple='1'>
                       <varRef name='Q{}element' slot='9'/>
                       <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
                      </slash>
                     </fn>
-                    <cvUntyped line='3064' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                    <cvUntyped line='3099' to='xs:string' diag='3|0|XTTE0570|class-mod'>
                      <cast as='xs:untypedAtomic' emptiable='0'>
                       <fn name='string-join'>
                        <sequence>
@@ -5573,13 +5789,13 @@
                      </cast>
                     </cvUntyped>
                     <true/>
-                    <varRef line='3067' name='Q{}class' slot='10'/>
+                    <varRef line='3102' name='Q{}class' slot='10'/>
                    </choose>
-                   <choose line='3071'>
+                   <choose line='3106'>
                     <fn name='exists'>
                      <varRef name='Q{}class-mod' slot='11'/>
                     </fn>
-                    <treat line='3072' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                    <treat line='3107' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
                      <att name='class' flags='l'>
                       <varRef name='Q{}class-mod' slot='11'/>
                      </att>
@@ -5588,7 +5804,7 @@
                   </let>
                  </let>
                 </let>
-                <copyOf line='1605' flags='vc'>
+                <copyOf line='1606' flags='vc'>
                  <except op='except'>
                   <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
                   <docOrder intra='1'>
@@ -5600,11 +5816,11 @@
                   </docOrder>
                  </except>
                 </copyOf>
-                <att line='1607' name='data-ref' flags='l'>
+                <att line='1608' name='data-ref' flags='l'>
                  <varRef name='Q{}refi' slot='6'/>
                 </att>
-                <att line='1608' name='data-element' flags='l'>
-                 <lastOf line='1598'>
+                <att line='1609' name='data-element' flags='l'>
+                 <lastOf line='1599'>
                   <fn name='tokenize'>
                    <varRef name='Q{}refi' slot='6'/>
                    <str val='/'/>
@@ -5612,7 +5828,7 @@
                   </fn>
                  </lastOf>
                 </att>
-                <choose line='1610'>
+                <choose line='1611'>
                  <and op='and'>
                   <fn name='exists'>
                    <varRef name='Q{}bindingi' slot='5'/>
@@ -5624,7 +5840,7 @@
                    </slash>
                   </fn>
                  </and>
-                 <att line='1611' name='data-constraint' flags='l'>
+                 <att line='1612' name='data-constraint' flags='l'>
                   <convert from='xs:untypedAtomic' to='xs:string'>
                    <data>
                     <slash simple='1'>
@@ -5635,19 +5851,19 @@
                   </convert>
                  </att>
                 </choose>
-                <choose line='1614'>
+                <choose line='1615'>
                  <vc op='eq' onEmpty='0' comp='CCC'>
                   <fn name='local-name'>
                    <dot type='element()'/>
                   </fn>
                   <str val='select'/>
                  </vc>
-                 <sequence line='1615'>
+                 <sequence line='1616'>
                   <att name='multiple' flags='l'>
                    <str val='true'/>
                   </att>
-                  <att line='1616' name='size' flags='l'>
-                   <convert line='1617' from='xs:integer' to='xs:string'>
+                  <att line='1617' name='size' flags='l'>
+                   <convert line='1618' from='xs:integer' to='xs:string'>
                     <fn name='count'>
                      <axis name='descendant' nodeTest='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
                     </fn>
@@ -5655,22 +5871,22 @@
                   </att>
                  </sequence>
                 </choose>
-                <choose line='1620'>
+                <choose line='1621'>
                  <fn name='exists'>
                   <varRef name='Q{}actions' slot='8'/>
                  </fn>
-                 <att line='1621' name='data-action' flags='l'>
+                 <att line='1622' name='data-action' flags='l'>
                   <varRef name='Q{}myid' slot='2'/>
                  </att>
                 </choose>
-                <applyT line='1624' bSlot='8'>
+                <applyT line='1625' bSlot='8'>
                  <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
                  <withParam name='Q{}selectedValue' as='xs:string'>
-                  <choose line='1589'>
+                  <choose line='1590'>
                    <fn name='exists'>
                     <varRef name='Q{}instanceField' slot='7'/>
                    </fn>
-                   <cvUntyped line='1590' to='xs:string' diag='3|0|XTTE0570|selectedValue'>
+                   <cvUntyped line='1591' to='xs:string' diag='3|0|XTTE0570|selectedValue'>
                     <cast as='xs:untypedAtomic' emptiable='0'>
                      <fn name='string'>
                       <convert from='xs:anyAtomicType' to='xs:string'>
@@ -5699,24 +5915,24 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='25' rank='1' minImp='0' slots='1' flags='s' line='2111' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='25' rank='1' minImp='0' slots='1' flags='s' line='2117' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}action)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;action&#39;;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2117' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2118' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2123' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2124' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
       <check card='1' diag='3|0|XTTE0570|action-map'>
        <callT name='Q{}setAction' bSlot='2'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2119' type='element()'/>
+         <dot line='2125' type='element()'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <varRef line='2132' name='Q{}action-map' slot='0'/>
+     <varRef line='2138' name='Q{}action-map' slot='0'/>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='19' rank='1' minImp='0' slots='15' flags='s' line='1745' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='19' rank='1' minImp='0' slots='15' flags='s' line='1746' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1746'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1747'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -5729,7 +5945,7 @@
        </check>
       </treat>
      </param>
-     <param line='1747' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1748' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -5741,7 +5957,7 @@
        </check>
       </treat>
      </param>
-     <param line='1748' name='Q{}recalculate' slot='2' as='xs:boolean'>
+     <param line='1749' name='Q{}recalculate' slot='2' as='xs:boolean'>
       <false role='select'/>
       <treat role='conversion' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='8|0|XTTE0590|recalculate'>
        <check card='1' diag='8|0|XTTE0590|recalculate'>
@@ -5753,7 +5969,7 @@
        </check>
       </treat>
      </param>
-     <param line='1749' name='Q{}refreshRepeats' slot='3' as='xs:boolean'>
+     <param line='1750' name='Q{}refreshRepeats' slot='3' as='xs:boolean'>
       <false role='select'/>
       <treat role='conversion' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='8|0|XTTE0590|refreshRepeats'>
        <check card='1' diag='8|0|XTTE0590|refreshRepeats'>
@@ -5765,7 +5981,7 @@
        </check>
       </treat>
      </param>
-     <let line='1753' var='Q{}myid' as='xs:string' slot='4' eval='16'>
+     <let line='1754' var='Q{}myid' as='xs:string' slot='4' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -5781,7 +5997,7 @@
          <dot type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
         </fn>
         <str val='-'/>
-        <choose line='1751'>
+        <choose line='1752'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -5791,27 +6007,27 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1760'>
+      <sequence line='1761'>
        <choose>
         <fn name='not'>
          <varRef name='Q{}recalculate' slot='2'/>
         </fn>
-        <ifCall line='1776' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1777' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
          <str val='setRepeatIndex'/>
          <arrayBlock>
           <varRef name='Q{}myid' slot='4'/>
-          <choose line='1763'>
+          <choose line='1764'>
            <fn name='empty'>
             <axis name='attribute' nodeTest='attribute(Q{}startindex)' jsTest='return item.name===&#39;startindex&#39;'/>
            </fn>
            <dbl val='1'/>
-           <castable line='1766' as='xs:double' emptiable='0'>
+           <castable line='1767' as='xs:double' emptiable='0'>
             <axis name='attribute' nodeTest='attribute(Q{}startindex)' jsTest='return item.name===&#39;startindex&#39;'/>
            </castable>
-           <cvUntyped line='1767' to='xs:double' diag='3|0|XTTE0570|this-index'>
+           <cvUntyped line='1768' to='xs:double' diag='3|0|XTTE0570|this-index'>
             <convert from='xs:double' to='xs:untypedAtomic'>
              <fn name='number'>
               <attVal name='Q{}startindex' chk='0'/>
@@ -5819,7 +6035,7 @@
             </convert>
            </cvUntyped>
            <true/>
-           <check line='1770' card='1' diag='3|0|XTTE0570|this-index'>
+           <check line='1771' card='1' diag='3|0|XTTE0570|this-index'>
             <sequence>
              <convert from='xs:anyAtomicType' to='xs:double' flags='p' diag='3|0|XTTE0570|this-index'>
               <cvUntyped to='xs:double' diag='3|0|XTTE0570|this-index'>
@@ -5851,67 +6067,67 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1783' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='1784' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='1784' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1785' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
           <callT name='Q{}getBinding' bSlot='9'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='1785' type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
+            <dot line='1786' type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='1790' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='1791' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='1791' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1792' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
              <callT name='Q{}getDataRef' bSlot='10'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='1792' type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
+               <dot line='1793' type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='1793' name='Q{}bindingi' slot='5'/>
+               <varRef line='1794' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='1799' var='Q{}selectedRepeatVar' as='element()*' slot='7' eval='8'>
-          <treat line='1801' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|selectedRepeatVar'>
+         <let line='1800' var='Q{}selectedRepeatVar' as='element()*' slot='7' eval='8'>
+          <treat line='1802' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|selectedRepeatVar'>
            <callT name='Q{}getReferencedInstanceField' bSlot='11'>
             <withParam name='Q{}refi' flags='c' as='xs:string'>
-             <varRef line='1802' name='Q{}refi' slot='6'/>
+             <varRef line='1803' name='Q{}refi' slot='6'/>
             </withParam>
            </callT>
           </treat>
-          <let line='1817' var='Q{}repeat-items' as='element(Q{}div, Q{http://www.w3.org/2001/XMLSchema}untyped)*' slot='8' eval='3'>
-           <let line='1818' var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}repeat)' slot='9' eval='16'>
+          <let line='1818' var='Q{}repeat-items' as='element(Q{}div, Q{http://www.w3.org/2001/XMLSchema}untyped)*' slot='8' eval='3'>
+           <let line='1819' var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}repeat)' slot='9' eval='16'>
             <dot type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
-            <let line='1823' var='Q{http://saxon.sf.net/generated-variable}v0' as='element()*' slot='10' eval='4'>
+            <let line='1824' var='Q{http://saxon.sf.net/generated-variable}v0' as='element()*' slot='10' eval='4'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='9'/>
               <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
              </slash>
-             <forEach line='1819'>
+             <forEach line='1820'>
               <varRef name='Q{}selectedRepeatVar' slot='7'/>
-              <let line='1820' var='Q{}string-position' as='xs:string' slot='11' eval='8'>
+              <let line='1821' var='Q{}string-position' as='xs:string' slot='11' eval='8'>
                <fn name='string'>
                 <fn name='position'/>
                </fn>
-               <elem line='1822' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+               <elem line='1823' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
                 <sequence>
                  <att name='data-repeat-item' flags='l'>
                   <str val='true'/>
                  </att>
-                 <applyT line='1823' bSlot='12'>
+                 <applyT line='1824' bSlot='12'>
                   <varRef role='select' name='Q{http://saxon.sf.net/generated-variable}v0' slot='10'/>
                   <withParam name='Q{}position' as='xs:integer'>
-                   <fn line='1825' name='position'/>
+                   <fn line='1826' name='position'/>
                   </withParam>
                   <withParam name='Q{}context-position' as='xs:string'>
-                   <choose line='1821'>
+                   <choose line='1822'>
                     <varRef name='Q{}context-position' slot='1'/>
                     <fn name='concat'>
                      <varRef name='Q{}context-position' slot='1'/>
@@ -5923,7 +6139,7 @@
                    </choose>
                   </withParam>
                   <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                   <fn line='1824' name='concat'>
+                   <fn line='1825' name='concat'>
                     <varRef name='Q{}refi' slot='6'/>
                     <str val='['/>
                     <fn name='position'/>
@@ -5937,24 +6153,24 @@
              </forEach>
             </let>
            </let>
-           <sequence line='1834'>
+           <sequence line='1835'>
             <choose>
              <varRef name='Q{}refreshRepeats' slot='3'/>
-             <varRef line='1835' name='Q{}repeat-items' slot='8'/>
+             <varRef line='1836' name='Q{}repeat-items' slot='8'/>
              <true/>
-             <elem line='1838' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-              <sequence line='1839'>
+             <elem line='1839' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+              <sequence line='1840'>
                <let var='Q{}element' as='element(Q{http://www.w3.org/2002/xforms}repeat)' slot='12' eval='16'>
                 <dot type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
-                <let line='3056' var='Q{}class' as='xs:string?' slot='13' eval='7'>
-                 <choose line='3057'>
+                <let line='3091' var='Q{}class' as='xs:string?' slot='13' eval='7'>
+                 <choose line='3092'>
                   <fn name='exists'>
                    <slash simple='1'>
                     <varRef name='Q{}element' slot='12'/>
                     <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
                    </slash>
                   </fn>
-                  <cvUntyped line='3058' to='xs:string' diag='3|0|XTTE0570|class'>
+                  <cvUntyped line='3093' to='xs:string' diag='3|0|XTTE0570|class'>
                    <cast as='xs:untypedAtomic' emptiable='0'>
                     <fn name='string'>
                      <convert from='xs:untypedAtomic' to='xs:string'>
@@ -5969,15 +6185,15 @@
                    </cast>
                   </cvUntyped>
                  </choose>
-                 <let line='3061' var='Q{}class-mod' as='xs:string?' slot='14' eval='7'>
-                  <choose line='3063'>
+                 <let line='3096' var='Q{}class-mod' as='xs:string?' slot='14' eval='7'>
+                  <choose line='3098'>
                    <fn name='exists'>
                     <slash simple='1'>
                      <varRef name='Q{}element' slot='12'/>
                      <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
                     </slash>
                    </fn>
-                   <cvUntyped line='3064' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                   <cvUntyped line='3099' to='xs:string' diag='3|0|XTTE0570|class-mod'>
                     <cast as='xs:untypedAtomic' emptiable='0'>
                      <fn name='string-join'>
                       <sequence>
@@ -5989,13 +6205,13 @@
                     </cast>
                    </cvUntyped>
                    <true/>
-                   <varRef line='3067' name='Q{}class' slot='13'/>
+                   <varRef line='3102' name='Q{}class' slot='13'/>
                   </choose>
-                  <choose line='3071'>
+                  <choose line='3106'>
                    <fn name='exists'>
                     <varRef name='Q{}class-mod' slot='14'/>
                    </fn>
-                   <treat line='3072' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                   <treat line='3107' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
                     <att name='class' flags='l'>
                      <varRef name='Q{}class-mod' slot='14'/>
                     </att>
@@ -6004,24 +6220,24 @@
                  </let>
                 </let>
                </let>
-               <att line='1841' name='data-repeatable-context' flags='l'>
+               <att line='1842' name='data-repeatable-context' flags='l'>
                 <varRef name='Q{}refi' slot='6'/>
                </att>
-               <att line='1842' name='data-count' flags='l'>
+               <att line='1843' name='data-count' flags='l'>
                 <convert from='xs:integer' to='xs:string'>
                  <fn name='count'>
                   <varRef name='Q{}selectedRepeatVar' slot='7'/>
                  </fn>
                 </convert>
                </att>
-               <att line='1843' name='id' flags='l'>
+               <att line='1844' name='id' flags='l'>
                 <varRef name='Q{}myid' slot='4'/>
                </att>
-               <varRef line='1845' name='Q{}repeat-items' slot='8'/>
+               <varRef line='1846' name='Q{}repeat-items' slot='8'/>
               </sequence>
              </elem>
             </choose>
-            <choose line='1853'>
+            <choose line='1854'>
              <and op='and'>
               <fn name='not'>
                <varRef name='Q{}recalculate' slot='2'/>
@@ -6033,7 +6249,7 @@
                </slash>
               </fn>
              </and>
-             <sequence line='1855'>
+             <sequence line='1856'>
               <message>
                <fn role='select' name='concat'>
                 <str val='[xforms:repeat] Registering repeat with ID '/>
@@ -6044,7 +6260,7 @@
                <str role='terminate' val='no'/>
                <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
               </message>
-              <ifCall line='1857' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+              <ifCall line='1858' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                <check card='1' diag='0|0||ixsl:call'>
                 <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                </check>
@@ -6056,7 +6272,7 @@
               </ifCall>
              </sequence>
             </choose>
-            <ifCall line='1861' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+            <ifCall line='1862' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
              <check card='1' diag='0|0||ixsl:call'>
               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
              </check>
@@ -6077,9 +6293,9 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='18' rank='1' minImp='0' slots='6' flags='s' line='1701' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='18' rank='1' minImp='0' slots='6' flags='s' line='1702' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}group)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;group&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1702'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1703'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -6092,7 +6308,7 @@
        </check>
       </treat>
      </param>
-     <param line='1703' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1704' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -6104,7 +6320,7 @@
        </check>
       </treat>
      </param>
-     <let line='1707' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='1708' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -6120,7 +6336,7 @@
          <dot type='element(Q{http://www.w3.org/2002/xforms}group)'/>
         </fn>
         <str val='-'/>
-        <choose line='1705'>
+        <choose line='1706'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -6130,13 +6346,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1709'>
+      <sequence line='1710'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}group)' slot='3' eval='16'>
           <dot type='element(Q{http://www.w3.org/2002/xforms}group)'/>
-          <fn line='2990' name='exists'>
-           <sequence line='2965'>
+          <fn line='3025' name='exists'>
+           <sequence line='3000'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -6148,7 +6364,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2968'>
+             <choose role='matching' line='3003'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -6160,7 +6376,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='2977'>
+            <analyzeString line='3012'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -6171,7 +6387,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2980'>
+             <choose role='matching' line='3015'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -6194,8 +6410,8 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='2990' name='exists'>
-             <sequence line='2965'>
+            <fn line='3025' name='exists'>
+             <sequence line='3000'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
@@ -6207,7 +6423,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2968'>
+               <choose role='matching' line='3003'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -6219,7 +6435,7 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
-              <analyzeString line='2977'>
+              <analyzeString line='3012'>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
@@ -6230,7 +6446,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2980'>
+               <choose role='matching' line='3015'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -6248,7 +6464,7 @@
           </filter>
          </fn>
         </and>
-        <ifCall line='1710' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1711' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -6259,38 +6475,38 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1713' var='Q{}refi' as='xs:string?' slot='5' eval='7'>
-        <choose line='1715'>
+       <let line='1714' var='Q{}refi' as='xs:string?' slot='5' eval='7'>
+        <choose line='1716'>
          <fn name='exists'>
           <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
          </fn>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
           <attVal name='Q{}nodeset' chk='0'/>
          </cvUntyped>
-         <fn line='1716' name='exists'>
+         <fn line='1717' name='exists'>
           <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
          </fn>
-         <cvUntyped line='1716' to='xs:string' diag='3|0|XTTE0570|refi'>
+         <cvUntyped line='1717' to='xs:string' diag='3|0|XTTE0570|refi'>
           <attVal name='Q{}ref' chk='0'/>
          </cvUntyped>
         </choose>
-        <elem line='1722' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-         <sequence line='1723'>
+        <elem line='1723' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+         <sequence line='1724'>
           <att name='id' flags='l'>
            <varRef name='Q{}myid' slot='2'/>
           </att>
-          <choose line='1724'>
+          <choose line='1725'>
            <fn name='exists'>
             <varRef name='Q{}refi' slot='5'/>
            </fn>
-           <att line='1725' name='data-group-ref' flags='l'>
+           <att line='1726' name='data-group-ref' flags='l'>
             <varRef name='Q{}refi' slot='5'/>
            </att>
           </choose>
-          <applyT line='1727' bSlot='13'>
+          <applyT line='1728' bSlot='13'>
            <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
            <withParam name='Q{}nodeset' flags='t' as='xs:string?'>
-            <choose line='1728'>
+            <choose line='1729'>
              <fn name='exists'>
               <varRef name='Q{}refi' slot='5'/>
              </fn>
@@ -6307,15 +6523,15 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='8' rank='1' minImp='0' slots='0' flags='s' line='1105' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='8' rank='1' minImp='0' slots='0' flags='s' line='1106' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/1999/xhtml}html)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/1999/xhtml&#39;&amp;&amp;q.local===&#39;html&#39;;'/>
-    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1106' name='html' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-     <sequence line='1107'>
+    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1107' name='html' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+     <sequence line='1108'>
       <copyOf flags='vc'>
        <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
       </copyOf>
-      <elem line='1108' name='head' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-       <sequence line='1109'>
+      <elem line='1109' name='head' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+       <sequence line='1110'>
         <copyOf flags='vc'>
          <union op='|'>
           <slash simple='2'>
@@ -6328,7 +6544,7 @@
           </slash>
          </union>
         </copyOf>
-        <elem line='1110' name='meta' nsuri='' flags='l'>
+        <elem line='1111' name='meta' nsuri='' flags='l'>
          <sequence>
           <att name='http-equiv' flags='l'>
            <str val='Content-Type'/>
@@ -6338,7 +6554,7 @@
           </att>
          </sequence>
         </elem>
-        <forEach line='1112'>
+        <forEach line='1113'>
          <union op='|'>
           <filter flags='b'>
            <slash simple='2'>
@@ -6365,19 +6581,19 @@
            </vc>
           </filter>
          </union>
-         <elem line='1113' name='meta' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-          <copyOf line='1114' flags='vc'>
+         <elem line='1114' name='meta' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+          <copyOf line='1115' flags='vc'>
            <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
           </copyOf>
          </elem>
         </forEach>
-        <copyOf line='1119' flags='vc'>
+        <copyOf line='1120' flags='vc'>
          <axis name='child' nodeTest='element(Q{}script)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;script&#39;;'/>
         </copyOf>
        </sequence>
       </elem>
-      <elem line='1121' name='body' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-       <applyT line='1122' bSlot='14'>
+      <elem line='1122' name='body' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+       <applyT line='1123' bSlot='14'>
         <slash role='select' simple='2'>
          <axis name='child' nodeTest='element(Q{}body)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;body&#39;;'/>
          <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
@@ -6387,9 +6603,9 @@
      </sequence>
     </elem>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='9' rank='1' minImp='0' slots='15' flags='s' line='1137' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='9' rank='1' minImp='0' slots='15' flags='s' line='1138' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}output)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;output&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1138'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1139'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -6402,7 +6618,7 @@
        </check>
       </treat>
      </param>
-     <param line='1139' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1140' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -6414,7 +6630,7 @@
        </check>
       </treat>
      </param>
-     <let line='1143' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='1144' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -6430,7 +6646,7 @@
          <dot type='element(Q{http://www.w3.org/2002/xforms}output)'/>
         </fn>
         <str val='-'/>
-        <choose line='1141'>
+        <choose line='1142'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -6440,13 +6656,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1145'>
+      <sequence line='1146'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}output)' slot='3' eval='16'>
           <dot type='element(Q{http://www.w3.org/2002/xforms}output)'/>
-          <fn line='2990' name='exists'>
-           <sequence line='2965'>
+          <fn line='3025' name='exists'>
+           <sequence line='3000'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -6458,7 +6674,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2968'>
+             <choose role='matching' line='3003'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -6470,7 +6686,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='2977'>
+            <analyzeString line='3012'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -6481,7 +6697,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2980'>
+             <choose role='matching' line='3015'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -6504,8 +6720,8 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='2990' name='exists'>
-             <sequence line='2965'>
+            <fn line='3025' name='exists'>
+             <sequence line='3000'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
@@ -6517,7 +6733,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2968'>
+               <choose role='matching' line='3003'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -6529,7 +6745,7 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
-              <analyzeString line='2977'>
+              <analyzeString line='3012'>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
@@ -6540,7 +6756,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2980'>
+               <choose role='matching' line='3015'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -6558,7 +6774,7 @@
           </filter>
          </fn>
         </and>
-        <ifCall line='1146' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1147' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -6569,44 +6785,44 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1151' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='1152' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='1152' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1153' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
           <callT name='Q{}getBinding' bSlot='15'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='1153' type='element(Q{http://www.w3.org/2002/xforms}output)'/>
+            <dot line='1154' type='element(Q{http://www.w3.org/2002/xforms}output)'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='1158' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='1159' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='1159' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1160' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
              <callT name='Q{}getDataRef' bSlot='16'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='1160' type='element(Q{http://www.w3.org/2002/xforms}output)'/>
+               <dot line='1161' type='element(Q{http://www.w3.org/2002/xforms}output)'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='1161' name='Q{}bindingi' slot='5'/>
+               <varRef line='1162' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='1166' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
-          <treat line='1167' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+         <let line='1167' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
+          <treat line='1168' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
            <check card='?' diag='3|0|XTTE0570|instanceField'>
             <callT name='Q{}getReferencedInstanceField' bSlot='17'>
              <withParam name='Q{}refi' flags='c' as='xs:string'>
-              <varRef line='1168' name='Q{}refi' slot='6'/>
+              <varRef line='1169' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </check>
           </treat>
-          <let line='1179' var='Q{}namespace-context-item' as='element()' slot='8' eval='16'>
+          <let line='1180' var='Q{}namespace-context-item' as='element()' slot='8' eval='16'>
            <choose>
             <fn name='exists'>
              <varRef name='Q{}instanceField' slot='7'/>
@@ -6641,16 +6857,16 @@
                <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
               </slash>
              </check>
-             <compElem line='3000'>
+             <compElem line='3035'>
               <fn role='name' name='name'>
                <varRef name='Q{}this' slot='9'/>
               </fn>
-              <sequence role='content' line='3001'>
+              <sequence role='content' line='3036'>
                <namespace flags='l'>
                 <str role='name' val='xforms'/>
                 <str role='select' val='http://www.w3.org/2002/xforms'/>
                </namespace>
-               <forEach line='3002'>
+               <forEach line='3037'>
                 <filter flags='b'>
                  <filter flags='b'>
                   <slash simple='1'>
@@ -6689,21 +6905,21 @@
                   </gc>
                  </fn>
                 </filter>
-                <namespace line='3005' flags='l'>
-                 <fn role='name' line='3004' name='substring-before'>
+                <namespace line='3040' flags='l'>
+                 <fn role='name' line='3039' name='substring-before'>
                   <fn name='name'>
                    <dot type='element()'/>
                   </fn>
                   <str val=':'/>
                  </fn>
                  <convert role='select' from='xs:anyURI' to='xs:string'>
-                  <fn line='3003' name='namespace-uri'>
+                  <fn line='3038' name='namespace-uri'>
                    <dot type='element()'/>
                   </fn>
                  </convert>
                 </namespace>
                </forEach>
-               <copyOf line='3007' flags='vc'>
+               <copyOf line='3042' flags='vc'>
                 <sequence>
                  <slash simple='1'>
                   <varRef name='Q{}this' slot='9'/>
@@ -6719,12 +6935,12 @@
              </compElem>
             </let>
            </choose>
-           <let line='1181' var='Q{}valueExecuted' as='xs:string' slot='10' eval='16'>
-            <choose line='1183'>
+           <let line='1182' var='Q{}valueExecuted' as='xs:string' slot='10' eval='16'>
+            <choose line='1184'>
              <fn name='exists'>
               <axis name='attribute' nodeTest='attribute(Q{}value)' jsTest='return item.name===&#39;value&#39;'/>
              </fn>
-             <evaluate line='1184' as='xs:string' dxns=''>
+             <evaluate line='1185' as='xs:string' dxns=''>
               <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='18' eval='16'>
                <check card='1' diag='0|0||xforms:impose'>
                 <cvUntyped to='xs:string'>
@@ -6739,7 +6955,7 @@
               <map role='wp' size='0'/>
              </evaluate>
              <true/>
-             <cvUntyped line='1187' to='xs:string' diag='3|0|XTTE0570|valueExecuted'>
+             <cvUntyped line='1188' to='xs:string' diag='3|0|XTTE0570|valueExecuted'>
               <cast as='xs:untypedAtomic' emptiable='0'>
                <fn name='string'>
                 <convert from='xs:anyAtomicType' to='xs:string'>
@@ -6751,8 +6967,8 @@
               </cast>
              </cvUntyped>
             </choose>
-            <let line='1193' var='Q{}relevantVar' as='xs:boolean' slot='11' eval='16'>
-             <choose line='1195'>
+            <let line='1194' var='Q{}relevantVar' as='xs:boolean' slot='11' eval='16'>
+             <choose line='1196'>
               <and op='and'>
                <and op='and'>
                 <fn name='exists'>
@@ -6769,7 +6985,7 @@
                 <varRef name='Q{}instanceField' slot='7'/>
                </fn>
               </and>
-              <treat line='1196' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantVar'>
+              <treat line='1197' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantVar'>
                <check card='1' diag='3|0|XTTE0570|relevantVar'>
                 <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|relevantVar'>
                  <data>
@@ -6799,20 +7015,20 @@
               <true/>
               <true/>
              </choose>
-             <sequence line='1207'>
+             <sequence line='1208'>
               <elem name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-               <sequence line='1208'>
+               <sequence line='1209'>
                 <let var='Q{}element' as='element(Q{http://www.w3.org/2002/xforms}output)' slot='12' eval='16'>
                  <dot type='element(Q{http://www.w3.org/2002/xforms}output)'/>
-                 <let line='3056' var='Q{}class' as='xs:string?' slot='13' eval='7'>
-                  <choose line='3057'>
+                 <let line='3091' var='Q{}class' as='xs:string?' slot='13' eval='7'>
+                  <choose line='3092'>
                    <fn name='exists'>
                     <slash simple='1'>
                      <varRef name='Q{}element' slot='12'/>
                      <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
                     </slash>
                    </fn>
-                   <cvUntyped line='3058' to='xs:string' diag='3|0|XTTE0570|class'>
+                   <cvUntyped line='3093' to='xs:string' diag='3|0|XTTE0570|class'>
                     <cast as='xs:untypedAtomic' emptiable='0'>
                      <fn name='string'>
                       <convert from='xs:untypedAtomic' to='xs:string'>
@@ -6827,15 +7043,15 @@
                     </cast>
                    </cvUntyped>
                   </choose>
-                  <let line='3061' var='Q{}class-mod' as='xs:string?' slot='14' eval='7'>
-                   <choose line='3063'>
+                  <let line='3096' var='Q{}class-mod' as='xs:string?' slot='14' eval='7'>
+                   <choose line='3098'>
                     <fn name='exists'>
                      <slash simple='1'>
                       <varRef name='Q{}element' slot='12'/>
                       <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
                      </slash>
                     </fn>
-                    <cvUntyped line='3064' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                    <cvUntyped line='3099' to='xs:string' diag='3|0|XTTE0570|class-mod'>
                      <cast as='xs:untypedAtomic' emptiable='0'>
                       <fn name='string-join'>
                        <sequence>
@@ -6847,13 +7063,13 @@
                      </cast>
                     </cvUntyped>
                     <true/>
-                    <varRef line='3067' name='Q{}class' slot='13'/>
+                    <varRef line='3102' name='Q{}class' slot='13'/>
                    </choose>
-                   <choose line='3071'>
+                   <choose line='3106'>
                     <fn name='exists'>
                      <varRef name='Q{}class-mod' slot='14'/>
                     </fn>
-                    <treat line='3072' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                    <treat line='3107' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
                      <att name='class' flags='l'>
                       <varRef name='Q{}class-mod' slot='14'/>
                      </att>
@@ -6862,15 +7078,15 @@
                   </let>
                  </let>
                 </let>
-                <applyT line='1210' bSlot='20'>
+                <applyT line='1211' bSlot='20'>
                  <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
                 </applyT>
-                <elem line='1212' name='span' nsuri='' flags='l'>
-                 <sequence line='1213'>
+                <elem line='1213' name='span' nsuri='' flags='l'>
+                 <sequence line='1214'>
                   <att name='id' flags='l'>
                    <varRef name='Q{}myid' slot='2'/>
                   </att>
-                  <att line='1214' name='style' flags='l'>
+                  <att line='1215' name='style' flags='l'>
                    <choose>
                     <varRef name='Q{}relevantVar' slot='11'/>
                     <str val='display:inline'/>
@@ -6878,22 +7094,22 @@
                     <str val='display:none'/>
                    </choose>
                   </att>
-                  <att line='1215' name='data-ref' flags='l'>
+                  <att line='1216' name='data-ref' flags='l'>
                    <varRef name='Q{}refi' slot='6'/>
                   </att>
-                  <varRef line='1217' name='Q{}valueExecuted' slot='10'/>
+                  <varRef line='1218' name='Q{}valueExecuted' slot='10'/>
                  </sequence>
                 </elem>
                </sequence>
               </elem>
-              <choose line='1222'>
+              <choose line='1223'>
                <fn name='empty'>
                 <slash simple='1'>
                  <dot type='element(Q{http://www.w3.org/2002/xforms}output)'/>
                  <axis name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
                 </slash>
                </fn>
-               <sequence line='1239'>
+               <sequence line='1240'>
                 <message>
                  <fn role='select' name='concat'>
                   <str val='[xforms:output] Registering output with ID '/>
@@ -6902,27 +7118,27 @@
                  <str role='terminate' val='no'/>
                  <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
                 </message>
-                <ifCall line='1241' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                <ifCall line='1242' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                  <check card='1' diag='0|0||ixsl:call'>
                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                  </check>
                  <str val='addOutput'/>
                  <arrayBlock>
                   <varRef name='Q{}myid' slot='2'/>
-                  <ifCall line='1225' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+                  <ifCall line='1226' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
                    <sequence>
                     <choose>
                      <varRef name='Q{}refi' slot='6'/>
-                     <ifCall line='1226' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                     <ifCall line='1227' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                       <str val='@ref'/>
                       <varRef name='Q{}refi' slot='6'/>
                      </ifCall>
                     </choose>
-                    <choose line='1229'>
+                    <choose line='1230'>
                      <fn name='exists'>
                       <axis name='attribute' nodeTest='attribute(Q{}value)' jsTest='return item.name===&#39;value&#39;'/>
                      </fn>
-                     <ifCall line='1230' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                     <ifCall line='1231' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                       <str val='@value'/>
                       <cast as='xs:string' emptiable='1'>
                        <attVal name='Q{}value' chk='0'/>
@@ -6952,34 +7168,34 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='5' rank='1' minImp='0' slots='0' flags='s' line='1069' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='5' rank='1' minImp='0' slots='0' flags='s' line='1070' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
-    <applyT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1070' flags='t' bSlot='21'>
+    <applyT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1071' flags='t' bSlot='21'>
      <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
     </applyT>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='25' part='3' rank='1' minImp='0' slots='1' flags='s' line='2111' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='25' part='3' rank='1' minImp='0' slots='1' flags='s' line='2117' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}hide)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;hide&#39;;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2117' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2118' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2123' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2124' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
       <check card='1' diag='3|0|XTTE0570|action-map'>
        <callT name='Q{}setAction' bSlot='2'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2119' type='element()'/>
+         <dot line='2125' type='element()'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <varRef line='2132' name='Q{}action-map' slot='0'/>
+     <varRef line='2138' name='Q{}action-map' slot='0'/>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='12' rank='1' minImp='0' slots='0' flags='s' line='1526' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='12' rank='1' minImp='0' slots='0' flags='s' line='1527' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}hint)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;hint&#39;;'/>
     <empty role='action'/>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='20' rank='1' minImp='0' slots='2' flags='s' line='1874' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='20' rank='1' minImp='0' slots='2' flags='s' line='1875' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}submit)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;submit&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1875'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1876'>
      <param name='Q{}submissions' slot='0' flags='t' as='map(xs:string, map(*))'>
       <map role='select' size='0'/>
       <treat role='conversion' as='map(xs:string, map(*))' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isMap(item)};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|submissions'>
@@ -6988,31 +7204,46 @@
        </check>
       </treat>
      </param>
-     <let line='1877' var='Q{}innerbody' as='document-node()' slot='1' eval='16'>
-      <doc line='1878' validation='preserve'>
+     <message line='1878'>
+      <sequence role='select'>
+       <valueOf>
+        <str val='[xforms:submit] Generating form control for submission ID &#39;'/>
+       </valueOf>
+       <fn name='string'>
+        <axis name='attribute' nodeTest='attribute(Q{}submission)' jsTest='return item.name===&#39;submission&#39;'/>
+       </fn>
+       <valueOf flags='S'>
+        <str val='&#39;'/>
+       </valueOf>
+      </sequence>
+      <str role='terminate' val='no'/>
+      <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+     </message>
+     <let line='1882' var='Q{}innerbody' as='document-node()' slot='1' eval='16'>
+      <doc line='1883' validation='preserve'>
        <applyT bSlot='22'>
         <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
        </applyT>
       </doc>
-      <choose line='1882'>
+      <choose line='1887'>
        <vc op='eq' onEmpty='0' comp='CCC'>
         <cast as='xs:string' emptiable='1'>
          <attVal name='Q{}appearance' chk='0'/>
         </cast>
         <str val='minimal'/>
        </vc>
-       <elem line='1883' name='a' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-        <copyOf line='1884' flags='vc'>
+       <elem line='1888' name='a' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+        <copyOf line='1889' flags='vc'>
          <varRef name='Q{}innerbody' slot='1'/>
         </copyOf>
        </elem>
        <true/>
-       <elem line='1888' name='button' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+       <elem line='1893' name='button' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
         <sequence>
          <att name='type' flags='l'>
           <str val='button'/>
          </att>
-         <copyOf line='1889' flags='vc'>
+         <copyOf line='1894' flags='vc'>
           <filter flags='b'>
            <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
            <vc op='ne' onEmpty='0' comp='CCC'>
@@ -7023,7 +7254,7 @@
            </vc>
           </filter>
          </copyOf>
-         <choose line='1890'>
+         <choose line='1895'>
           <and op='and'>
            <fn name='exists'>
             <axis name='attribute' nodeTest='attribute(Q{}submission)' jsTest='return item.name===&#39;submission&#39;'/>
@@ -7035,13 +7266,22 @@
             </atomSing>
            </ifCall>
           </and>
-          <att line='1891' name='data-submit' flags='l'>
-           <convert from='xs:untypedAtomic' to='xs:string'>
-            <attVal name='Q{}submission' chk='0'/>
-           </convert>
-          </att>
+          <sequence line='1896'>
+           <message>
+            <valueOf role='select'>
+             <str val='[xforms:submit] Submission found'/>
+            </valueOf>
+            <str role='terminate' val='no'/>
+            <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+           </message>
+           <att line='1897' name='data-submit' flags='l'>
+            <convert from='xs:untypedAtomic' to='xs:string'>
+             <attVal name='Q{}submission' chk='0'/>
+            </convert>
+           </att>
+          </sequence>
          </choose>
-         <copyOf line='1893' flags='vc'>
+         <copyOf line='1899' flags='vc'>
           <varRef name='Q{}innerbody' slot='1'/>
          </copyOf>
         </sequence>
@@ -7050,15 +7290,15 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='8' part='1' rank='1' minImp='0' slots='0' flags='s' line='1105' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='8' part='1' rank='1' minImp='0' slots='0' flags='s' line='1106' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{}html)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;html&#39;;'/>
-    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1106' name='html' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-     <sequence line='1107'>
+    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1107' name='html' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+     <sequence line='1108'>
       <copyOf flags='vc'>
        <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
       </copyOf>
-      <elem line='1108' name='head' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-       <sequence line='1109'>
+      <elem line='1109' name='head' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+       <sequence line='1110'>
         <copyOf flags='vc'>
          <union op='|'>
           <slash simple='2'>
@@ -7071,7 +7311,7 @@
           </slash>
          </union>
         </copyOf>
-        <elem line='1110' name='meta' nsuri='' flags='l'>
+        <elem line='1111' name='meta' nsuri='' flags='l'>
          <sequence>
           <att name='http-equiv' flags='l'>
            <str val='Content-Type'/>
@@ -7081,7 +7321,7 @@
           </att>
          </sequence>
         </elem>
-        <forEach line='1112'>
+        <forEach line='1113'>
          <union op='|'>
           <filter flags='b'>
            <slash simple='2'>
@@ -7108,19 +7348,19 @@
            </vc>
           </filter>
          </union>
-         <elem line='1113' name='meta' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-          <copyOf line='1114' flags='vc'>
+         <elem line='1114' name='meta' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+          <copyOf line='1115' flags='vc'>
            <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
           </copyOf>
          </elem>
         </forEach>
-        <copyOf line='1119' flags='vc'>
+        <copyOf line='1120' flags='vc'>
          <axis name='child' nodeTest='element(Q{}script)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;script&#39;;'/>
         </copyOf>
        </sequence>
       </elem>
-      <elem line='1121' name='body' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-       <applyT line='1122' bSlot='14'>
+      <elem line='1122' name='body' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+       <applyT line='1123' bSlot='14'>
         <slash role='select' simple='2'>
          <axis name='child' nodeTest='element(Q{}body)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;body&#39;;'/>
          <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
@@ -7130,9 +7370,9 @@
      </sequence>
     </elem>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='13' rank='1' minImp='0' slots='12' flags='s' line='1537' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='13' rank='1' minImp='0' slots='12' flags='s' line='1538' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}select1)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;select1&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1538'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1539'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -7145,7 +7385,7 @@
        </check>
       </treat>
      </param>
-     <param line='1539' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1540' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -7157,7 +7397,7 @@
        </check>
       </treat>
      </param>
-     <let line='1543' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='1544' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -7173,7 +7413,7 @@
          <dot type='element()'/>
         </fn>
         <str val='-'/>
-        <choose line='1541'>
+        <choose line='1542'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -7183,13 +7423,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1545'>
+      <sequence line='1546'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element()' slot='3' eval='16'>
           <dot type='element()'/>
-          <fn line='2990' name='exists'>
-           <sequence line='2965'>
+          <fn line='3025' name='exists'>
+           <sequence line='3000'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -7201,7 +7441,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2968'>
+             <choose role='matching' line='3003'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -7213,7 +7453,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='2977'>
+            <analyzeString line='3012'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -7224,7 +7464,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2980'>
+             <choose role='matching' line='3015'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -7247,8 +7487,8 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='2990' name='exists'>
-             <sequence line='2965'>
+            <fn line='3025' name='exists'>
+             <sequence line='3000'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
@@ -7260,7 +7500,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2968'>
+               <choose role='matching' line='3003'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -7272,7 +7512,7 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
-              <analyzeString line='2977'>
+              <analyzeString line='3012'>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
@@ -7283,7 +7523,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2980'>
+               <choose role='matching' line='3015'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -7301,7 +7541,7 @@
           </filter>
          </fn>
         </and>
-        <ifCall line='1546' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1547' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -7312,60 +7552,60 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1553' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='1554' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='1554' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1555' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
           <callT name='Q{}getBinding' bSlot='3'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='1555' type='element()'/>
+            <dot line='1556' type='element()'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='1560' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='1561' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='1561' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1562' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
              <callT name='Q{}getDataRef' bSlot='4'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='1562' type='element()'/>
+               <dot line='1563' type='element()'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='1563' name='Q{}bindingi' slot='5'/>
+               <varRef line='1564' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='1568' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
-          <treat line='1569' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+         <let line='1569' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
+          <treat line='1570' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
            <check card='?' diag='3|0|XTTE0570|instanceField'>
             <callT name='Q{}getReferencedInstanceField' bSlot='5'>
              <withParam name='Q{}refi' flags='c' as='xs:string'>
-              <varRef line='1570' name='Q{}refi' slot='6'/>
+              <varRef line='1571' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </check>
           </treat>
-          <let line='1575' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
-           <treat line='1576' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+          <let line='1576' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
+           <treat line='1577' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
             <callT name='Q{}setActions' bSlot='6'>
              <withParam name='Q{}this' flags='c' as='element()'>
-              <dot line='1577' type='element()'/>
+              <dot line='1578' type='element()'/>
              </withParam>
              <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-              <varRef line='1578' name='Q{}refi' slot='6'/>
+              <varRef line='1579' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </treat>
-           <sequence line='1582'>
+           <sequence line='1583'>
             <choose>
              <fn name='exists'>
               <varRef name='Q{}actions' slot='8'/>
              </fn>
-             <ifCall line='1583' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+             <ifCall line='1584' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
               <check card='1' diag='0|0||ixsl:call'>
                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
               </check>
@@ -7376,27 +7616,27 @@
               </arrayBlock>
              </ifCall>
             </choose>
-            <elem line='1600' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+            <elem line='1601' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
              <sequence>
               <att name='class' flags='l'>
                <str val='xforms-select'/>
               </att>
-              <applyT line='1601' bSlot='7'>
+              <applyT line='1602' bSlot='7'>
                <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
               </applyT>
-              <elem line='1603' name='select' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-               <sequence line='1604'>
+              <elem line='1604' name='select' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+               <sequence line='1605'>
                 <let var='Q{}element' as='element()' slot='9' eval='16'>
                  <dot type='element()'/>
-                 <let line='3056' var='Q{}class' as='xs:string?' slot='10' eval='7'>
-                  <choose line='3057'>
+                 <let line='3091' var='Q{}class' as='xs:string?' slot='10' eval='7'>
+                  <choose line='3092'>
                    <fn name='exists'>
                     <slash simple='1'>
                      <varRef name='Q{}element' slot='9'/>
                      <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
                     </slash>
                    </fn>
-                   <cvUntyped line='3058' to='xs:string' diag='3|0|XTTE0570|class'>
+                   <cvUntyped line='3093' to='xs:string' diag='3|0|XTTE0570|class'>
                     <cast as='xs:untypedAtomic' emptiable='0'>
                      <fn name='string'>
                       <convert from='xs:untypedAtomic' to='xs:string'>
@@ -7411,15 +7651,15 @@
                     </cast>
                    </cvUntyped>
                   </choose>
-                  <let line='3061' var='Q{}class-mod' as='xs:string?' slot='11' eval='7'>
-                   <choose line='3063'>
+                  <let line='3096' var='Q{}class-mod' as='xs:string?' slot='11' eval='7'>
+                   <choose line='3098'>
                     <fn name='exists'>
                      <slash simple='1'>
                       <varRef name='Q{}element' slot='9'/>
                       <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
                      </slash>
                     </fn>
-                    <cvUntyped line='3064' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                    <cvUntyped line='3099' to='xs:string' diag='3|0|XTTE0570|class-mod'>
                      <cast as='xs:untypedAtomic' emptiable='0'>
                       <fn name='string-join'>
                        <sequence>
@@ -7431,13 +7671,13 @@
                      </cast>
                     </cvUntyped>
                     <true/>
-                    <varRef line='3067' name='Q{}class' slot='10'/>
+                    <varRef line='3102' name='Q{}class' slot='10'/>
                    </choose>
-                   <choose line='3071'>
+                   <choose line='3106'>
                     <fn name='exists'>
                      <varRef name='Q{}class-mod' slot='11'/>
                     </fn>
-                    <treat line='3072' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                    <treat line='3107' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
                      <att name='class' flags='l'>
                       <varRef name='Q{}class-mod' slot='11'/>
                      </att>
@@ -7446,7 +7686,7 @@
                   </let>
                  </let>
                 </let>
-                <copyOf line='1605' flags='vc'>
+                <copyOf line='1606' flags='vc'>
                  <except op='except'>
                   <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
                   <docOrder intra='1'>
@@ -7458,11 +7698,11 @@
                   </docOrder>
                  </except>
                 </copyOf>
-                <att line='1607' name='data-ref' flags='l'>
+                <att line='1608' name='data-ref' flags='l'>
                  <varRef name='Q{}refi' slot='6'/>
                 </att>
-                <att line='1608' name='data-element' flags='l'>
-                 <lastOf line='1598'>
+                <att line='1609' name='data-element' flags='l'>
+                 <lastOf line='1599'>
                   <fn name='tokenize'>
                    <varRef name='Q{}refi' slot='6'/>
                    <str val='/'/>
@@ -7470,7 +7710,7 @@
                   </fn>
                  </lastOf>
                 </att>
-                <choose line='1610'>
+                <choose line='1611'>
                  <and op='and'>
                   <fn name='exists'>
                    <varRef name='Q{}bindingi' slot='5'/>
@@ -7482,7 +7722,7 @@
                    </slash>
                   </fn>
                  </and>
-                 <att line='1611' name='data-constraint' flags='l'>
+                 <att line='1612' name='data-constraint' flags='l'>
                   <convert from='xs:untypedAtomic' to='xs:string'>
                    <data>
                     <slash simple='1'>
@@ -7493,19 +7733,19 @@
                   </convert>
                  </att>
                 </choose>
-                <choose line='1614'>
+                <choose line='1615'>
                  <vc op='eq' onEmpty='0' comp='CCC'>
                   <fn name='local-name'>
                    <dot type='element()'/>
                   </fn>
                   <str val='select'/>
                  </vc>
-                 <sequence line='1615'>
+                 <sequence line='1616'>
                   <att name='multiple' flags='l'>
                    <str val='true'/>
                   </att>
-                  <att line='1616' name='size' flags='l'>
-                   <convert line='1617' from='xs:integer' to='xs:string'>
+                  <att line='1617' name='size' flags='l'>
+                   <convert line='1618' from='xs:integer' to='xs:string'>
                     <fn name='count'>
                      <axis name='descendant' nodeTest='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
                     </fn>
@@ -7513,22 +7753,22 @@
                   </att>
                  </sequence>
                 </choose>
-                <choose line='1620'>
+                <choose line='1621'>
                  <fn name='exists'>
                   <varRef name='Q{}actions' slot='8'/>
                  </fn>
-                 <att line='1621' name='data-action' flags='l'>
+                 <att line='1622' name='data-action' flags='l'>
                   <varRef name='Q{}myid' slot='2'/>
                  </att>
                 </choose>
-                <applyT line='1624' bSlot='8'>
+                <applyT line='1625' bSlot='8'>
                  <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
                  <withParam name='Q{}selectedValue' as='xs:string'>
-                  <choose line='1589'>
+                  <choose line='1590'>
                    <fn name='exists'>
                     <varRef name='Q{}instanceField' slot='7'/>
                    </fn>
-                   <cvUntyped line='1590' to='xs:string' diag='3|0|XTTE0570|selectedValue'>
+                   <cvUntyped line='1591' to='xs:string' diag='3|0|XTTE0570|selectedValue'>
                     <cast as='xs:untypedAtomic' emptiable='0'>
                      <fn name='string'>
                       <convert from='xs:anyAtomicType' to='xs:string'>
@@ -7557,14 +7797,14 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='16' rank='1' minImp='0' slots='0' flags='s' line='1662' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='16' rank='1' minImp='0' slots='0' flags='s' line='1663' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
-    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1663' name='label' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-     <choose line='1665'>
+    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1664' name='label' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+     <choose line='1666'>
       <fn name='exists'>
        <axis name='child' nodeTest='( element() | text() | comment() | processing-instruction() )' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);'/>
       </fn>
-      <applyT line='1666' bSlot='23'>
+      <applyT line='1667' bSlot='23'>
        <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
       </applyT>
       <true/>
@@ -7574,39 +7814,39 @@
      </choose>
     </elem>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='25' part='5' rank='1' minImp='0' slots='1' flags='s' line='2111' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='25' part='5' rank='1' minImp='0' slots='1' flags='s' line='2117' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}unload)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;unload&#39;;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2117' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2118' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2123' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2124' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
       <check card='1' diag='3|0|XTTE0570|action-map'>
        <callT name='Q{}setAction' bSlot='2'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2119' type='element()'/>
+         <dot line='2125' type='element()'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <varRef line='2132' name='Q{}action-map' slot='0'/>
+     <varRef line='2138' name='Q{}action-map' slot='0'/>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='25' part='2' rank='1' minImp='0' slots='1' flags='s' line='2111' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='25' part='2' rank='1' minImp='0' slots='1' flags='s' line='2117' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}show)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;show&#39;;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2117' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2118' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2123' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2124' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
       <check card='1' diag='3|0|XTTE0570|action-map'>
        <callT name='Q{}setAction' bSlot='2'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2119' type='element()'/>
+         <dot line='2125' type='element()'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <varRef line='2132' name='Q{}action-map' slot='0'/>
+     <varRef line='2138' name='Q{}action-map' slot='0'/>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='10' rank='1' minImp='0' slots='17' flags='s' line='1255' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='10' rank='1' minImp='0' slots='17' flags='s' line='1256' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1256'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1257'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -7619,7 +7859,7 @@
        </check>
       </treat>
      </param>
-     <param line='1257' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1258' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -7631,7 +7871,7 @@
        </check>
       </treat>
      </param>
-     <let line='1259' var='Q{}string-position' as='xs:string' slot='2' eval='16'>
+     <let line='1260' var='Q{}string-position' as='xs:string' slot='2' eval='16'>
       <choose>
        <varRef name='Q{}context-position' slot='1'/>
        <varRef name='Q{}context-position' slot='1'/>
@@ -7640,7 +7880,7 @@
         <varRef name='Q{}position' slot='0'/>
        </fn>
       </choose>
-      <let line='1261' var='Q{}myid' as='xs:string' slot='3' eval='16'>
+      <let line='1262' var='Q{}myid' as='xs:string' slot='3' eval='16'>
        <choose>
         <fn name='exists'>
          <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -7659,13 +7899,13 @@
          <varRef name='Q{}string-position' slot='2'/>
         </fn>
        </choose>
-       <sequence line='1263'>
+       <sequence line='1264'>
         <choose>
          <and op='and'>
           <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}input)' slot='4' eval='16'>
            <dot type='element(Q{http://www.w3.org/2002/xforms}input)'/>
-           <fn line='2990' name='exists'>
-            <sequence line='2965'>
+           <fn line='3025' name='exists'>
+            <sequence line='3000'>
              <analyzeString>
               <cvUntyped role='select' to='xs:string'>
                <data>
@@ -7677,7 +7917,7 @@
               </cvUntyped>
               <str role='regex' val='\i\c*\('/>
               <str role='flags' val=''/>
-              <choose role='matching' line='2968'>
+              <choose role='matching' line='3003'>
                <vc op='eq' onEmpty='0' comp='CCC'>
                 <fn name='substring-before'>
                  <dot type='xs:string'/>
@@ -7689,7 +7929,7 @@
               </choose>
               <empty role='nonMatching'/>
              </analyzeString>
-             <analyzeString line='2977'>
+             <analyzeString line='3012'>
               <cvUntyped role='select' to='xs:string'>
                <data>
                 <slash simple='1'>
@@ -7700,7 +7940,7 @@
               </cvUntyped>
               <str role='regex' val='\i\c*\('/>
               <str role='flags' val=''/>
-              <choose role='matching' line='2980'>
+              <choose role='matching' line='3015'>
                <vc op='eq' onEmpty='0' comp='CCC'>
                 <fn name='substring-before'>
                  <dot type='xs:string'/>
@@ -7723,8 +7963,8 @@
             </slash>
             <let var='Q{}this' as='element()' slot='5' eval='16'>
              <dot type='element()'/>
-             <fn line='2990' name='exists'>
-              <sequence line='2965'>
+             <fn line='3025' name='exists'>
+              <sequence line='3000'>
                <analyzeString>
                 <cvUntyped role='select' to='xs:string'>
                  <data>
@@ -7736,7 +7976,7 @@
                 </cvUntyped>
                 <str role='regex' val='\i\c*\('/>
                 <str role='flags' val=''/>
-                <choose role='matching' line='2968'>
+                <choose role='matching' line='3003'>
                  <vc op='eq' onEmpty='0' comp='CCC'>
                   <fn name='substring-before'>
                    <dot type='xs:string'/>
@@ -7748,7 +7988,7 @@
                 </choose>
                 <empty role='nonMatching'/>
                </analyzeString>
-               <analyzeString line='2977'>
+               <analyzeString line='3012'>
                 <cvUntyped role='select' to='xs:string'>
                  <data>
                   <slash simple='1'>
@@ -7759,7 +7999,7 @@
                 </cvUntyped>
                 <str role='regex' val='\i\c*\('/>
                 <str role='flags' val=''/>
-                <choose role='matching' line='2980'>
+                <choose role='matching' line='3015'>
                  <vc op='eq' onEmpty='0' comp='CCC'>
                   <fn name='substring-before'>
                    <dot type='xs:string'/>
@@ -7777,7 +8017,7 @@
            </filter>
           </fn>
          </and>
-         <ifCall line='1264' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+         <ifCall line='1265' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
           <check card='1' diag='0|0||ixsl:call'>
            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
           </check>
@@ -7788,45 +8028,45 @@
           </arrayBlock>
          </ifCall>
         </choose>
-        <let line='1272' var='Q{}bindingi' as='node()?' slot='6' eval='7'>
-         <treat line='1273' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+        <let line='1273' var='Q{}bindingi' as='node()?' slot='6' eval='7'>
+         <treat line='1274' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
           <check card='?' diag='3|0|XTTE0570|bindingi'>
            <callT name='Q{}getBinding' bSlot='24'>
             <withParam name='Q{}this' flags='c' as='element()'>
-             <dot line='1274' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
+             <dot line='1275' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
             </withParam>
            </callT>
           </check>
          </treat>
-         <let line='1282' var='Q{}refi' as='xs:string' slot='7' eval='16'>
-          <treat line='1283' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+         <let line='1283' var='Q{}refi' as='xs:string' slot='7' eval='16'>
+          <treat line='1284' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
            <check card='1' diag='3|0|XTTE0570|refi'>
             <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
              <data>
               <callT name='Q{}getDataRef' bSlot='25'>
                <withParam name='Q{}this' flags='c' as='element()'>
-                <dot line='1284' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
+                <dot line='1285' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
                </withParam>
                <withParam name='Q{}bindingi' flags='c' as='node()?'>
-                <varRef line='1285' name='Q{}bindingi' slot='6'/>
+                <varRef line='1286' name='Q{}bindingi' slot='6'/>
                </withParam>
               </callT>
              </data>
             </cvUntyped>
            </check>
           </treat>
-          <let line='1292' var='Q{}instanceField' as='node()?' slot='8' eval='7'>
-           <treat line='1293' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+          <let line='1293' var='Q{}instanceField' as='node()?' slot='8' eval='7'>
+           <treat line='1294' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
             <check card='?' diag='3|0|XTTE0570|instanceField'>
              <callT name='Q{}getReferencedInstanceField' bSlot='26'>
               <withParam name='Q{}refi' flags='c' as='xs:string'>
-               <varRef line='1294' name='Q{}refi' slot='7'/>
+               <varRef line='1295' name='Q{}refi' slot='7'/>
               </withParam>
              </callT>
             </check>
            </treat>
-           <let line='1308' var='Q{}relevantVar' as='xs:boolean' slot='9' eval='16'>
-            <choose line='1310'>
+           <let line='1309' var='Q{}relevantVar' as='xs:boolean' slot='9' eval='16'>
+            <choose line='1311'>
              <and op='and'>
               <and op='and'>
                <fn name='exists'>
@@ -7843,7 +8083,7 @@
                <varRef name='Q{}instanceField' slot='8'/>
               </fn>
              </and>
-             <treat line='1311' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantVar'>
+             <treat line='1312' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantVar'>
               <check card='1' diag='3|0|XTTE0570|relevantVar'>
                <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|relevantVar'>
                 <data>
@@ -7861,7 +8101,7 @@
                    </check>
                   </ufCall>
                   <varRef role='cxt' name='Q{}instanceField' slot='8'/>
-                  <choose role='nsCxt' line='1303'>
+                  <choose role='nsCxt' line='1304'>
                    <fn name='exists'>
                     <varRef name='Q{}instanceField' slot='8'/>
                    </fn>
@@ -7878,16 +8118,16 @@
                       <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
                      </slash>
                     </check>
-                    <compElem line='3000'>
+                    <compElem line='3035'>
                      <fn role='name' name='name'>
                       <varRef name='Q{}this' slot='10'/>
                      </fn>
-                     <sequence role='content' line='3001'>
+                     <sequence role='content' line='3036'>
                       <namespace flags='l'>
                        <str role='name' val='xforms'/>
                        <str role='select' val='http://www.w3.org/2002/xforms'/>
                       </namespace>
-                      <forEach line='3002'>
+                      <forEach line='3037'>
                        <filter flags='b'>
                         <filter flags='b'>
                          <slash simple='1'>
@@ -7926,21 +8166,21 @@
                          </gc>
                         </fn>
                        </filter>
-                       <namespace line='3005' flags='l'>
-                        <fn role='name' line='3004' name='substring-before'>
+                       <namespace line='3040' flags='l'>
+                        <fn role='name' line='3039' name='substring-before'>
                          <fn name='name'>
                           <dot type='element()'/>
                          </fn>
                          <str val=':'/>
                         </fn>
                         <convert role='select' from='xs:anyURI' to='xs:string'>
-                         <fn line='3003' name='namespace-uri'>
+                         <fn line='3038' name='namespace-uri'>
                           <dot type='element()'/>
                          </fn>
                         </convert>
                        </namespace>
                       </forEach>
-                      <copyOf line='3007' flags='vc'>
+                      <copyOf line='3042' flags='vc'>
                        <sequence>
                         <slash simple='1'>
                          <varRef name='Q{}this' slot='10'/>
@@ -7967,23 +8207,23 @@
              <true/>
              <true/>
             </choose>
-            <let line='1321' var='Q{}actions' as='map(*)*' slot='11' eval='8'>
-             <treat line='1322' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+            <let line='1322' var='Q{}actions' as='map(*)*' slot='11' eval='8'>
+             <treat line='1323' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
               <callT name='Q{}setActions' bSlot='28'>
                <withParam name='Q{}this' flags='c' as='element()'>
-                <dot line='1323' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
+                <dot line='1324' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
                </withParam>
                <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                <varRef line='1324' name='Q{}refi' slot='7'/>
+                <varRef line='1325' name='Q{}refi' slot='7'/>
                </withParam>
               </callT>
              </treat>
-             <sequence line='1329'>
+             <sequence line='1330'>
               <choose>
                <fn name='exists'>
                 <varRef name='Q{}actions' slot='11'/>
                </fn>
-               <ifCall line='1330' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+               <ifCall line='1331' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                 <check card='1' diag='0|0||ixsl:call'>
                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                 </check>
@@ -7994,12 +8234,12 @@
                 </arrayBlock>
                </ifCall>
               </choose>
-              <elem line='1335' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+              <elem line='1336' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
                <sequence>
                 <att name='class' flags='l'>
                  <str val='xforms-input'/>
                 </att>
-                <att line='1336' name='style' flags='l'>
+                <att line='1337' name='style' flags='l'>
                  <choose>
                   <varRef name='Q{}relevantVar' slot='9'/>
                   <str val='display:block'/>
@@ -8007,27 +8247,27 @@
                   <str val='display:none'/>
                  </choose>
                 </att>
-                <applyT line='1338' bSlot='29'>
+                <applyT line='1339' bSlot='29'>
                  <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
                 </applyT>
-                <let line='1340' var='Q{}hints' as='text()*' slot='12' eval='4'>
+                <let line='1341' var='Q{}hints' as='text()*' slot='12' eval='4'>
                  <slash simple='2'>
                   <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}hint)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;hint&#39;;'/>
                   <axis name='child' nodeTest='text()' jsTest='return item.nodeType===3;'/>
                  </slash>
-                 <elem line='1344' name='input' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-                  <sequence line='1345'>
+                 <elem line='1345' name='input' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+                  <sequence line='1346'>
                    <let var='Q{}element' as='element(Q{http://www.w3.org/2002/xforms}input)' slot='13' eval='16'>
                     <dot type='element(Q{http://www.w3.org/2002/xforms}input)'/>
-                    <let line='3056' var='Q{}class' as='xs:string?' slot='14' eval='7'>
-                     <choose line='3057'>
+                    <let line='3091' var='Q{}class' as='xs:string?' slot='14' eval='7'>
+                     <choose line='3092'>
                       <fn name='exists'>
                        <slash simple='1'>
                         <varRef name='Q{}element' slot='13'/>
                         <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
                        </slash>
                       </fn>
-                      <cvUntyped line='3058' to='xs:string' diag='3|0|XTTE0570|class'>
+                      <cvUntyped line='3093' to='xs:string' diag='3|0|XTTE0570|class'>
                        <cast as='xs:untypedAtomic' emptiable='0'>
                         <fn name='string'>
                          <convert from='xs:untypedAtomic' to='xs:string'>
@@ -8042,15 +8282,15 @@
                        </cast>
                       </cvUntyped>
                      </choose>
-                     <let line='3061' var='Q{}class-mod' as='xs:string?' slot='15' eval='7'>
-                      <choose line='3063'>
+                     <let line='3096' var='Q{}class-mod' as='xs:string?' slot='15' eval='7'>
+                      <choose line='3098'>
                        <fn name='exists'>
                         <slash simple='1'>
                          <varRef name='Q{}element' slot='13'/>
                          <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
                         </slash>
                        </fn>
-                       <cvUntyped line='3064' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                       <cvUntyped line='3099' to='xs:string' diag='3|0|XTTE0570|class-mod'>
                         <cast as='xs:untypedAtomic' emptiable='0'>
                          <fn name='string-join'>
                           <sequence>
@@ -8062,13 +8302,13 @@
                         </cast>
                        </cvUntyped>
                        <true/>
-                       <varRef line='3067' name='Q{}class' slot='14'/>
+                       <varRef line='3102' name='Q{}class' slot='14'/>
                       </choose>
-                      <choose line='3071'>
+                      <choose line='3106'>
                        <fn name='exists'>
                         <varRef name='Q{}class-mod' slot='15'/>
                        </fn>
-                       <treat line='3072' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                       <treat line='3107' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
                         <att name='class' flags='l'>
                          <varRef name='Q{}class-mod' slot='15'/>
                         </att>
@@ -8077,14 +8317,14 @@
                      </let>
                     </let>
                    </let>
-                   <att line='1346' name='id' flags='l'>
+                   <att line='1347' name='id' flags='l'>
                     <varRef name='Q{}myid' slot='3'/>
                    </att>
-                   <att line='1348' name='data-ref' flags='l'>
+                   <att line='1349' name='data-ref' flags='l'>
                     <varRef name='Q{}refi' slot='7'/>
                    </att>
-                   <att line='1349' name='data-element' flags='l'>
-                    <lastOf line='1342'>
+                   <att line='1350' name='data-element' flags='l'>
+                    <lastOf line='1343'>
                      <fn name='tokenize'>
                       <varRef name='Q{}refi' slot='7'/>
                       <str val='/'/>
@@ -8092,7 +8332,7 @@
                      </fn>
                     </lastOf>
                    </att>
-                   <choose line='1351'>
+                   <choose line='1352'>
                     <and op='and'>
                      <fn name='exists'>
                       <varRef name='Q{}bindingi' slot='6'/>
@@ -8104,7 +8344,7 @@
                       </slash>
                      </fn>
                     </and>
-                    <att line='1352' name='data-required' flags='l'>
+                    <att line='1353' name='data-required' flags='l'>
                      <convert from='xs:untypedAtomic' to='xs:string'>
                       <data>
                        <slash simple='1'>
@@ -8115,7 +8355,7 @@
                      </convert>
                     </att>
                    </choose>
-                   <choose line='1354'>
+                   <choose line='1355'>
                     <and op='and'>
                      <fn name='exists'>
                       <varRef name='Q{}bindingi' slot='6'/>
@@ -8127,7 +8367,7 @@
                       </slash>
                      </fn>
                     </and>
-                    <att line='1355' name='data-constraint' flags='l'>
+                    <att line='1356' name='data-constraint' flags='l'>
                      <convert from='xs:untypedAtomic' to='xs:string'>
                       <data>
                        <slash simple='1'>
@@ -8138,15 +8378,15 @@
                      </convert>
                     </att>
                    </choose>
-                   <choose line='1357'>
+                   <choose line='1358'>
                     <fn name='exists'>
                      <varRef name='Q{}actions' slot='11'/>
                     </fn>
-                    <att line='1358' name='data-action' flags='l'>
+                    <att line='1359' name='data-action' flags='l'>
                      <varRef name='Q{}myid' slot='3'/>
                     </att>
                    </choose>
-                   <choose line='1361'>
+                   <choose line='1362'>
                     <and op='and'>
                      <fn name='exists'>
                       <varRef name='Q{}bindingi' slot='6'/>
@@ -8158,7 +8398,7 @@
                       </slash>
                      </fn>
                     </and>
-                    <att line='1362' name='data-relevant' flags='l'>
+                    <att line='1363' name='data-relevant' flags='l'>
                      <convert from='xs:untypedAtomic' to='xs:string'>
                       <data>
                        <slash simple='1'>
@@ -8169,12 +8409,12 @@
                      </convert>
                     </att>
                    </choose>
-                   <let line='1365' var='Q{}input-value' as='xs:string' slot='16' eval='16'>
-                    <choose line='1367'>
+                   <let line='1366' var='Q{}input-value' as='xs:string' slot='16' eval='16'>
+                    <choose line='1368'>
                      <fn name='exists'>
                       <varRef name='Q{}instanceField' slot='8'/>
                      </fn>
-                     <cvUntyped line='1368' to='xs:string' diag='3|0|XTTE0570|input-value'>
+                     <cvUntyped line='1369' to='xs:string' diag='3|0|XTTE0570|input-value'>
                       <cast as='xs:untypedAtomic' emptiable='0'>
                        <fn name='string'>
                         <convert from='xs:anyAtomicType' to='xs:string'>
@@ -8188,7 +8428,7 @@
                      <true/>
                      <str val=''/>
                     </choose>
-                    <sequence line='1382'>
+                    <sequence line='1383'>
                      <choose>
                       <choose>
                        <fn name='exists'>
@@ -8208,18 +8448,18 @@
                        <true/>
                        <false/>
                       </choose>
-                      <sequence line='1383'>
+                      <sequence line='1384'>
                        <att name='data-type' flags='l'>
                         <str val='date'/>
                        </att>
-                       <att line='1385' name='type' flags='l'>
+                       <att line='1386' name='type' flags='l'>
                         <str val='date'/>
                        </att>
-                       <att line='1387' name='value' flags='l'>
+                       <att line='1388' name='value' flags='l'>
                         <varRef name='Q{}input-value' slot='16'/>
                        </att>
                       </sequence>
-                      <choose line='1394'>
+                      <choose line='1395'>
                        <fn name='exists'>
                         <varRef name='Q{}bindingi' slot='6'/>
                        </fn>
@@ -8237,18 +8477,18 @@
                        <true/>
                        <false/>
                       </choose>
-                      <sequence line='1395'>
+                      <sequence line='1396'>
                        <att name='data-type' flags='l'>
                         <str val='time'/>
                        </att>
-                       <att line='1397' name='type' flags='l'>
+                       <att line='1398' name='type' flags='l'>
                         <str val='time'/>
                        </att>
-                       <att line='1400' name='value' flags='l'>
+                       <att line='1401' name='value' flags='l'>
                         <varRef name='Q{}input-value' slot='16'/>
                        </att>
                       </sequence>
-                      <choose line='1407'>
+                      <choose line='1408'>
                        <fn name='exists'>
                         <varRef name='Q{}bindingi' slot='6'/>
                        </fn>
@@ -8266,48 +8506,48 @@
                        <true/>
                        <false/>
                       </choose>
-                      <sequence line='1408'>
+                      <sequence line='1409'>
                        <att name='data-type' flags='l'>
                         <str val='checkbox'/>
                        </att>
-                       <att line='1410' name='type' flags='l'>
+                       <att line='1411' name='type' flags='l'>
                         <str val='checkbox'/>
                        </att>
-                       <choose line='1415'>
+                       <choose line='1416'>
                         <fn name='exists'>
                          <varRef name='Q{}instanceField' slot='8'/>
                         </fn>
-                        <choose line='1416'>
+                        <choose line='1417'>
                          <and op='and'>
                           <varRef name='Q{}input-value' slot='16'/>
                           <cast as='xs:boolean' emptiable='0'>
                            <varRef name='Q{}input-value' slot='16'/>
                           </cast>
                          </and>
-                         <att line='1417' name='checked' flags='l'>
+                         <att line='1418' name='checked' flags='l'>
                           <varRef name='Q{}input-value' slot='16'/>
                          </att>
                         </choose>
                        </choose>
                       </sequence>
                       <true/>
-                      <sequence line='1423'>
+                      <sequence line='1424'>
                        <choose>
                         <varRef name='Q{}relevantVar' slot='9'/>
-                        <att line='1424' name='type' flags='l'>
+                        <att line='1425' name='type' flags='l'>
                          <str val='text'/>
                         </att>
                        </choose>
-                       <att line='1426' name='value' flags='l'>
+                       <att line='1427' name='value' flags='l'>
                         <varRef name='Q{}input-value' slot='16'/>
                        </att>
                       </sequence>
                      </choose>
-                     <choose line='1430'>
+                     <choose line='1431'>
                       <fn name='exists'>
                        <varRef name='Q{}hints' slot='12'/>
                       </fn>
-                      <att line='1431' name='title' flags='l'>
+                      <att line='1432' name='title' flags='l'>
                        <fn name='string-join'>
                         <convert from='xs:untypedAtomic' to='xs:string'>
                          <data>
@@ -8320,11 +8560,11 @@
                        </fn>
                       </att>
                      </choose>
-                     <choose line='1433'>
+                     <choose line='1434'>
                       <fn name='exists'>
                        <axis name='attribute' nodeTest='attribute(Q{}size)' jsTest='return item.name===&#39;size&#39;'/>
                       </fn>
-                      <att line='1434' name='size' flags='l'>
+                      <att line='1435' name='size' flags='l'>
                        <convert from='xs:untypedAtomic' to='xs:string'>
                         <attVal name='Q{}size' chk='0'/>
                        </convert>
@@ -8348,9 +8588,9 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='2.0' seq='11' rank='3' minImp='0' slots='10' flags='s' line='1452' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='2.0' seq='11' rank='3' minImp='0' slots='10' flags='s' line='1453' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}textarea)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;textarea&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1453'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1454'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -8363,7 +8603,7 @@
        </check>
       </treat>
      </param>
-     <param line='1454' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1455' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -8375,7 +8615,7 @@
        </check>
       </treat>
      </param>
-     <let line='1458' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='1459' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -8391,7 +8631,7 @@
          <dot type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
         </fn>
         <str val='-'/>
-        <choose line='1456'>
+        <choose line='1457'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -8401,13 +8641,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1460'>
+      <sequence line='1461'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}textarea)' slot='3' eval='16'>
           <dot type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
-          <fn line='2990' name='exists'>
-           <sequence line='2965'>
+          <fn line='3025' name='exists'>
+           <sequence line='3000'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -8419,7 +8659,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2968'>
+             <choose role='matching' line='3003'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -8431,7 +8671,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='2977'>
+            <analyzeString line='3012'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -8442,7 +8682,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2980'>
+             <choose role='matching' line='3015'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -8465,8 +8705,8 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='2990' name='exists'>
-             <sequence line='2965'>
+            <fn line='3025' name='exists'>
+             <sequence line='3000'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
@@ -8478,7 +8718,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2968'>
+               <choose role='matching' line='3003'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -8490,7 +8730,7 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
-              <analyzeString line='2977'>
+              <analyzeString line='3012'>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
@@ -8501,7 +8741,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2980'>
+               <choose role='matching' line='3015'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -8519,7 +8759,7 @@
           </filter>
          </fn>
         </and>
-        <ifCall line='1461' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1462' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -8530,60 +8770,60 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1465' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='1466' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='1466' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1467' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
           <callT name='Q{}getBinding' bSlot='30'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='1467' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
+            <dot line='1468' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='1472' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='1473' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='1473' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1474' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
              <callT name='Q{}getDataRef' bSlot='31'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='1474' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
+               <dot line='1475' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='1475' name='Q{}bindingi' slot='5'/>
+               <varRef line='1476' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='1480' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
-          <treat line='1481' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+         <let line='1481' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
+          <treat line='1482' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
            <check card='?' diag='3|0|XTTE0570|instanceField'>
             <callT name='Q{}getReferencedInstanceField' bSlot='32'>
              <withParam name='Q{}refi' flags='c' as='xs:string'>
-              <varRef line='1482' name='Q{}refi' slot='6'/>
+              <varRef line='1483' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </check>
           </treat>
-          <let line='1487' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
-           <treat line='1488' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+          <let line='1488' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
+           <treat line='1489' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
             <callT name='Q{}setActions' bSlot='33'>
              <withParam name='Q{}this' flags='c' as='element()'>
-              <dot line='1489' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
+              <dot line='1490' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
              </withParam>
              <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-              <varRef line='1490' name='Q{}refi' slot='6'/>
+              <varRef line='1491' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </treat>
-           <sequence line='1494'>
+           <sequence line='1495'>
             <choose>
              <fn name='exists'>
               <varRef name='Q{}actions' slot='8'/>
              </fn>
-             <ifCall line='1495' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+             <ifCall line='1496' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
               <check card='1' diag='0|0||ixsl:call'>
                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
               </check>
@@ -8594,13 +8834,13 @@
               </arrayBlock>
              </ifCall>
             </choose>
-            <let line='1500' var='Q{}hints' as='text()*' slot='9' eval='4'>
+            <let line='1501' var='Q{}hints' as='text()*' slot='9' eval='4'>
              <slash simple='2'>
               <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}hint)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;hint&#39;;'/>
               <axis name='child' nodeTest='text()' jsTest='return item.nodeType===3;'/>
              </slash>
-             <elem line='1502' name='textarea' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-              <sequence line='1503'>
+             <elem line='1503' name='textarea' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+              <sequence line='1504'>
                <copyOf flags='vc'>
                 <filter flags='b'>
                  <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
@@ -8612,8 +8852,8 @@
                  </vc>
                 </filter>
                </copyOf>
-               <att line='1504' name='data-element' flags='l'>
-                <lastOf line='1498'>
+               <att line='1505' name='data-element' flags='l'>
+                <lastOf line='1499'>
                  <fn name='tokenize'>
                   <varRef name='Q{}refi' slot='6'/>
                   <str val='/'/>
@@ -8621,14 +8861,14 @@
                  </fn>
                 </lastOf>
                </att>
-               <att line='1505' name='data-ref' flags='l'>
+               <att line='1506' name='data-ref' flags='l'>
                 <varRef name='Q{}refi' slot='6'/>
                </att>
-               <choose line='1507'>
+               <choose line='1508'>
                 <fn name='exists'>
                  <varRef name='Q{}instanceField' slot='7'/>
                 </fn>
-                <valueOf line='1508' flags='l'>
+                <valueOf line='1509' flags='l'>
                  <convert from='xs:anyAtomicType' to='xs:string'>
                   <data>
                    <varRef name='Q{}instanceField' slot='7'/>
@@ -8636,7 +8876,7 @@
                  </convert>
                 </valueOf>
                 <true/>
-                <sequence line='1510'>
+                <sequence line='1511'>
                  <valueOf flags='Sl'>
                   <str val=''/>
                  </valueOf>
@@ -8645,11 +8885,11 @@
                  </valueOf>
                 </sequence>
                </choose>
-               <choose line='1513'>
+               <choose line='1514'>
                 <fn name='exists'>
                  <varRef name='Q{}hints' slot='9'/>
                 </fn>
-                <att line='1514' name='title' flags='l'>
+                <att line='1515' name='title' flags='l'>
                  <fn name='string-join'>
                   <convert from='xs:untypedAtomic' to='xs:string'>
                    <data>
@@ -8674,9 +8914,9 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='24' rank='1' minImp='0' slots='9' flags='s' line='2029' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='24' rank='1' minImp='0' slots='9' flags='s' line='2035' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}trigger)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;trigger&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2030'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2036'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -8689,7 +8929,7 @@
        </check>
       </treat>
      </param>
-     <param line='2031' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='2037' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -8701,7 +8941,7 @@
        </check>
       </treat>
      </param>
-     <let line='2035' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='2041' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -8717,7 +8957,7 @@
          <dot type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
         </fn>
         <str val='-'/>
-        <choose line='2033'>
+        <choose line='2039'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -8727,13 +8967,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='2037'>
+      <sequence line='2043'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}trigger)' slot='3' eval='16'>
           <dot type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
-          <fn line='2990' name='exists'>
-           <sequence line='2965'>
+          <fn line='3025' name='exists'>
+           <sequence line='3000'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -8745,7 +8985,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2968'>
+             <choose role='matching' line='3003'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -8757,7 +8997,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='2977'>
+            <analyzeString line='3012'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -8768,7 +9008,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2980'>
+             <choose role='matching' line='3015'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -8791,8 +9031,8 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='2990' name='exists'>
-             <sequence line='2965'>
+            <fn line='3025' name='exists'>
+             <sequence line='3000'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
@@ -8804,7 +9044,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2968'>
+               <choose role='matching' line='3003'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -8816,7 +9056,7 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
-              <analyzeString line='2977'>
+              <analyzeString line='3012'>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
@@ -8827,7 +9067,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2980'>
+               <choose role='matching' line='3015'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -8845,7 +9085,7 @@
           </filter>
          </fn>
         </and>
-        <ifCall line='2038' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='2044' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -8856,50 +9096,50 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='2042' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='2043' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='2048' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='2049' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
           <callT name='Q{}getBinding' bSlot='34'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='2044' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
+            <dot line='2050' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='2049' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='2050' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='2055' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='2056' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
              <callT name='Q{}getDataRef' bSlot='35'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='2051' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
+               <dot line='2057' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='2052' name='Q{}bindingi' slot='5'/>
+               <varRef line='2058' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='2059' var='Q{}actions' as='map(*)*' slot='7' eval='8'>
-          <treat line='2060' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+         <let line='2065' var='Q{}actions' as='map(*)*' slot='7' eval='8'>
+          <treat line='2066' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
            <callT name='Q{}setActions' bSlot='36'>
             <withParam name='Q{}this' flags='c' as='element()'>
-             <dot line='2061' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
+             <dot line='2067' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
             </withParam>
             <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-             <varRef line='2062' name='Q{}refi' slot='6'/>
+             <varRef line='2068' name='Q{}refi' slot='6'/>
             </withParam>
            </callT>
           </treat>
-          <sequence line='2066'>
+          <sequence line='2072'>
            <choose>
             <fn name='exists'>
              <varRef name='Q{}actions' slot='7'/>
             </fn>
-            <ifCall line='2067' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+            <ifCall line='2073' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
              <check card='1' diag='0|0||ixsl:call'>
               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
              </check>
@@ -8910,28 +9150,28 @@
              </arrayBlock>
             </ifCall>
            </choose>
-           <let line='2070' var='Q{}innerbody' as='document-node()' slot='8' eval='16'>
-            <doc line='2072' validation='preserve'>
+           <let line='2076' var='Q{}innerbody' as='document-node()' slot='8' eval='16'>
+            <doc line='2078' validation='preserve'>
              <choose>
               <fn name='exists'>
                <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
               </fn>
-              <applyT line='2073' bSlot='37'>
+              <applyT line='2079' bSlot='37'>
                <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
               </applyT>
               <true/>
-              <valueOf line='2075' flags='l'>
+              <valueOf line='2081' flags='l'>
                <str val=' '/>
               </valueOf>
              </choose>
             </doc>
-            <elem line='2079' name='span' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+            <elem line='2085' name='span' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
              <sequence>
               <att name='style' flags='l'>
                <str val='display:&#39;inline&#39;'/>
               </att>
-              <compElem line='2090' flags='l'>
-               <choose role='name' line='2082'>
+              <compElem line='2096' flags='l'>
+               <choose role='name' line='2088'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <cast as='xs:string' emptiable='1'>
                   <attVal name='Q{}appearance' chk='0'/>
@@ -8942,7 +9182,7 @@
                 <true/>
                 <str val='button'/>
                </choose>
-               <sequence role='content' line='2091'>
+               <sequence role='content' line='2097'>
                 <choose>
                  <vc op='eq' onEmpty='0' comp='CCC'>
                   <cast as='xs:string' emptiable='1'>
@@ -8950,17 +9190,17 @@
                   </cast>
                   <str val='minimal'/>
                  </vc>
-                 <att line='2092' name='type' flags='l'>
+                 <att line='2098' name='type' flags='l'>
                   <str val='button'/>
                  </att>
                 </choose>
-                <att line='2095' name='data-ref' flags='l'>
+                <att line='2101' name='data-ref' flags='l'>
                  <varRef name='Q{}refi' slot='6'/>
                 </att>
-                <att line='2096' name='data-action' flags='l'>
+                <att line='2102' name='data-action' flags='l'>
                  <varRef name='Q{}myid' slot='2'/>
                 </att>
-                <copyOf line='2097' flags='vc'>
+                <copyOf line='2103' flags='vc'>
                  <varRef name='Q{}innerbody' slot='8'/>
                 </copyOf>
                </sequence>
@@ -8976,13 +9216,13 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='6' rank='1' minImp='0' slots='0' flags='s' line='1079' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='6' rank='1' minImp='0' slots='0' flags='s' line='1080' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
     <empty role='action'/>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='17' rank='1' minImp='0' slots='1' flags='s' line='1680' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='17' rank='1' minImp='0' slots='1' flags='s' line='1681' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1681'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1682'>
      <param name='Q{}selectedValue' slot='0' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|selectedValue'>
@@ -8995,7 +9235,7 @@
        </check>
       </treat>
      </param>
-     <elem line='1683' name='option' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+     <elem line='1684' name='option' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
       <sequence>
        <att name='value' flags='l'>
         <fn name='string-join'>
@@ -9007,7 +9247,7 @@
          <str val=' '/>
         </fn>
        </att>
-       <choose line='1684'>
+       <choose line='1685'>
         <vc op='eq' onEmpty='0' comp='CCC'>
          <varRef name='Q{}selectedValue' slot='0'/>
          <cast as='xs:string' emptiable='1'>
@@ -9019,11 +9259,11 @@
           </atomSing>
          </cast>
         </vc>
-        <att line='1685' name='selected' flags='l'>
+        <att line='1686' name='selected' flags='l'>
          <varRef name='Q{}selectedValue' slot='0'/>
         </att>
        </choose>
-       <valueOf line='1688' flags='l'>
+       <valueOf line='1689' flags='l'>
         <fn name='string-join'>
          <convert from='xs:untypedAtomic' to='xs:string'>
           <data>
@@ -9037,24 +9277,24 @@
      </elem>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='25' part='4' rank='1' minImp='0' slots='1' flags='s' line='2111' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='25' part='4' rank='1' minImp='0' slots='1' flags='s' line='2117' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}script)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;script&#39;;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2117' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2118' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2123' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2124' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
       <check card='1' diag='3|0|XTTE0570|action-map'>
        <callT name='Q{}setAction' bSlot='2'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2119' type='element()'/>
+         <dot line='2125' type='element()'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <varRef line='2132' name='Q{}action-map' slot='0'/>
+     <varRef line='2138' name='Q{}action-map' slot='0'/>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='-0.5' seq='14' part='1' rank='0' minImp='0' slots='0' flags='s' line='1641' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='14' part='1' rank='0' minImp='0' slots='0' flags='s' line='1642' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
-    <copy role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1643' flags='cin'>
+    <copy role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1644' flags='cin'>
      <applyT role='content' bSlot='38'>
       <sequence role='select'>
        <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
@@ -9063,16 +9303,16 @@
      </applyT>
     </copy>
    </templateRule>
-   <templateRule prec='0' prio='0.5' seq='15' rank='2' minImp='0' slots='0' flags='s' line='1652' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.5' seq='15' rank='2' minImp='0' slots='0' flags='s' line='1653' module='saxon-xforms.xsl'>
     <p.withPredicate role='match'>
      <p.nodeTest test='text()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===3;'/>
-     <axis ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1652' name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
+     <axis ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1653' name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
     </p.withPredicate>
     <empty role='action'/>
    </templateRule>
-   <templateRule prec='0' prio='-0.5' seq='14' rank='0' minImp='0' slots='0' flags='s' line='1641' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='14' rank='0' minImp='0' slots='0' flags='s' line='1642' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='( element() | text() | comment() | processing-instruction() )' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);'/>
-    <copy role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1643' flags='cin'>
+    <copy role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1644' flags='cin'>
      <applyT role='content' bSlot='38'>
       <sequence role='select'>
        <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
@@ -9084,8 +9324,8 @@
   </mode>
  </co>
  <co id='63' binds='62'>
-  <template name='Q{}getDataRef' flags='os' line='3321' module='saxon-xforms.xsl' slots='11'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3322'>
+  <template name='Q{}getDataRef' flags='os' line='3353' module='saxon-xforms.xsl' slots='11'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3354'>
     <param name='Q{}this' slot='0' flags='r' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
       <check card='1' diag='8|0|XTTE0590|this'>
@@ -9093,7 +9333,7 @@
       </check>
      </treat>
     </param>
-    <param line='3323' name='Q{}nodeset' slot='1' flags='t' as='xs:string'>
+    <param line='3355' name='Q{}nodeset' slot='1' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -9105,7 +9345,7 @@
       </check>
      </treat>
     </param>
-    <param line='3324' name='Q{}bindingi' slot='2' as='node()?'>
+    <param line='3356' name='Q{}bindingi' slot='2' as='node()?'>
      <empty role='select'/>
      <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|bindingi'>
       <check card='?' diag='8|0|XTTE0590|bindingi'>
@@ -9113,7 +9353,7 @@
       </check>
      </treat>
     </param>
-    <let line='3332' var='Q{}this-ref' as='xs:string?' slot='3' eval='7'>
+    <let line='3364' var='Q{}this-ref' as='xs:string?' slot='3' eval='7'>
      <choose>
       <fn name='exists'>
        <slash simple='1'>
@@ -9148,12 +9388,12 @@
        </cast>
       </fn>
      </choose>
-     <let line='3335' var='Q{}this-binding-ref' as='xs:string?' slot='4' eval='7'>
-      <choose line='3337'>
+     <let line='3367' var='Q{}this-binding-ref' as='xs:string?' slot='4' eval='7'>
+      <choose line='3369'>
        <fn name='exists'>
         <varRef name='Q{}bindingi' slot='2'/>
        </fn>
-       <cvUntyped line='3348' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
+       <cvUntyped line='3380' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
         <cast as='xs:untypedAtomic' emptiable='0'>
          <choose>
           <fn name='exists'>
@@ -9187,23 +9427,23 @@
         </cast>
        </cvUntyped>
        <true/>
-       <let line='3352' var='Q{}this-binding' as='node()?' slot='5' eval='7'>
-        <treat line='3353' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|this-binding'>
+       <let line='3384' var='Q{}this-binding' as='node()?' slot='5' eval='7'>
+        <treat line='3385' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|this-binding'>
          <check card='?' diag='3|0|XTTE0570|this-binding'>
           <callT name='Q{}getBinding' bSlot='0'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <treat line='3354' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+            <treat line='3386' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
              <dot flags='a'/>
             </treat>
            </withParam>
           </callT>
          </check>
         </treat>
-        <choose line='3357'>
+        <choose line='3389'>
          <fn name='exists'>
           <varRef name='Q{}this-binding' slot='5'/>
          </fn>
-         <cvUntyped line='3364' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
+         <cvUntyped line='3396' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
           <cast as='xs:untypedAtomic' emptiable='0'>
            <choose>
             <fn name='exists'>
@@ -9239,52 +9479,52 @@
         </choose>
        </let>
       </choose>
-      <choose line='3374'>
+      <choose line='3406'>
        <fn name='exists'>
         <varRef name='Q{}bindingi' slot='2'/>
        </fn>
-       <let line='3376' var='Q{}relative' as='xs:string' slot='6' eval='16'>
+       <let line='3408' var='Q{}relative' as='xs:string' slot='6' eval='16'>
         <check card='1' diag='0|1||xforms:resolveXPathStrings'>
          <varRef name='Q{}this-binding-ref' slot='4'/>
         </check>
-        <choose line='835'>
+        <choose line='836'>
          <fn name='starts-with'>
           <varRef name='Q{}relative' slot='6'/>
           <str val='/'/>
          </fn>
-         <varRef line='836' name='Q{}relative' slot='6'/>
-         <fn line='838' name='starts-with'>
+         <varRef line='837' name='Q{}relative' slot='6'/>
+         <fn line='839' name='starts-with'>
           <varRef name='Q{}relative' slot='6'/>
           <str val='instance('/>
          </fn>
-         <varRef line='839' name='Q{}relative' slot='6'/>
+         <varRef line='840' name='Q{}relative' slot='6'/>
          <true/>
-         <varRef line='842' name='Q{}relative' slot='6'/>
+         <varRef line='843' name='Q{}relative' slot='6'/>
         </choose>
        </let>
-       <fn line='3378' name='exists'>
+       <fn line='3410' name='exists'>
         <varRef name='Q{}this-ref' slot='3'/>
        </fn>
-       <let line='3380' var='Q{}relative' as='xs:string' slot='7' eval='16'>
+       <let line='3412' var='Q{}relative' as='xs:string' slot='7' eval='16'>
         <check card='1' diag='0|1||xforms:resolveXPathStrings'>
          <varRef name='Q{}this-ref' slot='3'/>
         </check>
-        <choose line='835'>
+        <choose line='836'>
          <fn name='starts-with'>
           <varRef name='Q{}relative' slot='7'/>
           <str val='/'/>
          </fn>
-         <varRef line='836' name='Q{}relative' slot='7'/>
-         <fn line='838' name='starts-with'>
+         <varRef line='837' name='Q{}relative' slot='7'/>
+         <fn line='839' name='starts-with'>
           <varRef name='Q{}relative' slot='7'/>
           <str val='instance('/>
          </fn>
-         <varRef line='839' name='Q{}relative' slot='7'/>
-         <fn line='3380' name='not'>
+         <varRef line='840' name='Q{}relative' slot='7'/>
+         <fn line='3412' name='not'>
           <varRef name='Q{}nodeset' slot='1'/>
          </fn>
-         <varRef line='842' name='Q{}relative' slot='7'/>
-         <or line='844' op='or'>
+         <varRef line='843' name='Q{}relative' slot='7'/>
+         <or line='845' op='or'>
           <fn name='not'>
            <varRef name='Q{}relative' slot='7'/>
           </fn>
@@ -9293,9 +9533,9 @@
            <str val='.'/>
           </vc>
          </or>
-         <varRef line='3380' name='Q{}nodeset' slot='1'/>
+         <varRef line='3412' name='Q{}nodeset' slot='1'/>
          <true/>
-         <let line='849' var='Q{}parentCallCount' as='xs:integer' slot='8' eval='16'>
+         <let line='850' var='Q{}parentCallCount' as='xs:integer' slot='8' eval='16'>
           <choose>
            <fn name='contains'>
             <varRef name='Q{}relative' slot='7'/>
@@ -9322,30 +9562,30 @@
            <true/>
            <int val='0'/>
           </choose>
-          <let line='852' var='Q{}slashes' as='xs:integer*' slot='9' eval='4'>
+          <let line='853' var='Q{}slashes' as='xs:integer*' slot='9' eval='4'>
            <choose>
-            <fn line='3380' name='contains'>
+            <fn line='3412' name='contains'>
              <varRef name='Q{}nodeset' slot='1'/>
              <str val='/'/>
             </fn>
             <fn name='index-of'>
              <fn name='string-to-codepoints'>
-              <varRef line='3380' name='Q{}nodeset' slot='1'/>
+              <varRef line='3412' name='Q{}nodeset' slot='1'/>
              </fn>
              <int val='47'/>
             </fn>
             <true/>
             <int val='0'/>
            </choose>
-           <choose line='884'>
+           <choose line='885'>
             <compareToInt op='gt' val='0'>
              <varRef name='Q{}parentCallCount' slot='8'/>
             </compareToInt>
-            <fn line='888' name='concat'>
+            <fn line='889' name='concat'>
              <fn name='substring'>
-              <varRef line='3380' name='Q{}nodeset' slot='1'/>
+              <varRef line='3412' name='Q{}nodeset' slot='1'/>
               <int val='1'/>
-              <choose line='863'>
+              <choose line='864'>
                <and op='and'>
                 <vc op='ge' onEmpty='0' comp='CAVC'>
                  <fn name='count'>
@@ -9357,7 +9597,7 @@
                  <varRef name='Q{}parentCallCount' slot='8'/>
                 </compareToInt>
                </and>
-               <let line='864' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='10' eval='13'>
+               <let line='865' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='10' eval='13'>
                 <arith op='-' calc='i-i'>
                  <varRef name='Q{}parentCallCount' slot='8'/>
                  <int val='1'/>
@@ -9373,7 +9613,7 @@
                 </check>
                </let>
                <true/>
-               <check line='867' card='1' diag='3|0|XTTE0570|parentSlash'>
+               <check line='868' card='1' diag='3|0|XTTE0570|parentSlash'>
                 <lastOf>
                  <varRef name='Q{}slashes' slot='9'/>
                 </lastOf>
@@ -9388,18 +9628,18 @@
              </fn>
             </fn>
             <true/>
-            <fn line='3380' name='concat'>
+            <fn line='3412' name='concat'>
              <varRef name='Q{}nodeset' slot='1'/>
              <str val='/'/>
-             <varRef line='891' name='Q{}relative' slot='7'/>
+             <varRef line='892' name='Q{}relative' slot='7'/>
             </fn>
            </choose>
           </let>
          </let>
         </choose>
        </let>
-       <varRef line='3382' name='Q{}nodeset' slot='1'/>
-       <choose line='3385'>
+       <varRef line='3414' name='Q{}nodeset' slot='1'/>
+       <choose line='3417'>
         <fn name='starts-with'>
          <varRef name='Q{}nodeset' slot='1'/>
          <str val='/'/>
@@ -9414,7 +9654,7 @@
         <varRef name='Q{}nodeset' slot='1'/>
        </choose>
        <true/>
-       <cvUntyped line='3389' to='xs:string' diag='3|0|XTTE0570|data-ref'>
+       <cvUntyped line='3421' to='xs:string' diag='3|0|XTTE0570|data-ref'>
         <cast as='xs:untypedAtomic' emptiable='0'>
          <varRef name='Q{}nodeset' slot='1'/>
         </cast>
@@ -9425,18 +9665,18 @@
    </sequence>
   </template>
  </co>
- <co id='5' binds='22'>
-  <function name='Q{http://www.w3.org/2002/xforms}setInstance-JS' line='3230' module='saxon-xforms.xsl' eval='7' flags='pU' as='empty-sequence()' slots='2'>
+ <co id='5' binds='24'>
+  <function name='Q{http://www.w3.org/2002/xforms}setInstance-JS' line='3262' module='saxon-xforms.xsl' eval='7' flags='pU' as='empty-sequence()' slots='2'>
    <arg name='Q{}ref' as='xs:string'/>
    <arg name='Q{}updatedInstance' as='element()'/>
-   <check role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3238' card='°' diag='5|0|XTTE0780|xforms:setInstance-JS#2'>
+   <check role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3270' card='°' diag='5|0|XTTE0780|xforms:setInstance-JS#2'>
     <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
      <check card='1' diag='0|0||ixsl:call'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
      </check>
      <str val='setInstance'/>
      <arrayBlock>
-      <check line='3236' card='1' diag='3|0|XTTE0570|this-instance-id'>
+      <check line='3268' card='1' diag='3|0|XTTE0570|this-instance-id'>
        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
         <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='0' eval='6'>
          <varRef name='Q{}ref' slot='0'/>
@@ -9450,15 +9690,15 @@
    </check>
   </function>
  </co>
- <co id='2' binds='41 22'>
-  <function name='Q{http://www.w3.org/2002/xforms}getInstance-JS' line='3203' module='saxon-xforms.xsl' eval='7' flags='pU' as='element()?' slots='1'>
+ <co id='2' binds='43 24'>
+  <function name='Q{http://www.w3.org/2002/xforms}getInstance-JS' line='3235' module='saxon-xforms.xsl' eval='7' flags='pU' as='element()?' slots='1'>
    <arg name='Q{}ref' as='xs:string'/>
-   <tailCallLoop role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3207'>
+   <tailCallLoop role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3239'>
     <choose>
      <fn name='not'>
       <varRef name='Q{}ref' slot='0'/>
      </fn>
-     <treat line='3208' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='5|0|XTTE0780|xforms:getInstance-JS#1'>
+     <treat line='3240' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='5|0|XTTE0780|xforms:getInstance-JS#1'>
       <message>
        <valueOf role='select'>
         <str val='[xforms:getInstance-JS] Empty ref supplied, no instance will be returned'/>
@@ -9468,8 +9708,8 @@
       </message>
      </treat>
      <true/>
-     <ufCall line='3213' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='foreign' bSlot='0' eval='16'>
-      <check line='3211' card='1' diag='3|0|XTTE0570|this-instance-id'>
+     <ufCall line='3245' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='foreign' bSlot='0' eval='16'>
+      <check line='3243' card='1' diag='3|0|XTTE0570|this-instance-id'>
        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
         <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='1' eval='6'>
          <varRef name='Q{}ref' slot='0'/>
@@ -9482,95 +9722,54 @@
    </tailCallLoop>
   </function>
  </co>
- <co id='22' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}getInstanceMap' line='3097' module='saxon-xforms.xsl' eval='8' flags='pU' as='map(xs:string, xs:string)' slots='3'>
+ <co id='24' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}getInstanceMap' line='3132' module='saxon-xforms.xsl' eval='8' flags='pU' as='map(xs:string, xs:string)' slots='3'>
    <arg name='Q{}nodeset' as='xs:string'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3121' var='Q{http://saxon.sf.net/generated-variable}v0' as='map(xs:string, xs:string)+' slot='1' eval='4'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3153' var='Q{http://saxon.sf.net/generated-variable}v0' as='map(xs:string, xs:string)+' slot='1' eval='4'>
     <sequence>
      <map size='1'>
       <str val='instance-id'/>
       <str val='saxon-forms-default'/>
      </map>
-     <ifCall line='3122' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+     <ifCall line='3154' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
       <str val='xpath'/>
       <fn name='normalize-space'>
        <varRef name='Q{}nodeset' slot='0'/>
       </fn>
      </ifCall>
     </sequence>
-    <ifCall line='3102' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+    <ifCall line='3137' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
      <analyzeString>
       <fn role='select' name='normalize-space'>
        <varRef name='Q{}nodeset' slot='0'/>
       </fn>
       <str role='regex' val='^instance\s*\(\s*&#39;([^&#39;]+)&#39;\s*\)\s*(/\s*(.*)|)$'/>
       <str role='flags' val=''/>
-      <let role='matching' line='3104' var='Q{}xpath' as='xs:string' slot='2' eval='16'>
-       <choose line='3106'>
+      <let role='matching' line='3139' var='Q{}xpath' as='xs:string' slot='2' eval='16'>
+       <choose line='3141'>
         <fn name='regex-group'>
          <int val='2'/>
         </fn>
-        <fn line='3107' name='regex-group'>
+        <fn line='3142' name='regex-group'>
          <int val='3'/>
         </fn>
         <true/>
         <str val='.'/>
        </choose>
-       <sequence line='3114'>
-        <message>
-         <sequence role='select'>
-          <valueOf>
-           <str val='[xforms:getInstanceMap] From $nodeset = &#39;'/>
-          </valueOf>
-          <varRef name='Q{}nodeset' slot='0'/>
-          <valueOf flags='S'>
-           <str val='&#39;'/>
-          </valueOf>
-         </sequence>
-         <str role='terminate' val='no'/>
-         <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-        </message>
-        <message line='3115'>
-         <sequence role='select'>
-          <valueOf>
-           <str val='[xforms:getInstanceMap] &#39;instance-id&#39; = &#39;'/>
-          </valueOf>
-          <fn name='regex-group'>
-           <int val='1'/>
-          </fn>
-          <valueOf flags='S'>
-           <str val='&#39;'/>
-          </valueOf>
-         </sequence>
-         <str role='terminate' val='no'/>
-         <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-        </message>
-        <message line='3116'>
-         <sequence role='select'>
-          <valueOf>
-           <str val='[xforms:getInstanceMap] &#39;xpath&#39; = &#39;'/>
-          </valueOf>
-          <varRef name='Q{}xpath' slot='2'/>
-          <valueOf flags='S'>
-           <str val='&#39;'/>
-          </valueOf>
-         </sequence>
-         <str role='terminate' val='no'/>
-         <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-        </message>
-        <ifCall line='3117' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+       <sequence line='3149'>
+        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
          <str val='instance-id'/>
          <fn name='regex-group'>
           <int val='1'/>
          </fn>
         </ifCall>
-        <ifCall line='3118' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+        <ifCall line='3150' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
          <str val='xpath'/>
          <varRef name='Q{}xpath' slot='2'/>
         </ifCall>
        </sequence>
       </let>
-      <varRef role='nonMatching' line='3121' name='Q{http://saxon.sf.net/generated-variable}v0' slot='1'/>
+      <varRef role='nonMatching' line='3153' name='Q{http://saxon.sf.net/generated-variable}v0' slot='1'/>
      </analyzeString>
      <map size='2'>
       <str val='duplicates'/>
@@ -9582,14 +9781,14 @@
    </let>
   </function>
  </co>
- <co id='1' binds='22'>
-  <function name='Q{http://www.w3.org/2002/xforms}getInstanceId' line='3084' module='saxon-xforms.xsl' eval='8' flags='pU' as='xs:string' slots='1'>
+ <co id='1' binds='24'>
+  <function name='Q{http://www.w3.org/2002/xforms}getInstanceId' line='3119' module='saxon-xforms.xsl' eval='8' flags='pU' as='xs:string' slots='1'>
    <arg name='Q{}nodeset' as='xs:string'/>
-   <cvUntyped role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3087' to='xs:string' diag='5|0|XTTE0780|xforms:getInstanceId#1'>
+   <cvUntyped role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3122' to='xs:string' diag='5|0|XTTE0780|xforms:getInstanceId#1'>
     <cast as='xs:untypedAtomic' emptiable='0'>
      <fn name='string'>
       <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-       <ufCall line='3086' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='0' eval='6'>
+       <ufCall line='3121' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='0' eval='6'>
         <varRef name='Q{}nodeset' slot='0'/>
        </ufCall>
        <str val='instance-id'/>
@@ -9605,14 +9804,14 @@
   </globalVariable>
  </co>
  <co id='66' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}getWhileStatement' line='806' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
+  <function name='Q{http://www.w3.org/2002/xforms}getWhileStatement' line='807' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
    <arg name='Q{}map' as='map(*)'/>
-   <choose role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='809'>
+   <choose role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='810'>
     <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
      <varRef name='Q{}map' slot='0'/>
      <str val='@while'/>
     </ifCall>
-    <treat line='810' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
+    <treat line='811' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
      <check card='?' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
       <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
        <data>
@@ -9625,7 +9824,7 @@
      </check>
     </treat>
     <true/>
-    <treat line='813' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
+    <treat line='814' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
      <check card='?' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
       <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
        <data>
@@ -9646,9 +9845,9 @@
    </choose>
   </function>
  </co>
- <co id='67' binds='2 16 1 19'>
-  <template name='Q{}DOMActivate' flags='os' line='4364' module='saxon-xforms.xsl' slots='6'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4365'>
+ <co id='67' binds='2 16 1 21'>
+  <template name='Q{}DOMActivate' flags='os' line='4421' module='saxon-xforms.xsl' slots='6'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4422'>
     <param name='Q{}form-control' slot='0' flags='i' as='node()'>
      <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|form-control'>
       <check card='1' diag='8|0|XTTE0590|form-control'>
@@ -9656,7 +9855,7 @@
       </check>
      </treat>
     </param>
-    <let line='4367' var='Q{}actions' as='map(*)?' slot='1' eval='7'>
+    <let line='4424' var='Q{}actions' as='map(*)?' slot='1' eval='7'>
      <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
@@ -9673,12 +9872,12 @@
        </arrayBlock>
       </ifCall>
      </treat>
-     <let line='4369' var='Q{}refi' as='attribute(Q{}data-ref)?' slot='2' eval='8'>
+     <let line='4426' var='Q{}refi' as='attribute(Q{}data-ref)?' slot='2' eval='8'>
       <slash simple='1'>
        <varRef name='Q{}form-control' slot='0'/>
        <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
       </slash>
-      <let line='4373' var='Q{}instanceXML' as='element()?' slot='3' eval='7'>
+      <let line='4430' var='Q{}instanceXML' as='element()?' slot='3' eval='7'>
        <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='0' eval='16'>
         <check card='1' diag='0|0||xforms:getInstance-JS'>
          <cvUntyped to='xs:string'>
@@ -9688,17 +9887,17 @@
          </cvUntyped>
         </check>
        </ufCall>
-       <let line='4375' var='Q{}updatedInstanceXML' as='element()?' slot='4' eval='7'>
-        <choose line='4376'>
+       <let line='4432' var='Q{}updatedInstanceXML' as='element()?' slot='4' eval='7'>
+        <choose line='4433'>
          <fn name='exists'>
           <varRef name='Q{}instanceXML' slot='3'/>
          </fn>
-         <treat line='4377' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+         <treat line='4434' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
           <check card='?' diag='3|0|XTTE0570|updatedInstanceXML'>
            <applyT mode='Q{}form-check-initial' bSlot='1'>
             <varRef role='select' name='Q{}instanceXML' slot='3'/>
             <withParam name='Q{}instance-id' as='xs:string'>
-             <ufCall line='4371' name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='2' eval='16'>
+             <ufCall line='4428' name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='2' eval='16'>
               <check card='1' diag='0|0||xforms:getInstanceId'>
                <cvUntyped to='xs:string'>
                 <data>
@@ -9712,16 +9911,16 @@
           </check>
          </treat>
         </choose>
-        <forEach line='4383'>
+        <forEach line='4440'>
          <varRef name='Q{}actions' slot='1'/>
-         <let line='4384' var='Q{}action-map' as='map(*)' slot='5' eval='16'>
+         <let line='4441' var='Q{}action-map' as='map(*)' slot='5' eval='16'>
           <dot type='map(*)'/>
-          <choose line='4387'>
+          <choose line='4444'>
            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
             <varRef name='Q{}action-map' slot='5'/>
             <str val='@event'/>
            </ifCall>
-           <choose line='4388'>
+           <choose line='4445'>
             <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
              <data>
               <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
@@ -9731,12 +9930,12 @@
              </data>
              <str val='DOMActivate'/>
             </gc>
-            <callT line='4389' name='Q{}applyActions' bSlot='3' flags='t'>
+            <callT line='4446' name='Q{}applyActions' bSlot='3' flags='t'>
              <withParam name='Q{}action-map' flags='t' as='item()'>
-              <varRef line='4390' name='Q{}action-map' slot='5'/>
+              <varRef line='4447' name='Q{}action-map' slot='5'/>
              </withParam>
              <withParam name='Q{}instanceXML' flags='t' as='element()?'>
-              <varRef line='4391' name='Q{}updatedInstanceXML' slot='4'/>
+              <varRef line='4448' name='Q{}updatedInstanceXML' slot='4'/>
              </withParam>
             </callT>
            </choose>
@@ -9750,9 +9949,9 @@
    </sequence>
   </template>
  </co>
- <co id='64' binds='42'>
-  <template name='Q{}setActions' flags='os' line='3638' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3639'>
+ <co id='64' binds='44'>
+  <template name='Q{}setActions' flags='os' line='3674' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3675'>
     <param name='Q{}this' slot='0' flags='i' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
       <check card='1' diag='8|0|XTTE0590|this'>
@@ -9760,7 +9959,7 @@
       </check>
      </treat>
     </param>
-    <applyT line='3641' flags='t' bSlot='0'>
+    <applyT line='3677' flags='t' bSlot='0'>
      <union role='select' op='|'>
       <union op='|'>
        <union op='|'>
@@ -9824,8 +10023,8 @@
   </template>
  </co>
  <co id='68' binds=''>
-  <template name='Q{}serverError' flags='os' line='1058' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1059'>
+  <template name='Q{}serverError' flags='os' line='1059' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1060'>
     <param name='Q{}responseMap' slot='0' flags='i' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|responseMap'>
       <check card='1' diag='8|0|XTTE0590|responseMap'>
@@ -9833,7 +10032,7 @@
       </check>
      </treat>
     </param>
-    <message line='1060'>
+    <message line='1061'>
      <sequence role='select'>
       <valueOf>
        <str val='Server side error HTTP response - '/>
@@ -9862,9 +10061,9 @@
    </sequence>
   </template>
  </co>
- <co id='61' binds='62 63 42'>
-  <template name='Q{}setAction' flags='os' line='3805' module='saxon-xforms.xsl' slots='15'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3806'>
+ <co id='61' binds='62 63 44'>
+  <template name='Q{}setAction' flags='os' line='3841' module='saxon-xforms.xsl' slots='15'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3842'>
     <param name='Q{}this' slot='0' flags='i' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
       <check card='1' diag='8|0|XTTE0590|this'>
@@ -9872,42 +10071,42 @@
       </check>
      </treat>
     </param>
-    <param line='3807' name='Q{}nodeset' slot='1' flags='t'>
+    <param line='3843' name='Q{}nodeset' slot='1' flags='t'>
      <str role='select' val=''/>
      <supplied role='conversion' slot='1'/>
     </param>
-    <let line='3810' var='Q{}bindingi' as='node()?' slot='2' eval='7'>
-     <treat line='3811' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+    <let line='3846' var='Q{}bindingi' as='node()?' slot='2' eval='7'>
+     <treat line='3847' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
       <check card='?' diag='3|0|XTTE0570|bindingi'>
        <callT name='Q{}getBinding' bSlot='0'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <treat line='3812' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+         <treat line='3848' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
           <dot flags='a'/>
          </treat>
         </withParam>
        </callT>
       </check>
      </treat>
-     <let line='3817' var='Q{}refi' as='xs:string' slot='3' eval='16'>
-      <treat line='3818' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+     <let line='3853' var='Q{}refi' as='xs:string' slot='3' eval='16'>
+      <treat line='3854' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
        <check card='1' diag='3|0|XTTE0570|refi'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
          <data>
           <callT name='Q{}getDataRef' bSlot='1'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <treat line='3819' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+            <treat line='3855' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
              <dot flags='a'/>
             </treat>
            </withParam>
            <withParam name='Q{}bindingi' flags='c' as='node()?'>
-            <varRef line='3820' name='Q{}bindingi' slot='2'/>
+            <varRef line='3856' name='Q{}bindingi' slot='2'/>
            </withParam>
           </callT>
          </data>
         </cvUntyped>
        </check>
       </treat>
-      <ifCall line='3828' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+      <ifCall line='3864' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
        <sequence>
         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
          <str val='name'/>
@@ -9917,14 +10116,14 @@
           </treat>
          </fn>
         </ifCall>
-        <choose line='3830'>
+        <choose line='3866'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}value)' jsTest='return item.name===&#39;value&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3831' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3867' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@value'/>
           <fn name='string'>
            <slash simple='1'>
@@ -9934,7 +10133,7 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3833'>
+        <choose line='3869'>
          <and op='and'>
           <fn name='empty'>
            <slash simple='1'>
@@ -9951,25 +10150,25 @@
            </slash>
           </fn>
          </and>
-         <ifCall line='3834' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3870' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='value'/>
           <fn name='string'>
            <dot flags='a'/>
           </fn>
          </ifCall>
         </choose>
-        <ifCall line='3837' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+        <ifCall line='3873' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
          <str val='@ref'/>
          <varRef name='Q{}refi' slot='3'/>
         </ifCall>
-        <choose line='3843'>
+        <choose line='3879'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}position)' jsTest='return item.name===&#39;position&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3844' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3880' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@position'/>
           <fn name='string'>
            <slash simple='1'>
@@ -9979,14 +10178,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3846'>
+        <choose line='3882'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}at)' jsTest='return item.name===&#39;at&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3847' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3883' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@at'/>
           <fn name='string'>
            <slash simple='1'>
@@ -9996,14 +10195,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3851'>
+        <choose line='3887'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}if)' jsTest='return item.name===&#39;if&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3852' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3888' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@if'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10013,14 +10212,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3856'>
+        <choose line='3892'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}while)' jsTest='return item.name===&#39;while&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3857' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3893' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@while'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10030,14 +10229,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3860'>
+        <choose line='3896'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='@*:event' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===2&amp;&amp;q.local===&#39;event&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3861' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3897' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@event'/>
           <fn name='string'>
            <check card='?' diag='0|0||fn:string'>
@@ -10049,14 +10248,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3863'>
+        <choose line='3899'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}submission)' jsTest='return item.name===&#39;submission&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3864' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3900' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@submission'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10066,14 +10265,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3867'>
+        <choose line='3903'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}model)' jsTest='return item.name===&#39;model&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3868' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3904' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@model'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10083,14 +10282,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3871'>
+        <choose line='3907'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}control)' jsTest='return item.name===&#39;control&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3872' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3908' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@control'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10100,14 +10299,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3875'>
+        <choose line='3911'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}repeat)' jsTest='return item.name===&#39;repeat&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3876' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3912' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@repeat'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10117,14 +10316,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3879'>
+        <choose line='3915'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}index)' jsTest='return item.name===&#39;index&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3880' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3916' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@index'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10134,16 +10333,16 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3885'>
+        <choose line='3921'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}origin)' jsTest='return item.name===&#39;origin&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3893' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3929' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@origin'/>
-          <let line='3889' var='Q{}base' as='xs:string' slot='4' eval='16'>
+          <let line='3925' var='Q{}base' as='xs:string' slot='4' eval='16'>
            <choose>
             <fn name='exists'>
              <slash simple='1'>
@@ -10172,22 +10371,22 @@
                 </data>
                </cvUntyped>
               </check>
-              <choose line='835'>
+              <choose line='836'>
                <fn name='starts-with'>
                 <varRef name='Q{}relative' slot='6'/>
                 <str val='/'/>
                </fn>
-               <varRef line='836' name='Q{}relative' slot='6'/>
-               <fn line='838' name='starts-with'>
+               <varRef line='837' name='Q{}relative' slot='6'/>
+               <fn line='839' name='starts-with'>
                 <varRef name='Q{}relative' slot='6'/>
                 <str val='instance('/>
                </fn>
-               <varRef line='839' name='Q{}relative' slot='6'/>
-               <fn line='841' name='not'>
+               <varRef line='840' name='Q{}relative' slot='6'/>
+               <fn line='842' name='not'>
                 <varRef name='Q{}base' slot='5'/>
                </fn>
-               <varRef line='842' name='Q{}relative' slot='6'/>
-               <or line='844' op='or'>
+               <varRef line='843' name='Q{}relative' slot='6'/>
+               <or line='845' op='or'>
                 <fn name='not'>
                  <varRef name='Q{}relative' slot='6'/>
                 </fn>
@@ -10196,9 +10395,9 @@
                  <str val='.'/>
                 </vc>
                </or>
-               <varRef line='845' name='Q{}base' slot='5'/>
+               <varRef line='846' name='Q{}base' slot='5'/>
                <true/>
-               <let line='849' var='Q{}parentCallCount' as='xs:integer' slot='7' eval='16'>
+               <let line='850' var='Q{}parentCallCount' as='xs:integer' slot='7' eval='16'>
                 <choose>
                  <fn name='contains'>
                   <varRef name='Q{}relative' slot='6'/>
@@ -10225,7 +10424,7 @@
                  <true/>
                  <int val='0'/>
                 </choose>
-                <let line='852' var='Q{}slashes' as='xs:integer*' slot='8' eval='4'>
+                <let line='853' var='Q{}slashes' as='xs:integer*' slot='8' eval='4'>
                  <choose>
                   <fn name='contains'>
                    <varRef name='Q{}base' slot='5'/>
@@ -10240,15 +10439,15 @@
                   <true/>
                   <int val='0'/>
                  </choose>
-                 <choose line='884'>
+                 <choose line='885'>
                   <compareToInt op='gt' val='0'>
                    <varRef name='Q{}parentCallCount' slot='7'/>
                   </compareToInt>
-                  <fn line='888' name='concat'>
+                  <fn line='889' name='concat'>
                    <fn name='substring'>
                     <varRef name='Q{}base' slot='5'/>
                     <int val='1'/>
-                    <choose line='863'>
+                    <choose line='864'>
                      <and op='and'>
                       <vc op='ge' onEmpty='0' comp='CAVC'>
                        <fn name='count'>
@@ -10260,7 +10459,7 @@
                        <varRef name='Q{}parentCallCount' slot='7'/>
                       </compareToInt>
                      </and>
-                     <let line='864' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='9' eval='16'>
+                     <let line='865' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='9' eval='16'>
                       <arith op='-' calc='i-i'>
                        <varRef name='Q{}parentCallCount' slot='7'/>
                        <int val='1'/>
@@ -10276,7 +10475,7 @@
                       </check>
                      </let>
                      <true/>
-                     <check line='867' card='1' diag='3|0|XTTE0570|parentSlash'>
+                     <check line='868' card='1' diag='3|0|XTTE0570|parentSlash'>
                       <lastOf>
                        <varRef name='Q{}slashes' slot='8'/>
                       </lastOf>
@@ -10291,7 +10490,7 @@
                    </fn>
                   </fn>
                   <true/>
-                  <fn line='891' name='concat'>
+                  <fn line='892' name='concat'>
                    <varRef name='Q{}base' slot='5'/>
                    <str val='/'/>
                    <varRef name='Q{}relative' slot='6'/>
@@ -10313,7 +10512,7 @@
              </check>
             </treat>
            </choose>
-           <let line='3891' var='Q{}relative' as='xs:string' slot='10' eval='16'>
+           <let line='3927' var='Q{}relative' as='xs:string' slot='10' eval='16'>
             <check card='1' diag='0|1||xforms:resolveXPathStrings'>
              <cvUntyped to='xs:string'>
               <data>
@@ -10324,22 +10523,22 @@
               </data>
              </cvUntyped>
             </check>
-            <choose line='835'>
+            <choose line='836'>
              <fn name='starts-with'>
               <varRef name='Q{}relative' slot='10'/>
               <str val='/'/>
              </fn>
-             <varRef line='836' name='Q{}relative' slot='10'/>
-             <fn line='838' name='starts-with'>
+             <varRef line='837' name='Q{}relative' slot='10'/>
+             <fn line='839' name='starts-with'>
               <varRef name='Q{}relative' slot='10'/>
               <str val='instance('/>
              </fn>
-             <varRef line='839' name='Q{}relative' slot='10'/>
-             <fn line='841' name='not'>
+             <varRef line='840' name='Q{}relative' slot='10'/>
+             <fn line='842' name='not'>
               <varRef name='Q{}base' slot='4'/>
              </fn>
-             <varRef line='842' name='Q{}relative' slot='10'/>
-             <or line='844' op='or'>
+             <varRef line='843' name='Q{}relative' slot='10'/>
+             <or line='845' op='or'>
               <fn name='not'>
                <varRef name='Q{}relative' slot='10'/>
               </fn>
@@ -10348,9 +10547,9 @@
                <str val='.'/>
               </vc>
              </or>
-             <varRef line='845' name='Q{}base' slot='4'/>
+             <varRef line='846' name='Q{}base' slot='4'/>
              <true/>
-             <let line='849' var='Q{}parentCallCount' as='xs:integer' slot='11' eval='16'>
+             <let line='850' var='Q{}parentCallCount' as='xs:integer' slot='11' eval='16'>
               <choose>
                <fn name='contains'>
                 <varRef name='Q{}relative' slot='10'/>
@@ -10377,7 +10576,7 @@
                <true/>
                <int val='0'/>
               </choose>
-              <let line='852' var='Q{}slashes' as='xs:integer*' slot='12' eval='4'>
+              <let line='853' var='Q{}slashes' as='xs:integer*' slot='12' eval='4'>
                <choose>
                 <fn name='contains'>
                  <varRef name='Q{}base' slot='4'/>
@@ -10392,15 +10591,15 @@
                 <true/>
                 <int val='0'/>
                </choose>
-               <choose line='884'>
+               <choose line='885'>
                 <compareToInt op='gt' val='0'>
                  <varRef name='Q{}parentCallCount' slot='11'/>
                 </compareToInt>
-                <fn line='888' name='concat'>
+                <fn line='889' name='concat'>
                  <fn name='substring'>
                   <varRef name='Q{}base' slot='4'/>
                   <int val='1'/>
-                  <choose line='863'>
+                  <choose line='864'>
                    <and op='and'>
                     <vc op='ge' onEmpty='0' comp='CAVC'>
                      <fn name='count'>
@@ -10412,7 +10611,7 @@
                      <varRef name='Q{}parentCallCount' slot='11'/>
                     </compareToInt>
                    </and>
-                   <let line='864' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='13' eval='13'>
+                   <let line='865' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='13' eval='13'>
                     <arith op='-' calc='i-i'>
                      <varRef name='Q{}parentCallCount' slot='11'/>
                      <int val='1'/>
@@ -10428,7 +10627,7 @@
                     </check>
                    </let>
                    <true/>
-                   <check line='867' card='1' diag='3|0|XTTE0570|parentSlash'>
+                   <check line='868' card='1' diag='3|0|XTTE0570|parentSlash'>
                     <lastOf>
                      <varRef name='Q{}slashes' slot='12'/>
                     </lastOf>
@@ -10443,7 +10642,7 @@
                  </fn>
                 </fn>
                 <true/>
-                <fn line='891' name='concat'>
+                <fn line='892' name='concat'>
                  <varRef name='Q{}base' slot='4'/>
                  <str val='/'/>
                  <varRef name='Q{}relative' slot='10'/>
@@ -10456,28 +10655,28 @@
           </let>
          </ifCall>
         </choose>
-        <choose line='3897'>
+        <choose line='3933'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
           </slash>
          </fn>
-         <ifCall line='3898' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3934' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='nested-actions'/>
-          <let line='3899' var='Q{}array' as='map(*)*' slot='14' eval='3'>
-           <treat line='3900' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|array'>
+          <let line='3935' var='Q{}array' as='map(*)*' slot='14' eval='3'>
+           <treat line='3936' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|array'>
             <forEach>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
              </slash>
-             <applyT line='3901' bSlot='2'>
+             <applyT line='3937' bSlot='2'>
               <dot role='select' type='element()'/>
              </applyT>
             </forEach>
            </treat>
-           <ifCall line='3904' name='Q{http://www.w3.org/2005/xpath-functions/array}_from-sequence' type='array(*)'>
+           <ifCall line='3940' name='Q{http://www.w3.org/2005/xpath-functions/array}_from-sequence' type='array(*)'>
             <varRef name='Q{}array' slot='14'/>
            </ifCall>
           </let>
@@ -10497,9 +10696,9 @@
   </template>
  </co>
  <co id='69' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}check-constraints-on-fields' line='956' module='saxon-xforms.xsl' eval='8' flags='pU' as='item()*' slots='4'>
+  <function name='Q{http://www.w3.org/2002/xforms}check-constraints-on-fields' line='957' module='saxon-xforms.xsl' eval='8' flags='pU' as='item()*' slots='4'>
    <arg name='Q{}updatedInstanceXML' as='document-node()'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='959' var='Q{}constraint-fieldsi' as='element()*' slot='1' eval='8'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='960' var='Q{}constraint-fieldsi' as='element()*' slot='1' eval='8'>
     <filter flags='b'>
      <slash simple='1'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
@@ -10509,10 +10708,10 @@
       <axis name='attribute' nodeTest='attribute(Q{}data-constraint)' jsTest='return item.name===&#39;data-constraint&#39;'/>
      </fn>
     </filter>
-    <forEach line='963'>
+    <forEach line='964'>
      <varRef name='Q{}constraint-fieldsi' slot='1'/>
-     <let line='964' var='Q{}contexti' as='node()' slot='2' eval='16'>
-      <treat line='965' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|contexti'>
+     <let line='965' var='Q{}contexti' as='node()' slot='2' eval='16'>
+      <treat line='966' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|contexti'>
        <check card='1' diag='3|0|XTTE0570|contexti'>
         <evaluate dxns=''>
          <check role='xpath' card='1' diag='4|0||xsl:evaluate/xpath'>
@@ -10528,8 +10727,8 @@
         </evaluate>
        </check>
       </treat>
-      <let line='968' var='Q{}resulti' as='xs:boolean' slot='3' eval='16'>
-       <treat line='971' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|resulti'>
+      <let line='969' var='Q{}resulti' as='xs:boolean' slot='3' eval='16'>
+       <treat line='972' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|resulti'>
         <check card='1' diag='3|0|XTTE0570|resulti'>
          <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|resulti'>
           <data>
@@ -10549,7 +10748,7 @@
          </cvUntyped>
         </check>
        </treat>
-       <choose line='979'>
+       <choose line='980'>
         <fn name='not'>
          <varRef name='Q{}resulti' slot='3'/>
         </fn>
@@ -10563,9 +10762,9 @@
  </co>
  <co id='48' binds='57'>
   <mode name='Q{}binding-calculation-initial' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='28' rank='0' minImp='0' slots='2' flags='s' line='2709' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='28' rank='0' minImp='0' slots='2' flags='s' line='2744' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2710'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2745'>
      <param name='Q{}instance-id' slot='0' as='xs:string'>
       <str role='select' val='saxon-forms-default'/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|instance-id'>
@@ -10578,7 +10777,7 @@
        </check>
       </treat>
      </param>
-     <let line='2712' var='Q{}calculationMap' as='map(xs:string, xs:string)' slot='1' eval='16'>
+     <let line='2747' var='Q{}calculationMap' as='map(xs:string, xs:string)' slot='1' eval='16'>
       <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|calculationMap'>
        <check card='1' diag='3|0|XTTE0570|calculationMap'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
@@ -10590,18 +10789,18 @@
         </ifCall>
        </check>
       </treat>
-      <copy line='2726' flags='cin'>
+      <copy line='2761' flags='cin'>
        <applyT role='content' mode='Q{}binding-calculation' bSlot='0'>
         <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
         <withParam name='Q{}curPath' as='xs:string'>
-         <choose line='2716'>
+         <choose line='2751'>
           <vc op='eq' onEmpty='0' comp='CCC'>
            <varRef name='Q{}instance-id' slot='0'/>
            <str val='saxon-forms-default'/>
           </vc>
           <str val=''/>
           <true/>
-          <cvUntyped line='2720' to='xs:string' diag='3|0|XTTE0570|curPath'>
+          <cvUntyped line='2755' to='xs:string' diag='3|0|XTTE0570|curPath'>
            <cast as='xs:untypedAtomic' emptiable='0'>
             <fn name='concat'>
              <str val='instance(&#39;'/>
@@ -10613,7 +10812,7 @@
          </choose>
         </withParam>
         <withParam name='Q{}calculationMap' flags='t' as='map(xs:string, xs:string)'>
-         <varRef line='2728' name='Q{}calculationMap' slot='1'/>
+         <varRef line='2763' name='Q{}calculationMap' slot='1'/>
         </withParam>
        </applyT>
       </copy>
@@ -10622,29 +10821,29 @@
    </templateRule>
   </mode>
  </co>
- <co id='70' binds='18 18'>
+ <co id='70' binds='20 20'>
   <mode name='Q{http://saxonica.com/ns/interactiveXSLT}onchange' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='0.0' seq='1' rank='0' minImp='0' slots='0' flags='s' line='709' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='1' rank='0' minImp='0' slots='0' flags='s' line='710' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
-    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='710' name='Q{}xforms-value-changed' bSlot='0' flags='t'>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='711' name='Q{}xforms-value-changed' bSlot='0' flags='t'>
      <withParam name='Q{}form-control' flags='c' as='node()'>
-      <dot line='711' type='element(Q{}input)'/>
+      <dot line='712' type='element(Q{}input)'/>
      </withParam>
     </callT>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='2' rank='0' minImp='0' slots='0' flags='s' line='719' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='2' rank='0' minImp='0' slots='0' flags='s' line='720' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{}select)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;select&#39;;'/>
-    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='720' name='Q{}xforms-value-changed' bSlot='1' flags='t'>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='721' name='Q{}xforms-value-changed' bSlot='1' flags='t'>
      <withParam name='Q{}form-control' flags='c' as='node()'>
-      <dot line='721' type='element(Q{}select)'/>
+      <dot line='722' type='element(Q{}select)'/>
      </withParam>
     </callT>
    </templateRule>
   </mode>
  </co>
- <co id='54' binds='46 71 58 58 72 42'>
-  <template name='Q{}xformsjs-main' flags='os' line='111' module='saxon-xforms.xsl' slots='23'>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='607' var='Q{http://saxon.sf.net/generated-variable}v1' as='item()' slot='5' eval='13'>
+ <co id='54' binds='46 71 58 58 72 44'>
+  <template name='Q{}xformsjs-main' flags='os' line='111' module='saxon-xforms.xsl' slots='24'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='608' var='Q{http://saxon.sf.net/generated-variable}v1' as='item()' slot='5' eval='13'>
     <check card='1' diag='0|0||ixsl:call'>
      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
     </check>
@@ -10726,16 +10925,16 @@
             <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
            </slash>
           </check>
-          <compElem line='3000'>
+          <compElem line='3035'>
            <fn role='name' name='name'>
             <varRef name='Q{}this' slot='9'/>
            </fn>
-           <sequence role='content' line='3001'>
+           <sequence role='content' line='3036'>
             <namespace flags='l'>
              <str role='name' val='xforms'/>
              <str role='select' val='http://www.w3.org/2002/xforms'/>
             </namespace>
-            <forEach line='3002'>
+            <forEach line='3037'>
              <filter flags='b'>
               <filter flags='b'>
                <slash simple='1'>
@@ -10774,21 +10973,21 @@
                </gc>
               </fn>
              </filter>
-             <namespace line='3005' flags='l'>
-              <fn role='name' line='3004' name='substring-before'>
+             <namespace line='3040' flags='l'>
+              <fn role='name' line='3039' name='substring-before'>
                <fn name='name'>
                 <dot type='element()'/>
                </fn>
                <str val=':'/>
               </fn>
               <convert role='select' from='xs:anyURI' to='xs:string'>
-               <fn line='3003' name='namespace-uri'>
+               <fn line='3038' name='namespace-uri'>
                 <dot type='element()'/>
                </fn>
               </convert>
              </namespace>
             </forEach>
-            <copyOf line='3007' flags='vc'>
+            <copyOf line='3042' flags='vc'>
              <sequence>
               <slash simple='1'>
                <varRef name='Q{}this' slot='9'/>
@@ -11235,7 +11434,7 @@
                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
                    <axis name='descendant' nodeTest='element(Q{}head)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;head&#39;;'/>
                   </slash>
-                  <resultDoc line='293' global='#&#xA;#Sat Feb 22 17:48:53 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sat Feb 22 17:48:53 GMT 2020&#xA;'>
+                  <resultDoc line='293' global='#&#xA;#Sat Feb 22 22:54:41 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sat Feb 22 22:54:41 GMT 2020&#xA;'>
                    <str role='href' val='?.'/>
                    <elem role='content' line='294' name='script' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
                     <sequence>
@@ -11420,55 +11619,75 @@
                     </ifCall>
                    </cvUntyped>
                   </treat>
-                  <sequence line='606'>
-                   <message>
-                    <sequence role='select'>
-                     <valueOf>
-                      <str val='Setting submission with ID &#39;'/>
-                     </valueOf>
-                     <valueOf>
-                      <dot type='xs:string'/>
-                     </valueOf>
-                     <valueOf flags='S'>
-                      <str val='&#39;'/>
-                     </valueOf>
-                    </sequence>
-                    <str role='terminate' val='no'/>
-                    <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-                   </message>
-                   <ifCall line='607' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                    <varRef name='Q{http://saxon.sf.net/generated-variable}v1' slot='5'/>
-                    <str val='addSubmission'/>
-                    <arrayBlock>
+                  <let line='605' var='Q{}submission' as='map(*)' slot='23' eval='16'>
+                   <check card='1' diag='3|0|XTTE0570|submission'>
+                    <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                     <varRef name='Q{}submissions' slot='20'/>
                      <dot type='xs:string'/>
-                     <check line='605' card='1' diag='3|0|XTTE0570|submission'>
-                      <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                       <varRef name='Q{}submissions' slot='20'/>
+                    </ifCall>
+                   </check>
+                   <sequence line='606'>
+                    <message>
+                     <sequence role='select'>
+                      <valueOf>
+                       <str val='Setting submission with ID &#39;'/>
+                      </valueOf>
+                      <valueOf>
                        <dot type='xs:string'/>
-                      </ifCall>
-                     </check>
-                    </arrayBlock>
-                   </ifCall>
-                  </sequence>
+                      </valueOf>
+                      <valueOf flags='S'>
+                       <str val='&#39;'/>
+                      </valueOf>
+                     </sequence>
+                     <str role='terminate' val='no'/>
+                     <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+                    </message>
+                    <message line='607'>
+                     <sequence role='select'>
+                      <valueOf>
+                       <str val='Submission map: &#39;'/>
+                      </valueOf>
+                      <valueOf>
+                       <fn name='serialize'>
+                        <varRef name='Q{}submission' slot='23'/>
+                       </fn>
+                      </valueOf>
+                      <valueOf flags='S'>
+                       <str val='&#39;'/>
+                      </valueOf>
+                     </sequence>
+                     <str role='terminate' val='no'/>
+                     <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+                    </message>
+                    <ifCall line='608' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                     <varRef name='Q{http://saxon.sf.net/generated-variable}v1' slot='5'/>
+                     <str val='addSubmission'/>
+                     <arrayBlock>
+                      <dot type='xs:string'/>
+                      <varRef name='Q{}submission' slot='23'/>
+                     </arrayBlock>
+                    </ifCall>
+                   </sequence>
+                  </let>
                  </forEach>
-                 <resultDoc line='616' global='#&#xA;#Sat Feb 22 17:48:53 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sat Feb 22 17:48:53 GMT 2020&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xA;'>
+                 <resultDoc line='617' global='#&#xA;#Sat Feb 22 22:54:41 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sat Feb 22 22:54:41 GMT 2020&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xA;'>
                   <fn role='href' name='concat'>
                    <str val='#'/>
                    <varRef name='Q{}xFormsId' slot='4'/>
                   </fn>
-                  <applyT role='content' line='617' bSlot='5'>
+                  <applyT role='content' line='618' bSlot='5'>
                    <slash role='select' simple='1'>
                     <varRef name='Q{}xforms-doci' slot='7'/>
                     <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
                    </slash>
                    <withParam name='Q{}instances' flags='t' as='map(xs:string, element())'>
-                    <varRef line='618' name='Q{}xforms-instances' slot='10'/>
+                    <varRef line='619' name='Q{}xforms-instances' slot='10'/>
                    </withParam>
                    <withParam name='Q{}bindings' flags='t' as='map(xs:string, node())'>
-                    <varRef line='619' name='Q{}bindings' slot='14'/>
+                    <varRef line='620' name='Q{}bindings' slot='14'/>
                    </withParam>
                    <withParam name='Q{}submissions' flags='t' as='map(xs:string, map(*))'>
-                    <varRef line='620' name='Q{}submissions' slot='20'/>
+                    <varRef line='621' name='Q{}submissions' slot='20'/>
                    </withParam>
                    <withParam name='Q{}nodeset' flags='t' as='xs:string'>
                     <str val=''/>
@@ -11493,15 +11712,15 @@
  </co>
  <co id='71' binds='71'>
   <mode name='Q{}namespace-fix' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='31' rank='0' minImp='0' slots='1' flags='s' line='2864' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='31' rank='0' minImp='0' slots='1' flags='s' line='2899' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2865' var='Q{}current-namespace' as='xs:anyURI' slot='0' eval='8'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2900' var='Q{}current-namespace' as='xs:anyURI' slot='0' eval='8'>
      <fn name='namespace-uri'>
       <dot type='element()'/>
      </fn>
-     <compElem line='2867'>
+     <compElem line='2902'>
       <convert role='name' from='xs:QName' to='xs:string'>
-       <fn line='2866' name='QName'>
+       <fn line='2901' name='QName'>
         <convert from='xs:anyURI' to='xs:string'>
          <varRef name='Q{}current-namespace' slot='0'/>
         </convert>
@@ -11513,12 +11732,12 @@
       <convert role='namespace' from='xs:anyURI' to='xs:string'>
        <varRef name='Q{}current-namespace' slot='0'/>
       </convert>
-      <sequence role='content' line='2868'>
+      <sequence role='content' line='2903'>
        <namespace flags='l'>
         <str role='name' val='xforms'/>
         <str role='select' val='http://www.w3.org/2002/xforms'/>
        </namespace>
-       <applyT line='2870' mode='Q{}namespace-fix' bSlot='0'>
+       <applyT line='2905' mode='Q{}namespace-fix' bSlot='0'>
         <sequence role='select'>
          <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
          <axis name='child' nodeTest='( element() | text() | comment() | processing-instruction() )' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);'/>
@@ -11530,9 +11749,9 @@
    </templateRule>
   </mode>
  </co>
- <co id='53' binds='68 5 35'>
-  <template name='Q{}HTTPsubmit' cxt='map(*)' jsTest='return SaxonJS.U.isMap(item)' flags='s' line='1008' module='saxon-xforms.xsl' slots='5'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1014'>
+ <co id='53' binds='68 5 37'>
+  <template name='Q{}HTTPsubmit' cxt='map(*)' jsTest='return SaxonJS.U.isMap(item)' flags='s' line='1009' module='saxon-xforms.xsl' slots='5'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1015'>
     <param name='Q{}instance-id' slot='0' as='xs:string'>
      <str role='select' val='saxon-forms-default'/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|instance-id'>
@@ -11545,7 +11764,7 @@
       </check>
      </treat>
     </param>
-    <param line='1015' name='Q{}targetref' slot='1' as='xs:string?'>
+    <param line='1016' name='Q{}targetref' slot='1' as='xs:string?'>
      <empty role='select'/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|targetref'>
       <check card='?' diag='8|0|XTTE0590|targetref'>
@@ -11557,7 +11776,7 @@
       </check>
      </treat>
     </param>
-    <param line='1016' name='Q{}replace' slot='2' as='xs:string?'>
+    <param line='1017' name='Q{}replace' slot='2' as='xs:string?'>
      <empty role='select'/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|replace'>
       <check card='?' diag='8|0|XTTE0590|replace'>
@@ -11569,13 +11788,13 @@
       </check>
      </treat>
     </param>
-    <let line='1018' var='Q{}refi' as='xs:string' slot='3' eval='8'>
+    <let line='1019' var='Q{}refi' as='xs:string' slot='3' eval='8'>
      <fn name='concat'>
       <str val='instance(&#39;'/>
       <varRef name='Q{}instance-id' slot='0'/>
       <str val='&#39;)/'/>
      </fn>
-     <let line='1020' var='Q{}responseXML' as='document-node()' slot='4' eval='16'>
+     <let line='1021' var='Q{}responseXML' as='document-node()' slot='4' eval='16'>
       <treat as='document-node()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);' diag='3|0|XTTE0570|responseXML'>
        <check card='1' diag='3|0|XTTE0570|responseXML'>
         <lookup>
@@ -11584,20 +11803,20 @@
         </lookup>
        </check>
       </treat>
-      <choose line='1023'>
+      <choose line='1024'>
        <fn name='empty'>
         <varRef name='Q{}responseXML' slot='4'/>
        </fn>
-       <callT line='1024' name='Q{}serverError' bSlot='0' flags='t'>
+       <callT line='1025' name='Q{}serverError' bSlot='0' flags='t'>
         <withParam name='Q{}responseMap' flags='c' as='map(*)'>
-         <dot line='1025' type='map(*)'/>
+         <dot line='1026' type='map(*)'/>
         </withParam>
        </callT>
-       <vc line='1037' op='eq' onEmpty='0' comp='CCC'>
+       <vc line='1038' op='eq' onEmpty='0' comp='CCC'>
         <varRef name='Q{}replace' slot='2'/>
         <str val='instance'/>
        </vc>
-       <sequence line='1038'>
+       <sequence line='1039'>
         <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='1' eval='6 16'>
          <varRef name='Q{}refi' slot='3'/>
          <check card='1' diag='0|1||xforms:setInstance-JS'>
@@ -11607,7 +11826,7 @@
           </slash>
          </check>
         </ufCall>
-        <callT line='1040' name='Q{}xforms-rebuild' bSlot='2' flags='t'/>
+        <callT line='1041' name='Q{}xforms-rebuild' bSlot='2' flags='t'/>
        </sequence>
       </choose>
      </let>
@@ -11615,7 +11834,7 @@
    </sequence>
   </template>
  </co>
- <co id='41' binds=''>
+ <co id='43' binds=''>
   <function name='Q{http://www.w3.org/2002/xforms}instance' line='126' module='xforms-function-library.xsl' eval='7' flags='pU' as='element()?' slots='1'>
    <arg name='Q{}instance-id' as='xs:string'/>
    <treat role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='128' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='5|0|XTTE0780|xforms:instance#1'>
@@ -11633,18 +11852,18 @@
  </co>
  <co id='73' binds='49 67 11'>
   <mode name='Q{http://saxonica.com/ns/interactiveXSLT}onclick' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='0.5' seq='3' rank='0' minImp='0' slots='3' flags='s' line='731' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.5' seq='3' rank='0' minImp='0' slots='3' flags='s' line='732' module='saxon-xforms.xsl'>
     <p.withUpper role='match' axis='ancestor' upFirst='false'>
      <p.withPredicate>
       <p.nodeTest test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-      <or ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='731' op='or'>
+      <or ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='732' op='or'>
        <axis name='self' nodeTest='element(Q{}span)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;span&#39;;'/>
        <axis name='self' nodeTest='element(Q{}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
       </or>
      </p.withPredicate>
      <p.withPredicate>
       <p.nodeTest test='element(Q{}div)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;div&#39;;'/>
-      <vc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='731' op='eq' onEmpty='0' comp='CCC'>
+      <vc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='732' op='eq' onEmpty='0' comp='CCC'>
        <cast as='xs:string' emptiable='1'>
         <data>
          <axis name='attribute' nodeTest='attribute(Q{}data-repeat-item)' jsTest='return item.name===&#39;data-repeat-item&#39;'/>
@@ -11654,11 +11873,11 @@
       </vc>
      </p.withPredicate>
     </p.withUpper>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='740' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='0' eval='13'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='741' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='0' eval='13'>
      <check card='1' diag='0|0||ixsl:call'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
      </check>
-     <sequence line='732'>
+     <sequence line='733'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -11670,7 +11889,7 @@
         </fn>
        </arrayBlock>
       </ifCall>
-      <forEach line='735'>
+      <forEach line='736'>
        <fn name='reverse'>
         <filter flags='b'>
          <axis name='ancestor' nodeTest='element(Q{}div)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;div&#39;;'/>
@@ -11682,7 +11901,7 @@
          </vc>
         </filter>
        </fn>
-       <let line='736' var='Q{}repeat-id' as='xs:string' slot='1' eval='16'>
+       <let line='737' var='Q{}repeat-id' as='xs:string' slot='1' eval='16'>
         <check card='1' diag='3|0|XTTE0570|repeat-id'>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|repeat-id'>
           <data>
@@ -11700,7 +11919,7 @@
           </data>
          </cvUntyped>
         </check>
-        <let line='737' var='Q{}item-position' as='xs:integer' slot='2' eval='16'>
+        <let line='738' var='Q{}item-position' as='xs:integer' slot='2' eval='16'>
          <arith op='+' calc='i+i'>
           <fn name='count'>
            <filter flags='b'>
@@ -11715,7 +11934,7 @@
           </fn>
           <int val='1'/>
          </arith>
-         <sequence line='739'>
+         <sequence line='740'>
           <message>
            <sequence role='select'>
             <valueOf>
@@ -11739,7 +11958,7 @@
            <str role='terminate' val='no'/>
            <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
           </message>
-          <ifCall line='740' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+          <ifCall line='741' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
            <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='0'/>
            <str val='setRepeatIndex'/>
            <arrayBlock>
@@ -11751,38 +11970,38 @@
         </let>
        </let>
       </forEach>
-      <choose line='743'>
+      <choose line='744'>
        <fn name='exists'>
         <axis name='self' nodeTest='element(Q{}span)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;span&#39;;'/>
        </fn>
-       <callT line='744' name='Q{}refreshElementsUsingIndexFunction-JS' bSlot='0' flags='t'/>
+       <callT line='745' name='Q{}refreshElementsUsingIndexFunction-JS' bSlot='0' flags='t'/>
       </choose>
      </sequence>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.5' seq='23' rank='0' minImp='0' slots='0' flags='s' line='2011' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.5' seq='23' rank='0' minImp='0' slots='0' flags='s' line='2017' module='saxon-xforms.xsl'>
     <p.withPredicate role='match'>
      <p.nodeTest test='element(Q{}button)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;button&#39;;'/>
-     <fn ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2011' name='exists'>
+     <fn ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2017' name='exists'>
       <axis name='attribute' nodeTest='attribute(Q{}data-action)' jsTest='return item.name===&#39;data-action&#39;'/>
      </fn>
     </p.withPredicate>
-    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2013' name='Q{}DOMActivate' bSlot='1' flags='t'>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2019' name='Q{}DOMActivate' bSlot='1' flags='t'>
      <withParam name='Q{}form-control' flags='c' as='node()'>
-      <dot line='2014' type='element(Q{}button)'/>
+      <dot line='2020' type='element(Q{}button)'/>
      </withParam>
     </callT>
    </templateRule>
-   <templateRule prec='0' prio='0.5' seq='4' rank='0' minImp='0' slots='0' flags='s' line='991' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.5' seq='4' rank='0' minImp='0' slots='0' flags='s' line='992' module='saxon-xforms.xsl'>
     <p.withPredicate role='match'>
      <p.nodeTest test='element(Q{}button)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;button&#39;;'/>
-     <fn ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='991' name='exists'>
+     <fn ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='992' name='exists'>
       <axis name='attribute' nodeTest='attribute(Q{}data-submit)' jsTest='return item.name===&#39;data-submit&#39;'/>
      </fn>
     </p.withPredicate>
-    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='993' name='Q{}xforms-submit' bSlot='2' flags='t'>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='994' name='Q{}xforms-submit' bSlot='2' flags='t'>
      <withParam name='Q{}submission' flags='c' as='xs:string'>
-      <fn line='994' name='string'>
+      <fn line='995' name='string'>
        <axis name='attribute' nodeTest='attribute(Q{}data-submit)' jsTest='return item.name===&#39;data-submit&#39;'/>
       </fn>
      </withParam>
@@ -11791,8 +12010,8 @@
   </mode>
  </co>
  <co id='72' binds='62 63 64'>
-  <template name='Q{}setSubmission' flags='os' line='3922' module='saxon-xforms.xsl' slots='5'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3923'>
+  <template name='Q{}setSubmission' flags='os' line='3958' module='saxon-xforms.xsl' slots='5'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3959'>
     <param name='Q{}this' slot='0' flags='i' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
       <check card='1' diag='8|0|XTTE0590|this'>
@@ -11800,7 +12019,7 @@
       </check>
      </treat>
     </param>
-    <param line='3924' name='Q{}submission-id' slot='1' flags='i' as='xs:string'>
+    <param line='3960' name='Q{}submission-id' slot='1' flags='i' as='xs:string'>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|submission-id'>
       <check card='1' diag='8|0|XTTE0590|submission-id'>
        <cvUntyped to='xs:string' diag='8|0|XTTE0590|submission-id'>
@@ -11811,52 +12030,52 @@
       </check>
      </treat>
     </param>
-    <let line='3927' var='Q{}bindingi' as='node()?' slot='2' eval='7'>
-     <treat line='3928' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+    <let line='3963' var='Q{}bindingi' as='node()?' slot='2' eval='7'>
+     <treat line='3964' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
       <check card='?' diag='3|0|XTTE0570|bindingi'>
        <callT name='Q{}getBinding' bSlot='0'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <varRef line='3929' name='Q{}this' slot='0'/>
+         <varRef line='3965' name='Q{}this' slot='0'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <let line='3934' var='Q{}refi' as='xs:string' slot='3' eval='16'>
-      <treat line='3935' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+     <let line='3970' var='Q{}refi' as='xs:string' slot='3' eval='16'>
+      <treat line='3971' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
        <check card='1' diag='3|0|XTTE0570|refi'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
          <data>
           <callT name='Q{}getDataRef' bSlot='1'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <varRef line='3936' name='Q{}this' slot='0'/>
+            <varRef line='3972' name='Q{}this' slot='0'/>
            </withParam>
            <withParam name='Q{}bindingi' flags='c' as='node()?'>
-            <varRef line='3937' name='Q{}bindingi' slot='2'/>
+            <varRef line='3973' name='Q{}bindingi' slot='2'/>
            </withParam>
           </callT>
          </data>
         </cvUntyped>
        </check>
       </treat>
-      <let line='3942' var='Q{}actions' as='map(*)*' slot='4' eval='8'>
-       <treat line='3943' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+      <let line='3978' var='Q{}actions' as='map(*)*' slot='4' eval='8'>
+       <treat line='3979' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
         <callT name='Q{}setActions' bSlot='2'>
          <withParam name='Q{}this' flags='c' as='element()'>
-          <treat line='3944' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+          <treat line='3980' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
            <dot flags='a'/>
           </treat>
          </withParam>
          <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-          <varRef line='3945' name='Q{}refi' slot='3'/>
+          <varRef line='3981' name='Q{}refi' slot='3'/>
          </withParam>
         </callT>
        </treat>
-       <sequence line='3949'>
+       <sequence line='3985'>
         <choose>
          <fn name='exists'>
           <varRef name='Q{}actions' slot='4'/>
          </fn>
-         <ifCall line='3950' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+         <ifCall line='3986' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
           <check card='1' diag='0|0||ixsl:call'>
            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
           </check>
@@ -11867,20 +12086,20 @@
           </arrayBlock>
          </ifCall>
         </choose>
-        <ifCall line='3955' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+        <ifCall line='3991' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
          <sequence>
-          <ifCall line='3956' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <ifCall line='3992' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
            <str val='@ref'/>
            <varRef name='Q{}refi' slot='3'/>
           </ifCall>
-          <choose line='3959'>
+          <choose line='3995'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}resource)' jsTest='return item.name===&#39;resource&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3960' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='3996' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@resource'/>
             <cast as='xs:string' emptiable='1'>
              <data>
@@ -11892,14 +12111,14 @@
             </cast>
            </ifCall>
           </choose>
-          <choose line='3962'>
+          <choose line='3998'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}mode)' jsTest='return item.name===&#39;mode&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3963' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='3999' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@mode'/>
             <cast as='xs:string' emptiable='1'>
              <data>
@@ -11911,16 +12130,16 @@
             </cast>
            </ifCall>
           </choose>
-          <ifCall line='3966' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <ifCall line='4002' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
            <str val='@method'/>
-           <choose line='3968'>
+           <choose line='4004'>
             <fn name='exists'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='attribute' nodeTest='attribute(Q{}method)' jsTest='return item.name===&#39;method&#39;'/>
              </slash>
             </fn>
-            <fn line='3969' name='string'>
+            <fn line='4005' name='string'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='attribute' nodeTest='attribute(Q{}method)' jsTest='return item.name===&#39;method&#39;'/>
@@ -11930,14 +12149,14 @@
             <str val='POST'/>
            </choose>
           </ifCall>
-          <choose line='3978'>
+          <choose line='4014'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}validate)' jsTest='return item.name===&#39;validate&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3979' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4015' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@validate'/>
             <fn name='string'>
              <slash simple='1'>
@@ -11947,14 +12166,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='3981'>
+          <choose line='4017'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}relevant)' jsTest='return item.name===&#39;relevant&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3982' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4018' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@relevant'/>
             <fn name='string'>
              <slash simple='1'>
@@ -11964,14 +12183,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='3984'>
+          <choose line='4020'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}serialization)' jsTest='return item.name===&#39;serialization&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3985' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4021' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@serialization'/>
             <fn name='string'>
              <slash simple='1'>
@@ -11981,14 +12200,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='3987'>
+          <choose line='4023'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}version)' jsTest='return item.name===&#39;version&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3988' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4024' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@version'/>
             <fn name='string'>
              <slash simple='1'>
@@ -11998,14 +12217,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='3990'>
+          <choose line='4026'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}indent)' jsTest='return item.name===&#39;indent&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3991' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4027' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@indent'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12015,16 +12234,16 @@
             </fn>
            </ifCall>
           </choose>
-          <ifCall line='3995' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <ifCall line='4031' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
            <str val='@mediatype'/>
-           <choose line='3997'>
+           <choose line='4033'>
             <fn name='exists'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='attribute' nodeTest='attribute(Q{}mediatype)' jsTest='return item.name===&#39;mediatype&#39;'/>
              </slash>
             </fn>
-            <fn line='3998' name='string'>
+            <fn line='4034' name='string'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='attribute' nodeTest='attribute(Q{}mediatype)' jsTest='return item.name===&#39;mediatype&#39;'/>
@@ -12034,14 +12253,14 @@
             <str val='text/plain'/>
            </choose>
           </ifCall>
-          <choose line='4008'>
+          <choose line='4044'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}encoding)' jsTest='return item.name===&#39;encoding&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4009' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4045' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@encoding'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12051,14 +12270,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='4011'>
+          <choose line='4047'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}omit-xml-declaration)' jsTest='return item.name===&#39;omit-xml-declaration&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4012' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4048' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@omit-xml-declaration'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12068,14 +12287,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='4014'>
+          <choose line='4050'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}standalone)' jsTest='return item.name===&#39;standalone&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4015' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4051' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@standalone'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12085,14 +12304,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='4017'>
+          <choose line='4053'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}cdata-section-elements)' jsTest='return item.name===&#39;cdata-section-elements&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4018' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4054' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@cdata-section-elements'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12102,16 +12321,16 @@
             </fn>
            </ifCall>
           </choose>
-          <ifCall line='4021' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <ifCall line='4057' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
            <str val='@replace'/>
-           <choose line='4023'>
+           <choose line='4059'>
             <fn name='exists'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='attribute' nodeTest='attribute(Q{}replace)' jsTest='return item.name===&#39;replace&#39;'/>
              </slash>
             </fn>
-            <fn line='4024' name='string'>
+            <fn line='4060' name='string'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='attribute' nodeTest='attribute(Q{}replace)' jsTest='return item.name===&#39;replace&#39;'/>
@@ -12121,14 +12340,14 @@
             <str val='all'/>
            </choose>
           </ifCall>
-          <choose line='4035'>
+          <choose line='4071'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}instance)' jsTest='return item.name===&#39;instance&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4036' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4072' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@instance'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12138,14 +12357,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='4038'>
+          <choose line='4074'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}targetref)' jsTest='return item.name===&#39;targetref&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4039' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4075' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@targetref'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12155,14 +12374,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='4041'>
+          <choose line='4077'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}separator)' jsTest='return item.name===&#39;separator&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4042' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4078' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@separator'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12172,14 +12391,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='4044'>
+          <choose line='4080'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}includenamespaceprefixes)' jsTest='return item.name===&#39;includenamespaceprefixes&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4045' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4081' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@includenamespaceprefixes'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12204,18 +12423,18 @@
    </sequence>
   </template>
  </co>
- <co id='74' binds='18'>
+ <co id='74' binds='20'>
   <mode name='Q{http://saxonica.com/ns/interactiveXSLT}onkeyup' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='0.5' seq='0' rank='0' minImp='0' slots='0' flags='s' line='698' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.5' seq='0' rank='0' minImp='0' slots='0' flags='s' line='699' module='saxon-xforms.xsl'>
     <p.withPredicate role='match'>
      <p.nodeTest test='element(Q{}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
-     <gc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='698' op='=' card='N:1' comp='CCC'>
+     <gc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='699' op='=' card='N:1' comp='CCC'>
       <fn name='tokenize'>
        <cvUntyped to='xs:string' diag='3|0|XTTE0570|class'>
         <data>
          <slash simple='1'>
           <dot type='element(Q{}input)'/>
-          <axis line='3036' name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
+          <axis line='3071' name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
          </slash>
         </data>
        </cvUntyped>
@@ -12223,17 +12442,17 @@
       <str val='incremental'/>
      </gc>
     </p.withPredicate>
-    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='700' name='Q{}xforms-value-changed' bSlot='0' flags='t'>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='701' name='Q{}xforms-value-changed' bSlot='0' flags='t'>
      <withParam name='Q{}form-control' flags='c' as='node()'>
-      <dot line='701' type='element(Q{}input)'/>
+      <dot line='702' type='element(Q{}input)'/>
      </withParam>
     </callT>
    </templateRule>
   </mode>
  </co>
  <co id='62' binds=''>
-  <template name='Q{}getBinding' flags='os' line='3277' module='saxon-xforms.xsl' slots='4'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3278'>
+  <template name='Q{}getBinding' flags='os' line='3309' module='saxon-xforms.xsl' slots='4'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3310'>
     <param name='Q{}this' slot='0' flags='r' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
       <check card='1' diag='8|0|XTTE0590|this'>
@@ -12241,7 +12460,7 @@
       </check>
      </treat>
     </param>
-    <param line='3279' name='Q{}bindings' slot='1' flags='t' as='map(xs:string, node())'>
+    <param line='3311' name='Q{}bindings' slot='1' flags='t' as='map(xs:string, node())'>
      <map role='select' size='0'/>
      <treat role='conversion' as='map(xs:string, node())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|bindings'>
       <check card='1' diag='8|0|XTTE0590|bindings'>
@@ -12249,7 +12468,7 @@
       </check>
      </treat>
     </param>
-    <let line='3288' var='Q{}ref-binding' as='xs:string' slot='2' eval='16'>
+    <let line='3320' var='Q{}ref-binding' as='xs:string' slot='2' eval='16'>
      <choose>
       <fn name='exists'>
        <slash simple='1'>
@@ -12286,8 +12505,8 @@
       <true/>
       <str val=''/>
      </choose>
-     <let line='3290' var='Q{}binding' as='element()?' slot='3' eval='7'>
-      <choose line='3295'>
+     <let line='3322' var='Q{}binding' as='element()?' slot='3' eval='7'>
+      <choose line='3327'>
        <fn name='empty'>
         <varRef name='Q{}ref-binding' slot='2'/>
        </fn>
@@ -12300,12 +12519,12 @@
         </ifCall>
        </treat>
       </choose>
-      <sequence line='3298'>
+      <sequence line='3330'>
        <choose>
         <fn name='exists'>
          <varRef name='Q{}binding' slot='3'/>
         </fn>
-        <message line='3304'>
+        <message line='3336'>
          <sequence role='select'>
           <valueOf>
            <str val='[getBinding for '/>
@@ -12328,7 +12547,7 @@
          <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
         </message>
        </choose>
-       <varRef line='3308' name='Q{}binding' slot='3'/>
+       <varRef line='3340' name='Q{}binding' slot='3'/>
       </sequence>
      </let>
     </let>
@@ -12345,11 +12564,11 @@
    <false/>
   </globalVariable>
  </co>
- <co id='44' binds='62'>
-  <function name='Q{http://www.w3.org/2002/xforms}getDataRef' line='3136' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:string' slots='11'>
+ <co id='45' binds='62'>
+  <function name='Q{http://www.w3.org/2002/xforms}getDataRef' line='3168' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:string' slots='11'>
    <arg name='Q{}this' as='element()'/>
    <arg name='Q{}nodeset' as='xs:string?'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3145' var='Q{}this-ref' as='xs:string?' slot='2' eval='7'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3177' var='Q{}this-ref' as='xs:string?' slot='2' eval='7'>
     <choose>
      <fn name='exists'>
       <slash simple='1'>
@@ -12384,27 +12603,27 @@
       </cast>
      </fn>
     </choose>
-    <let line='3148' var='Q{}this-binding' as='node()?' slot='3' eval='7'>
-     <treat line='3149' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|this-binding'>
+    <let line='3180' var='Q{}this-binding' as='node()?' slot='3' eval='7'>
+     <treat line='3181' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|this-binding'>
       <check card='?' diag='3|0|XTTE0570|this-binding'>
        <callT name='Q{}getBinding' bSlot='0'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <varRef line='3150' name='Q{}this' slot='0'/>
+         <varRef line='3182' name='Q{}this' slot='0'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <choose line='3175'>
+     <choose line='3207'>
       <fn name='exists'>
        <varRef name='Q{}this-binding' slot='3'/>
       </fn>
-      <let line='3156' var='Q{}relative' as='xs:string' slot='4' eval='16'>
+      <let line='3188' var='Q{}relative' as='xs:string' slot='4' eval='16'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
         <choose>
          <fn name='exists'>
           <varRef name='Q{}this-binding' slot='3'/>
          </fn>
-         <cvUntyped line='3167' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
+         <cvUntyped line='3199' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
           <cast as='xs:untypedAtomic' emptiable='0'>
            <choose>
             <fn name='exists'>
@@ -12439,25 +12658,25 @@
          </cvUntyped>
         </choose>
        </check>
-       <choose line='835'>
+       <choose line='836'>
         <fn name='starts-with'>
          <varRef name='Q{}relative' slot='4'/>
          <str val='/'/>
         </fn>
-        <varRef line='836' name='Q{}relative' slot='4'/>
-        <fn line='838' name='starts-with'>
+        <varRef line='837' name='Q{}relative' slot='4'/>
+        <fn line='839' name='starts-with'>
          <varRef name='Q{}relative' slot='4'/>
          <str val='instance('/>
         </fn>
-        <varRef line='839' name='Q{}relative' slot='4'/>
+        <varRef line='840' name='Q{}relative' slot='4'/>
         <true/>
-        <varRef line='842' name='Q{}relative' slot='4'/>
+        <varRef line='843' name='Q{}relative' slot='4'/>
        </choose>
       </let>
-      <fn line='3178' name='exists'>
+      <fn line='3210' name='exists'>
        <varRef name='Q{}this-ref' slot='2'/>
       </fn>
-      <let line='3179' var='Q{}base' as='xs:string' slot='5' eval='16'>
+      <let line='3211' var='Q{}base' as='xs:string' slot='5' eval='16'>
        <check card='1' diag='0|0||xforms:resolveXPathStrings'>
         <varRef name='Q{}nodeset' slot='1'/>
        </check>
@@ -12465,22 +12684,22 @@
         <check card='1' diag='0|1||xforms:resolveXPathStrings'>
          <varRef name='Q{}this-ref' slot='2'/>
         </check>
-        <choose line='835'>
+        <choose line='836'>
          <fn name='starts-with'>
           <varRef name='Q{}relative' slot='6'/>
           <str val='/'/>
          </fn>
-         <varRef line='836' name='Q{}relative' slot='6'/>
-         <fn line='838' name='starts-with'>
+         <varRef line='837' name='Q{}relative' slot='6'/>
+         <fn line='839' name='starts-with'>
           <varRef name='Q{}relative' slot='6'/>
           <str val='instance('/>
          </fn>
-         <varRef line='839' name='Q{}relative' slot='6'/>
-         <fn line='841' name='not'>
+         <varRef line='840' name='Q{}relative' slot='6'/>
+         <fn line='842' name='not'>
           <varRef name='Q{}base' slot='5'/>
          </fn>
-         <varRef line='842' name='Q{}relative' slot='6'/>
-         <or line='844' op='or'>
+         <varRef line='843' name='Q{}relative' slot='6'/>
+         <or line='845' op='or'>
           <fn name='not'>
            <varRef name='Q{}relative' slot='6'/>
           </fn>
@@ -12489,9 +12708,9 @@
            <str val='.'/>
           </vc>
          </or>
-         <varRef line='845' name='Q{}base' slot='5'/>
+         <varRef line='846' name='Q{}base' slot='5'/>
          <true/>
-         <let line='849' var='Q{}parentCallCount' as='xs:integer' slot='7' eval='16'>
+         <let line='850' var='Q{}parentCallCount' as='xs:integer' slot='7' eval='16'>
           <choose>
            <fn name='contains'>
             <varRef name='Q{}relative' slot='6'/>
@@ -12518,7 +12737,7 @@
            <true/>
            <int val='0'/>
           </choose>
-          <let line='852' var='Q{}slashes' as='xs:integer*' slot='8' eval='4'>
+          <let line='853' var='Q{}slashes' as='xs:integer*' slot='8' eval='4'>
            <choose>
             <fn name='contains'>
              <varRef name='Q{}base' slot='5'/>
@@ -12533,15 +12752,15 @@
             <true/>
             <int val='0'/>
            </choose>
-           <choose line='884'>
+           <choose line='885'>
             <compareToInt op='gt' val='0'>
              <varRef name='Q{}parentCallCount' slot='7'/>
             </compareToInt>
-            <fn line='888' name='concat'>
+            <fn line='889' name='concat'>
              <fn name='substring'>
               <varRef name='Q{}base' slot='5'/>
               <int val='1'/>
-              <choose line='863'>
+              <choose line='864'>
                <and op='and'>
                 <vc op='ge' onEmpty='0' comp='CAVC'>
                  <fn name='count'>
@@ -12553,7 +12772,7 @@
                  <varRef name='Q{}parentCallCount' slot='7'/>
                 </compareToInt>
                </and>
-               <let line='864' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='9' eval='16'>
+               <let line='865' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='9' eval='16'>
                 <arith op='-' calc='i-i'>
                  <varRef name='Q{}parentCallCount' slot='7'/>
                  <int val='1'/>
@@ -12569,7 +12788,7 @@
                 </check>
                </let>
                <true/>
-               <check line='867' card='1' diag='3|0|XTTE0570|parentSlash'>
+               <check line='868' card='1' diag='3|0|XTTE0570|parentSlash'>
                 <lastOf>
                  <varRef name='Q{}slashes' slot='8'/>
                 </lastOf>
@@ -12584,7 +12803,7 @@
              </fn>
             </fn>
             <true/>
-            <fn line='891' name='concat'>
+            <fn line='892' name='concat'>
              <varRef name='Q{}base' slot='5'/>
              <str val='/'/>
              <varRef name='Q{}relative' slot='6'/>
@@ -12595,24 +12814,24 @@
         </choose>
        </let>
       </let>
-      <varRef line='3181' name='Q{}nodeset' slot='1'/>
-      <let line='3182' var='Q{}relative' as='xs:string' slot='10' eval='16'>
+      <varRef line='3213' name='Q{}nodeset' slot='1'/>
+      <let line='3214' var='Q{}relative' as='xs:string' slot='10' eval='16'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
         <varRef name='Q{}nodeset' slot='1'/>
        </check>
-       <choose line='835'>
+       <choose line='836'>
         <fn name='starts-with'>
          <varRef name='Q{}relative' slot='10'/>
          <str val='/'/>
         </fn>
-        <varRef line='836' name='Q{}relative' slot='10'/>
-        <fn line='838' name='starts-with'>
+        <varRef line='837' name='Q{}relative' slot='10'/>
+        <fn line='839' name='starts-with'>
          <varRef name='Q{}relative' slot='10'/>
          <str val='instance('/>
         </fn>
-        <varRef line='839' name='Q{}relative' slot='10'/>
+        <varRef line='840' name='Q{}relative' slot='10'/>
         <true/>
-        <varRef line='842' name='Q{}relative' slot='10'/>
+        <varRef line='843' name='Q{}relative' slot='10'/>
        </choose>
       </let>
       <true/>
@@ -12622,9 +12841,9 @@
    </let>
   </function>
  </co>
- <co id='23' binds=''>
-  <template name='Q{}getInstance' flags='os' as='element()?' line='3251' module='saxon-xforms.xsl' slots='2'>
-   <check role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3252' card='?' diag='7|0|XTTE0505|getInstance'>
+ <co id='25' binds=''>
+  <template name='Q{}getInstance' flags='os' as='element()?' line='3283' module='saxon-xforms.xsl' slots='2'>
+   <check role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3284' card='?' diag='7|0|XTTE0505|getInstance'>
     <sequence>
      <param name='Q{}instance-id' slot='0' as='xs:string'>
       <str role='select' val=''/>
@@ -12638,21 +12857,21 @@
        </check>
       </treat>
      </param>
-     <param line='3253' name='Q{}instances' slot='1' flags='ti' as='map(xs:string, element())'>
+     <param line='3285' name='Q{}instances' slot='1' flags='ti' as='map(xs:string, element())'>
       <treat role='conversion' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|instances'>
        <check card='1' diag='8|0|XTTE0590|instances'>
         <supplied slot='1'/>
        </check>
       </treat>
      </param>
-     <choose line='3257'>
+     <choose line='3289'>
       <varRef name='Q{}instance-id' slot='0'/>
-      <ifCall line='3258' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+      <ifCall line='3290' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
        <varRef name='Q{}instances' slot='1'/>
        <varRef name='Q{}instance-id' slot='0'/>
       </ifCall>
       <true/>
-      <copyOf line='3262' flags='vc'>
+      <copyOf line='3294' flags='vc'>
        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
         <varRef name='Q{}instances' slot='1'/>
         <str val='saxon-forms-default'/>
@@ -12675,4 +12894,4 @@
  </output>
  <decimalFormat/>
 </package>
-<?Σ c2e05e34?>
+<?Σ 1bf0edc6?>

--- a/src/saxon-xforms.xsl
+++ b/src/saxon-xforms.xsl
@@ -54,11 +54,11 @@
         doctype-public="-//W3C//DTD XHTML 1.0 Transitional//EN"
         doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"/>
     
-    <xsl:use-package name="http://saxon.sf.net/packages/logger.xsl" package-version="1.0">
+    <!--<xsl:use-package name="http://saxon.sf.net/packages/logger.xsl" package-version="1.0">
         <xsl:override>
             <xsl:variable name="sfp:LOGLEVEL" select="$sfp:LOGLEVEL_ALL"/>
         </xsl:override>
-    </xsl:use-package>
+    </xsl:use-package>-->
 
     <xsl:param name="xforms-instance-id" select="'xforms-jinstance'"/>
     <xsl:param name="xforms-cache-id" select="'xforms-cache'"/>
@@ -3098,7 +3098,7 @@
         <xsl:param name="nodeset" as="xs:string"/>
         <xsl:map>
             <xsl:analyze-string select="normalize-space($nodeset)"
-                regex="^instance\s*\(\s*&apos;(.*)&apos;\s*\)\s*(/\s*(.*)|)$"
+                regex="^instance\s*\(\s*&apos;([^&apos;]+)&apos;\s*\)\s*(/\s*(.*)|)$"
                 >
                 <xsl:matching-substring>
                     <xsl:variable name="xpath" as="xs:string">
@@ -3111,6 +3111,9 @@
                             </xsl:otherwise>
                         </xsl:choose>
                     </xsl:variable>
+                    <xsl:message use-when="$debugMode">[xforms:getInstanceMap] From $nodeset = '<xsl:sequence select="$nodeset"/>'</xsl:message>
+                    <xsl:message use-when="$debugMode">[xforms:getInstanceMap] 'instance-id' = '<xsl:sequence select="regex-group(1)"/>'</xsl:message>
+                    <xsl:message use-when="$debugMode">[xforms:getInstanceMap] 'xpath' = '<xsl:sequence select="$xpath"/>'</xsl:message>
                     <xsl:map-entry key="'instance-id'" select="regex-group(1)"/>
                     <xsl:map-entry key="'xpath'" select="$xpath"/>
                 </xsl:matching-substring>
@@ -3402,7 +3405,7 @@
     <xsl:template name="getReferencedInstanceField">
         <xsl:param name="refi" as="xs:string" required="no" select="''"/>
         
-<!--        <xsl:message use-when="$debugMode">[getReferencedInstanceField] $refi = '<xsl:value-of select="$refi"/>'</xsl:message>-->
+        <xsl:message use-when="$debugMode">[getReferencedInstanceField] $refi = '<xsl:value-of select="$refi"/>'</xsl:message>
         
         <xsl:variable name="field" as="node()*">
             <xsl:choose>
@@ -3422,6 +3425,7 @@
                     
                     <xsl:variable name="xpath-mod" as="xs:string" select="xforms:impose(map:get($instance-map,'xpath'))"/>
                                       
+                 
                     
                     <xsl:evaluate xpath="$xpath-mod" context-item="$this-instance" namespace-context="$this-instance"/>
                     

--- a/src/xforms-function-library.xsl
+++ b/src/xforms-function-library.xsl
@@ -35,6 +35,7 @@
                     <xsl:choose>
                         <xsl:when test="substring-before(.,'(')=$xform-functions">
                             <xsl:sequence select="concat('xforms:',.)" />
+<!--                            <xsl:sequence select="concat('Q{http://www.w3.org/2002/xforms}',.)" />-->
                         </xsl:when>
                         <xsl:otherwise>
                             <xsl:sequence select="." />

--- a/src/xforms-function-library.xsl
+++ b/src/xforms-function-library.xsl
@@ -3,15 +3,18 @@
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:math="http://www.w3.org/2005/xpath-functions/math"
     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-    xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:xhtml="http://www.w3.org/1999/xhtml"
+    xmlns:xforms="http://www.w3.org/2002/xforms" 
+    xmlns:xhtml="http://www.w3.org/1999/xhtml"
     xmlns:xf="http://www.w3.org/2002/xforms"
-    xmlns:js="http://saxonica.com/ns/globalJS" xmlns:ixsl="http://saxonica.com/ns/interactiveXSLT"
+    xmlns:js="http://saxonica.com/ns/globalJS" 
+    xmlns:ixsl="http://saxonica.com/ns/interactiveXSLT"
     xmlns:in="http://www.w3.org/2002/xforms-instance"
     xmlns:fn="http://www.w3.org/2005/xpath-functions"
     xmlns:map="http://www.w3.org/2005/xpath-functions/map"
     xmlns:array="http://www.w3.org/2005/xpath-functions/array"
     xmlns:sfl="http://saxonica.com/ns/forms-local"
-    xmlns:ev="http://www.w3.org/2001/xml-events" exclude-result-prefixes="xs math xforms"
+    xmlns:ev="http://www.w3.org/2001/xml-events" 
+    exclude-result-prefixes="xs math xforms"
     extension-element-prefixes="ixsl" version="3.0">
     
     <xsl:variable name="xform-functions" select="'instance', 'index', 'avg', 'foo', 'current-date', random"/>
@@ -63,6 +66,24 @@
         </xsl:variable>
         
         <xsl:sequence select="string-join($parts2)" />
+    </xsl:function>
+    
+    <xsl:function name="xforms:resolve-index" as="xs:string">
+        <xsl:param name="input" as="xs:string" />
+        <xsl:variable name="parts" as="xs:string*">
+            <xsl:analyze-string select="$input" regex="index\s*\(\s*&apos;([^&apos;]+)&apos;\s*\)">
+                <xsl:matching-substring>
+<!--                    <xsl:message>[xforms:resolve-index] Resolving index of '<xsl:value-of select="regex-group(1)"/>' to '<xsl:value-of select="xforms:index(regex-group(1))"/>'</xsl:message>-->
+                    <xsl:sequence select="xs:string(xforms:index(regex-group(1)))"/>
+                </xsl:matching-substring>
+                <xsl:non-matching-substring>
+                    <xsl:sequence select="." />
+                </xsl:non-matching-substring>
+            </xsl:analyze-string>
+        </xsl:variable>
+<!--        <xsl:message>[xforms:resolve-index] XPath '<xsl:value-of select="$input"/>' resolves to '<xsl:value-of select="string-join($parts)"/>'</xsl:message>-->
+        
+        <xsl:sequence select="string-join($parts)" />
     </xsl:function>
     
     <xsl:function name="xforms:foo" as="xs:boolean">


### PR DESCRIPTION
Handle setFocus (including in a repeat)

Set index after an insert or delete.

Recalculate rather than rebuild after a form change.

Separate "refresh" steps for outputs, repeats, and elements that use the index() function

Actions whose node set depends on an index now have the index calculated when the action is applied, not when the action is set. (This enables us to do a recalculate rather than a rebuild and hlpes with setting focus.)