### PR TITLE
Handle insert of a child into a parent

### DIFF
--- a/demos/xml/demo-repeat-xform.xml
+++ b/demos/xml/demo-repeat-xform.xml
@@ -96,7 +96,10 @@
             <xf:trigger>
                 <xf:label>Delete selected ingredient</xf:label>
                 <xf:action ev:event="DOMActivate">
+                    <xf:setindex repeat="edit-ingredient-repeat" index="index('edit-ingredient-repeat') - 1" if="index('edit-ingredient-repeat') != 1"/>
                     <xf:delete context="." nodeset="demo:ingredients/demo:ingredient" at="index('edit-ingredient-repeat')"/>
+                    <xf:insert context="./demo:ingredients" if="not(demo:ingredient)" nodeset="demo:ingredient" origin="instance('i-new-ingredient')"/>
+                    
                     <xf:setfocus control="edit-ingredient-repeat-input"/>
                 </xf:action>
             </xf:trigger>

--- a/sef/saxon-xforms.sef.xml
+++ b/sef/saxon-xforms.sef.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns='http://ns.saxonica.com/xslt/export' xmlns:fn='http://www.w3.org/2005/xpath-functions' xmlns:xs='http://www.w3.org/2001/XMLSchema' xmlns:vv='http://saxon.sf.net/generated-variable' xmlns:java-type='http://saxon.sf.net/java-type' when='2020-02-23T16:30:37.976Z' id='0' version='30' packageVersion='1' saxonVersion='9.9.1.5' target='JS' targetVersion='1' relocatable='true' implicit='true'>
- <co id='0' binds='1 2 1 2 3 3 4 5 6 3 7'>
-  <template name='Q{}action-insert' flags='os' line='4646' module='saxon-xforms.xsl' slots='20'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4647'>
+<package xmlns='http://ns.saxonica.com/xslt/export' xmlns:fn='http://www.w3.org/2005/xpath-functions' xmlns:xs='http://www.w3.org/2001/XMLSchema' xmlns:vv='http://saxon.sf.net/generated-variable' xmlns:java-type='http://saxon.sf.net/java-type' when='2020-03-13T14:41:49.557Z' id='0' version='30' packageVersion='1' saxonVersion='9.9.1.5' target='JS' targetVersion='1' relocatable='true' implicit='true'>
+ <co id='0' binds='1 2 1 2 3 3 3 4 5 6 3 7'>
+  <template name='Q{}action-insert' flags='os' line='4673' module='saxon-xforms.xsl' slots='21'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4674'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -10,7 +10,7 @@
       </check>
      </treat>
     </param>
-    <param line='4648' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
+    <param line='4675' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
      <empty role='select'/>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|instanceXML'>
       <check card='?' diag='8|0|XTTE0590|instanceXML'>
@@ -18,7 +18,7 @@
       </check>
      </treat>
     </param>
-    <param line='4649' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
+    <param line='4676' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -30,7 +30,7 @@
       </check>
      </treat>
     </param>
-    <let line='4651' var='Q{}ref' as='xs:string' slot='3' eval='16'>
+    <let line='4678' var='Q{}ref' as='xs:string' slot='3' eval='16'>
      <let var='Q{}relative' as='xs:string' slot='4' eval='16'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|1||xforms:resolveXPathStrings'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
@@ -55,7 +55,7 @@
         <str val='instance('/>
        </fn>
        <varRef line='842' name='Q{}relative' slot='4'/>
-       <fn line='4651' name='not'>
+       <fn line='4678' name='not'>
         <varRef name='Q{}nodeset' slot='2'/>
        </fn>
        <varRef line='845' name='Q{}relative' slot='4'/>
@@ -68,7 +68,7 @@
          <str val='.'/>
         </vc>
        </or>
-       <varRef line='4651' name='Q{}nodeset' slot='2'/>
+       <varRef line='4678' name='Q{}nodeset' slot='2'/>
        <true/>
        <let line='852' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
         <choose>
@@ -99,13 +99,13 @@
         </choose>
         <let line='855' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
          <choose>
-          <fn line='4651' name='contains'>
+          <fn line='4678' name='contains'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
           </fn>
           <fn name='index-of'>
            <fn name='string-to-codepoints'>
-            <varRef line='4651' name='Q{}nodeset' slot='2'/>
+            <varRef line='4678' name='Q{}nodeset' slot='2'/>
            </fn>
            <int val='47'/>
           </fn>
@@ -118,7 +118,7 @@
           </compareToInt>
           <fn line='891' name='concat'>
            <fn name='substring'>
-            <varRef line='4651' name='Q{}nodeset' slot='2'/>
+            <varRef line='4678' name='Q{}nodeset' slot='2'/>
             <int val='1'/>
             <choose line='866'>
              <and op='and'>
@@ -163,7 +163,7 @@
            </fn>
           </fn>
           <true/>
-          <fn line='4651' name='concat'>
+          <fn line='4678' name='concat'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
            <varRef line='894' name='Q{}relative' slot='4'/>
@@ -173,7 +173,7 @@
        </let>
       </choose>
      </let>
-     <let line='4652' var='Q{}at' as='xs:string?' slot='8' eval='7'>
+     <let line='4679' var='Q{}at' as='xs:string?' slot='8' eval='7'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|at'>
        <check card='?' diag='3|0|XTTE0570|at'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|at'>
@@ -186,7 +186,7 @@
         </cvUntyped>
        </check>
       </treat>
-      <let line='4653' var='Q{}position' as='xs:string?' slot='9' eval='7'>
+      <let line='4680' var='Q{}position' as='xs:string?' slot='9' eval='7'>
        <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|position'>
         <check card='?' diag='3|0|XTTE0570|position'>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|position'>
@@ -199,7 +199,7 @@
          </cvUntyped>
         </check>
        </treat>
-       <let line='4654' var='Q{}origin-ref' as='xs:string?' slot='10' eval='7'>
+       <let line='4681' var='Q{}origin-ref' as='xs:string?' slot='10' eval='7'>
         <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|origin-ref'>
          <check card='?' diag='3|0|XTTE0570|origin-ref'>
           <cvUntyped to='xs:string' diag='3|0|XTTE0570|origin-ref'>
@@ -212,12 +212,12 @@
           </cvUntyped>
          </check>
         </treat>
-        <let line='4667' var='Q{}instance-id' as='xs:string' slot='11' eval='16'>
+        <let line='4695' var='Q{}instance-id' as='xs:string' slot='11' eval='16'>
          <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='6'>
           <varRef name='Q{}ref' slot='3'/>
          </ufCall>
-         <let line='4669' var='Q{}instanceXML2' as='element()' slot='12' eval='16'>
-          <choose line='4671'>
+         <let line='4697' var='Q{}instanceXML2' as='element()' slot='12' eval='16'>
+          <choose line='4699'>
            <and op='and'>
             <vc op='eq' onEmpty='0' comp='CCC'>
              <varRef name='Q{}instance-id' slot='11'/>
@@ -227,24 +227,24 @@
              <varRef name='Q{}instanceXML' slot='1'/>
             </fn>
            </and>
-           <check line='4672' card='1' diag='3|0|XTTE0570|instanceXML2'>
+           <check line='4700' card='1' diag='3|0|XTTE0570|instanceXML2'>
             <varRef name='Q{}instanceXML' slot='1'/>
            </check>
            <true/>
-           <check line='4675' card='1' diag='3|0|XTTE0570|instanceXML2'>
+           <check line='4703' card='1' diag='3|0|XTTE0570|instanceXML2'>
             <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='6'>
              <varRef name='Q{}instance-id' slot='11'/>
             </ufCall>
            </check>
           </choose>
-          <let line='4680' var='Q{}instance-id-origin' as='xs:string' slot='13' eval='16'>
+          <let line='4716' var='Q{}instance-id-origin' as='xs:string' slot='13' eval='16'>
            <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='2' eval='16'>
             <check card='1' diag='0|0||xforms:getInstanceId'>
              <varRef name='Q{}origin-ref' slot='10'/>
             </check>
            </ufCall>
-           <let line='4682' var='Q{}instanceXML-origin' as='element()' slot='14' eval='16'>
-            <choose line='4684'>
+           <let line='4718' var='Q{}instanceXML-origin' as='element()' slot='14' eval='16'>
+            <choose line='4720'>
              <and op='and'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <varRef name='Q{}instance-id-origin' slot='13'/>
@@ -254,18 +254,18 @@
                <varRef name='Q{}instanceXML' slot='1'/>
               </fn>
              </and>
-             <check line='4685' card='1' diag='3|0|XTTE0570|instanceXML-origin'>
+             <check line='4721' card='1' diag='3|0|XTTE0570|instanceXML-origin'>
               <varRef name='Q{}instanceXML' slot='1'/>
              </check>
              <true/>
-             <check line='4688' card='1' diag='3|0|XTTE0570|instanceXML-origin'>
+             <check line='4724' card='1' diag='3|0|XTTE0570|instanceXML-origin'>
               <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='3' eval='6'>
                <varRef name='Q{}instance-id-origin' slot='13'/>
               </ufCall>
              </check>
             </choose>
-            <let line='4700' var='Q{}origin-node' as='node()?' slot='15' eval='7'>
-             <treat line='4701' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|origin-node'>
+            <let line='4729' var='Q{}origin-node' as='node()?' slot='15' eval='7'>
+             <treat line='4730' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|origin-node'>
               <check card='?' diag='3|0|XTTE0570|origin-node'>
                <evaluate dxns=''>
                 <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='4' eval='16'>
@@ -281,13 +281,13 @@
                </evaluate>
               </check>
              </treat>
-             <let line='4704' var='Q{}insert-node-location' as='node()' slot='16' eval='16'>
-              <treat line='4705' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|insert-node-location'>
-               <check card='1' diag='3|0|XTTE0570|insert-node-location'>
+             <let line='4733' var='Q{}insert-node-location' as='node()?' slot='16' eval='7'>
+              <treat line='4734' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|insert-node-location'>
+               <check card='?' diag='3|0|XTTE0570|insert-node-location'>
                 <evaluate dxns=''>
                  <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='5' eval='16'>
                   <check card='1' diag='0|0||xforms:impose'>
-                   <choose line='4665'>
+                   <choose line='4693'>
                     <vc op='ne' onEmpty='0' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
                      <varRef name='Q{}ref' slot='3'/>
                      <str val=''/>
@@ -316,111 +316,154 @@
                 </evaluate>
                </check>
               </treat>
-              <let line='4726' var='Q{}instance-with-insert' as='element()' slot='17' eval='16'>
-               <treat line='4727' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-insert'>
-                <check card='1' diag='3|0|XTTE0570|instance-with-insert'>
-                 <applyT mode='Q{}insert-node' bSlot='6'>
-                  <varRef role='select' name='Q{}instanceXML2' slot='12'/>
-                  <withParam name='Q{}insert-node-location' flags='t' as='node()'>
-                   <varRef line='4728' name='Q{}insert-node-location' slot='16'/>
-                  </withParam>
-                  <withParam name='Q{}node-to-insert' flags='t' as='node()?'>
-                   <choose line='4715'>
-                    <fn name='exists'>
-                     <varRef name='Q{}origin-node' slot='15'/>
-                    </fn>
-                    <copyOf line='4716' flags='vc'>
-                     <varRef name='Q{}origin-node' slot='15'/>
-                    </copyOf>
-                    <true/>
-                    <copyOf line='4719' flags='vc'>
-                     <varRef name='Q{}insert-node-location' slot='16'/>
-                    </copyOf>
-                   </choose>
-                  </withParam>
-                  <withParam name='Q{}position-relative' flags='t' as='xs:string?'>
-                   <varRef line='4730' name='Q{}position' slot='9'/>
-                  </withParam>
-                 </applyT>
-                </check>
-               </treat>
-               <sequence line='4736'>
-                <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='7' eval='6 6'>
-                 <varRef name='Q{}ref' slot='3'/>
-                 <varRef name='Q{}instance-with-insert' slot='17'/>
-                </ufCall>
-                <choose line='4740'>
-                 <fn name='matches'>
-                  <varRef name='Q{}at' slot='8'/>
-                  <str val='index\s*\('/>
-                  <str val=''/>
-                 </fn>
-                 <let line='4741' var='Q{}repeat-id' as='xs:string?' slot='18' eval='7'>
-                  <ufCall name='Q{http://www.w3.org/2002/xforms}getRepeatID' tailCall='false' bSlot='8' eval='16'>
-                   <check card='1' diag='0|0||xforms:getRepeatID'>
-                    <varRef name='Q{}at' slot='8'/>
-                   </check>
-                  </ufCall>
-                  <let line='4742' var='Q{}at-position' as='xs:integer' slot='19' eval='16'>
-                   <treat line='4743' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|at-position'>
-                    <check card='1' diag='3|0|XTTE0570|at-position'>
-                     <cvUntyped to='xs:integer' diag='3|0|XTTE0570|at-position'>
-                      <data>
-                       <evaluate dxns=''>
-                        <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='9' eval='16'>
-                         <check card='1' diag='0|0||xforms:impose'>
-                          <varRef name='Q{}at' slot='8'/>
-                         </check>
-                        </ufCall>
-                        <empty role='cxt'/>
-                        <str role='sa' val='no'/>
-                        <map role='options' size='0'/>
-                        <map role='wp' size='0'/>
-                       </evaluate>
-                      </data>
-                     </cvUntyped>
+              <let line='4737' var='Q{}context-node' as='node()' slot='17' eval='16'>
+               <treat line='4738' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|context-node'>
+                <check card='1' diag='3|0|XTTE0570|context-node'>
+                 <evaluate dxns=''>
+                  <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='6' eval='16'>
+                   <treat line='4682' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|context'>
+                    <check line='4738' card='1' diag='0|0||xforms:impose'>
+                     <check line='4682' card='?' diag='3|0|XTTE0570|context'>
+                      <cvUntyped to='xs:string' diag='3|0|XTTE0570|context'>
+                       <data>
+                        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                         <varRef name='Q{}action-map' slot='0'/>
+                         <str val='@context'/>
+                        </ifCall>
+                       </data>
+                      </cvUntyped>
+                     </check>
                     </check>
                    </treat>
-                   <choose line='4748'>
-                    <fn name='exists'>
-                     <varRef name='Q{}repeat-id' slot='18'/>
-                    </fn>
-                    <choose line='4750'>
-                     <vc op='eq' onEmpty='0' comp='CCC'>
-                      <varRef name='Q{}position' slot='9'/>
-                      <str val='before'/>
-                     </vc>
-                     <ifCall line='4751' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                      <check card='1' diag='0|0||ixsl:call'>
-                       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-                      </check>
-                      <str val='setRepeatIndex'/>
-                      <arrayBlock>
-                       <varRef name='Q{}repeat-id' slot='18'/>
-                       <varRef name='Q{}at-position' slot='19'/>
-                      </arrayBlock>
-                     </ifCall>
+                  </ufCall>
+                  <varRef role='cxt' name='Q{}instanceXML2' slot='12'/>
+                  <varRef role='nsCxt' name='Q{}instanceXML2' slot='12'/>
+                  <str role='sa' val='no'/>
+                  <map role='options' size='0'/>
+                  <map role='wp' size='0'/>
+                 </evaluate>
+                </check>
+               </treat>
+               <let line='4755' var='Q{}instance-with-insert' as='element()' slot='18' eval='16'>
+                <treat line='4756' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-insert'>
+                 <check card='1' diag='3|0|XTTE0570|instance-with-insert'>
+                  <applyT mode='Q{}insert-node' bSlot='7'>
+                   <varRef role='select' name='Q{}instanceXML2' slot='12'/>
+                   <withParam name='Q{}insert-node-location' flags='t' as='node()?'>
+                    <choose line='4757'>
+                     <fn name='exists'>
+                      <varRef name='Q{}insert-node-location' slot='16'/>
+                     </fn>
+                     <varRef name='Q{}insert-node-location' slot='16'/>
                      <true/>
-                     <ifCall line='4754' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                      <check card='1' diag='0|0||ixsl:call'>
-                       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-                      </check>
-                      <str val='setRepeatIndex'/>
-                      <arrayBlock>
-                       <varRef name='Q{}repeat-id' slot='18'/>
-                       <arith op='+' calc='i+i'>
-                        <varRef name='Q{}at-position' slot='19'/>
-                        <int val='1'/>
-                       </arith>
-                      </arrayBlock>
-                     </ifCall>
+                     <varRef name='Q{}context-node' slot='17'/>
                     </choose>
-                   </choose>
+                   </withParam>
+                   <withParam name='Q{}node-to-insert' flags='t' as='node()?'>
+                    <choose line='4744'>
+                     <fn name='exists'>
+                      <varRef name='Q{}origin-node' slot='15'/>
+                     </fn>
+                     <copyOf line='4745' flags='vc'>
+                      <varRef name='Q{}origin-node' slot='15'/>
+                     </copyOf>
+                     <true/>
+                     <copyOf line='4748' flags='vc'>
+                      <varRef name='Q{}insert-node-location' slot='16'/>
+                     </copyOf>
+                    </choose>
+                   </withParam>
+                   <withParam name='Q{}position-relative' flags='t' as='xs:string?'>
+                    <choose line='4759'>
+                     <fn name='exists'>
+                      <varRef name='Q{}insert-node-location' slot='16'/>
+                     </fn>
+                     <varRef name='Q{}position' slot='9'/>
+                     <true/>
+                     <str val='child'/>
+                    </choose>
+                   </withParam>
+                  </applyT>
+                 </check>
+                </treat>
+                <sequence line='4765'>
+                 <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='8' eval='6 6'>
+                  <varRef name='Q{}ref' slot='3'/>
+                  <varRef name='Q{}instance-with-insert' slot='18'/>
+                 </ufCall>
+                 <choose line='4769'>
+                  <fn name='matches'>
+                   <varRef name='Q{}at' slot='8'/>
+                   <str val='index\s*\('/>
+                   <str val=''/>
+                  </fn>
+                  <let line='4770' var='Q{}repeat-id' as='xs:string?' slot='19' eval='7'>
+                   <ufCall name='Q{http://www.w3.org/2002/xforms}getRepeatID' tailCall='false' bSlot='9' eval='16'>
+                    <check card='1' diag='0|0||xforms:getRepeatID'>
+                     <varRef name='Q{}at' slot='8'/>
+                    </check>
+                   </ufCall>
+                   <let line='4771' var='Q{}at-position' as='xs:integer' slot='20' eval='16'>
+                    <treat line='4772' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|at-position'>
+                     <check card='1' diag='3|0|XTTE0570|at-position'>
+                      <cvUntyped to='xs:integer' diag='3|0|XTTE0570|at-position'>
+                       <data>
+                        <evaluate dxns=''>
+                         <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='10' eval='16'>
+                          <check card='1' diag='0|0||xforms:impose'>
+                           <varRef name='Q{}at' slot='8'/>
+                          </check>
+                         </ufCall>
+                         <empty role='cxt'/>
+                         <str role='sa' val='no'/>
+                         <map role='options' size='0'/>
+                         <map role='wp' size='0'/>
+                        </evaluate>
+                       </data>
+                      </cvUntyped>
+                     </check>
+                    </treat>
+                    <choose line='4777'>
+                     <fn name='exists'>
+                      <varRef name='Q{}repeat-id' slot='19'/>
+                     </fn>
+                     <choose line='4779'>
+                      <vc op='eq' onEmpty='0' comp='CCC'>
+                       <varRef name='Q{}position' slot='9'/>
+                       <str val='before'/>
+                      </vc>
+                      <ifCall line='4780' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                       <check card='1' diag='0|0||ixsl:call'>
+                        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                       </check>
+                       <str val='setRepeatIndex'/>
+                       <arrayBlock>
+                        <varRef name='Q{}repeat-id' slot='19'/>
+                        <varRef name='Q{}at-position' slot='20'/>
+                       </arrayBlock>
+                      </ifCall>
+                      <true/>
+                      <ifCall line='4783' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                       <check card='1' diag='0|0||ixsl:call'>
+                        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                       </check>
+                       <str val='setRepeatIndex'/>
+                       <arrayBlock>
+                        <varRef name='Q{}repeat-id' slot='19'/>
+                        <arith op='+' calc='i+i'>
+                         <varRef name='Q{}at-position' slot='20'/>
+                         <int val='1'/>
+                        </arith>
+                       </arrayBlock>
+                      </ifCall>
+                     </choose>
+                    </choose>
+                   </let>
                   </let>
-                 </let>
-                </choose>
-                <callT line='4764' name='Q{}xforms-recalculate' bSlot='10' flags='t'/>
-               </sequence>
+                 </choose>
+                 <callT line='4793' name='Q{}xforms-recalculate' bSlot='11' flags='t'/>
+                </sequence>
+               </let>
               </let>
              </let>
             </let>
@@ -435,9 +478,9 @@
    </sequence>
   </template>
  </co>
- <co id='8' binds='1 2 3 3 9 5 6 3 7'>
-  <template name='Q{}action-delete' flags='os' line='4777' module='saxon-xforms.xsl' slots='19'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4778'>
+ <co id='8' binds='1 2 3 3 9 5 7'>
+  <template name='Q{}action-delete' flags='os' line='4805' module='saxon-xforms.xsl' slots='16'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4806'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -445,14 +488,14 @@
       </check>
      </treat>
     </param>
-    <param line='4779' name='Q{}instanceXML' slot='1' flags='ti' as='element()'>
+    <param line='4807' name='Q{}instanceXML' slot='1' flags='ti' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|instanceXML'>
       <check card='1' diag='8|0|XTTE0590|instanceXML'>
        <supplied slot='1'/>
       </check>
      </treat>
     </param>
-    <param line='4780' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
+    <param line='4808' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -464,7 +507,7 @@
       </check>
      </treat>
     </param>
-    <let line='4782' var='Q{}ref' as='xs:string' slot='3' eval='16'>
+    <let line='4810' var='Q{}ref' as='xs:string' slot='3' eval='16'>
      <let var='Q{}relative' as='xs:string' slot='4' eval='16'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|1||xforms:resolveXPathStrings'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
@@ -489,7 +532,7 @@
         <str val='instance('/>
        </fn>
        <varRef line='842' name='Q{}relative' slot='4'/>
-       <fn line='4782' name='not'>
+       <fn line='4810' name='not'>
         <varRef name='Q{}nodeset' slot='2'/>
        </fn>
        <varRef line='845' name='Q{}relative' slot='4'/>
@@ -502,7 +545,7 @@
          <str val='.'/>
         </vc>
        </or>
-       <varRef line='4782' name='Q{}nodeset' slot='2'/>
+       <varRef line='4810' name='Q{}nodeset' slot='2'/>
        <true/>
        <let line='852' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
         <choose>
@@ -533,13 +576,13 @@
         </choose>
         <let line='855' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
          <choose>
-          <fn line='4782' name='contains'>
+          <fn line='4810' name='contains'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
           </fn>
           <fn name='index-of'>
            <fn name='string-to-codepoints'>
-            <varRef line='4782' name='Q{}nodeset' slot='2'/>
+            <varRef line='4810' name='Q{}nodeset' slot='2'/>
            </fn>
            <int val='47'/>
           </fn>
@@ -552,7 +595,7 @@
           </compareToInt>
           <fn line='891' name='concat'>
            <fn name='substring'>
-            <varRef line='4782' name='Q{}nodeset' slot='2'/>
+            <varRef line='4810' name='Q{}nodeset' slot='2'/>
             <int val='1'/>
             <choose line='866'>
              <and op='and'>
@@ -597,7 +640,7 @@
            </fn>
           </fn>
           <true/>
-          <fn line='4782' name='concat'>
+          <fn line='4810' name='concat'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
            <varRef line='894' name='Q{}relative' slot='4'/>
@@ -607,7 +650,7 @@
        </let>
       </choose>
      </let>
-     <let line='4783' var='Q{}at' as='xs:string?' slot='8' eval='7'>
+     <let line='4811' var='Q{}at' as='xs:string?' slot='8' eval='7'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|at'>
        <check card='?' diag='3|0|XTTE0570|at'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|at'>
@@ -620,7 +663,7 @@
         </cvUntyped>
        </check>
       </treat>
-      <let line='4793' var='Q{}ref-qualified' as='xs:string' slot='9' eval='16'>
+      <let line='4821' var='Q{}ref-qualified' as='xs:string' slot='9' eval='16'>
        <choose>
         <fn name='exists'>
          <varRef name='Q{}at' slot='8'/>
@@ -634,28 +677,28 @@
         <true/>
         <varRef name='Q{}ref' slot='3'/>
        </choose>
-       <let line='4795' var='Q{}instance-id' as='xs:string' slot='10' eval='16'>
+       <let line='4823' var='Q{}instance-id' as='xs:string' slot='10' eval='16'>
         <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='6'>
          <varRef name='Q{}ref' slot='3'/>
         </ufCall>
-        <let line='4797' var='Q{}instanceXML2' as='element()' slot='11' eval='16'>
-         <choose line='4799'>
+        <let line='4825' var='Q{}instanceXML2' as='element()' slot='11' eval='16'>
+         <choose line='4827'>
           <vc op='eq' onEmpty='0' comp='CCC'>
            <varRef name='Q{}instance-id' slot='10'/>
            <str val='saxon-forms-default'/>
           </vc>
-          <varRef line='4800' name='Q{}instanceXML' slot='1'/>
+          <varRef line='4828' name='Q{}instanceXML' slot='1'/>
           <true/>
-          <check line='4803' card='1' diag='3|0|XTTE0570|instanceXML2'>
+          <check line='4831' card='1' diag='3|0|XTTE0570|instanceXML2'>
            <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='6'>
             <varRef name='Q{}instance-id' slot='10'/>
            </ufCall>
           </check>
          </choose>
-         <let line='4808' var='Q{}ifVar' as='xs:string?' slot='12' eval='7'>
+         <let line='4836' var='Q{}ifVar' as='xs:string?' slot='12' eval='7'>
           <choose line='793'>
            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
-            <varRef line='4808' name='Q{}action-map' slot='0'/>
+            <varRef line='4836' name='Q{}action-map' slot='0'/>
             <str val='@if'/>
            </ifCall>
            <treat line='794' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
@@ -663,7 +706,7 @@
              <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
               <data>
                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                <varRef line='4808' name='Q{}action-map' slot='0'/>
+                <varRef line='4836' name='Q{}action-map' slot='0'/>
                 <str val='@if'/>
                </ifCall>
               </data>
@@ -671,8 +714,8 @@
             </check>
            </treat>
           </choose>
-          <let line='4811' var='Q{}delete-node' as='node()?' slot='13' eval='7'>
-           <choose line='4813'>
+          <let line='4839' var='Q{}delete-node' as='node()*' slot='13' eval='8'>
+           <choose line='4841'>
             <and op='and'>
              <fn name='exists'>
               <varRef name='Q{}ref-qualified' slot='9'/>
@@ -682,29 +725,27 @@
               <str val=''/>
              </vc>
             </and>
-            <treat line='4814' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|delete-node'>
-             <check card='?' diag='3|0|XTTE0570|delete-node'>
-              <evaluate dxns=''>
-               <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
-                <check card='1' diag='0|0||xforms:impose'>
-                 <varRef name='Q{}ref-qualified' slot='9'/>
-                </check>
-               </ufCall>
-               <varRef role='cxt' name='Q{}instanceXML2' slot='11'/>
-               <varRef role='nsCxt' name='Q{}instanceXML2' slot='11'/>
-               <str role='sa' val='no'/>
-               <map role='options' size='0'/>
-               <map role='wp' size='0'/>
-              </evaluate>
-             </check>
+            <treat line='4842' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|delete-node'>
+             <evaluate dxns=''>
+              <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
+               <check card='1' diag='0|0||xforms:impose'>
+                <varRef name='Q{}ref-qualified' slot='9'/>
+               </check>
+              </ufCall>
+              <varRef role='cxt' name='Q{}instanceXML2' slot='11'/>
+              <varRef role='nsCxt' name='Q{}instanceXML2' slot='11'/>
+              <str role='sa' val='no'/>
+              <map role='options' size='0'/>
+              <map role='wp' size='0'/>
+             </evaluate>
             </treat>
            </choose>
-           <let line='4819' var='Q{}ifExecuted' as='xs:boolean' slot='14' eval='16'>
-            <choose line='4821'>
+           <let line='4847' var='Q{}ifExecuted' as='xs:boolean' slot='14' eval='16'>
+            <choose line='4849'>
              <fn name='exists'>
               <varRef name='Q{}ifVar' slot='12'/>
              </fn>
-             <treat line='4822' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|ifExecuted'>
+             <treat line='4850' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|ifExecuted'>
               <check card='1' diag='3|0|XTTE0570|ifExecuted'>
                <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|ifExecuted'>
                 <data>
@@ -714,7 +755,9 @@
                     <varRef name='Q{}ifVar' slot='12'/>
                    </check>
                   </ufCall>
-                  <varRef role='cxt' name='Q{}delete-node' slot='13'/>
+                  <check role='cxt' card='?' diag='4|0|XTTE3210|xsl:evaluate/context-item'>
+                   <varRef name='Q{}delete-node' slot='13'/>
+                  </check>
                   <check role='nsCxt' card='1' diag='4|0|XTTE3170|xsl:evaluate/namespace-context'>
                    <varRef name='Q{}delete-node' slot='13'/>
                   </check>
@@ -729,133 +772,25 @@
              <true/>
              <true/>
             </choose>
-            <choose line='4830'>
+            <choose line='4858'>
              <varRef name='Q{}ifExecuted' slot='14'/>
-             <let line='4831' var='Q{}instance-with-delete' as='element()' slot='15' eval='16'>
-              <treat line='4832' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-delete'>
+             <let line='4859' var='Q{}instance-with-delete' as='element()' slot='15' eval='16'>
+              <treat line='4860' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-delete'>
                <check card='1' diag='3|0|XTTE0570|instance-with-delete'>
                 <applyT mode='Q{}delete-node' bSlot='4'>
                  <varRef role='select' name='Q{}instanceXML2' slot='11'/>
-                 <withParam name='Q{}delete-node' flags='t' as='node()?'>
-                  <varRef line='4833' name='Q{}delete-node' slot='13'/>
+                 <withParam name='Q{}delete-node' flags='t' as='node()*'>
+                  <varRef line='4861' name='Q{}delete-node' slot='13'/>
                  </withParam>
                 </applyT>
                </check>
               </treat>
-              <sequence line='4839'>
+              <sequence line='4867'>
                <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='5' eval='6 6'>
                 <varRef name='Q{}ref' slot='3'/>
                 <varRef name='Q{}instance-with-delete' slot='15'/>
                </ufCall>
-               <choose line='4842'>
-                <fn name='matches'>
-                 <varRef name='Q{}at' slot='8'/>
-                 <str val='index\s*\('/>
-                 <str val=''/>
-                </fn>
-                <let line='4843' var='Q{}repeat-id' as='xs:string?' slot='16' eval='7'>
-                 <ufCall name='Q{http://www.w3.org/2002/xforms}getRepeatID' tailCall='false' bSlot='6' eval='16'>
-                  <check card='1' diag='0|0||xforms:getRepeatID'>
-                   <varRef name='Q{}at' slot='8'/>
-                  </check>
-                 </ufCall>
-                 <let line='4844' var='Q{}at-position' as='xs:integer' slot='17' eval='16'>
-                  <treat line='4845' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|at-position'>
-                   <check card='1' diag='3|0|XTTE0570|at-position'>
-                    <cvUntyped to='xs:integer' diag='3|0|XTTE0570|at-position'>
-                     <data>
-                      <evaluate dxns=''>
-                       <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='7' eval='16'>
-                        <check card='1' diag='0|0||xforms:impose'>
-                         <varRef name='Q{}at' slot='8'/>
-                        </check>
-                       </ufCall>
-                       <empty role='cxt'/>
-                       <str role='sa' val='no'/>
-                       <map role='options' size='0'/>
-                       <map role='wp' size='0'/>
-                      </evaluate>
-                     </data>
-                    </cvUntyped>
-                   </check>
-                  </treat>
-                  <choose line='4848'>
-                   <fn name='exists'>
-                    <varRef name='Q{}repeat-id' slot='16'/>
-                   </fn>
-                   <let line='4849' var='Q{}repeat-size' as='xs:double' slot='18' eval='16'>
-                    <check card='1' diag='3|0|XTTE0570|repeat-size'>
-                     <convert from='xs:anyAtomicType' to='xs:double' flags='p' diag='3|0|XTTE0570|repeat-size'>
-                      <cvUntyped to='xs:double' diag='3|0|XTTE0570|repeat-size'>
-                       <data>
-                        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                         <check card='1' diag='0|0||ixsl:call'>
-                          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-                         </check>
-                         <str val='getRepeatSize'/>
-                         <arrayBlock>
-                          <varRef name='Q{}repeat-id' slot='16'/>
-                         </arrayBlock>
-                        </ifCall>
-                       </data>
-                      </cvUntyped>
-                     </convert>
-                    </check>
-                    <sequence line='4851'>
-                     <message>
-                      <sequence role='select'>
-                       <valueOf>
-                        <str val='[action-delete] Size of repeat &#39;'/>
-                       </valueOf>
-                       <valueOf>
-                        <varRef name='Q{}repeat-id' slot='16'/>
-                       </valueOf>
-                       <valueOf>
-                        <str val='&#39; is '/>
-                       </valueOf>
-                       <valueOf>
-                        <convert from='xs:double' to='xs:string'>
-                         <varRef name='Q{}repeat-size' slot='18'/>
-                        </convert>
-                       </valueOf>
-                       <valueOf>
-                        <str val=', index is '/>
-                       </valueOf>
-                       <valueOf>
-                        <convert from='xs:integer' to='xs:string'>
-                         <varRef name='Q{}at-position' slot='17'/>
-                        </convert>
-                       </valueOf>
-                      </sequence>
-                      <str role='terminate' val='no'/>
-                      <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-                     </message>
-                     <choose line='4854'>
-                      <vc op='eq' onEmpty='0' comp='CAVC'>
-                       <varRef name='Q{}at-position' slot='17'/>
-                       <varRef name='Q{}repeat-size' slot='18'/>
-                      </vc>
-                      <ifCall line='4856' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                       <check card='1' diag='0|0||ixsl:call'>
-                        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-                       </check>
-                       <str val='setRepeatIndex'/>
-                       <arrayBlock>
-                        <varRef name='Q{}repeat-id' slot='16'/>
-                        <arith op='-' calc='d-d'>
-                         <varRef name='Q{}repeat-size' slot='18'/>
-                         <dbl val='1'/>
-                        </arith>
-                       </arrayBlock>
-                      </ifCall>
-                     </choose>
-                    </sequence>
-                   </let>
-                  </choose>
-                 </let>
-                </let>
-               </choose>
-               <callT line='4865' name='Q{}xforms-recalculate' bSlot='8' flags='t'/>
+               <callT line='4896' name='Q{}xforms-recalculate' bSlot='6' flags='t'/>
               </sequence>
              </let>
             </choose>
@@ -871,8 +806,8 @@
   </template>
  </co>
  <co id='10' binds='11'>
-  <template name='Q{}action-send' flags='os' line='4910' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4911'>
+  <template name='Q{}action-send' flags='os' line='4941' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4942'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -880,9 +815,9 @@
       </check>
      </treat>
     </param>
-    <callT line='4917' name='Q{}xforms-submit' bSlot='0' flags='t'>
+    <callT line='4948' name='Q{}xforms-submit' bSlot='0' flags='t'>
      <withParam name='Q{}submission' flags='c' as='xs:string'>
-      <treat line='4915' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|submission'>
+      <treat line='4946' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|submission'>
        <check card='1' diag='3|0|XTTE0570|submission'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|submission'>
          <data>
@@ -900,39 +835,16 @@
   </template>
  </co>
  <co id='12' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}usesIndexFunction' line='2962' module='saxon-xforms.xsl' eval='8' flags='pU' as='xs:boolean' slots='1'>
+  <function name='Q{http://www.w3.org/2002/xforms}usesIndexFunction' line='2974' module='saxon-xforms.xsl' eval='8' flags='pU' as='xs:boolean' slots='1'>
    <arg name='Q{}this' as='element()'/>
-   <fn role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2998' name='exists'>
-    <sequence line='2973'>
+   <fn role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3010' name='exists'>
+    <sequence line='2985'>
      <analyzeString>
       <cvUntyped role='select' to='xs:string'>
        <data>
         <slash simple='1'>
          <varRef name='Q{}this' slot='0'/>
          <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
-        </slash>
-       </data>
-      </cvUntyped>
-      <str role='regex' val='\i\c*\('/>
-      <str role='flags' val=''/>
-      <choose role='matching' line='2976'>
-       <vc op='eq' onEmpty='0' comp='CCC'>
-        <fn name='substring-before'>
-         <dot type='xs:string'/>
-         <str val='('/>
-        </fn>
-        <str val='index'/>
-       </vc>
-       <str val='i'/>
-      </choose>
-      <empty role='nonMatching'/>
-     </analyzeString>
-     <analyzeString line='2985'>
-      <cvUntyped role='select' to='xs:string'>
-       <data>
-        <slash simple='1'>
-         <varRef name='Q{}this' slot='0'/>
-         <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
         </slash>
        </data>
       </cvUntyped>
@@ -950,24 +862,47 @@
       </choose>
       <empty role='nonMatching'/>
      </analyzeString>
+     <analyzeString line='2997'>
+      <cvUntyped role='select' to='xs:string'>
+       <data>
+        <slash simple='1'>
+         <varRef name='Q{}this' slot='0'/>
+         <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+        </slash>
+       </data>
+      </cvUntyped>
+      <str role='regex' val='\i\c*\('/>
+      <str role='flags' val=''/>
+      <choose role='matching' line='3000'>
+       <vc op='eq' onEmpty='0' comp='CCC'>
+        <fn name='substring-before'>
+         <dot type='xs:string'/>
+         <str val='('/>
+        </fn>
+        <str val='index'/>
+       </vc>
+       <str val='i'/>
+      </choose>
+      <empty role='nonMatching'/>
+     </analyzeString>
     </sequence>
    </fn>
   </function>
  </co>
  <co id='13' binds='14 13 14 15 13 13 15'>
   <mode name='Q{}form-check' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='27' rank='0' minImp='0' slots='12' flags='s' line='2621' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='27' rank='0' minImp='0' slots='12' flags='s' line='2633' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2622'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2634'>
      <param name='Q{}curPath' slot='0'>
       <str role='select' val=''/>
       <supplied role='conversion' slot='0'/>
      </param>
-     <param line='2623' name='Q{}position' slot='1'>
+     <param line='2635' name='Q{}position' slot='1'>
       <int role='select' val='0'/>
       <supplied role='conversion' slot='1'/>
      </param>
-     <param line='2624' name='Q{}pendingUpdates' slot='2' flags='t' as='map(xs:string, xs:string)?'>
+     <param line='2636' name='Q{}pendingUpdates' slot='2' flags='t' as='map(xs:string, xs:string)?'>
       <empty role='select'/>
       <treat role='conversion' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|pendingUpdates'>
        <check card='?' diag='8|0|XTTE0590|pendingUpdates'>
@@ -975,7 +910,7 @@
        </check>
       </treat>
      </param>
-     <param line='2625' name='Q{}updated-node' slot='3' flags='t' as='node()?'>
+     <param line='2637' name='Q{}updated-node' slot='3' flags='t' as='node()?'>
       <empty role='select'/>
       <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|updated-node'>
        <check card='?' diag='8|0|XTTE0590|updated-node'>
@@ -983,7 +918,7 @@
        </check>
       </treat>
      </param>
-     <param line='2626' name='Q{}value' slot='4' flags='t' as='xs:string?'>
+     <param line='2638' name='Q{}value' slot='4' flags='t' as='xs:string?'>
       <empty role='select'/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|value'>
        <check card='?' diag='8|0|XTTE0590|value'>
@@ -995,7 +930,7 @@
        </check>
       </treat>
      </param>
-     <let line='2647' var='Q{}updatedPath' as='xs:string' slot='5' eval='16'>
+     <let line='2659' var='Q{}updatedPath' as='xs:string' slot='5' eval='16'>
       <choose>
        <gc op='&gt;' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
         <data>
@@ -1026,7 +961,7 @@
         </fn>
        </fn>
       </choose>
-      <sequence line='2653'>
+      <sequence line='2665'>
        <message>
         <sequence role='select'>
          <valueOf>
@@ -1040,7 +975,7 @@
         <str role='terminate' val='no'/>
         <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
        </message>
-       <forEach line='2654'>
+       <forEach line='2666'>
         <filter flags='b'>
          <slash simple='1'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
@@ -1060,7 +995,7 @@
           </fn>
          </or>
         </filter>
-        <sequence line='2655'>
+        <sequence line='2667'>
          <message>
           <sequence role='select'>
            <valueOf>
@@ -1080,7 +1015,7 @@
           <str role='terminate' val='no'/>
           <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
          </message>
-         <message line='2656'>
+         <message line='2668'>
           <sequence role='select'>
            <valueOf>
             <str val='[form-check] resolved @data-ref = &#39;'/>
@@ -1101,18 +1036,18 @@
          </message>
         </sequence>
        </forEach>
-       <copy line='2661' flags='cin'>
+       <copy line='2673' flags='cin'>
         <sequence role='content'>
          <applyT mode='Q{}form-check' bSlot='1'>
           <axis role='select' name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
           <withParam name='Q{}curPath' as='xs:string'>
-           <fn line='2662' name='concat'>
+           <fn line='2674' name='concat'>
             <varRef name='Q{}updatedPath' slot='5'/>
             <str val='/'/>
            </fn>
           </withParam>
          </applyT>
-         <let line='2668' var='Q{}associated-form-control' as='element()*' slot='6' eval='8'>
+         <let line='2680' var='Q{}associated-form-control' as='element()*' slot='6' eval='8'>
           <filter flags='b'>
            <filter flags='b'>
             <slash simple='1'>
@@ -1144,14 +1079,14 @@
             <varRef name='Q{}updatedPath' slot='5'/>
            </vc>
           </filter>
-          <sequence line='2670'>
+          <sequence line='2682'>
            <choose>
             <fn name='exists'>
              <tail start='2'>
               <varRef name='Q{}associated-form-control' slot='6'/>
              </tail>
             </fn>
-            <message line='2671'>
+            <message line='2683'>
              <sequence role='select'>
               <valueOf>
                <str val='[form-check] More than one form element controls the value of XForm node at '/>
@@ -1167,12 +1102,12 @@
              <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
             </message>
            </choose>
-           <choose line='2675'>
+           <choose line='2687'>
             <is op='is'>
              <varRef name='Q{}updated-node' slot='3'/>
              <dot type='element()'/>
             </is>
-            <sequence line='2676'>
+            <sequence line='2688'>
              <message>
               <valueOf role='select'>
                <str val='&#xA;                        [form-check] Matched node!!&#xA;                    '/>
@@ -1180,14 +1115,14 @@
               <str role='terminate' val='no'/>
               <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
              </message>
-             <valueOf line='2679' flags='l'>
+             <valueOf line='2691' flags='l'>
               <varRef name='Q{}value' slot='4'/>
              </valueOf>
             </sequence>
-            <fn line='2681' name='exists'>
+            <fn line='2693' name='exists'>
              <varRef name='Q{}associated-form-control' slot='6'/>
             </fn>
-            <valueOf line='2685' flags='l'>
+            <valueOf line='2697' flags='l'>
              <fn name='string-join'>
               <convert from='xs:anyAtomicType' to='xs:string'>
                <data>
@@ -1203,7 +1138,7 @@
               <str val=''/>
              </fn>
             </valueOf>
-            <and line='2688' op='and'>
+            <and line='2700' op='and'>
              <fn name='exists'>
               <varRef name='Q{}pendingUpdates' slot='2'/>
              </fn>
@@ -1214,7 +1149,7 @@
               <varRef name='Q{}updatedPath' slot='5'/>
              </ifCall>
             </and>
-            <valueOf line='2696' flags='l'>
+            <valueOf line='2708' flags='l'>
              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
               <check card='1' diag='0|0||map:get'>
                <varRef name='Q{}pendingUpdates' slot='2'/>
@@ -1223,7 +1158,7 @@
              </ifCall>
             </valueOf>
             <true/>
-            <valueOf line='2705' flags='l'>
+            <valueOf line='2717' flags='l'>
              <fn name='normalize-space'>
               <fn name='string-join'>
                <data>
@@ -1234,13 +1169,13 @@
              </fn>
             </valueOf>
            </choose>
-           <forEachGroup line='2710' algorithm='by'>
+           <forEachGroup line='2722' algorithm='by'>
             <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
             <fn role='key' name='local-name'>
              <dot type='element()'/>
             </fn>
             <str role='collation' val='http://www.w3.org/2005/xpath-functions/collation/codepoint'/>
-            <let role='content' line='2712' var='Q{}updatedChildPath' as='xs:string' slot='7' eval='8'>
+            <let role='content' line='2724' var='Q{}updatedChildPath' as='xs:string' slot='7' eval='8'>
              <fn name='concat'>
               <varRef name='Q{}updatedPath' slot='5'/>
               <str val='/'/>
@@ -1248,7 +1183,7 @@
                <currentGroupingKey/>
               </check>
              </fn>
-             <let line='2717' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='8' eval='13'>
+             <let line='2729' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='8' eval='13'>
               <fn name='concat'>
                <varRef name='Q{}updatedChildPath' slot='7'/>
                <str val='['/>
@@ -1266,7 +1201,7 @@
                  <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='8'/>
                 </fn>
                </filter>
-               <choose line='2720'>
+               <choose line='2732'>
                 <or op='or'>
                  <fn name='exists'>
                   <tail start='2'>
@@ -1277,36 +1212,36 @@
                   <varRef name='Q{}dataRefWithFilter' slot='9'/>
                  </fn>
                 </or>
-                <let line='2723' var='Q{http://saxon.sf.net/generated-variable}v1' as='xs:string' slot='10' eval='13'>
+                <let line='2735' var='Q{http://saxon.sf.net/generated-variable}v1' as='xs:string' slot='10' eval='13'>
                  <fn name='concat'>
                   <varRef name='Q{}updatedPath' slot='5'/>
                   <str val='/'/>
                  </fn>
-                 <forEach line='2721'>
+                 <forEach line='2733'>
                   <currentGroup/>
-                  <applyT line='2722' mode='Q{}form-check' bSlot='4'>
+                  <applyT line='2734' mode='Q{}form-check' bSlot='4'>
                    <dot role='select'/>
                    <withParam name='Q{}curPath' as='xs:string'>
-                    <varRef line='2723' name='Q{http://saxon.sf.net/generated-variable}v1' slot='10'/>
+                    <varRef line='2735' name='Q{http://saxon.sf.net/generated-variable}v1' slot='10'/>
                    </withParam>
                    <withParam name='Q{}position' as='xs:integer'>
-                    <fn line='2724' name='position'/>
+                    <fn line='2736' name='position'/>
                    </withParam>
                   </applyT>
                  </forEach>
                 </let>
                 <true/>
-                <let line='2732' var='Q{http://saxon.sf.net/generated-variable}v2' as='xs:string' slot='11' eval='13'>
+                <let line='2744' var='Q{http://saxon.sf.net/generated-variable}v2' as='xs:string' slot='11' eval='13'>
                  <fn name='concat'>
                   <varRef name='Q{}updatedPath' slot='5'/>
                   <str val='/'/>
                  </fn>
-                 <forEach line='2730'>
+                 <forEach line='2742'>
                   <currentGroup/>
-                  <applyT line='2731' mode='Q{}form-check' bSlot='5'>
+                  <applyT line='2743' mode='Q{}form-check' bSlot='5'>
                    <dot role='select'/>
                    <withParam name='Q{}curPath' as='xs:string'>
-                    <varRef line='2732' name='Q{http://saxon.sf.net/generated-variable}v2' slot='11'/>
+                    <varRef line='2744' name='Q{http://saxon.sf.net/generated-variable}v2' slot='11'/>
                    </withParam>
                   </applyT>
                  </forEach>
@@ -1324,14 +1259,14 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='-0.5' seq='30' rank='0' minImp='0' slots='4' flags='s' line='2807' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='30' rank='0' minImp='0' slots='4' flags='s' line='2819' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2808'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2820'>
      <param name='Q{}curPath' slot='0'>
       <str role='select' val=''/>
       <supplied role='conversion' slot='0'/>
      </param>
-     <param line='2809' name='Q{}pendingUpdates' slot='1' flags='t' as='map(xs:string, xs:string)?'>
+     <param line='2821' name='Q{}pendingUpdates' slot='1' flags='t' as='map(xs:string, xs:string)?'>
       <empty role='select'/>
       <treat role='conversion' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|pendingUpdates'>
        <check card='?' diag='8|0|XTTE0590|pendingUpdates'>
@@ -1339,7 +1274,7 @@
        </check>
       </treat>
      </param>
-     <let line='2810' var='Q{}updatedPath' as='xs:string' slot='2' eval='8'>
+     <let line='2822' var='Q{}updatedPath' as='xs:string' slot='2' eval='8'>
       <fn name='concat'>
        <atomSing card='?' diag='0|0||fn:concat'>
         <varRef name='Q{}curPath' slot='0'/>
@@ -1349,7 +1284,7 @@
         <dot type='attribute()'/>
        </fn>
       </fn>
-      <let line='2819' var='Q{}associated-form-control' as='element()*' slot='3' eval='8'>
+      <let line='2831' var='Q{}associated-form-control' as='element()*' slot='3' eval='8'>
        <filter flags='b'>
         <slash simple='1'>
          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
@@ -1362,15 +1297,15 @@
          <varRef name='Q{}updatedPath' slot='2'/>
         </vc>
        </filter>
-       <choose line='2822'>
+       <choose line='2834'>
         <fn name='exists'>
          <varRef name='Q{}associated-form-control' slot='3'/>
         </fn>
-        <compAtt line='2825'>
+        <compAtt line='2837'>
          <fn role='name' name='local-name'>
           <dot type='attribute()'/>
          </fn>
-         <fn role='select' line='2826' name='string-join'>
+         <fn role='select' line='2838' name='string-join'>
           <convert from='xs:anyAtomicType' to='xs:string'>
            <data>
             <mergeAdj>
@@ -1383,7 +1318,7 @@
           <str val=''/>
          </fn>
         </compAtt>
-        <and line='2829' op='and'>
+        <and line='2841' op='and'>
          <fn name='exists'>
           <varRef name='Q{}pendingUpdates' slot='1'/>
          </fn>
@@ -1394,11 +1329,11 @@
           <varRef name='Q{}updatedPath' slot='2'/>
          </ifCall>
         </and>
-        <compAtt line='2830'>
+        <compAtt line='2842'>
          <fn role='name' name='local-name'>
           <dot type='attribute()'/>
          </fn>
-         <ifCall role='select' line='2831' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+         <ifCall role='select' line='2843' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
           <check card='1' diag='0|0||map:get'>
            <varRef name='Q{}pendingUpdates' slot='1'/>
           </check>
@@ -1406,7 +1341,7 @@
          </ifCall>
         </compAtt>
         <true/>
-        <forEach line='2835'>
+        <forEach line='2847'>
          <dot type='attribute()'/>
          <copyOf flags='vsc'>
           <dot type='attribute()'/>
@@ -1421,9 +1356,9 @@
  </co>
  <co id='16' binds='13 13'>
   <mode name='Q{}form-check-initial' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='26' rank='0' minImp='0' slots='6' flags='s' line='2559' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='26' rank='0' minImp='0' slots='6' flags='s' line='2571' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2560'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2572'>
      <param name='Q{}instance-id' slot='0' as='xs:string'>
       <str role='select' val='saxon-forms-default'/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|instance-id'>
@@ -1436,7 +1371,7 @@
        </check>
       </treat>
      </param>
-     <param line='2561' name='Q{}pendingUpdates' slot='1' flags='t' as='map(xs:string, xs:string)?'>
+     <param line='2573' name='Q{}pendingUpdates' slot='1' flags='t' as='map(xs:string, xs:string)?'>
       <empty role='select'/>
       <treat role='conversion' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|pendingUpdates'>
        <check card='?' diag='8|0|XTTE0590|pendingUpdates'>
@@ -1444,15 +1379,15 @@
        </check>
       </treat>
      </param>
-     <let line='2567' var='Q{}curPath' as='xs:string' slot='2' eval='16'>
-      <choose line='2569'>
+     <let line='2579' var='Q{}curPath' as='xs:string' slot='2' eval='16'>
+      <choose line='2581'>
        <vc op='eq' onEmpty='0' comp='CCC'>
         <varRef name='Q{}instance-id' slot='0'/>
         <str val='saxon-forms-default'/>
        </vc>
        <str val=''/>
        <true/>
-       <cvUntyped line='2573' to='xs:string' diag='3|0|XTTE0570|curPath'>
+       <cvUntyped line='2585' to='xs:string' diag='3|0|XTTE0570|curPath'>
         <cast as='xs:untypedAtomic' emptiable='0'>
          <fn name='concat'>
           <str val='instance(&#39;'/>
@@ -1462,21 +1397,21 @@
         </cast>
        </cvUntyped>
       </choose>
-      <copy line='2580' flags='cin'>
+      <copy line='2592' flags='cin'>
        <forEachGroup role='content' algorithm='by'>
         <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
         <fn role='key' name='local-name'>
          <dot type='element()'/>
         </fn>
         <str role='collation' val='http://www.w3.org/2005/xpath-functions/collation/codepoint'/>
-        <let role='content' line='2582' var='Q{}updatedChildPath' as='xs:string' slot='3' eval='8'>
+        <let role='content' line='2594' var='Q{}updatedChildPath' as='xs:string' slot='3' eval='8'>
          <fn name='concat'>
           <varRef name='Q{}curPath' slot='2'/>
           <check card='?' diag='0|1||fn:concat'>
            <currentGroupingKey/>
           </check>
          </fn>
-         <let line='2587' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='4' eval='13'>
+         <let line='2599' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='4' eval='13'>
           <fn name='concat'>
            <varRef name='Q{}updatedChildPath' slot='3'/>
            <str val='['/>
@@ -1494,7 +1429,7 @@
              <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='4'/>
             </fn>
            </filter>
-           <choose line='2589'>
+           <choose line='2601'>
             <or op='or'>
              <fn name='exists'>
               <tail start='2'>
@@ -1505,25 +1440,25 @@
               <varRef name='Q{}dataRefWithFilter' slot='5'/>
              </fn>
             </or>
-            <forEach line='2590'>
+            <forEach line='2602'>
              <currentGroup/>
-             <applyT line='2591' mode='Q{}form-check' bSlot='0'>
+             <applyT line='2603' mode='Q{}form-check' bSlot='0'>
               <dot role='select'/>
               <withParam name='Q{}curPath' as='xs:string'>
-               <varRef line='2592' name='Q{}curPath' slot='2'/>
+               <varRef line='2604' name='Q{}curPath' slot='2'/>
               </withParam>
               <withParam name='Q{}position' as='xs:integer'>
-               <fn line='2593' name='position'/>
+               <fn line='2605' name='position'/>
               </withParam>
              </applyT>
             </forEach>
             <true/>
-            <forEach line='2599'>
+            <forEach line='2611'>
              <currentGroup/>
-             <applyT line='2600' mode='Q{}form-check' bSlot='1'>
+             <applyT line='2612' mode='Q{}form-check' bSlot='1'>
               <dot role='select'/>
               <withParam name='Q{}curPath' as='xs:string'>
-               <varRef line='2601' name='Q{}curPath' slot='2'/>
+               <varRef line='2613' name='Q{}curPath' slot='2'/>
               </withParam>
              </applyT>
             </forEach>
@@ -1575,8 +1510,8 @@
   </function>
  </co>
  <co id='17' binds=''>
-  <template name='Q{}action-reset' flags='os' line='4957' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4958'>
+  <template name='Q{}action-reset' flags='os' line='4988' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4989'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -1584,7 +1519,7 @@
       </check>
      </treat>
     </param>
-    <message line='4960'>
+    <message line='4991'>
      <valueOf role='select'>
       <str val='[action-reset] Reset triggered!'/>
      </valueOf>
@@ -1595,8 +1530,8 @@
   </template>
  </co>
  <co id='18' binds='1 2 3 15 19 5 20 7 21'>
-  <template name='Q{}xforms-value-changed' flags='os' line='4171' module='saxon-xforms.xsl' slots='9'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4172'>
+  <template name='Q{}xforms-value-changed' flags='os' line='4198' module='saxon-xforms.xsl' slots='9'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4199'>
     <param name='Q{}form-control' slot='0' flags='i' as='node()'>
      <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|form-control'>
       <check card='1' diag='8|0|XTTE0590|form-control'>
@@ -1604,12 +1539,12 @@
       </check>
      </treat>
     </param>
-    <let line='4174' var='Q{}refi' as='attribute(Q{}data-ref)?' slot='1' eval='8'>
+    <let line='4201' var='Q{}refi' as='attribute(Q{}data-ref)?' slot='1' eval='8'>
      <slash simple='1'>
       <varRef name='Q{}form-control' slot='0'/>
       <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
      </slash>
-     <let line='4177' var='Q{}instance-id' as='xs:string' slot='2' eval='16'>
+     <let line='4204' var='Q{}instance-id' as='xs:string' slot='2' eval='16'>
       <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='16'>
        <check card='1' diag='0|0||xforms:getInstanceId'>
         <cvUntyped to='xs:string'>
@@ -1619,7 +1554,7 @@
         </cvUntyped>
        </check>
       </ufCall>
-      <let line='4178' var='Q{}actions' as='item()?' slot='3' eval='8'>
+      <let line='4205' var='Q{}actions' as='item()?' slot='3' eval='8'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
         <check card='1' diag='0|0||ixsl:call'>
          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -1634,14 +1569,14 @@
          </fn>
         </arrayBlock>
        </ifCall>
-       <let line='4189' var='Q{}instanceXML' as='element()' slot='4' eval='16'>
+       <let line='4216' var='Q{}instanceXML' as='element()' slot='4' eval='16'>
         <check card='1' diag='3|0|XTTE0570|instanceXML'>
          <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='6'>
           <varRef name='Q{}instance-id' slot='2'/>
          </ufCall>
         </check>
-        <let line='4190' var='Q{}updatedNode' as='node()' slot='5' eval='16'>
-         <treat line='4191' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|updatedNode'>
+        <let line='4217' var='Q{}updatedNode' as='node()' slot='5' eval='16'>
+         <treat line='4218' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|updatedNode'>
           <check card='1' diag='3|0|XTTE0570|updatedNode'>
            <evaluate dxns=''>
             <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
@@ -1661,8 +1596,8 @@
            </evaluate>
           </check>
          </treat>
-         <let line='4193' var='Q{}new-value' as='xs:string' slot='6' eval='16'>
-          <treat line='4194' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-value'>
+         <let line='4220' var='Q{}new-value' as='xs:string' slot='6' eval='16'>
+          <treat line='4221' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-value'>
            <check card='1' diag='3|0|XTTE0570|new-value'>
             <cvUntyped to='xs:string' diag='3|0|XTTE0570|new-value'>
              <data>
@@ -1673,24 +1608,24 @@
             </cvUntyped>
            </check>
           </treat>
-          <let line='4196' var='Q{}updatedInstanceXML' as='element()' slot='7' eval='16'>
-           <treat line='4197' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+          <let line='4223' var='Q{}updatedInstanceXML' as='element()' slot='7' eval='16'>
+           <treat line='4224' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
             <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
              <applyT mode='Q{}recalculate' bSlot='4'>
               <varRef role='select' name='Q{}instanceXML' slot='4'/>
               <withParam name='Q{}instance-id' as='xs:string'>
-               <varRef line='4198' name='Q{}instance-id' slot='2'/>
+               <varRef line='4225' name='Q{}instance-id' slot='2'/>
               </withParam>
               <withParam name='Q{}updated-nodes' flags='t' as='node()'>
-               <varRef line='4199' name='Q{}updatedNode' slot='5'/>
+               <varRef line='4226' name='Q{}updatedNode' slot='5'/>
               </withParam>
               <withParam name='Q{}updated-values' flags='t' as='xs:string'>
-               <varRef line='4200' name='Q{}new-value' slot='6'/>
+               <varRef line='4227' name='Q{}new-value' slot='6'/>
               </withParam>
              </applyT>
             </check>
            </treat>
-           <sequence line='4207'>
+           <sequence line='4234'>
             <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='5' eval='16 6'>
              <check card='1' diag='0|0||xforms:setInstance-JS'>
               <cvUntyped to='xs:string'>
@@ -1701,40 +1636,40 @@
              </check>
              <varRef name='Q{}updatedInstanceXML' slot='7'/>
             </ufCall>
-            <ifCall line='4214' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+            <ifCall line='4241' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
              <check card='1' diag='0|0||ixsl:call'>
               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
              </check>
              <str val='setPendingUpdates'/>
              <arrayBlock>
-              <treat line='4211' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||pendingInstanceUpdates'>
+              <treat line='4238' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||pendingInstanceUpdates'>
                <map size='0'/>
               </treat>
              </arrayBlock>
             </ifCall>
-            <ifCall line='4215' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+            <ifCall line='4242' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
              <check card='1' diag='0|0||ixsl:call'>
               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
              </check>
              <str val='setUpdates'/>
              <arrayBlock>
-              <treat line='4212' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||instanceUpdates'>
+              <treat line='4239' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||instanceUpdates'>
                <map size='0'/>
               </treat>
              </arrayBlock>
             </ifCall>
-            <forEach line='4217'>
+            <forEach line='4244'>
              <varRef name='Q{}actions' slot='3'/>
-             <let line='4218' var='Q{}action-map' as='item()' slot='8' eval='16'>
+             <let line='4245' var='Q{}action-map' as='item()' slot='8' eval='16'>
               <dot/>
-              <choose line='4220'>
+              <choose line='4247'>
                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
                 <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:contains'>
                  <varRef name='Q{}action-map' slot='8'/>
                 </treat>
                 <str val='@event'/>
                </ifCall>
-               <choose line='4221'>
+               <choose line='4248'>
                 <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
                  <data>
                   <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
@@ -1746,12 +1681,12 @@
                  </data>
                  <str val='xforms-value-changed'/>
                 </gc>
-                <callT line='4223' name='Q{}applyActions' bSlot='6'>
+                <callT line='4250' name='Q{}applyActions' bSlot='6'>
                  <withParam name='Q{}action-map' flags='t' as='item()'>
-                  <varRef line='4224' name='Q{}action-map' slot='8'/>
+                  <varRef line='4251' name='Q{}action-map' slot='8'/>
                  </withParam>
                  <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                  <check line='4225' card='1' diag='8|0|XTTE0590|nodeset'>
+                  <check line='4252' card='1' diag='8|0|XTTE0590|nodeset'>
                    <cvUntyped to='xs:string' diag='8|0|XTTE0590|nodeset'>
                     <data>
                      <varRef name='Q{}refi' slot='1'/>
@@ -1760,19 +1695,19 @@
                   </check>
                  </withParam>
                  <withParam name='Q{}instanceXML' flags='t' as='element()'>
-                  <varRef line='4226' name='Q{}updatedInstanceXML' slot='7'/>
+                  <varRef line='4253' name='Q{}updatedInstanceXML' slot='7'/>
                  </withParam>
                 </callT>
                </choose>
               </choose>
              </let>
             </forEach>
-            <callT line='4232' name='Q{}xforms-recalculate' bSlot='7'/>
-            <ufCall line='4234' name='Q{http://www.w3.org/2002/xforms}checkRelevantFields' tailCall='false' bSlot='8' eval='16'>
+            <callT line='4259' name='Q{}xforms-recalculate' bSlot='7'/>
+            <ufCall line='4261' name='Q{http://www.w3.org/2002/xforms}checkRelevantFields' tailCall='false' bSlot='8' eval='16'>
              <check card='1' diag='0|0||xforms:checkRelevantFields'>
               <cvUntyped to='xs:string'>
                <data>
-                <slash line='4175' simple='1'>
+                <slash line='4202' simple='1'>
                  <varRef name='Q{}form-control' slot='0'/>
                  <axis name='attribute' nodeTest='attribute(Q{}data-element)' jsTest='return item.name===&#39;data-element&#39;'/>
                 </slash>
@@ -1792,8 +1727,8 @@
   </template>
  </co>
  <co id='22' binds='23 24 3 24'>
-  <template name='Q{}getReferencedInstanceField' flags='os' line='3417' module='saxon-xforms.xsl' slots='5'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3418'>
+  <template name='Q{}getReferencedInstanceField' flags='os' line='3429' module='saxon-xforms.xsl' slots='5'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3430'>
     <param name='Q{}refi' slot='0' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|refi'>
@@ -1806,17 +1741,17 @@
       </check>
      </treat>
     </param>
-    <let line='3422' var='Q{}field' as='node()*' slot='1' eval='8'>
-     <choose line='3424'>
+    <let line='3434' var='Q{}field' as='node()*' slot='1' eval='8'>
+     <choose line='3436'>
       <varRef name='Q{}refi' slot='0'/>
-      <let line='3425' var='Q{}instance-map' as='map(xs:string, xs:string)' slot='2' eval='16'>
+      <let line='3437' var='Q{}instance-map' as='map(xs:string, xs:string)' slot='2' eval='16'>
        <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='0' eval='6'>
         <varRef name='Q{}refi' slot='0'/>
        </ufCall>
-       <let line='3432' var='Q{}this-instance' as='element()?' slot='3' eval='9'>
-        <callT line='3433' name='Q{}getInstance' bSlot='1'>
+       <let line='3444' var='Q{}this-instance' as='element()?' slot='3' eval='9'>
+        <callT line='3445' name='Q{}getInstance' bSlot='1'>
          <withParam name='Q{}instance-id' flags='c' as='xs:string'>
-          <check line='3434' card='1' diag='8|0|XTTE0590|instance-id'>
+          <check line='3446' card='1' diag='8|0|XTTE0590|instance-id'>
            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
             <varRef name='Q{}instance-map' slot='2'/>
             <str val='instance-id'/>
@@ -1824,9 +1759,9 @@
           </check>
          </withParam>
         </callT>
-        <treat line='3442' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|field'>
+        <treat line='3454' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|field'>
          <evaluate dxns=''>
-          <ufCall role='xpath' line='3438' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
+          <ufCall role='xpath' line='3450' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
            <check card='1' diag='0|0||xforms:impose'>
             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
              <varRef name='Q{}instance-map' slot='2'/>
@@ -1846,23 +1781,23 @@
        </let>
       </let>
       <true/>
-      <let line='3447' var='Q{}default-instance' as='element()?' slot='4' eval='9'>
-       <callT line='3448' name='Q{}getInstance' bSlot='3'>
+      <let line='3459' var='Q{}default-instance' as='element()?' slot='4' eval='9'>
+       <callT line='3460' name='Q{}getInstance' bSlot='3'>
         <withParam name='Q{}instance-id' flags='c' as='xs:string'>
          <str val='saxon-forms-default'/>
         </withParam>
        </callT>
-       <varRef line='3452' name='Q{}default-instance' slot='4'/>
+       <varRef line='3464' name='Q{}default-instance' slot='4'/>
       </let>
      </choose>
-     <varRef line='3457' name='Q{}field' slot='1'/>
+     <varRef line='3469' name='Q{}field' slot='1'/>
     </let>
    </sequence>
   </template>
  </co>
  <co id='25' binds=''>
-  <template name='Q{}action-message' flags='os' line='4877' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4878'>
+  <template name='Q{}action-message' flags='os' line='4908' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4909'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -1870,13 +1805,13 @@
       </check>
      </treat>
     </param>
-    <message line='4882'>
+    <message line='4913'>
      <sequence role='select'>
       <valueOf>
        <str val='[action-message] Message reads "'/>
       </valueOf>
       <valueOf>
-       <treat line='4880' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|message-value'>
+       <treat line='4911' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|message-value'>
         <check card='1' diag='3|0|XTTE0570|message-value'>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|message-value'>
           <data>
@@ -2076,8 +2011,8 @@
   </function>
  </co>
  <co id='29' binds='3'>
-  <template name='Q{}action-setindex' flags='os' line='4930' module='saxon-xforms.xsl' slots='2'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4931'>
+  <template name='Q{}action-setindex' flags='os' line='4961' module='saxon-xforms.xsl' slots='2'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4962'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -2085,14 +2020,14 @@
       </check>
      </treat>
     </param>
-    <let line='4937' var='Q{}new-index' as='xs:integer' slot='1' eval='16'>
-     <treat line='4938' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|new-index'>
+    <let line='4968' var='Q{}new-index' as='xs:integer' slot='1' eval='16'>
+     <treat line='4969' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|new-index'>
       <check card='1' diag='3|0|XTTE0570|new-index'>
        <cvUntyped to='xs:integer' diag='3|0|XTTE0570|new-index'>
         <data>
          <evaluate dxns=''>
           <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='0' eval='16'>
-           <treat line='4934' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-index-ref'>
+           <treat line='4965' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-index-ref'>
             <check card='1' diag='3|0|XTTE0570|new-index-ref'>
              <cvUntyped to='xs:string' diag='3|0|XTTE0570|new-index-ref'>
               <data>
@@ -2114,50 +2049,34 @@
        </cvUntyped>
       </check>
      </treat>
-     <sequence line='4941'>
-      <message>
-       <sequence role='select'>
-        <valueOf>
-         <str val='[action-setindex] $action-map = '/>
-        </valueOf>
-        <valueOf>
-         <fn name='serialize'>
-          <varRef name='Q{}action-map' slot='0'/>
-         </fn>
-        </valueOf>
-       </sequence>
-       <str role='terminate' val='no'/>
-       <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-      </message>
-      <ifCall line='4943' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-       <check card='1' diag='0|0||ixsl:call'>
-        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-       </check>
-       <str val='setRepeatIndex'/>
-       <arrayBlock>
-        <treat line='4933' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|repeatID'>
-         <check card='1' diag='3|0|XTTE0570|repeatID'>
-          <cvUntyped to='xs:string' diag='3|0|XTTE0570|repeatID'>
-           <data>
-            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-             <varRef name='Q{}action-map' slot='0'/>
-             <str val='@repeat'/>
-            </ifCall>
-           </data>
-          </cvUntyped>
-         </check>
-        </treat>
-        <varRef name='Q{}new-index' slot='1'/>
-       </arrayBlock>
-      </ifCall>
-     </sequence>
+     <ifCall line='4974' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+      <check card='1' diag='0|0||ixsl:call'>
+       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+      </check>
+      <str val='setRepeatIndex'/>
+      <arrayBlock>
+       <treat line='4964' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|repeatID'>
+        <check card='1' diag='3|0|XTTE0570|repeatID'>
+         <cvUntyped to='xs:string' diag='3|0|XTTE0570|repeatID'>
+          <data>
+           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+            <varRef name='Q{}action-map' slot='0'/>
+            <str val='@repeat'/>
+           </ifCall>
+          </data>
+         </cvUntyped>
+        </check>
+       </treat>
+       <varRef name='Q{}new-index' slot='1'/>
+      </arrayBlock>
+     </ifCall>
     </let>
    </sequence>
   </template>
  </co>
  <co id='30' binds='31'>
-  <template name='Q{}action-setfocus' flags='os' line='4892' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4893'>
+  <template name='Q{}action-setfocus' flags='os' line='4923' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4924'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -2165,9 +2084,9 @@
       </check>
      </treat>
     </param>
-    <callT line='4897' name='Q{}xforms-focus' bSlot='0' flags='t'>
+    <callT line='4928' name='Q{}xforms-focus' bSlot='0' flags='t'>
      <withParam name='Q{}control' flags='c' as='xs:string'>
-      <treat line='4895' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|control'>
+      <treat line='4926' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|control'>
        <check card='1' diag='3|0|XTTE0570|control'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|control'>
          <data>
@@ -2185,8 +2104,8 @@
   </template>
  </co>
  <co id='32' binds='1 3 3 33 16 34 5 35'>
-  <template name='Q{}action-setvalue' flags='os' line='4558' module='saxon-xforms.xsl' slots='14'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4559'>
+  <template name='Q{}action-setvalue' flags='os' line='4585' module='saxon-xforms.xsl' slots='14'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4586'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -2194,7 +2113,7 @@
       </check>
      </treat>
     </param>
-    <param line='4560' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
+    <param line='4587' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
      <empty role='select'/>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|instanceXML'>
       <check card='?' diag='8|0|XTTE0590|instanceXML'>
@@ -2202,7 +2121,7 @@
       </check>
      </treat>
     </param>
-    <param line='4561' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
+    <param line='4588' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -2214,7 +2133,7 @@
       </check>
      </treat>
     </param>
-    <let line='4565' var='Q{}refz' as='xs:string' slot='3' eval='16'>
+    <let line='4592' var='Q{}refz' as='xs:string' slot='3' eval='16'>
      <let var='Q{}relative' as='xs:string' slot='4' eval='16'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|1||xforms:resolveXPathStrings'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
@@ -2239,7 +2158,7 @@
         <str val='instance('/>
        </fn>
        <varRef line='842' name='Q{}relative' slot='4'/>
-       <fn line='4565' name='not'>
+       <fn line='4592' name='not'>
         <varRef name='Q{}nodeset' slot='2'/>
        </fn>
        <varRef line='845' name='Q{}relative' slot='4'/>
@@ -2252,7 +2171,7 @@
          <str val='.'/>
         </vc>
        </or>
-       <varRef line='4565' name='Q{}nodeset' slot='2'/>
+       <varRef line='4592' name='Q{}nodeset' slot='2'/>
        <true/>
        <let line='852' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
         <choose>
@@ -2283,13 +2202,13 @@
         </choose>
         <let line='855' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
          <choose>
-          <fn line='4565' name='contains'>
+          <fn line='4592' name='contains'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
           </fn>
           <fn name='index-of'>
            <fn name='string-to-codepoints'>
-            <varRef line='4565' name='Q{}nodeset' slot='2'/>
+            <varRef line='4592' name='Q{}nodeset' slot='2'/>
            </fn>
            <int val='47'/>
           </fn>
@@ -2302,7 +2221,7 @@
           </compareToInt>
           <fn line='891' name='concat'>
            <fn name='substring'>
-            <varRef line='4565' name='Q{}nodeset' slot='2'/>
+            <varRef line='4592' name='Q{}nodeset' slot='2'/>
             <int val='1'/>
             <choose line='866'>
              <and op='and'>
@@ -2347,7 +2266,7 @@
            </fn>
           </fn>
           <true/>
-          <fn line='4565' name='concat'>
+          <fn line='4592' name='concat'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
            <varRef line='894' name='Q{}relative' slot='4'/>
@@ -2357,19 +2276,19 @@
        </let>
       </choose>
      </let>
-     <let line='4567' var='Q{}instance-id' as='xs:string' slot='8' eval='16'>
+     <let line='4594' var='Q{}instance-id' as='xs:string' slot='8' eval='16'>
       <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='6'>
        <varRef name='Q{}refz' slot='3'/>
       </ufCall>
-      <let line='4580' var='Q{}valuez' as='document-node()' slot='9' eval='16'>
-       <doc line='4582' validation='preserve'>
+      <let line='4607' var='Q{}valuez' as='document-node()' slot='9' eval='16'>
+       <doc line='4609' validation='preserve'>
         <choose>
          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
           <varRef name='Q{}action-map' slot='0'/>
           <str val='@value'/>
          </ifCall>
-         <let line='4583' var='Q{}contexti' as='node()' slot='10' eval='8'>
-          <evaluate line='4584' as='node()' dxns=''>
+         <let line='4610' var='Q{}contexti' as='node()' slot='10' eval='8'>
+          <evaluate line='4611' as='node()' dxns=''>
            <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='1' eval='6'>
             <varRef name='Q{}nodeset' slot='2'/>
            </ufCall>
@@ -2381,7 +2300,7 @@
            <map role='options' size='0'/>
            <map role='wp' size='0'/>
           </evaluate>
-          <evaluate line='4587' dxns=''>
+          <evaluate line='4614' dxns=''>
            <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
             <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:impose'>
              <check card='1' diag='0|0||xforms:impose'>
@@ -2403,13 +2322,13 @@
            <map role='wp' size='0'/>
           </evaluate>
          </let>
-         <ifCall line='4590' name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+         <ifCall line='4617' name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
           <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:contains'>
            <dot flags='a'/>
           </treat>
           <str val='value'/>
          </ifCall>
-         <ifCall line='4591' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+         <ifCall line='4618' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
           <varRef name='Q{}action-map' slot='0'/>
           <str val='value'/>
          </ifCall>
@@ -2417,8 +2336,8 @@
          <str val=''/>
         </choose>
        </doc>
-       <sequence line='4601'>
-        <let line='4603' var='Q{}associated-form-control' as='element()?' slot='11' eval='7'>
+       <sequence line='4628'>
+        <let line='4630' var='Q{}associated-form-control' as='element()?' slot='11' eval='7'>
          <check card='?' diag='3|0|XTTE0570|associated-form-control'>
           <filter flags='b'>
            <slash simple='1'>
@@ -2433,22 +2352,22 @@
            </vc>
           </filter>
          </check>
-         <choose line='4605'>
+         <choose line='4632'>
           <fn name='exists'>
            <varRef name='Q{}associated-form-control' slot='11'/>
           </fn>
-          <sequence line='4606'>
+          <sequence line='4633'>
            <applyT mode='Q{}set-field' bSlot='3'>
             <varRef role='select' name='Q{}associated-form-control' slot='11'/>
             <withParam name='Q{}value' flags='t' as='xs:string'>
-             <cast line='4607' as='xs:string' emptiable='0'>
+             <cast line='4634' as='xs:string' emptiable='0'>
               <data>
                <varRef name='Q{}valuez' slot='9'/>
               </data>
              </cast>
             </withParam>
            </applyT>
-           <ifCall line='4609' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+           <ifCall line='4636' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
             <check card='1' diag='0|0||ixsl:call'>
              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
             </check>
@@ -2477,7 +2396,7 @@
            </ifCall>
           </sequence>
           <true/>
-          <ifCall line='4612' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+          <ifCall line='4639' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
            <check card='1' diag='0|0||ixsl:call'>
             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
            </check>
@@ -2506,12 +2425,12 @@
           </ifCall>
          </choose>
         </let>
-        <choose line='4618'>
+        <choose line='4645'>
          <vc op='ne' onEmpty='1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
           <varRef name='Q{}refz' slot='3'/>
           <str val=''/>
          </vc>
-         <let line='4620' var='Q{}pendingUpdates' as='map(xs:string, xs:string)?' slot='12' eval='7'>
+         <let line='4647' var='Q{}pendingUpdates' as='map(xs:string, xs:string)?' slot='12' eval='7'>
           <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|pendingUpdates'>
            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
             <check card='1' diag='0|0||ixsl:call'>
@@ -2521,11 +2440,11 @@
             <array size='0'/>
            </ifCall>
           </treat>
-          <let line='4622' var='Q{}updatedInstanceXML' as='element()' slot='13' eval='16'>
-           <treat line='4623' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+          <let line='4649' var='Q{}updatedInstanceXML' as='element()' slot='13' eval='16'>
+           <treat line='4650' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
             <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
              <applyT mode='Q{}form-check-initial' bSlot='4'>
-              <choose role='select' line='4571'>
+              <choose role='select' line='4598'>
                <and op='and'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <varRef name='Q{}instance-id' slot='8'/>
@@ -2535,31 +2454,31 @@
                  <varRef name='Q{}instanceXML' slot='1'/>
                 </fn>
                </and>
-               <check line='4572' card='1' diag='3|0|XTTE0570|instanceXML2'>
+               <check line='4599' card='1' diag='3|0|XTTE0570|instanceXML2'>
                 <varRef name='Q{}instanceXML' slot='1'/>
                </check>
                <true/>
-               <check line='4575' card='1' diag='3|0|XTTE0570|instanceXML2'>
+               <check line='4602' card='1' diag='3|0|XTTE0570|instanceXML2'>
                 <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='5' eval='6'>
                  <varRef name='Q{}refz' slot='3'/>
                 </ufCall>
                </check>
               </choose>
               <withParam name='Q{}instance-id' as='xs:string'>
-               <varRef line='4624' name='Q{}instance-id' slot='8'/>
+               <varRef line='4651' name='Q{}instance-id' slot='8'/>
               </withParam>
               <withParam name='Q{}pendingUpdates' flags='t' as='map(xs:string, xs:string)?'>
-               <varRef line='4625' name='Q{}pendingUpdates' slot='12'/>
+               <varRef line='4652' name='Q{}pendingUpdates' slot='12'/>
               </withParam>
              </applyT>
             </check>
            </treat>
-           <sequence line='4630'>
+           <sequence line='4657'>
             <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='6' eval='6 6'>
              <varRef name='Q{}refz' slot='3'/>
              <varRef name='Q{}updatedInstanceXML' slot='13'/>
             </ufCall>
-            <callT line='4631' name='Q{}refreshOutputs-JS' bSlot='7' flags='t'/>
+            <callT line='4658' name='Q{}refreshOutputs-JS' bSlot='7' flags='t'/>
            </sequence>
           </let>
          </let>
@@ -2576,9 +2495,9 @@
    <str val='saxon-forms-default-submission'/>
   </globalVariable>
  </co>
- <co id='20' binds='1 34 3 3 32 0 8 29 30 37 7 17 10 25 20'>
-  <template name='Q{}applyActions' flags='os' line='3669' module='saxon-xforms.xsl' slots='12'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3670'>
+ <co id='20' binds='1 34 3 3 3 32 0 8 29 30 37 7 17 10 25 20'>
+  <template name='Q{}applyActions' flags='os' line='3681' module='saxon-xforms.xsl' slots='15'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3682'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -2586,7 +2505,7 @@
       </check>
      </treat>
     </param>
-    <param line='3671' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
+    <param line='3683' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
      <empty role='select'/>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|instanceXML'>
       <check card='?' diag='8|0|XTTE0590|instanceXML'>
@@ -2594,7 +2513,7 @@
       </check>
      </treat>
     </param>
-    <param line='3672' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
+    <param line='3684' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -2606,7 +2525,7 @@
       </check>
      </treat>
     </param>
-    <let line='3674' var='Q{}ref' as='xs:string?' slot='3' eval='7'>
+    <let line='3686' var='Q{}ref' as='xs:string?' slot='3' eval='7'>
      <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|ref'>
       <check card='?' diag='3|0|XTTE0570|ref'>
        <cvUntyped to='xs:string' diag='3|0|XTTE0570|ref'>
@@ -2619,7 +2538,7 @@
        </cvUntyped>
       </check>
      </treat>
-     <let line='3675' var='Q{}at' as='xs:string?' slot='4' eval='7'>
+     <let line='3687' var='Q{}at' as='xs:string?' slot='4' eval='7'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|at'>
        <check card='?' diag='3|0|XTTE0570|at'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|at'>
@@ -2632,286 +2551,343 @@
         </cvUntyped>
        </check>
       </treat>
-      <let line='3687' var='Q{}ref-qualified' as='xs:string?' slot='5' eval='7'>
-       <choose>
-        <and op='and'>
-         <fn name='exists'>
-          <varRef name='Q{}ref' slot='3'/>
-         </fn>
-         <varRef name='Q{}ref' slot='3'/>
-        </and>
+      <let line='3689' var='Q{}context' as='xs:string?' slot='5' eval='7'>
+       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|context'>
+        <check card='?' diag='3|0|XTTE0570|context'>
+         <cvUntyped to='xs:string' diag='3|0|XTTE0570|context'>
+          <data>
+           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+            <varRef name='Q{}action-map' slot='0'/>
+            <str val='@context'/>
+           </ifCall>
+          </data>
+         </cvUntyped>
+        </check>
+       </treat>
+       <let line='3700' var='Q{}ref-qualified' as='xs:string?' slot='6' eval='7'>
         <choose>
-         <fn name='exists'>
-          <varRef name='Q{}at' slot='4'/>
-         </fn>
-         <fn name='concat'>
-          <varRef name='Q{}ref' slot='3'/>
-          <str val='['/>
-          <varRef name='Q{}at' slot='4'/>
-          <str val=']'/>
-         </fn>
-         <true/>
-         <varRef name='Q{}ref' slot='3'/>
-        </choose>
-       </choose>
-       <let line='3689' var='Q{}instance-id' as='xs:string' slot='6' eval='16'>
-        <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='16'>
-         <check card='1' diag='0|0||xforms:getInstanceId'>
-          <varRef name='Q{}ref' slot='3'/>
-         </check>
-        </ufCall>
-        <let line='3691' var='Q{}instanceXML2' as='element()?' slot='7' eval='7'>
-         <choose line='3693'>
-          <and op='and'>
-           <vc op='eq' onEmpty='0' comp='CCC'>
-            <varRef name='Q{}instance-id' slot='6'/>
-            <str val='saxon-forms-default'/>
-           </vc>
-           <fn name='exists'>
-            <varRef name='Q{}instanceXML' slot='1'/>
-           </fn>
-          </and>
-          <varRef line='3694' name='Q{}instanceXML' slot='1'/>
-          <fn line='3696' name='exists'>
-           <varRef name='Q{}ref-qualified' slot='5'/>
+         <and op='and'>
+          <fn name='exists'>
+           <varRef name='Q{}ref' slot='3'/>
           </fn>
-          <ufCall line='3697' name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='1' eval='16'>
-           <check card='1' diag='0|0||xforms:getInstance-JS'>
-            <varRef name='Q{}ref-qualified' slot='5'/>
-           </check>
-          </ufCall>
+          <varRef name='Q{}ref' slot='3'/>
+         </and>
+         <choose>
+          <fn name='exists'>
+           <varRef name='Q{}at' slot='4'/>
+          </fn>
+          <fn name='concat'>
+           <varRef name='Q{}ref' slot='3'/>
+           <str val='['/>
+           <varRef name='Q{}at' slot='4'/>
+           <str val=']'/>
+          </fn>
+          <true/>
+          <varRef name='Q{}ref' slot='3'/>
          </choose>
-         <let line='3705' var='Q{}context' as='node()?' slot='8' eval='7'>
-          <choose line='3707'>
+        </choose>
+        <let line='3702' var='Q{}instance-id' as='xs:string' slot='7' eval='16'>
+         <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='16'>
+          <check card='1' diag='0|0||xforms:getInstanceId'>
+           <varRef name='Q{}ref' slot='3'/>
+          </check>
+         </ufCall>
+         <let line='3704' var='Q{}instanceXML2' as='element()?' slot='8' eval='7'>
+          <choose line='3706'>
            <and op='and'>
-            <and op='and'>
-             <fn name='exists'>
-              <varRef name='Q{}ref-qualified' slot='5'/>
-             </fn>
-             <vc op='ne' onEmpty='1' comp='CCC'>
-              <varRef name='Q{}ref-qualified' slot='5'/>
-              <str val=''/>
-             </vc>
-            </and>
+            <vc op='eq' onEmpty='0' comp='CCC'>
+             <varRef name='Q{}instance-id' slot='7'/>
+             <str val='saxon-forms-default'/>
+            </vc>
             <fn name='exists'>
-             <varRef name='Q{}instanceXML2' slot='7'/>
+             <varRef name='Q{}instanceXML' slot='1'/>
             </fn>
            </and>
-           <treat line='3708' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|context'>
-            <check card='?' diag='3|0|XTTE0570|context'>
+           <varRef line='3707' name='Q{}instanceXML' slot='1'/>
+           <fn line='3709' name='exists'>
+            <varRef name='Q{}ref-qualified' slot='6'/>
+           </fn>
+           <ufCall line='3710' name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='1' eval='16'>
+            <check card='1' diag='0|0||xforms:getInstance-JS'>
+             <varRef name='Q{}ref-qualified' slot='6'/>
+            </check>
+           </ufCall>
+          </choose>
+          <let line='3718' var='Q{}ref-node' as='node()*' slot='9' eval='8'>
+           <choose line='3720'>
+            <and op='and'>
+             <and op='and'>
+              <fn name='exists'>
+               <varRef name='Q{}ref-qualified' slot='6'/>
+              </fn>
+              <vc op='ne' onEmpty='1' comp='CCC'>
+               <varRef name='Q{}ref-qualified' slot='6'/>
+               <str val=''/>
+              </vc>
+             </and>
+             <fn name='exists'>
+              <varRef name='Q{}instanceXML2' slot='8'/>
+             </fn>
+            </and>
+            <treat line='3721' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|ref-node'>
              <evaluate dxns=''>
               <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
                <check card='1' diag='0|0||xforms:impose'>
-                <varRef name='Q{}ref-qualified' slot='5'/>
+                <varRef name='Q{}ref-qualified' slot='6'/>
                </check>
               </ufCall>
-              <varRef role='cxt' name='Q{}instanceXML2' slot='7'/>
+              <varRef role='cxt' name='Q{}instanceXML2' slot='8'/>
               <check role='nsCxt' card='1' diag='4|0|XTTE3170|xsl:evaluate/namespace-context'>
-               <varRef name='Q{}instanceXML2' slot='7'/>
+               <varRef name='Q{}instanceXML2' slot='8'/>
               </check>
               <str role='sa' val='no'/>
               <map role='options' size='0'/>
               <map role='wp' size='0'/>
              </evaluate>
-            </check>
-           </treat>
-          </choose>
-          <let line='3715' var='Q{}ifVar' as='xs:string?' slot='9' eval='7'>
-           <choose line='793'>
-            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
-             <varRef line='3715' name='Q{}action-map' slot='0'/>
-             <str val='@if'/>
-            </ifCall>
-            <treat line='794' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
-             <check card='?' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
-              <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
-               <data>
-                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                 <varRef line='3715' name='Q{}action-map' slot='0'/>
-                 <str val='@if'/>
-                </ifCall>
-               </data>
-              </cvUntyped>
-             </check>
             </treat>
            </choose>
-           <let line='3719' var='Q{}ifExecuted' as='xs:boolean' slot='10' eval='16'>
-            <choose line='3721'>
+           <let line='3726' var='Q{}context-node' as='node()?' slot='10' eval='7'>
+            <choose line='3728'>
              <and op='and'>
+              <and op='and'>
+               <fn name='exists'>
+                <varRef name='Q{}context' slot='5'/>
+               </fn>
+               <vc op='ne' onEmpty='1' comp='CCC'>
+                <varRef name='Q{}context' slot='5'/>
+                <str val=''/>
+               </vc>
+              </and>
               <fn name='exists'>
-               <varRef name='Q{}ifVar' slot='9'/>
-              </fn>
-              <fn name='exists'>
-               <varRef name='Q{}context' slot='8'/>
+               <varRef name='Q{}instanceXML2' slot='8'/>
               </fn>
              </and>
-             <treat line='3722' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|ifExecuted'>
-              <check card='1' diag='3|0|XTTE0570|ifExecuted'>
-               <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|ifExecuted'>
-                <data>
-                 <evaluate dxns=''>
-                  <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='3' eval='16'>
-                   <check card='1' diag='0|0||xforms:impose'>
-                    <varRef name='Q{}ifVar' slot='9'/>
-                   </check>
-                  </ufCall>
-                  <varRef role='cxt' name='Q{}context' slot='8'/>
-                  <check role='nsCxt' card='1' diag='4|0|XTTE3170|xsl:evaluate/namespace-context'>
-                   <varRef name='Q{}instanceXML2' slot='7'/>
-                  </check>
-                  <str role='sa' val='no'/>
-                  <map role='options' size='0'/>
-                  <map role='wp' size='0'/>
-                 </evaluate>
-                </data>
-               </cvUntyped>
+             <treat line='3729' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|context-node'>
+              <check card='?' diag='3|0|XTTE0570|context-node'>
+               <evaluate dxns=''>
+                <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='3' eval='16'>
+                 <check card='1' diag='0|0||xforms:impose'>
+                  <varRef name='Q{}context' slot='5'/>
+                 </check>
+                </ufCall>
+                <varRef role='cxt' name='Q{}instanceXML2' slot='8'/>
+                <check role='nsCxt' card='1' diag='4|0|XTTE3170|xsl:evaluate/namespace-context'>
+                 <varRef name='Q{}instanceXML2' slot='8'/>
+                </check>
+                <str role='sa' val='no'/>
+                <map role='options' size='0'/>
+                <map role='wp' size='0'/>
+               </evaluate>
               </check>
              </treat>
-             <true/>
-             <true/>
             </choose>
-            <choose line='3732'>
-             <varRef name='Q{}ifExecuted' slot='10'/>
-             <let line='3733' var='Q{}action-name' as='xs:string' slot='11' eval='16'>
-              <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|action-name'>
-               <check card='1' diag='3|0|XTTE0570|action-name'>
-                <cvUntyped to='xs:string' diag='3|0|XTTE0570|action-name'>
-                 <data>
-                  <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                   <varRef name='Q{}action-map' slot='0'/>
-                   <str val='name'/>
-                  </ifCall>
-                 </data>
-                </cvUntyped>
-               </check>
-              </treat>
-              <sequence line='3736'>
-               <choose>
-                <vc op='eq' onEmpty='0' comp='CCC'>
-                 <varRef name='Q{}action-name' slot='11'/>
-                 <str val='action'/>
-                </vc>
-                <empty/>
-                <vc line='3739' op='eq' onEmpty='0' comp='CCC'>
-                 <varRef name='Q{}action-name' slot='11'/>
-                 <str val='setvalue'/>
-                </vc>
-                <callT line='3740' name='Q{}action-setvalue' bSlot='4'>
-                 <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                  <check line='3741' card='1' diag='8|0|XTTE0590|nodeset'>
-                   <varRef name='Q{}ref' slot='3'/>
-                  </check>
-                 </withParam>
-                 <withParam name='Q{}instanceXML' flags='t' as='element()'>
-                  <check line='3742' card='1' diag='8|0|XTTE0590|instanceXML'>
-                   <varRef name='Q{}instanceXML2' slot='7'/>
-                  </check>
-                 </withParam>
-                </callT>
-                <vc line='3745' op='eq' onEmpty='0' comp='CCC'>
-                 <varRef name='Q{}action-name' slot='11'/>
-                 <str val='insert'/>
-                </vc>
-                <callT line='3746' name='Q{}action-insert' bSlot='5'>
-                 <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                  <check line='3747' card='1' diag='8|0|XTTE0590|nodeset'>
-                   <varRef name='Q{}ref-qualified' slot='5'/>
-                  </check>
-                 </withParam>
-                 <withParam name='Q{}instanceXML' flags='t' as='element()'>
-                  <check line='3748' card='1' diag='8|0|XTTE0590|instanceXML'>
-                   <varRef name='Q{}instanceXML2' slot='7'/>
-                  </check>
-                 </withParam>
-                </callT>
-                <vc line='3751' op='eq' onEmpty='0' comp='CCC'>
-                 <varRef name='Q{}action-name' slot='11'/>
-                 <str val='delete'/>
-                </vc>
-                <callT line='3752' name='Q{}action-delete' bSlot='6'>
-                 <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                  <check line='3753' card='1' diag='8|0|XTTE0590|nodeset'>
-                   <varRef name='Q{}ref-qualified' slot='5'/>
-                  </check>
-                 </withParam>
-                 <withParam name='Q{}instanceXML' flags='t' as='element()'>
-                  <check line='3754' card='1' diag='8|0|XTTE0590|instanceXML'>
-                   <varRef name='Q{}instanceXML2' slot='7'/>
-                  </check>
-                 </withParam>
-                </callT>
-                <vc line='3757' op='eq' onEmpty='0' comp='CCC'>
-                 <varRef name='Q{}action-name' slot='11'/>
-                 <str val='setindex'/>
-                </vc>
-                <callT line='3758' name='Q{}action-setindex' bSlot='7'/>
-                <vc line='3763' op='eq' onEmpty='0' comp='CCC'>
-                 <varRef name='Q{}action-name' slot='11'/>
-                 <str val='setfocus'/>
-                </vc>
-                <callT line='3764' name='Q{}action-setfocus' bSlot='8'/>
-                <vc line='3769' op='eq' onEmpty='0' comp='CCC'>
-                 <varRef name='Q{}action-name' slot='11'/>
-                 <str val='rebuild'/>
-                </vc>
-                <callT line='3770' name='Q{}xforms-rebuild' bSlot='9'/>
-                <vc line='3772' op='eq' onEmpty='0' comp='CCC'>
-                 <varRef name='Q{}action-name' slot='11'/>
-                 <str val='recalculate'/>
-                </vc>
-                <callT line='3773' name='Q{}xforms-recalculate' bSlot='10'/>
-                <vc line='3781' op='eq' onEmpty='0' comp='CCC'>
-                 <varRef name='Q{}action-name' slot='11'/>
-                 <str val='reset'/>
-                </vc>
-                <callT line='3782' name='Q{}action-reset' bSlot='11'/>
-                <vc line='3787' op='eq' onEmpty='0' comp='CCC'>
-                 <varRef name='Q{}action-name' slot='11'/>
-                 <str val='send'/>
-                </vc>
-                <callT line='3788' name='Q{}action-send' bSlot='12'/>
-                <vc line='3790' op='eq' onEmpty='0' comp='CCC'>
-                 <varRef name='Q{}action-name' slot='11'/>
-                 <str val='message'/>
-                </vc>
-                <callT line='3791' name='Q{}action-message' bSlot='13'/>
-                <true/>
-                <message line='3794'>
-                 <sequence role='select'>
-                  <valueOf>
-                   <str val='[applyActions] action &#39;'/>
-                  </valueOf>
-                  <valueOf>
-                   <varRef name='Q{}action-name' slot='11'/>
-                  </valueOf>
-                  <valueOf>
-                   <str val='&#39; not yet handled!'/>
-                  </valueOf>
-                 </sequence>
-                 <str role='terminate' val='no'/>
-                 <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-                </message>
-               </choose>
-               <forEach line='3803'>
-                <ifCall line='3799' name='Q{http://www.w3.org/2005/xpath-functions/array}flatten' type='item()*'>
-                 <treat as='array(map(*))' jsTest='function v(item) {return SaxonJS.U.isMap(item)};function c(n) {return n==1;};return SaxonJS.U.isArray(item) &amp;&amp; SaxonJS.U.ForArray(item.value).every(function(seq){return c(seq.length) &amp;&amp; SaxonJS.U.ForArray(seq).every(v)});' diag='3|0|XTTE0570|nested-actions-array'>
-                  <check card='?' diag='3|0|XTTE0570|nested-actions-array'>
+            <let line='3734' var='Q{}context' as='node()?' slot='11' eval='7'>
+             <first>
+              <sequence>
+               <varRef name='Q{}context-node' slot='10'/>
+               <varRef name='Q{}ref-node' slot='9'/>
+               <varRef name='Q{}instanceXML2' slot='8'/>
+              </sequence>
+             </first>
+             <let line='3740' var='Q{}ifVar' as='xs:string?' slot='12' eval='7'>
+              <choose line='793'>
+               <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+                <varRef line='3740' name='Q{}action-map' slot='0'/>
+                <str val='@if'/>
+               </ifCall>
+               <treat line='794' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
+                <check card='?' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
+                 <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
+                  <data>
                    <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                    <varRef name='Q{}action-map' slot='0'/>
-                    <str val='nested-actions'/>
+                    <varRef line='3740' name='Q{}action-map' slot='0'/>
+                    <str val='@if'/>
                    </ifCall>
+                  </data>
+                 </cvUntyped>
+                </check>
+               </treat>
+              </choose>
+              <let line='3744' var='Q{}ifExecuted' as='xs:boolean' slot='13' eval='16'>
+               <choose line='3746'>
+                <and op='and'>
+                 <fn name='exists'>
+                  <varRef name='Q{}ifVar' slot='12'/>
+                 </fn>
+                 <fn name='exists'>
+                  <varRef name='Q{}context' slot='11'/>
+                 </fn>
+                </and>
+                <treat line='3747' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|ifExecuted'>
+                 <check card='1' diag='3|0|XTTE0570|ifExecuted'>
+                  <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|ifExecuted'>
+                   <data>
+                    <evaluate dxns=''>
+                     <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='4' eval='16'>
+                      <check card='1' diag='0|0||xforms:impose'>
+                       <varRef name='Q{}ifVar' slot='12'/>
+                      </check>
+                     </ufCall>
+                     <varRef role='cxt' name='Q{}context' slot='11'/>
+                     <check role='nsCxt' card='1' diag='4|0|XTTE3170|xsl:evaluate/namespace-context'>
+                      <varRef name='Q{}instanceXML2' slot='8'/>
+                     </check>
+                     <str role='sa' val='no'/>
+                     <map role='options' size='0'/>
+                     <map role='wp' size='0'/>
+                    </evaluate>
+                   </data>
+                  </cvUntyped>
+                 </check>
+                </treat>
+                <true/>
+                <true/>
+               </choose>
+               <choose line='3757'>
+                <varRef name='Q{}ifExecuted' slot='13'/>
+                <let line='3758' var='Q{}action-name' as='xs:string' slot='14' eval='16'>
+                 <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|action-name'>
+                  <check card='1' diag='3|0|XTTE0570|action-name'>
+                   <cvUntyped to='xs:string' diag='3|0|XTTE0570|action-name'>
+                    <data>
+                     <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                      <varRef name='Q{}action-map' slot='0'/>
+                      <str val='name'/>
+                     </ifCall>
+                    </data>
+                   </cvUntyped>
                   </check>
                  </treat>
-                </ifCall>
-                <callT line='3804' name='Q{}applyActions' bSlot='14'>
-                 <withParam name='Q{}action-map' flags='t' as='item()'>
-                  <dot line='3805'/>
-                 </withParam>
-                </callT>
-               </forEach>
-              </sequence>
+                 <sequence line='3761'>
+                  <choose>
+                   <vc op='eq' onEmpty='0' comp='CCC'>
+                    <varRef name='Q{}action-name' slot='14'/>
+                    <str val='action'/>
+                   </vc>
+                   <empty/>
+                   <vc line='3764' op='eq' onEmpty='0' comp='CCC'>
+                    <varRef name='Q{}action-name' slot='14'/>
+                    <str val='setvalue'/>
+                   </vc>
+                   <callT line='3765' name='Q{}action-setvalue' bSlot='5'>
+                    <withParam name='Q{}nodeset' flags='t' as='xs:string'>
+                     <check line='3766' card='1' diag='8|0|XTTE0590|nodeset'>
+                      <varRef name='Q{}ref' slot='3'/>
+                     </check>
+                    </withParam>
+                    <withParam name='Q{}instanceXML' flags='t' as='element()'>
+                     <check line='3767' card='1' diag='8|0|XTTE0590|instanceXML'>
+                      <varRef name='Q{}instanceXML2' slot='8'/>
+                     </check>
+                    </withParam>
+                   </callT>
+                   <vc line='3770' op='eq' onEmpty='0' comp='CCC'>
+                    <varRef name='Q{}action-name' slot='14'/>
+                    <str val='insert'/>
+                   </vc>
+                   <callT line='3771' name='Q{}action-insert' bSlot='6'>
+                    <withParam name='Q{}nodeset' flags='t' as='xs:string'>
+                     <check line='3772' card='1' diag='8|0|XTTE0590|nodeset'>
+                      <varRef name='Q{}ref-qualified' slot='6'/>
+                     </check>
+                    </withParam>
+                    <withParam name='Q{}instanceXML' flags='t' as='element()'>
+                     <check line='3773' card='1' diag='8|0|XTTE0590|instanceXML'>
+                      <varRef name='Q{}instanceXML2' slot='8'/>
+                     </check>
+                    </withParam>
+                   </callT>
+                   <vc line='3776' op='eq' onEmpty='0' comp='CCC'>
+                    <varRef name='Q{}action-name' slot='14'/>
+                    <str val='delete'/>
+                   </vc>
+                   <callT line='3777' name='Q{}action-delete' bSlot='7'>
+                    <withParam name='Q{}nodeset' flags='t' as='xs:string'>
+                     <check line='3778' card='1' diag='8|0|XTTE0590|nodeset'>
+                      <varRef name='Q{}ref-qualified' slot='6'/>
+                     </check>
+                    </withParam>
+                    <withParam name='Q{}instanceXML' flags='t' as='element()'>
+                     <check line='3779' card='1' diag='8|0|XTTE0590|instanceXML'>
+                      <varRef name='Q{}instanceXML2' slot='8'/>
+                     </check>
+                    </withParam>
+                   </callT>
+                   <vc line='3782' op='eq' onEmpty='0' comp='CCC'>
+                    <varRef name='Q{}action-name' slot='14'/>
+                    <str val='setindex'/>
+                   </vc>
+                   <callT line='3783' name='Q{}action-setindex' bSlot='8'/>
+                   <vc line='3788' op='eq' onEmpty='0' comp='CCC'>
+                    <varRef name='Q{}action-name' slot='14'/>
+                    <str val='setfocus'/>
+                   </vc>
+                   <callT line='3789' name='Q{}action-setfocus' bSlot='9'/>
+                   <vc line='3794' op='eq' onEmpty='0' comp='CCC'>
+                    <varRef name='Q{}action-name' slot='14'/>
+                    <str val='rebuild'/>
+                   </vc>
+                   <callT line='3795' name='Q{}xforms-rebuild' bSlot='10'/>
+                   <vc line='3797' op='eq' onEmpty='0' comp='CCC'>
+                    <varRef name='Q{}action-name' slot='14'/>
+                    <str val='recalculate'/>
+                   </vc>
+                   <callT line='3798' name='Q{}xforms-recalculate' bSlot='11'/>
+                   <vc line='3806' op='eq' onEmpty='0' comp='CCC'>
+                    <varRef name='Q{}action-name' slot='14'/>
+                    <str val='reset'/>
+                   </vc>
+                   <callT line='3807' name='Q{}action-reset' bSlot='12'/>
+                   <vc line='3812' op='eq' onEmpty='0' comp='CCC'>
+                    <varRef name='Q{}action-name' slot='14'/>
+                    <str val='send'/>
+                   </vc>
+                   <callT line='3813' name='Q{}action-send' bSlot='13'/>
+                   <vc line='3815' op='eq' onEmpty='0' comp='CCC'>
+                    <varRef name='Q{}action-name' slot='14'/>
+                    <str val='message'/>
+                   </vc>
+                   <callT line='3816' name='Q{}action-message' bSlot='14'/>
+                   <true/>
+                   <message line='3819'>
+                    <sequence role='select'>
+                     <valueOf>
+                      <str val='[applyActions] action &#39;'/>
+                     </valueOf>
+                     <valueOf>
+                      <varRef name='Q{}action-name' slot='14'/>
+                     </valueOf>
+                     <valueOf>
+                      <str val='&#39; not yet handled!'/>
+                     </valueOf>
+                    </sequence>
+                    <str role='terminate' val='no'/>
+                    <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+                   </message>
+                  </choose>
+                  <forEach line='3828'>
+                   <ifCall line='3824' name='Q{http://www.w3.org/2005/xpath-functions/array}flatten' type='item()*'>
+                    <treat as='array(map(*))' jsTest='function v(item) {return SaxonJS.U.isMap(item)};function c(n) {return n==1;};return SaxonJS.U.isArray(item) &amp;&amp; SaxonJS.U.ForArray(item.value).every(function(seq){return c(seq.length) &amp;&amp; SaxonJS.U.ForArray(seq).every(v)});' diag='3|0|XTTE0570|nested-actions-array'>
+                     <check card='?' diag='3|0|XTTE0570|nested-actions-array'>
+                      <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                       <varRef name='Q{}action-map' slot='0'/>
+                       <str val='nested-actions'/>
+                      </ifCall>
+                     </check>
+                    </treat>
+                   </ifCall>
+                   <callT line='3829' name='Q{}applyActions' bSlot='15'>
+                    <withParam name='Q{}action-map' flags='t' as='item()'>
+                     <dot line='3830'/>
+                    </withParam>
+                   </callT>
+                  </forEach>
+                 </sequence>
+                </let>
+               </choose>
+              </let>
              </let>
-            </choose>
+            </let>
            </let>
           </let>
          </let>
@@ -2925,9 +2901,9 @@
  </co>
  <co id='4' binds='4'>
   <mode name='Q{}insert-node' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='21' rank='0' minImp='0' slots='3' flags='s' line='1922' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='21' rank='0' minImp='0' slots='3' flags='s' line='1927' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1923'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1928'>
      <param name='Q{}insert-node-location' slot='0' flags='ti' as='node()'>
       <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|insert-node-location'>
        <check card='1' diag='8|0|XTTE0590|insert-node-location'>
@@ -2935,14 +2911,14 @@
        </check>
       </treat>
      </param>
-     <param line='1924' name='Q{}node-to-insert' slot='1' flags='ti' as='node()'>
+     <param line='1929' name='Q{}node-to-insert' slot='1' flags='ti' as='node()'>
       <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|node-to-insert'>
        <check card='1' diag='8|0|XTTE0590|node-to-insert'>
         <supplied slot='1'/>
        </check>
       </treat>
      </param>
-     <param line='1925' name='Q{}position-relative' slot='2' flags='t' as='xs:string?'>
+     <param line='1930' name='Q{}position-relative' slot='2' flags='t' as='xs:string?'>
       <str role='select' val='after'/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|position-relative'>
        <check card='?' diag='8|0|XTTE0590|position-relative'>
@@ -2954,7 +2930,7 @@
        </check>
       </treat>
      </param>
-     <choose line='1928'>
+     <choose line='1933'>
       <and op='and'>
        <is op='is'>
         <dot type='element()'/>
@@ -2965,21 +2941,36 @@
         <str val='before'/>
        </vc>
       </and>
-      <copyOf line='1930' flags='vc'>
+      <copyOf line='1935' flags='vc'>
        <varRef name='Q{}node-to-insert' slot='1'/>
       </copyOf>
      </choose>
-     <copy line='1933' flags='cin'>
+     <copy line='1938' flags='cin'>
       <sequence role='content'>
        <copyOf flags='vc'>
         <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
        </copyOf>
-       <applyT line='1934' mode='Q{}insert-node' bSlot='0'>
+       <choose line='1943'>
+        <and op='and'>
+         <is op='is'>
+          <dot type='element()'/>
+          <varRef name='Q{}insert-node-location' slot='0'/>
+         </is>
+         <vc op='eq' onEmpty='0' comp='CCC'>
+          <varRef name='Q{}position-relative' slot='2'/>
+          <str val='child'/>
+         </vc>
+        </and>
+        <copyOf line='1944' flags='vc'>
+         <varRef name='Q{}node-to-insert' slot='1'/>
+        </copyOf>
+       </choose>
+       <applyT line='1946' mode='Q{}insert-node' bSlot='0'>
         <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
        </applyT>
       </sequence>
      </copy>
-     <choose line='1936'>
+     <choose line='1948'>
       <and op='and'>
        <is op='is'>
         <dot type='element()'/>
@@ -2990,7 +2981,7 @@
         <str val='after'/>
        </vc>
       </and>
-      <copyOf line='1937' flags='vc'>
+      <copyOf line='1949' flags='vc'>
        <varRef name='Q{}node-to-insert' slot='1'/>
       </copyOf>
      </choose>
@@ -2999,10 +2990,10 @@
   </mode>
  </co>
  <co id='38' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}hasClass' line='3040' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:boolean' slots='2'>
+  <function name='Q{http://www.w3.org/2002/xforms}hasClass' line='3052' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:boolean' slots='2'>
    <arg name='Q{}element' as='element()'/>
    <arg name='Q{}string' as='xs:string'/>
-   <gc role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3044' op='=' card='N:1' comp='CCC'>
+   <gc role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3056' op='=' card='N:1' comp='CCC'>
     <fn name='tokenize'>
      <cvUntyped to='xs:string' diag='3|0|XTTE0570|class'>
       <data>
@@ -3013,7 +3004,7 @@
       </data>
      </cvUntyped>
     </fn>
-    <varRef line='3047' name='Q{}string' slot='1'/>
+    <varRef line='3059' name='Q{}string' slot='1'/>
    </gc>
   </function>
  </co>
@@ -3046,17 +3037,17 @@
   </function>
  </co>
  <co id='41' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}getClass' line='3061' module='saxon-xforms.xsl' eval='7' flags='pU' as='attribute(Q{}class)?' slots='3'>
+  <function name='Q{http://www.w3.org/2002/xforms}getClass' line='3073' module='saxon-xforms.xsl' eval='7' flags='pU' as='attribute(Q{}class)?' slots='3'>
    <arg name='Q{}element' as='element()'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3064' var='Q{}class' as='xs:string?' slot='1' eval='7'>
-    <choose line='3065'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3076' var='Q{}class' as='xs:string?' slot='1' eval='7'>
+    <choose line='3077'>
      <fn name='exists'>
       <slash simple='1'>
        <varRef name='Q{}element' slot='0'/>
        <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
       </slash>
      </fn>
-     <cvUntyped line='3066' to='xs:string' diag='3|0|XTTE0570|class'>
+     <cvUntyped line='3078' to='xs:string' diag='3|0|XTTE0570|class'>
       <cast as='xs:untypedAtomic' emptiable='0'>
        <fn name='string'>
         <convert from='xs:untypedAtomic' to='xs:string'>
@@ -3071,15 +3062,15 @@
       </cast>
      </cvUntyped>
     </choose>
-    <let line='3069' var='Q{}class-mod' as='xs:string?' slot='2' eval='7'>
-     <choose line='3071'>
+    <let line='3081' var='Q{}class-mod' as='xs:string?' slot='2' eval='7'>
+     <choose line='3083'>
       <fn name='exists'>
        <slash simple='1'>
         <varRef name='Q{}element' slot='0'/>
         <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
        </slash>
       </fn>
-      <cvUntyped line='3072' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+      <cvUntyped line='3084' to='xs:string' diag='3|0|XTTE0570|class-mod'>
        <cast as='xs:untypedAtomic' emptiable='0'>
         <fn name='string-join'>
          <sequence>
@@ -3091,13 +3082,13 @@
        </cast>
       </cvUntyped>
       <true/>
-      <varRef line='3075' name='Q{}class' slot='1'/>
+      <varRef line='3087' name='Q{}class' slot='1'/>
      </choose>
-     <choose line='3079'>
+     <choose line='3091'>
       <fn name='exists'>
        <varRef name='Q{}class-mod' slot='2'/>
       </fn>
-      <treat line='3080' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+      <treat line='3092' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
        <att name='class'>
         <varRef name='Q{}class-mod' slot='2'/>
        </att>
@@ -3108,8 +3099,8 @@
   </function>
  </co>
  <co id='42' binds='2 23 43 44 45'>
-  <template name='Q{}refreshRepeats-JS' flags='os' line='3545' module='saxon-xforms.xsl' slots='8'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3547'>
+  <template name='Q{}refreshRepeats-JS' flags='os' line='3557' module='saxon-xforms.xsl' slots='8'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3559'>
     <message>
      <valueOf role='select'>
       <str val='[refreshRepeats-JS] START refreshRepeats'/>
@@ -3117,7 +3108,7 @@
      <str role='terminate' val='no'/>
      <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
     </message>
-    <let line='3550' var='Q{}repeat-keys' as='item()?' slot='0' eval='8'>
+    <let line='3562' var='Q{}repeat-keys' as='item()?' slot='0' eval='8'>
      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
       <check card='1' diag='0|0||ixsl:call'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -3125,9 +3116,9 @@
       <str val='getRepeatKeys'/>
       <array size='0'/>
      </ifCall>
-     <forEach line='3552'>
+     <forEach line='3564'>
       <varRef name='Q{}repeat-keys' slot='0'/>
-      <let line='3553' var='Q{}this-key' as='xs:string' slot='1' eval='16'>
+      <let line='3565' var='Q{}this-key' as='xs:string' slot='1' eval='16'>
        <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|this-key'>
         <check card='1' diag='3|0|XTTE0570|this-key'>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|this-key'>
@@ -3137,7 +3128,7 @@
          </cvUntyped>
         </check>
        </treat>
-       <let line='3554' var='Q{}this-repeat-nodeset' as='xs:string' slot='2' eval='16'>
+       <let line='3566' var='Q{}this-repeat-nodeset' as='xs:string' slot='2' eval='16'>
         <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|this-repeat-nodeset'>
          <check card='1' diag='3|0|XTTE0570|this-repeat-nodeset'>
           <cvUntyped to='xs:string' diag='3|0|XTTE0570|this-repeat-nodeset'>
@@ -3155,7 +3146,7 @@
           </cvUntyped>
          </check>
         </treat>
-        <sequence line='3556'>
+        <sequence line='3568'>
          <message>
           <sequence role='select'>
            <valueOf>
@@ -3169,9 +3160,9 @@
           <str role='terminate' val='no'/>
           <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
          </message>
-         <let line='3567' var='Q{}contexti' as='element()?' slot='3' eval='7'>
-          <ufCall line='3568' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='0' eval='16'>
-           <check line='3560' card='1' diag='3|0|XTTE0570|this-instance-id'>
+         <let line='3579' var='Q{}contexti' as='element()?' slot='3' eval='7'>
+          <ufCall line='3580' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='0' eval='16'>
+           <check line='3572' card='1' diag='3|0|XTTE0570|this-instance-id'>
             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
              <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='1' eval='6'>
               <varRef name='Q{}this-repeat-nodeset' slot='2'/>
@@ -3180,7 +3171,7 @@
             </ifCall>
            </check>
           </ufCall>
-          <let line='3575' var='Q{}namespace-context-item' as='element()' slot='4' eval='16'>
+          <let line='3587' var='Q{}namespace-context-item' as='element()' slot='4' eval='16'>
            <choose>
             <fn name='exists'>
              <varRef name='Q{}contexti' slot='3'/>
@@ -3201,7 +3192,7 @@
              </check>
             </treat>
            </choose>
-           <let line='3577' var='Q{}page-element' as='element()?' slot='5' eval='7'>
+           <let line='3589' var='Q{}page-element' as='element()?' slot='5' eval='7'>
             <check card='?' diag='3|0|XTTE0570|page-element'>
              <filter flags='b'>
               <slash simple='1'>
@@ -3216,11 +3207,11 @@
               </vc>
              </filter>
             </check>
-            <choose line='3580'>
+            <choose line='3592'>
              <fn name='exists'>
               <varRef name='Q{}page-element' slot='5'/>
              </fn>
-             <let line='3581' var='Q{}instance-keys' as='item()?' slot='6' eval='8'>
+             <let line='3593' var='Q{}instance-keys' as='item()?' slot='6' eval='8'>
               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                <check card='1' diag='0|0||ixsl:call'>
                 <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -3228,12 +3219,12 @@
                <str val='getInstanceKeys'/>
                <array size='0'/>
               </ifCall>
-              <let line='3582' var='Q{}instances' as='map(xs:string, element())' slot='7' eval='16'>
-               <treat line='3584' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances'>
+              <let line='3594' var='Q{}instances' as='map(xs:string, element())' slot='7' eval='16'>
+               <treat line='3596' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances'>
                 <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
                  <forEach>
                   <varRef name='Q{}instance-keys' slot='6'/>
-                  <ifCall line='3585' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                  <ifCall line='3597' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                    <atomSing diag='0|0||map:entry'>
                     <dot/>
                    </atomSing>
@@ -3256,12 +3247,12 @@
                  </map>
                 </ifCall>
                </treat>
-               <resultDoc line='3589' global='#&#xA;#Sun Feb 23 16:30:37 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sun Feb 23 16:30:37 GMT 2020&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xA;'>
+               <resultDoc line='3601' global='#&#xD;&#xA;#Fri Mar 13 14:41:49 GMT 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Fri Mar 13 14:41:49 GMT 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
                 <fn role='href' name='concat'>
                  <str val='#'/>
                  <varRef name='Q{}this-key' slot='1'/>
                 </fn>
-                <applyT role='content' line='3590' bSlot='2'>
+                <applyT role='content' line='3602' bSlot='2'>
                  <filter role='select' flags='b'>
                   <slash simple='1'>
                    <gVarRef name='Q{}xforms-doc' bSlot='3'/>
@@ -3282,7 +3273,7 @@
                   <true/>
                  </withParam>
                  <withParam name='Q{}instances' flags='t' as='map(xs:string, element())'>
-                  <varRef line='3591' name='Q{}instances' slot='7'/>
+                  <varRef line='3603' name='Q{}instances' slot='7'/>
                  </withParam>
                 </applyT>
                </resultDoc>
@@ -3301,8 +3292,8 @@
   </template>
  </co>
  <co id='35' binds='3 2 23 23'>
-  <template name='Q{}refreshOutputs-JS' flags='os' line='3466' module='saxon-xforms.xsl' slots='8'>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3473' var='Q{}output-keys' as='item()?' slot='0' eval='8'>
+  <template name='Q{}refreshOutputs-JS' flags='os' line='3478' module='saxon-xforms.xsl' slots='8'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3485' var='Q{}output-keys' as='item()?' slot='0' eval='8'>
     <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
      <check card='1' diag='0|0||ixsl:call'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -3310,9 +3301,9 @@
      <str val='getOutputKeys'/>
      <array size='0'/>
     </ifCall>
-    <forEach line='3475'>
+    <forEach line='3487'>
      <varRef name='Q{}output-keys' slot='0'/>
-     <let line='3476' var='Q{}this-key' as='xs:string' slot='1' eval='16'>
+     <let line='3488' var='Q{}this-key' as='xs:string' slot='1' eval='16'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|this-key'>
        <check card='1' diag='3|0|XTTE0570|this-key'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|this-key'>
@@ -3322,7 +3313,7 @@
         </cvUntyped>
        </check>
       </treat>
-      <let line='3477' var='Q{}this-output' as='map(*)' slot='2' eval='16'>
+      <let line='3489' var='Q{}this-output' as='map(*)' slot='2' eval='16'>
        <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|this-output'>
         <check card='1' diag='3|0|XTTE0570|this-output'>
          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
@@ -3336,7 +3327,7 @@
          </ifCall>
         </check>
        </treat>
-       <sequence line='3479'>
+       <sequence line='3491'>
         <message>
          <sequence role='select'>
           <valueOf>
@@ -3350,14 +3341,14 @@
          <str role='terminate' val='no'/>
          <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
         </message>
-        <let line='3496' var='Q{}xpath-mod' as='xs:string' slot='3' eval='16'>
+        <let line='3508' var='Q{}xpath-mod' as='xs:string' slot='3' eval='16'>
          <ufCall name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='0' eval='16'>
-          <choose line='3484'>
+          <choose line='3496'>
            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
             <varRef name='Q{}this-output' slot='2'/>
             <str val='@value'/>
            </ifCall>
-           <treat line='3485' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|xpath'>
+           <treat line='3497' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|xpath'>
             <check card='1' diag='3|0|XTTE0570|xpath'>
              <cvUntyped to='xs:string' diag='3|0|XTTE0570|xpath'>
               <data>
@@ -3369,11 +3360,11 @@
              </cvUntyped>
             </check>
            </treat>
-           <ifCall line='3487' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+           <ifCall line='3499' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
             <varRef name='Q{}this-output' slot='2'/>
             <str val='@ref'/>
            </ifCall>
-           <treat line='3488' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|xpath'>
+           <treat line='3500' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|xpath'>
             <check card='1' diag='3|0|XTTE0570|xpath'>
              <cvUntyped to='xs:string' diag='3|0|XTTE0570|xpath'>
               <data>
@@ -3389,7 +3380,7 @@
            <str val=''/>
           </choose>
          </ufCall>
-         <sequence line='3498'>
+         <sequence line='3510'>
           <message>
            <sequence role='select'>
             <valueOf>
@@ -3403,21 +3394,21 @@
            <str role='terminate' val='no'/>
            <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
           </message>
-          <let line='3514' var='Q{}contexti' as='element()?' slot='4' eval='7'>
-           <ufCall line='3515' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='16'>
-            <check line='3502' card='1' diag='3|0|XTTE0570|this-instance-id'>
+          <let line='3526' var='Q{}contexti' as='element()?' slot='4' eval='7'>
+           <ufCall line='3527' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='16'>
+            <check line='3514' card='1' diag='3|0|XTTE0570|this-instance-id'>
              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
               <choose>
                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
                 <varRef name='Q{}this-output' slot='2'/>
                 <str val='@ref'/>
                </ifCall>
-               <ufCall line='3504' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='2' eval='16'>
+               <ufCall line='3516' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='2' eval='16'>
                 <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:getInstanceMap'>
                  <check card='1' diag='0|0||xforms:getInstanceMap'>
                   <cvUntyped to='xs:string'>
                    <data>
-                    <ifCall line='3503' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                    <ifCall line='3515' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
                      <varRef name='Q{}this-output' slot='2'/>
                      <str val='@ref'/>
                     </ifCall>
@@ -3427,7 +3418,7 @@
                 </treat>
                </ufCall>
                <true/>
-               <ufCall line='3507' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='3' eval='0'>
+               <ufCall line='3519' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='3' eval='0'>
                 <str val='saxon-forms-default'/>
                </ufCall>
               </choose>
@@ -3435,7 +3426,7 @@
              </ifCall>
             </check>
            </ufCall>
-           <let line='3522' var='Q{}namespace-context-item' as='element()' slot='5' eval='16'>
+           <let line='3534' var='Q{}namespace-context-item' as='element()' slot='5' eval='16'>
             <choose>
              <fn name='exists'>
               <varRef name='Q{}contexti' slot='4'/>
@@ -3456,8 +3447,8 @@
               </check>
              </treat>
             </choose>
-            <let line='3524' var='Q{}value' as='xs:string?' slot='6' eval='7'>
-             <treat line='3525' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|value'>
+            <let line='3536' var='Q{}value' as='xs:string?' slot='6' eval='7'>
+             <treat line='3537' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|value'>
               <check card='?' diag='3|0|XTTE0570|value'>
                <cvUntyped to='xs:string' diag='3|0|XTTE0570|value'>
                 <data>
@@ -3473,7 +3464,7 @@
                </cvUntyped>
               </check>
              </treat>
-             <let line='3528' var='Q{}associated-form-control' as='element()?' slot='7' eval='7'>
+             <let line='3540' var='Q{}associated-form-control' as='element()?' slot='7' eval='7'>
               <check card='?' diag='3|0|XTTE0570|associated-form-control'>
                <filter flags='b'>
                 <slash simple='1'>
@@ -3488,16 +3479,16 @@
                 </vc>
                </filter>
               </check>
-              <choose line='3531'>
+              <choose line='3543'>
                <fn name='exists'>
                 <varRef name='Q{}associated-form-control' slot='7'/>
                </fn>
-               <resultDoc line='3532' global='#&#xA;#Sun Feb 23 16:30:38 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sun Feb 23 16:30:38 GMT 2020&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xA;'>
+               <resultDoc line='3544' global='#&#xD;&#xA;#Fri Mar 13 14:41:49 GMT 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Fri Mar 13 14:41:49 GMT 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
                 <fn role='href' name='concat'>
                  <str val='#'/>
                  <varRef name='Q{}this-key' slot='1'/>
                 </fn>
-                <valueOf role='content' line='3533'>
+                <valueOf role='content' line='3545'>
                  <varRef name='Q{}value' slot='6'/>
                 </valueOf>
                </resultDoc>
@@ -3516,8 +3507,8 @@
   </template>
  </co>
  <co id='31' binds='46'>
-  <template name='Q{}xforms-focus' flags='os' line='4245' module='saxon-xforms.xsl' slots='5'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4246'>
+  <template name='Q{}xforms-focus' flags='os' line='4272' module='saxon-xforms.xsl' slots='5'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4273'>
     <param name='Q{}control' slot='0' flags='i' as='xs:string'>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|control'>
       <check card='1' diag='8|0|XTTE0590|control'>
@@ -3529,10 +3520,10 @@
       </check>
      </treat>
     </param>
-    <let line='4247' var='Q{}xforms-control' as='element()' slot='1' eval='16'>
+    <let line='4274' var='Q{}xforms-control' as='element()' slot='1' eval='16'>
      <check card='1' diag='3|0|XTTE0570|xforms-control'>
       <filter flags='b'>
-       <gVarRef name='Q{http://saxon.sf.net/generated-variable}gg1399833911' bSlot='0'/>
+       <gVarRef name='Q{http://saxon.sf.net/generated-variable}gg1090039905' bSlot='0'/>
        <vc op='eq' onEmpty='0' comp='CCC'>
         <cast as='xs:string' emptiable='1'>
          <attVal name='Q{}id' chk='0'/>
@@ -3541,19 +3532,19 @@
        </vc>
       </filter>
      </check>
-     <choose line='4252'>
+     <choose line='4279'>
       <fn name='exists'>
        <slash simple='1'>
         <varRef name='Q{}xforms-control' slot='1'/>
         <axis name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
        </slash>
       </fn>
-      <let line='4256' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='2' eval='13'>
+      <let line='4283' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='2' eval='13'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
        </check>
-       <let line='4253' var='Q{}context-indexes' as='xs:double*' slot='3' eval='8'>
-        <convert line='4254' from='xs:anyAtomicType' to='xs:double' flags='p' diag='3|0|XTTE0570|context-indexes'>
+       <let line='4280' var='Q{}context-indexes' as='xs:double*' slot='3' eval='8'>
+        <convert line='4281' from='xs:anyAtomicType' to='xs:double' flags='p' diag='3|0|XTTE0570|context-indexes'>
          <cvUntyped to='xs:double' diag='3|0|XTTE0570|context-indexes'>
           <data>
            <forEach>
@@ -3564,7 +3555,7 @@
                <axis name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
               </fn>
              </slash>
-             <sortKey line='4255' comp='DESC|NC11'>
+             <sortKey line='4282' comp='DESC|NC11'>
               <fn role='select' name='position'/>
               <str role='order' val='descending'/>
               <str role='dataType' val='number'/>
@@ -3574,7 +3565,7 @@
               <str role='collation' val='http://www.w3.org/2005/xpath-functions/collation/codepoint'/>
              </sortKey>
             </sort>
-            <ifCall line='4256' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+            <ifCall line='4283' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
              <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='2'/>
              <str val='getRepeatIndex'/>
              <arrayBlock>
@@ -3587,12 +3578,12 @@
           </data>
          </cvUntyped>
         </convert>
-        <let line='4260' var='Q{}control-index' as='xs:string' slot='4' eval='8'>
+        <let line='4287' var='Q{}control-index' as='xs:string' slot='4' eval='8'>
          <fn name='string-join'>
           <varRef name='Q{}context-indexes' slot='3'/>
           <str val='.'/>
          </fn>
-         <sequence line='4261'>
+         <sequence line='4288'>
           <message>
            <sequence role='select'>
             <valueOf>
@@ -3610,7 +3601,7 @@
            <str role='terminate' val='no'/>
            <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
           </message>
-          <ifCall line='4262' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+          <ifCall line='4289' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
            <check card='1' diag='0|0||ixsl:call'>
             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
            </check>
@@ -3628,7 +3619,7 @@
        </let>
       </let>
       <true/>
-      <ifCall line='4265' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+      <ifCall line='4292' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
        </check>
@@ -3927,12 +3918,12 @@
   </function>
  </co>
  <co id='7' binds='1 2 3 3 19 35 42 49'>
-  <template name='Q{}xforms-recalculate' flags='os' line='4105' module='saxon-xforms.xsl' slots='11'>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4152' var='Q{http://saxon.sf.net/generated-variable}v1' as='item()' slot='0' eval='13'>
+  <template name='Q{}xforms-recalculate' flags='os' line='4132' module='saxon-xforms.xsl' slots='11'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4179' var='Q{http://saxon.sf.net/generated-variable}v1' as='item()' slot='0' eval='13'>
     <check card='1' diag='0|0||ixsl:call'>
      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
     </check>
-    <sequence line='4106'>
+    <sequence line='4133'>
      <message>
       <valueOf role='select'>
        <str val='[xforms-recalculate] START'/>
@@ -3940,7 +3931,7 @@
       <str role='terminate' val='no'/>
       <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
      </message>
-     <let line='4107' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
+     <let line='4134' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -3948,7 +3939,7 @@
        <str val='getInstanceKeys'/>
        <array size='0'/>
       </ifCall>
-      <let line='4108' var='Q{}calculationMap' as='map(xs:string, xs:string)' slot='2' eval='16'>
+      <let line='4135' var='Q{}calculationMap' as='map(xs:string, xs:string)' slot='2' eval='16'>
        <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|calculationMap'>
         <check card='1' diag='3|0|XTTE0570|calculationMap'>
          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
@@ -3960,8 +3951,8 @@
          </ifCall>
         </check>
        </treat>
-       <let line='4110' var='Q{}instances-with-calculations' as='map(xs:string, map(*)*)' slot='3' eval='16'>
-        <treat line='4112' as='map(xs:string, map(*)*)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isMap(item)};function c() {return true;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances-with-calculations'>
+       <let line='4137' var='Q{}instances-with-calculations' as='map(xs:string, map(*)*)' slot='3' eval='16'>
+        <treat line='4139' as='map(xs:string, map(*)*)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isMap(item)};function c() {return true;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances-with-calculations'>
          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
           <forEachGroup algorithm='by'>
            <ifCall role='select' name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
@@ -3975,7 +3966,7 @@
             </treat>
            </ufCall>
            <str role='collation' val='http://www.w3.org/2005/xpath-functions/collation/codepoint'/>
-           <ifCall role='content' line='4113' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall role='content' line='4140' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <check card='1' diag='0|0||map:entry'>
              <currentGroupingKey/>
             </check>
@@ -3990,12 +3981,12 @@
           </map>
          </ifCall>
         </treat>
-        <sequence line='4118'>
+        <sequence line='4145'>
          <forEach>
           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
            <varRef name='Q{}instances-with-calculations' slot='3'/>
           </ifCall>
-          <let line='4119' var='Q{}instanceXML' as='element()' slot='4' eval='16'>
+          <let line='4146' var='Q{}instanceXML' as='element()' slot='4' eval='16'>
            <check card='1' diag='3|0|XTTE0570|instanceXML'>
             <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='16'>
              <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:instance'>
@@ -4005,26 +3996,26 @@
              </treat>
             </ufCall>
            </check>
-           <let line='4121' var='Q{}calculations' as='map(xs:string, xs:string)*' slot='5' eval='4'>
+           <let line='4148' var='Q{}calculations' as='map(xs:string, xs:string)*' slot='5' eval='4'>
             <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|calculations'>
              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
               <varRef name='Q{}instances-with-calculations' slot='3'/>
               <dot type='xs:anyAtomicType'/>
              </ifCall>
             </treat>
-            <let line='4135' var='Q{http://saxon.sf.net/generated-variable}v0' as='map(xs:string, xs:string)' slot='6' eval='13'>
+            <let line='4162' var='Q{http://saxon.sf.net/generated-variable}v0' as='map(xs:string, xs:string)' slot='6' eval='13'>
              <check card='1' diag='0|0||map:get'>
               <varRef name='Q{}calculations' slot='5'/>
              </check>
-             <let line='4124' var='Q{}calculated-nodes' as='node()*' slot='7' eval='8'>
-              <treat line='4125' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|calculated-nodes'>
+             <let line='4151' var='Q{}calculated-nodes' as='node()*' slot='7' eval='8'>
+              <treat line='4152' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|calculated-nodes'>
                <forEach>
                 <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
                  <check card='1' diag='0|0||map:keys'>
                   <varRef name='Q{}calculations' slot='5'/>
                  </check>
                 </ifCall>
-                <evaluate line='4126' dxns=''>
+                <evaluate line='4153' dxns=''>
                  <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
                   <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:impose'>
                    <cvUntyped to='xs:string'>
@@ -4040,15 +4031,15 @@
                 </evaluate>
                </forEach>
               </treat>
-              <let line='4131' var='Q{}calculated-values' as='xs:string*' slot='8' eval='8'>
-               <forEach line='4132'>
+              <let line='4158' var='Q{}calculated-values' as='xs:string*' slot='8' eval='8'>
+               <forEach line='4159'>
                 <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
                  <check card='1' diag='0|0||map:keys'>
                   <varRef name='Q{}calculations' slot='5'/>
                  </check>
                 </ifCall>
-                <let line='4134' var='Q{}value' as='xs:string?' slot='9' eval='7'>
-                 <treat line='4135' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|value'>
+                <let line='4161' var='Q{}value' as='xs:string?' slot='9' eval='7'>
+                 <treat line='4162' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|value'>
                   <check card='?' diag='3|0|XTTE0570|value'>
                    <cvUntyped to='xs:string' diag='3|0|XTTE0570|value'>
                     <data>
@@ -4071,7 +4062,7 @@
                    </cvUntyped>
                   </check>
                  </treat>
-                 <first line='4141'>
+                 <first line='4168'>
                   <sequence>
                    <varRef name='Q{}value' slot='9'/>
                    <str val=''/>
@@ -4079,21 +4070,21 @@
                  </first>
                 </let>
                </forEach>
-               <let line='4145' var='Q{}updatedInstanceXML' as='element()' slot='10' eval='16'>
-                <treat line='4146' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+               <let line='4172' var='Q{}updatedInstanceXML' as='element()' slot='10' eval='16'>
+                <treat line='4173' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
                  <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
                   <applyT mode='Q{}recalculate' bSlot='4'>
                    <varRef role='select' name='Q{}instanceXML' slot='4'/>
                    <withParam name='Q{}updated-nodes' as='node()*'>
-                    <varRef line='4147' name='Q{}calculated-nodes' slot='7'/>
+                    <varRef line='4174' name='Q{}calculated-nodes' slot='7'/>
                    </withParam>
                    <withParam name='Q{}updated-values' as='xs:string*'>
-                    <varRef line='4148' name='Q{}calculated-values' slot='8'/>
+                    <varRef line='4175' name='Q{}calculated-values' slot='8'/>
                    </withParam>
                   </applyT>
                  </check>
                 </treat>
-                <ifCall line='4152' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                <ifCall line='4179' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                  <varRef name='Q{http://saxon.sf.net/generated-variable}v1' slot='0'/>
                  <str val='setInstance'/>
                  <arrayBlock>
@@ -4108,9 +4099,9 @@
            </let>
           </let>
          </forEach>
-         <callT line='4156' name='Q{}refreshOutputs-JS' bSlot='5'/>
-         <callT line='4157' name='Q{}refreshRepeats-JS' bSlot='6'/>
-         <callT line='4158' name='Q{}refreshElementsUsingIndexFunction-JS' bSlot='7' flags='t'/>
+         <callT line='4183' name='Q{}refreshOutputs-JS' bSlot='5'/>
+         <callT line='4184' name='Q{}refreshRepeats-JS' bSlot='6'/>
+         <callT line='4185' name='Q{}refreshElementsUsingIndexFunction-JS' bSlot='7' flags='t'/>
         </sequence>
        </let>
       </let>
@@ -4142,18 +4133,18 @@
   </globalParam>
  </co>
  <co id='51' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}addNamespaceDeclarations' line='3006' module='saxon-xforms.xsl' eval='16' flags='pU' as='element()' slots='1'>
+  <function name='Q{http://www.w3.org/2002/xforms}addNamespaceDeclarations' line='3018' module='saxon-xforms.xsl' eval='16' flags='pU' as='element()' slots='1'>
    <arg name='Q{}this' as='element()'/>
-   <compElem role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3008'>
+   <compElem role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3020'>
     <fn role='name' name='name'>
      <varRef name='Q{}this' slot='0'/>
     </fn>
-    <sequence role='content' line='3009'>
+    <sequence role='content' line='3021'>
      <namespace flags='l'>
       <str role='name' val='xforms'/>
       <str role='select' val='http://www.w3.org/2002/xforms'/>
      </namespace>
-     <forEach line='3010'>
+     <forEach line='3022'>
       <filter flags='b'>
        <filter flags='b'>
         <slash simple='1'>
@@ -4192,21 +4183,21 @@
         </gc>
        </fn>
       </filter>
-      <namespace line='3013' flags='l'>
-       <fn role='name' line='3012' name='substring-before'>
+      <namespace line='3025' flags='l'>
+       <fn role='name' line='3024' name='substring-before'>
         <fn name='name'>
          <dot type='element()'/>
         </fn>
         <str val=':'/>
        </fn>
        <convert role='select' from='xs:anyURI' to='xs:string'>
-        <fn line='3011' name='namespace-uri'>
+        <fn line='3023' name='namespace-uri'>
          <dot type='element()'/>
         </fn>
        </convert>
       </namespace>
      </forEach>
-     <copyOf line='3015' flags='vc'>
+     <copyOf line='3027' flags='vc'>
       <sequence>
        <slash simple='1'>
         <varRef name='Q{}this' slot='0'/>
@@ -4223,8 +4214,8 @@
   </function>
  </co>
  <co id='11' binds='2 1 3 15 19 52 3 53 20'>
-  <template name='Q{}xforms-submit' flags='os' line='4278' module='saxon-xforms.xsl' slots='20'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4279'>
+  <template name='Q{}xforms-submit' flags='os' line='4305' module='saxon-xforms.xsl' slots='20'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4306'>
     <param name='Q{}submission' slot='0' flags='i' as='xs:string'>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|submission'>
       <check card='1' diag='8|0|XTTE0590|submission'>
@@ -4236,7 +4227,7 @@
       </check>
      </treat>
     </param>
-    <let line='4281' var='Q{}submission-map' as='map(*)' slot='1' eval='16'>
+    <let line='4308' var='Q{}submission-map' as='map(*)' slot='1' eval='16'>
      <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|submission-map'>
       <check card='1' diag='3|0|XTTE0570|submission-map'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
@@ -4250,7 +4241,7 @@
        </ifCall>
       </check>
      </treat>
-     <let line='4282' var='Q{}actions' as='map(*)?' slot='2' eval='7'>
+     <let line='4309' var='Q{}actions' as='map(*)?' slot='2' eval='7'>
       <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
         <check card='1' diag='0|0||ixsl:call'>
@@ -4262,7 +4253,7 @@
         </arrayBlock>
        </ifCall>
       </treat>
-      <let line='4286' var='Q{}refi' as='xs:string?' slot='3' eval='7'>
+      <let line='4313' var='Q{}refi' as='xs:string?' slot='3' eval='7'>
        <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
         <check card='?' diag='3|0|XTTE0570|refi'>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
@@ -4275,13 +4266,13 @@
          </cvUntyped>
         </check>
        </treat>
-       <let line='4288' var='Q{}instance-id' as='xs:string' slot='4' eval='16'>
-        <choose line='4290'>
+       <let line='4315' var='Q{}instance-id' as='xs:string' slot='4' eval='16'>
+        <choose line='4317'>
          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
           <varRef name='Q{}submission-map' slot='1'/>
           <str val='@instance'/>
          </ifCall>
-         <treat line='4291' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|instance-id'>
+         <treat line='4318' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|instance-id'>
           <check card='1' diag='3|0|XTTE0570|instance-id'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|instance-id'>
             <data>
@@ -4296,13 +4287,13 @@
          <true/>
          <str val='saxon-forms-default'/>
         </choose>
-        <let line='4312' var='Q{}instanceXML' as='element()' slot='5' eval='16'>
+        <let line='4339' var='Q{}instanceXML' as='element()' slot='5' eval='16'>
          <check card='1' diag='3|0|XTTE0570|instanceXML'>
           <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='0' eval='6'>
            <varRef name='Q{}instance-id' slot='4'/>
           </ufCall>
          </check>
-         <let line='4313' var='Q{}data-fields' as='element()*' slot='6' eval='8'>
+         <let line='4340' var='Q{}data-fields' as='element()*' slot='6' eval='8'>
           <filter flags='b'>
            <filter flags='b'>
             <filter flags='b'>
@@ -4339,11 +4330,11 @@
             <varRef name='Q{}instance-id' slot='4'/>
            </vc>
           </filter>
-          <let line='4316' var='Q{}calculated-nodes' as='node()*' slot='7' eval='8'>
-           <treat line='4317' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|calculated-nodes'>
+          <let line='4343' var='Q{}calculated-nodes' as='node()*' slot='7' eval='8'>
+           <treat line='4344' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|calculated-nodes'>
             <forEach>
              <varRef name='Q{}data-fields' slot='6'/>
-             <evaluate line='4318' dxns=''>
+             <evaluate line='4345' dxns=''>
               <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
                <fn name='string'>
                 <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
@@ -4357,11 +4348,11 @@
              </evaluate>
             </forEach>
            </treat>
-           <let line='4323' var='Q{}calculated-values' as='xs:string*' slot='8' eval='3'>
-            <forEach line='4324'>
+           <let line='4350' var='Q{}calculated-values' as='xs:string*' slot='8' eval='3'>
+            <forEach line='4351'>
              <varRef name='Q{}data-fields' slot='6'/>
-             <let line='4326' var='Q{}value' as='xs:string' slot='9' eval='8'>
-              <cvUntyped line='4328' to='xs:string' diag='3|0|XTTE0570|value'>
+             <let line='4353' var='Q{}value' as='xs:string' slot='9' eval='8'>
+              <cvUntyped line='4355' to='xs:string' diag='3|0|XTTE0570|value'>
                <cast as='xs:untypedAtomic' emptiable='0'>
                 <fn name='string-join'>
                  <convert from='xs:anyAtomicType' to='xs:string'>
@@ -4377,7 +4368,7 @@
                 </fn>
                </cast>
               </cvUntyped>
-              <first line='4335'>
+              <first line='4362'>
                <sequence>
                 <varRef name='Q{}value' slot='9'/>
                 <str val=''/>
@@ -4385,21 +4376,21 @@
               </first>
              </let>
             </forEach>
-            <let line='4339' var='Q{}updatedInstanceXML' as='element()' slot='10' eval='16'>
-             <treat line='4340' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+            <let line='4366' var='Q{}updatedInstanceXML' as='element()' slot='10' eval='16'>
+             <treat line='4367' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
               <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
                <applyT mode='Q{}recalculate' bSlot='4'>
                 <varRef role='select' name='Q{}instanceXML' slot='5'/>
                 <withParam name='Q{}updated-nodes' as='node()*'>
-                 <varRef line='4341' name='Q{}calculated-nodes' slot='7'/>
+                 <varRef line='4368' name='Q{}calculated-nodes' slot='7'/>
                 </withParam>
                 <withParam name='Q{}updated-values' as='xs:string*'>
-                 <varRef line='4342' name='Q{}calculated-values' slot='8'/>
+                 <varRef line='4369' name='Q{}calculated-values' slot='8'/>
                 </withParam>
                </applyT>
               </check>
              </treat>
-             <let line='4347' var='Q{}required-fieldsi' as='element()*' slot='11' eval='8'>
+             <let line='4374' var='Q{}required-fieldsi' as='element()*' slot='11' eval='8'>
               <filter flags='b'>
                <slash simple='1'>
                 <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
@@ -4409,19 +4400,19 @@
                 <axis name='attribute' nodeTest='attribute(Q{}data-required)' jsTest='return item.name===&#39;data-required&#39;'/>
                </fn>
               </filter>
-              <let line='4349' var='Q{}required-fields-check' as='element()*' slot='12' eval='3'>
+              <let line='4376' var='Q{}required-fields-check' as='element()*' slot='12' eval='3'>
                <ufCall name='Q{http://www.w3.org/2002/xforms}check-required-fields' tailCall='false' bSlot='5' eval='6'>
                 <varRef name='Q{}updatedInstanceXML' slot='10'/>
                </ufCall>
-               <choose line='4355'>
+               <choose line='4382'>
                 <fn name='empty'>
                  <varRef name='Q{}required-fields-check' slot='12'/>
                 </fn>
-                <let line='4356' var='Q{}requestBodyXML' as='node()' slot='13' eval='16'>
-                 <choose line='4358'>
+                <let line='4383' var='Q{}requestBody' as='node()' slot='13' eval='16'>
+                 <choose line='4385'>
                   <varRef name='Q{}refi' slot='3'/>
-                  <treat line='4359' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|requestBodyXML'>
-                   <check card='1' diag='3|0|XTTE0570|requestBodyXML'>
+                  <treat line='4386' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|requestBody'>
+                   <check card='1' diag='3|0|XTTE0570|requestBody'>
                     <evaluate dxns=''>
                      <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='6' eval='16'>
                       <check card='1' diag='0|0||xforms:impose'>
@@ -4437,250 +4428,276 @@
                    </check>
                   </treat>
                   <true/>
-                  <varRef line='4362' name='Q{}instanceXML' slot='5'/>
+                  <varRef line='4389' name='Q{}instanceXML' slot='5'/>
                  </choose>
-                 <let line='4385' var='Q{}method' as='xs:string' slot='14' eval='16'>
-                  <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|method'>
-                   <check card='1' diag='3|0|XTTE0570|method'>
-                    <cvUntyped to='xs:string' diag='3|0|XTTE0570|method'>
-                     <data>
-                      <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                       <varRef name='Q{}submission-map' slot='1'/>
-                       <str val='@method'/>
-                      </ifCall>
-                     </data>
-                    </cvUntyped>
-                   </check>
-                  </treat>
-                  <let line='4387' var='Q{}serialization' as='xs:string?' slot='15' eval='7'>
-                   <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|serialization'>
-                    <check card='?' diag='3|0|XTTE0570|serialization'>
-                     <cvUntyped to='xs:string' diag='3|0|XTTE0570|serialization'>
+                 <let line='4394' var='Q{}requestBodyDoc' as='document-node()?' slot='14' eval='7'>
+                  <choose line='4395'>
+                   <fn name='exists'>
+                    <filter flags='b'>
+                     <varRef name='Q{}requestBody' slot='13'/>
+                     <fn name='exists'>
+                      <axis name='self' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+                     </fn>
+                    </filter>
+                   </fn>
+                   <doc line='4396'>
+                    <varRef line='4397' name='Q{}requestBody' slot='13'/>
+                   </doc>
+                  </choose>
+                  <let line='4402' var='Q{}method' as='xs:string' slot='15' eval='16'>
+                   <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|method'>
+                    <check card='1' diag='3|0|XTTE0570|method'>
+                     <cvUntyped to='xs:string' diag='3|0|XTTE0570|method'>
                       <data>
                        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
                         <varRef name='Q{}submission-map' slot='1'/>
-                        <str val='@serialization'/>
+                        <str val='@method'/>
                        </ifCall>
                       </data>
                      </cvUntyped>
                     </check>
                    </treat>
-                   <let line='4389' var='Q{}query-parameters' as='xs:string?' slot='16' eval='7'>
-                    <choose line='4390'>
-                     <and op='and'>
-                      <fn name='exists'>
-                       <varRef name='Q{}serialization' slot='15'/>
-                      </fn>
-                      <vc op='eq' onEmpty='0' comp='CCC'>
-                       <varRef name='Q{}serialization' slot='15'/>
-                       <str val='application/x-www-form-urlencoded'/>
-                      </vc>
-                     </and>
-                     <fn line='4401' name='string-join'>
-                      <forEach line='4392'>
-                       <slash simple='1'>
-                        <varRef name='Q{}requestBodyXML' slot='13'/>
-                        <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-                       </slash>
-                       <let line='4393' var='Q{}query-part' as='xs:string' slot='17' eval='8'>
-                        <fn name='concat'>
-                         <fn name='name'>
-                          <dot type='element()'/>
-                         </fn>
-                         <str val='='/>
-                         <fn name='string'>
-                          <dot type='element()'/>
-                         </fn>
+                   <let line='4404' var='Q{}serialization' as='xs:string?' slot='16' eval='7'>
+                    <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|serialization'>
+                     <check card='?' diag='3|0|XTTE0570|serialization'>
+                      <cvUntyped to='xs:string' diag='3|0|XTTE0570|serialization'>
+                       <data>
+                        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                         <varRef name='Q{}submission-map' slot='1'/>
+                         <str val='@serialization'/>
+                        </ifCall>
+                       </data>
+                      </cvUntyped>
+                     </check>
+                    </treat>
+                    <let line='4406' var='Q{}query-parameters' as='xs:string?' slot='17' eval='7'>
+                     <choose line='4407'>
+                      <and op='and'>
+                       <fn name='exists'>
+                        <varRef name='Q{}serialization' slot='16'/>
+                       </fn>
+                       <vc op='eq' onEmpty='0' comp='CCC'>
+                        <varRef name='Q{}serialization' slot='16'/>
+                        <str val='application/x-www-form-urlencoded'/>
+                       </vc>
+                      </and>
+                      <fn line='4425' name='string-join'>
+                       <choose line='4411'>
+                        <fn name='exists'>
+                         <varRef name='Q{}requestBodyDoc' slot='14'/>
                         </fn>
-                        <sequence line='4394'>
-                         <varRef name='Q{}query-part' slot='17'/>
-                         <message line='4395'>
-                          <sequence role='select'>
-                           <valueOf>
-                            <str val='[xforms-submit] Query part: '/>
-                           </valueOf>
-                           <valueOf>
-                            <varRef name='Q{}query-part' slot='17'/>
-                           </valueOf>
-                          </sequence>
-                          <str role='terminate' val='no'/>
-                          <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-                         </message>
-                        </sequence>
-                       </let>
-                      </forEach>
-                      <str val='&amp;'/>
-                     </fn>
-                    </choose>
-                    <let line='4405' var='Q{}href-base' as='xs:string' slot='18' eval='16'>
-                     <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|href-base'>
-                      <check card='1' diag='3|0|XTTE0570|href-base'>
-                       <cvUntyped to='xs:string' diag='3|0|XTTE0570|href-base'>
-                        <data>
-                         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                          <varRef name='Q{}submission-map' slot='1'/>
-                          <str val='@resource'/>
-                         </ifCall>
-                        </data>
-                       </cvUntyped>
-                      </check>
-                     </treat>
-                     <sequence line='4446'>
-                      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}schedule-action' type='item()*'>
-                       <int val='0'/>
-                       <empty/>
-                       <callT name='Q{}HTTPsubmit' bSlot='7'>
-                        <withParam name='Q{}instance-id' flags='c' as='xs:string'>
-                         <varRef line='4447' name='Q{}instance-id' slot='4'/>
-                        </withParam>
-                        <withParam name='Q{}targetref' flags='c' as='xs:string?'>
-                         <treat line='4448' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|targetref'>
-                          <check card='?' diag='8|0|XTTE0590|targetref'>
-                           <cvUntyped to='xs:string' diag='8|0|XTTE0590|targetref'>
-                            <data>
-                             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                              <varRef name='Q{}submission-map' slot='1'/>
-                              <str val='@targetref'/>
-                             </ifCall>
-                            </data>
-                           </cvUntyped>
-                          </check>
-                         </treat>
-                        </withParam>
-                        <withParam name='Q{}replace' flags='c' as='xs:string?'>
-                         <treat line='4449' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|replace'>
-                          <check card='?' diag='8|0|XTTE0590|replace'>
-                           <cvUntyped to='xs:string' diag='8|0|XTTE0590|replace'>
-                            <data>
-                             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                              <varRef name='Q{}submission-map' slot='1'/>
-                              <str val='@replace'/>
-                             </ifCall>
-                            </data>
-                           </cvUntyped>
-                          </check>
-                         </treat>
-                        </withParam>
-                       </callT>
-                       <ifCall line='4423' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
-                        <sequence>
-                         <choose>
-                          <vc op='ne' onEmpty='1' comp='CCC'>
-                           <fn name='upper-case'>
-                            <varRef name='Q{}method' slot='14'/>
-                           </fn>
-                           <str val='GET'/>
-                          </vc>
-                          <ifCall line='4432' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
-                           <str val='body'/>
-                           <doc line='4381'>
-                            <varRef line='4382' name='Q{}requestBodyXML' slot='13'/>
-                           </doc>
+                        <forEach line='4412'>
+                         <slash simple='1'>
+                          <varRef name='Q{}requestBody' slot='13'/>
+                          <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+                         </slash>
+                         <fn line='4413' name='concat'>
+                          <fn name='local-name'>
+                           <dot type='element()'/>
+                          </fn>
+                          <str val='='/>
+                          <fn name='string'>
+                           <dot type='element()'/>
+                          </fn>
+                         </fn>
+                        </forEach>
+                       </choose>
+                       <str val='&amp;'/>
+                      </fn>
+                     </choose>
+                     <let line='4429' var='Q{}href-base' as='xs:string' slot='18' eval='16'>
+                      <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|href-base'>
+                       <check card='1' diag='3|0|XTTE0570|href-base'>
+                        <cvUntyped to='xs:string' diag='3|0|XTTE0570|href-base'>
+                         <data>
+                          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                           <varRef name='Q{}submission-map' slot='1'/>
+                           <str val='@resource'/>
                           </ifCall>
-                         </choose>
-                         <ifCall line='4434' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
-                          <str val='method'/>
-                          <varRef name='Q{}method' slot='14'/>
-                         </ifCall>
-                         <ifCall line='4435' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
-                          <str val='href'/>
-                          <choose line='4409'>
-                           <fn name='exists'>
-                            <varRef name='Q{}query-parameters' slot='16'/>
-                           </fn>
-                           <fn line='4410' name='concat'>
-                            <varRef name='Q{}href-base' slot='18'/>
-                            <str val='?'/>
-                            <varRef name='Q{}query-parameters' slot='16'/>
-                           </fn>
-                           <true/>
-                           <varRef line='4413' name='Q{}href-base' slot='18'/>
-                          </choose>
-                         </ifCall>
-                         <ifCall line='4436' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
-                          <str val='media-type'/>
-                          <treat line='4418' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|mediatype'>
-                           <check card='1' diag='3|0|XTTE0570|mediatype'>
-                            <cvUntyped to='xs:string' diag='3|0|XTTE0570|mediatype'>
+                         </data>
+                        </cvUntyped>
+                       </check>
+                      </treat>
+                      <sequence line='4473'>
+                       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}schedule-action' type='item()*'>
+                        <int val='0'/>
+                        <empty/>
+                        <callT name='Q{}HTTPsubmit' bSlot='7'>
+                         <withParam name='Q{}instance-id' flags='c' as='xs:string'>
+                          <varRef line='4474' name='Q{}instance-id' slot='4'/>
+                         </withParam>
+                         <withParam name='Q{}targetref' flags='c' as='xs:string?'>
+                          <treat line='4475' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|targetref'>
+                           <check card='?' diag='8|0|XTTE0590|targetref'>
+                            <cvUntyped to='xs:string' diag='8|0|XTTE0590|targetref'>
                              <data>
                               <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
                                <varRef name='Q{}submission-map' slot='1'/>
-                               <str val='@mediatype'/>
+                               <str val='@targetref'/>
                               </ifCall>
                              </data>
                             </cvUntyped>
                            </check>
                           </treat>
-                         </ifCall>
-                        </sequence>
-                        <map size='2'>
-                         <str val='duplicates'/>
-                         <str val='reject'/>
-                         <str val='duplicates-error-code'/>
-                         <str val='XTDE3365'/>
-                        </map>
-                       </ifCall>
-                      </ifCall>
-                      <forEach line='4453'>
-                       <varRef name='Q{}actions' slot='2'/>
-                       <let line='4454' var='Q{}action-map' as='map(*)' slot='19' eval='16'>
-                        <dot type='map(*)'/>
-                        <choose line='4457'>
-                         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
-                          <varRef name='Q{}action-map' slot='19'/>
-                          <str val='@event'/>
-                         </ifCall>
-                         <choose line='4458'>
-                          <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
-                           <data>
-                            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                             <varRef name='Q{}action-map' slot='19'/>
-                             <str val='@event'/>
+                         </withParam>
+                         <withParam name='Q{}replace' flags='c' as='xs:string?'>
+                          <treat line='4476' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|replace'>
+                           <check card='?' diag='8|0|XTTE0590|replace'>
+                            <cvUntyped to='xs:string' diag='8|0|XTTE0590|replace'>
+                             <data>
+                              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                               <varRef name='Q{}submission-map' slot='1'/>
+                               <str val='@replace'/>
+                              </ifCall>
+                             </data>
+                            </cvUntyped>
+                           </check>
+                          </treat>
+                         </withParam>
+                        </callT>
+                        <ifCall line='4450' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+                         <sequence>
+                          <choose>
+                           <vc op='ne' onEmpty='1' comp='CCC'>
+                            <fn name='upper-case'>
+                             <varRef name='Q{}method' slot='15'/>
+                            </fn>
+                            <str val='GET'/>
+                           </vc>
+                           <choose line='4452'>
+                            <fn name='exists'>
+                             <varRef name='Q{}requestBodyDoc' slot='14'/>
+                            </fn>
+                            <ifCall line='4453' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                             <str val='body'/>
+                             <varRef name='Q{}requestBodyDoc' slot='14'/>
                             </ifCall>
-                           </data>
-                           <str val='xforms-submit-done'/>
-                          </gc>
-                          <callT line='4459' name='Q{}applyActions' bSlot='8' flags='t'>
-                           <withParam name='Q{}action-map' flags='t' as='item()'>
-                            <varRef line='4460' name='Q{}action-map' slot='19'/>
-                           </withParam>
-                           <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                            <check line='4461' card='1' diag='8|0|XTTE0590|nodeset'>
-                             <varRef name='Q{}refi' slot='3'/>
+                            <true/>
+                            <ifCall line='4456' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                             <str val='body'/>
+                             <varRef name='Q{}requestBody' slot='13'/>
+                            </ifCall>
+                           </choose>
+                          </choose>
+                          <ifCall line='4461' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                           <str val='method'/>
+                           <varRef name='Q{}method' slot='15'/>
+                          </ifCall>
+                          <ifCall line='4462' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                           <str val='href'/>
+                           <choose line='4433'>
+                            <fn name='exists'>
+                             <varRef name='Q{}query-parameters' slot='17'/>
+                            </fn>
+                            <fn line='4434' name='concat'>
+                             <varRef name='Q{}href-base' slot='18'/>
+                             <str val='?'/>
+                             <varRef name='Q{}query-parameters' slot='17'/>
+                            </fn>
+                            <fn line='4436' name='exists'>
+                             <filter flags='b'>
+                              <varRef name='Q{}requestBody' slot='13'/>
+                              <fn name='exists'>
+                               <axis name='self' nodeTest='text()' jsTest='return item.nodeType===3;'/>
+                              </fn>
+                             </filter>
+                            </fn>
+                            <fn line='4437' name='concat'>
+                             <varRef name='Q{}href-base' slot='18'/>
+                             <str val='/'/>
+                             <data>
+                              <varRef name='Q{}requestBody' slot='13'/>
+                             </data>
+                            </fn>
+                            <true/>
+                            <varRef line='4440' name='Q{}href-base' slot='18'/>
+                           </choose>
+                          </ifCall>
+                          <ifCall line='4463' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                           <str val='media-type'/>
+                           <treat line='4445' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|mediatype'>
+                            <check card='1' diag='3|0|XTTE0570|mediatype'>
+                             <cvUntyped to='xs:string' diag='3|0|XTTE0570|mediatype'>
+                              <data>
+                               <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                                <varRef name='Q{}submission-map' slot='1'/>
+                                <str val='@mediatype'/>
+                               </ifCall>
+                              </data>
+                             </cvUntyped>
                             </check>
-                           </withParam>
-                           <withParam name='Q{}instanceXML' flags='t' as='element()'>
-                            <varRef line='4462' name='Q{}instanceXML' slot='5'/>
-                           </withParam>
-                          </callT>
+                           </treat>
+                          </ifCall>
+                         </sequence>
+                         <map size='2'>
+                          <str val='duplicates'/>
+                          <str val='reject'/>
+                          <str val='duplicates-error-code'/>
+                          <str val='XTDE3365'/>
+                         </map>
+                        </ifCall>
+                       </ifCall>
+                       <forEach line='4480'>
+                        <varRef name='Q{}actions' slot='2'/>
+                        <let line='4481' var='Q{}action-map' as='map(*)' slot='19' eval='16'>
+                         <dot type='map(*)'/>
+                         <choose line='4484'>
+                          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+                           <varRef name='Q{}action-map' slot='19'/>
+                           <str val='@event'/>
+                          </ifCall>
+                          <choose line='4485'>
+                           <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+                            <data>
+                             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                              <varRef name='Q{}action-map' slot='19'/>
+                              <str val='@event'/>
+                             </ifCall>
+                            </data>
+                            <str val='xforms-submit-done'/>
+                           </gc>
+                           <callT line='4486' name='Q{}applyActions' bSlot='8' flags='t'>
+                            <withParam name='Q{}action-map' flags='t' as='item()'>
+                             <varRef line='4487' name='Q{}action-map' slot='19'/>
+                            </withParam>
+                            <withParam name='Q{}nodeset' flags='t' as='xs:string'>
+                             <check line='4488' card='1' diag='8|0|XTTE0590|nodeset'>
+                              <varRef name='Q{}refi' slot='3'/>
+                             </check>
+                            </withParam>
+                            <withParam name='Q{}instanceXML' flags='t' as='element()'>
+                             <varRef line='4489' name='Q{}instanceXML' slot='5'/>
+                            </withParam>
+                           </callT>
+                          </choose>
                          </choose>
-                        </choose>
-                       </let>
-                      </forEach>
-                     </sequence>
+                        </let>
+                       </forEach>
+                      </sequence>
+                     </let>
                     </let>
                    </let>
                   </let>
                  </let>
                 </let>
                 <true/>
-                <ifCall line='4475' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                <ifCall line='4502' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                  <check card='1' diag='0|0||ixsl:call'>
                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                  </check>
                  <str val='alert'/>
                  <arrayBlock>
                   <fn name='serialize'>
-                   <doc line='4470' flags='t' validation='preserve'>
+                   <doc line='4497' flags='t' validation='preserve'>
                     <forEach>
                      <varRef name='Q{}required-fields-check' slot='12'/>
-                     <valueOf line='4472' flags='l'>
+                     <valueOf line='4499' flags='l'>
                       <fn name='concat'>
                        <str val='Value error see: '/>
                        <fn name='serialize'>
-                        <slash line='4471' simple='1'>
+                        <slash line='4498' simple='1'>
                          <dot type='element()'/>
-                         <axis line='4472' name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
+                         <axis line='4499' name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
                         </slash>
                        </fn>
                        <str val='&#xA;'/>
@@ -4707,8 +4724,8 @@
   </template>
  </co>
  <co id='37' binds='34 54 50'>
-  <template name='Q{}xforms-rebuild' flags='os' line='4080' module='saxon-xforms.xsl' slots='2'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4081'>
+  <template name='Q{}xforms-rebuild' flags='os' line='4107' module='saxon-xforms.xsl' slots='2'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4108'>
     <message>
      <valueOf role='select'>
       <str val='[xforms-rebuild] START'/>
@@ -4716,8 +4733,8 @@
      <str role='terminate' val='no'/>
      <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
     </message>
-    <let line='4082' var='Q{}instanceDocs' as='map(xs:anyAtomicType, element()?)' slot='0' eval='8'>
-     <let line='4083' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
+    <let line='4109' var='Q{}instanceDocs' as='map(xs:anyAtomicType, element()?)' slot='0' eval='8'>
+     <let line='4110' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -4725,15 +4742,15 @@
        <str val='getInstanceKeys'/>
        <array size='0'/>
       </ifCall>
-      <ifCall line='4085' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+      <ifCall line='4112' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
        <forEach>
         <varRef name='Q{}instance-keys' slot='1'/>
-        <ifCall line='4087' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+        <ifCall line='4114' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
          <atomSing diag='0|0||map:entry'>
           <dot/>
          </atomSing>
          <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='0' eval='16'>
-          <fn line='4086' name='concat'>
+          <fn line='4113' name='concat'>
            <str val='instance(&#39;'/>
            <atomSing card='?' diag='0|1||fn:concat'>
             <dot/>
@@ -4751,12 +4768,12 @@
        </map>
       </ifCall>
      </let>
-     <callT line='4092' name='Q{}xformsjs-main' bSlot='1' flags='t'>
+     <callT line='4119' name='Q{}xformsjs-main' bSlot='1' flags='t'>
       <withParam name='Q{}xforms-file' flags='c' as='xs:string?'>
-       <gVarRef line='4093' name='Q{}xforms-file' bSlot='2'/>
+       <gVarRef line='4120' name='Q{}xforms-file' bSlot='2'/>
       </withParam>
       <withParam name='Q{}instance-docs' flags='c' as='map(*)'>
-       <varRef line='4094' name='Q{}instanceDocs' slot='0'/>
+       <varRef line='4121' name='Q{}instanceDocs' slot='0'/>
       </withParam>
      </callT>
     </let>
@@ -4765,27 +4782,27 @@
  </co>
  <co id='33' binds=''>
   <mode name='Q{}set-field' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.25' seq='37' rank='0' minImp='0' slots='1' flags='s' line='2940' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='37' rank='0' minImp='0' slots='1' flags='s' line='2952' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:textarea' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;textarea&#39;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2941'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2953'>
      <param name='Q{}value' slot='0' flags='t'>
       <str role='select' val=''/>
       <supplied role='conversion' slot='0'/>
      </param>
-     <ifCall line='2943' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+     <ifCall line='2955' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
       <dot type='*:textarea'/>
       <str val='value'/>
      </ifCall>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='-0.25' seq='36' rank='0' minImp='0' slots='1' flags='s' line='2926' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='36' rank='0' minImp='0' slots='1' flags='s' line='2938' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:select' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;select&#39;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2927'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2939'>
      <param name='Q{}value' slot='0' flags='t'>
       <str role='select' val=''/>
       <supplied role='conversion' slot='0'/>
      </param>
-     <forEach line='2929'>
+     <forEach line='2941'>
       <filter flags='b'>
        <axis name='child' nodeTest='element(Q{}option)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;option&#39;;'/>
        <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
@@ -4795,7 +4812,7 @@
         <attVal name='Q{}value' chk='0'/>
        </gc>
       </filter>
-      <ifCall line='2930' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+      <ifCall line='2942' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
        <str val='selected'/>
        <true/>
        <dot type='element(Q{}option)'/>
@@ -4803,14 +4820,14 @@
      </forEach>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='-0.25' seq='35' rank='0' minImp='0' slots='1' flags='s' line='2905' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='35' rank='0' minImp='0' slots='1' flags='s' line='2917' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:input' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;input&#39;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2906'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2918'>
      <param name='Q{}value' slot='0' flags='t'>
       <str role='select' val=''/>
       <supplied role='conversion' slot='0'/>
      </param>
-     <choose line='2910'>
+     <choose line='2922'>
       <and op='and'>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}type)' jsTest='return item.name===&#39;type&#39;'/>
@@ -4822,7 +4839,7 @@
         <str val='checkbox'/>
        </vc>
       </and>
-      <ifCall line='2911' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+      <ifCall line='2923' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
        <str val='checked'/>
        <choose>
         <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
@@ -4840,7 +4857,7 @@
        <dot type='*:input'/>
       </ifCall>
       <true/>
-      <ifCall line='2914' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+      <ifCall line='2926' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
        <str val='value'/>
        <check card='?' diag='0|1||ixsl:set-property'>
         <varRef name='Q{}value' slot='0'/>
@@ -4853,8 +4870,8 @@
   </mode>
  </co>
  <co id='49' binds='43'>
-  <template name='Q{}refreshElementsUsingIndexFunction-JS' flags='os' line='3609' module='saxon-xforms.xsl' slots='6'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3610'>
+  <template name='Q{}refreshElementsUsingIndexFunction-JS' flags='os' line='3621' module='saxon-xforms.xsl' slots='6'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3622'>
     <message>
      <valueOf role='select'>
       <str val='[refreshElementsUsingIndexFunction-JS] START'/>
@@ -4862,7 +4879,7 @@
      <str role='terminate' val='no'/>
      <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
     </message>
-    <let line='3611' var='Q{}ElementsUsingIndexFunction-keys' as='item()?' slot='0' eval='8'>
+    <let line='3623' var='Q{}ElementsUsingIndexFunction-keys' as='item()?' slot='0' eval='8'>
      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
       <check card='1' diag='0|0||ixsl:call'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -4870,7 +4887,7 @@
       <str val='getElementsUsingIndexFunctionKeys'/>
       <array size='0'/>
      </ifCall>
-     <let line='3613' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
+     <let line='3625' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -4878,12 +4895,12 @@
        <str val='getInstanceKeys'/>
        <array size='0'/>
       </ifCall>
-      <let line='3614' var='Q{}instances' as='map(xs:string, element())' slot='2' eval='16'>
-       <treat line='3616' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances'>
+      <let line='3626' var='Q{}instances' as='map(xs:string, element())' slot='2' eval='16'>
+       <treat line='3628' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances'>
         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
          <forEach>
           <varRef name='Q{}instance-keys' slot='1'/>
-          <ifCall line='3617' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <ifCall line='3629' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
            <atomSing diag='0|0||map:entry'>
             <dot/>
            </atomSing>
@@ -4906,9 +4923,9 @@
          </map>
         </ifCall>
        </treat>
-       <forEach line='3623'>
+       <forEach line='3635'>
         <varRef name='Q{}ElementsUsingIndexFunction-keys' slot='0'/>
-        <let line='3624' var='Q{}this-key' as='xs:string' slot='3' eval='16'>
+        <let line='3636' var='Q{}this-key' as='xs:string' slot='3' eval='16'>
          <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|this-key'>
           <check card='1' diag='3|0|XTTE0570|this-key'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|this-key'>
@@ -4918,7 +4935,7 @@
            </cvUntyped>
           </check>
          </treat>
-         <sequence line='3626'>
+         <sequence line='3638'>
           <message>
            <sequence role='select'>
             <valueOf>
@@ -4932,7 +4949,7 @@
            <str role='terminate' val='no'/>
            <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
           </message>
-          <let line='3628' var='Q{}this-element' as='element()' slot='4' eval='16'>
+          <let line='3640' var='Q{}this-element' as='element()' slot='4' eval='16'>
            <treat as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|this-element'>
             <check card='1' diag='3|0|XTTE0570|this-element'>
              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
@@ -4946,8 +4963,8 @@
              </ifCall>
             </check>
            </treat>
-           <let line='3629' var='Q{}this-element-refi' as='xs:string?' slot='5' eval='7'>
-            <choose line='3631'>
+           <let line='3641' var='Q{}this-element-refi' as='xs:string?' slot='5' eval='7'>
+            <choose line='3643'>
              <fn name='exists'>
               <slash simple='1'>
                <varRef name='Q{}this-element' slot='4'/>
@@ -4962,13 +4979,13 @@
                </slash>
               </data>
              </cvUntyped>
-             <fn line='3632' name='exists'>
+             <fn line='3644' name='exists'>
               <slash simple='1'>
                <varRef name='Q{}this-element' slot='4'/>
                <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
               </slash>
              </fn>
-             <cvUntyped line='3632' to='xs:string' diag='3|0|XTTE0570|this-element-refi'>
+             <cvUntyped line='3644' to='xs:string' diag='3|0|XTTE0570|this-element-refi'>
               <data>
                <slash simple='1'>
                 <varRef name='Q{}this-element' slot='4'/>
@@ -4977,12 +4994,12 @@
               </data>
              </cvUntyped>
             </choose>
-            <resultDoc line='3636' global='#&#xA;#Sun Feb 23 16:30:38 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sun Feb 23 16:30:38 GMT 2020&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xA;'>
+            <resultDoc line='3648' global='#&#xD;&#xA;#Fri Mar 13 14:41:49 GMT 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Fri Mar 13 14:41:49 GMT 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
              <fn role='href' name='concat'>
               <str val='#'/>
               <varRef name='Q{}this-key' slot='3'/>
              </fn>
-             <applyT role='content' line='3637' bSlot='0'>
+             <applyT role='content' line='3649' bSlot='0'>
               <slash role='select' simple='1'>
                <varRef name='Q{}this-element' slot='4'/>
                <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
@@ -4991,10 +5008,10 @@
                <true/>
               </withParam>
               <withParam name='Q{}instances' flags='t' as='map(xs:string, element())'>
-               <varRef line='3638' name='Q{}instances' slot='2'/>
+               <varRef line='3650' name='Q{}instances' slot='2'/>
               </withParam>
               <withParam name='Q{}nodeset' flags='t' as='xs:string?'>
-               <choose line='3639'>
+               <choose line='3651'>
                 <fn name='exists'>
                  <varRef name='Q{}this-element-refi' slot='5'/>
                 </fn>
@@ -5171,7 +5188,7 @@
   </function>
  </co>
  <co id='59' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}logToPage' line='3023' module='saxon-xforms.xsl' eval='7' flags='pU' as='empty-sequence()' slots='1'>
+  <function name='Q{http://www.w3.org/2002/xforms}logToPage' line='3035' module='saxon-xforms.xsl' eval='7' flags='pU' as='empty-sequence()' slots='1'>
    <arg name='Q{}message' as='xs:string'/>
    <check role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='-1' card='°' diag='5|0|XTTE0780|xforms:logToPage#1'>
     <error message='Call to xsl:result-document while in temporary output state' code='XTDE1480' isTypeErr='1'/>
@@ -5216,29 +5233,31 @@
  </co>
  <co id='9' binds='9'>
   <mode name='Q{}delete-node' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='22' rank='0' minImp='0' slots='1' flags='s' line='1949' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='22' rank='0' minImp='0' slots='2' flags='s' line='1961' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1950'>
-     <param name='Q{}delete-node' slot='0' flags='ti' as='node()'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1962'>
+     <param name='Q{}delete-node' slot='0' flags='t' as='node()*'>
+      <empty role='select'/>
       <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|delete-node'>
-       <check card='1' diag='8|0|XTTE0590|delete-node'>
-        <supplied slot='0'/>
-       </check>
+       <supplied slot='0'/>
       </treat>
      </param>
-     <choose line='1953'>
-      <is op='is'>
-       <dot type='element()'/>
+     <choose line='1965'>
+      <some var='Q{}n' slot='1'>
        <varRef name='Q{}delete-node' slot='0'/>
-      </is>
+       <is op='is'>
+        <varRef name='Q{}n' slot='1'/>
+        <dot type='element()'/>
+       </is>
+      </some>
       <empty/>
       <true/>
-      <copy line='1967' flags='cin'>
+      <copy line='1979' flags='cin'>
        <sequence role='content'>
         <copyOf flags='vc'>
          <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
         </copyOf>
-        <applyT line='1968' mode='Q{}delete-node' bSlot='0'>
+        <applyT line='1980' mode='Q{}delete-node' bSlot='0'>
          <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
         </applyT>
        </sequence>
@@ -5250,16 +5269,16 @@
  </co>
  <co id='15' binds=''>
   <mode name='Q{}get-field' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.25' seq='34' rank='0' minImp='0' slots='0' flags='s' line='2892' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='34' rank='0' minImp='0' slots='0' flags='s' line='2904' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:textarea' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;textarea&#39;'/>
-    <ifCall role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2895' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+    <ifCall role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2907' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
      <dot type='*:textarea'/>
      <str val='value'/>
     </ifCall>
    </templateRule>
-   <templateRule prec='0' prio='-0.25' seq='33' rank='0' minImp='0' slots='0' flags='s' line='2882' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='33' rank='0' minImp='0' slots='0' flags='s' line='2894' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:select' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;select&#39;'/>
-    <ifCall role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2884' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+    <ifCall role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2896' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
      <check card='?' diag='0|0||ixsl:get'>
       <filter flags='b'>
        <axis name='child' nodeTest='element(Q{}option)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;option&#39;;'/>
@@ -5277,9 +5296,9 @@
      <str val='value'/>
     </ifCall>
    </templateRule>
-   <templateRule prec='0' prio='-0.25' seq='32' rank='0' minImp='0' slots='0' flags='s' line='2863' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='32' rank='0' minImp='0' slots='0' flags='s' line='2875' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:input' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;input&#39;'/>
-    <choose role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2867'>
+    <choose role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2879'>
      <and op='and'>
       <fn name='exists'>
        <axis name='attribute' nodeTest='attribute(Q{}type)' jsTest='return item.name===&#39;type&#39;'/>
@@ -5291,12 +5310,12 @@
        <str val='checkbox'/>
       </vc>
      </and>
-     <ifCall line='2868' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+     <ifCall line='2880' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
       <dot type='*:input'/>
       <str val='checked'/>
      </ifCall>
      <true/>
-     <ifCall line='2871' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+     <ifCall line='2883' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
       <dot type='*:input'/>
       <str val='value'/>
      </ifCall>
@@ -5306,21 +5325,21 @@
  </co>
  <co id='43' binds='54 47 60 61 62 22 63 43 43 61 62 22 43 43 43 61 62 22 3 3 43 43 43 43 61 62 22 3 63 43 61 62 22 63 61 62 63 43 43'>
   <mode onNo='TC' flags='dW' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='7' rank='0' minImp='0' slots='0' flags='s' line='1096' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='7' rank='0' minImp='0' slots='0' flags='s' line='1097' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='document-node()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);'/>
-    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1097' name='Q{}xformsjs-main' bSlot='0' flags='t'>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1098' name='Q{}xformsjs-main' bSlot='0' flags='t'>
      <withParam name='Q{}xforms-doc' flags='c' as='document-node()'>
-      <dot line='1098' type='document-node()'/>
+      <dot line='1099' type='document-node()'/>
      </withParam>
      <withParam name='Q{}xFormsId' flags='c' as='xs:string'>
-      <gVarRef line='1099' name='Q{}xform-html-id' bSlot='1'/>
+      <gVarRef line='1100' name='Q{}xform-html-id' bSlot='1'/>
      </withParam>
     </callT>
    </templateRule>
-   <templateRule prec='0' prio='0.5' seq='25' part='1' rank='2' minImp='0' slots='1' flags='s' line='2124' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.5' seq='25' part='1' rank='2' minImp='0' slots='1' flags='s' line='2136' module='saxon-xforms.xsl'>
     <p.withPredicate role='match'>
      <p.nodeTest test='Q{http://www.w3.org/2002/xforms}*' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.uri===&#39;http://www.w3.org/2002/xforms&#39;'/>
-     <gc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2124' op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+     <gc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2136' op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
       <literal count='15'>
        <str val='setvalue'/>
        <str val='insert'/>
@@ -5343,22 +5362,22 @@
       </fn>
      </gc>
     </p.withPredicate>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2132' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2133' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2144' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2145' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
       <check card='1' diag='3|0|XTTE0570|action-map'>
        <callT name='Q{}setAction' bSlot='2'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2134' type='element()'/>
+         <dot line='2146' type='element()'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <varRef line='2147' name='Q{}action-map' slot='0'/>
+     <varRef line='2159' name='Q{}action-map' slot='0'/>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='13' part='1' rank='1' minImp='0' slots='12' flags='s' line='1545' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='13' part='1' rank='1' minImp='0' slots='12' flags='s' line='1546' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}select)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;select&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1546'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1547'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -5371,7 +5390,7 @@
        </check>
       </treat>
      </param>
-     <param line='1547' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1548' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -5383,7 +5402,7 @@
        </check>
       </treat>
      </param>
-     <let line='1551' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='1552' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -5399,7 +5418,7 @@
          <dot type='element()'/>
         </fn>
         <str val='-'/>
-        <choose line='1549'>
+        <choose line='1550'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -5409,13 +5428,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1553'>
+      <sequence line='1554'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element()' slot='3' eval='16'>
           <dot type='element()'/>
-          <fn line='2998' name='exists'>
-           <sequence line='2973'>
+          <fn line='3010' name='exists'>
+           <sequence line='2985'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -5427,7 +5446,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2976'>
+             <choose role='matching' line='2988'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -5439,7 +5458,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='2985'>
+            <analyzeString line='2997'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -5450,7 +5469,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2988'>
+             <choose role='matching' line='3000'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -5473,37 +5492,14 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='2998' name='exists'>
-             <sequence line='2973'>
+            <fn line='3010' name='exists'>
+             <sequence line='2985'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
                   <varRef name='Q{}this' slot='4'/>
                   <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
-                 </slash>
-                </data>
-               </cvUntyped>
-               <str role='regex' val='\i\c*\('/>
-               <str role='flags' val=''/>
-               <choose role='matching' line='2976'>
-                <vc op='eq' onEmpty='0' comp='CCC'>
-                 <fn name='substring-before'>
-                  <dot type='xs:string'/>
-                  <str val='('/>
-                 </fn>
-                 <str val='index'/>
-                </vc>
-                <str val='i'/>
-               </choose>
-               <empty role='nonMatching'/>
-              </analyzeString>
-              <analyzeString line='2985'>
-               <cvUntyped role='select' to='xs:string'>
-                <data>
-                 <slash simple='1'>
-                  <varRef name='Q{}this' slot='4'/>
-                  <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
                  </slash>
                 </data>
                </cvUntyped>
@@ -5521,13 +5517,36 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
+              <analyzeString line='2997'>
+               <cvUntyped role='select' to='xs:string'>
+                <data>
+                 <slash simple='1'>
+                  <varRef name='Q{}this' slot='4'/>
+                  <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+                 </slash>
+                </data>
+               </cvUntyped>
+               <str role='regex' val='\i\c*\('/>
+               <str role='flags' val=''/>
+               <choose role='matching' line='3000'>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <fn name='substring-before'>
+                  <dot type='xs:string'/>
+                  <str val='('/>
+                 </fn>
+                 <str val='index'/>
+                </vc>
+                <str val='i'/>
+               </choose>
+               <empty role='nonMatching'/>
+              </analyzeString>
              </sequence>
             </fn>
            </let>
           </filter>
          </fn>
         </and>
-        <ifCall line='1554' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1555' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -5538,60 +5557,60 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1561' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='1562' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='1562' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1563' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
           <callT name='Q{}getBinding' bSlot='3'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='1563' type='element()'/>
+            <dot line='1564' type='element()'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='1568' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='1569' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='1569' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1570' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
              <callT name='Q{}getDataRef' bSlot='4'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='1570' type='element()'/>
+               <dot line='1571' type='element()'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='1571' name='Q{}bindingi' slot='5'/>
+               <varRef line='1572' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='1576' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
-          <treat line='1577' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+         <let line='1577' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
+          <treat line='1578' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
            <check card='?' diag='3|0|XTTE0570|instanceField'>
             <callT name='Q{}getReferencedInstanceField' bSlot='5'>
              <withParam name='Q{}refi' flags='c' as='xs:string'>
-              <varRef line='1578' name='Q{}refi' slot='6'/>
+              <varRef line='1579' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </check>
           </treat>
-          <let line='1583' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
-           <treat line='1584' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+          <let line='1584' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
+           <treat line='1585' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
             <callT name='Q{}setActions' bSlot='6'>
              <withParam name='Q{}this' flags='c' as='element()'>
-              <dot line='1585' type='element()'/>
+              <dot line='1586' type='element()'/>
              </withParam>
              <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-              <varRef line='1586' name='Q{}refi' slot='6'/>
+              <varRef line='1587' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </treat>
-           <sequence line='1590'>
+           <sequence line='1591'>
             <choose>
              <fn name='exists'>
               <varRef name='Q{}actions' slot='8'/>
              </fn>
-             <ifCall line='1591' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+             <ifCall line='1592' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
               <check card='1' diag='0|0||ixsl:call'>
                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
               </check>
@@ -5602,27 +5621,27 @@
               </arrayBlock>
              </ifCall>
             </choose>
-            <elem line='1608' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+            <elem line='1609' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
              <sequence>
               <att name='class' flags='l'>
                <str val='xforms-select'/>
               </att>
-              <applyT line='1609' bSlot='7'>
+              <applyT line='1610' bSlot='7'>
                <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
               </applyT>
-              <elem line='1611' name='select' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-               <sequence line='1612'>
+              <elem line='1612' name='select' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+               <sequence line='1613'>
                 <let var='Q{}element' as='element()' slot='9' eval='16'>
                  <dot type='element()'/>
-                 <let line='3064' var='Q{}class' as='xs:string?' slot='10' eval='7'>
-                  <choose line='3065'>
+                 <let line='3076' var='Q{}class' as='xs:string?' slot='10' eval='7'>
+                  <choose line='3077'>
                    <fn name='exists'>
                     <slash simple='1'>
                      <varRef name='Q{}element' slot='9'/>
                      <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
                     </slash>
                    </fn>
-                   <cvUntyped line='3066' to='xs:string' diag='3|0|XTTE0570|class'>
+                   <cvUntyped line='3078' to='xs:string' diag='3|0|XTTE0570|class'>
                     <cast as='xs:untypedAtomic' emptiable='0'>
                      <fn name='string'>
                       <convert from='xs:untypedAtomic' to='xs:string'>
@@ -5637,15 +5656,15 @@
                     </cast>
                    </cvUntyped>
                   </choose>
-                  <let line='3069' var='Q{}class-mod' as='xs:string?' slot='11' eval='7'>
-                   <choose line='3071'>
+                  <let line='3081' var='Q{}class-mod' as='xs:string?' slot='11' eval='7'>
+                   <choose line='3083'>
                     <fn name='exists'>
                      <slash simple='1'>
                       <varRef name='Q{}element' slot='9'/>
                       <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
                      </slash>
                     </fn>
-                    <cvUntyped line='3072' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                    <cvUntyped line='3084' to='xs:string' diag='3|0|XTTE0570|class-mod'>
                      <cast as='xs:untypedAtomic' emptiable='0'>
                       <fn name='string-join'>
                        <sequence>
@@ -5657,13 +5676,13 @@
                      </cast>
                     </cvUntyped>
                     <true/>
-                    <varRef line='3075' name='Q{}class' slot='10'/>
+                    <varRef line='3087' name='Q{}class' slot='10'/>
                    </choose>
-                   <choose line='3079'>
+                   <choose line='3091'>
                     <fn name='exists'>
                      <varRef name='Q{}class-mod' slot='11'/>
                     </fn>
-                    <treat line='3080' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                    <treat line='3092' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
                      <att name='class' flags='l'>
                       <varRef name='Q{}class-mod' slot='11'/>
                      </att>
@@ -5672,7 +5691,7 @@
                   </let>
                  </let>
                 </let>
-                <copyOf line='1613' flags='vc'>
+                <copyOf line='1614' flags='vc'>
                  <except op='except'>
                   <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
                   <docOrder intra='1'>
@@ -5684,11 +5703,11 @@
                   </docOrder>
                  </except>
                 </copyOf>
-                <att line='1615' name='data-ref' flags='l'>
+                <att line='1616' name='data-ref' flags='l'>
                  <varRef name='Q{}refi' slot='6'/>
                 </att>
-                <att line='1616' name='data-element' flags='l'>
-                 <lastOf line='1606'>
+                <att line='1617' name='data-element' flags='l'>
+                 <lastOf line='1607'>
                   <fn name='tokenize'>
                    <varRef name='Q{}refi' slot='6'/>
                    <str val='/'/>
@@ -5696,7 +5715,7 @@
                   </fn>
                  </lastOf>
                 </att>
-                <choose line='1618'>
+                <choose line='1619'>
                  <and op='and'>
                   <fn name='exists'>
                    <varRef name='Q{}bindingi' slot='5'/>
@@ -5708,7 +5727,7 @@
                    </slash>
                   </fn>
                  </and>
-                 <att line='1619' name='data-constraint' flags='l'>
+                 <att line='1620' name='data-constraint' flags='l'>
                   <convert from='xs:untypedAtomic' to='xs:string'>
                    <data>
                     <slash simple='1'>
@@ -5719,19 +5738,19 @@
                   </convert>
                  </att>
                 </choose>
-                <choose line='1622'>
+                <choose line='1623'>
                  <vc op='eq' onEmpty='0' comp='CCC'>
                   <fn name='local-name'>
                    <dot type='element()'/>
                   </fn>
                   <str val='select'/>
                  </vc>
-                 <sequence line='1623'>
+                 <sequence line='1624'>
                   <att name='multiple' flags='l'>
                    <str val='true'/>
                   </att>
-                  <att line='1624' name='size' flags='l'>
-                   <convert line='1625' from='xs:integer' to='xs:string'>
+                  <att line='1625' name='size' flags='l'>
+                   <convert line='1626' from='xs:integer' to='xs:string'>
                     <fn name='count'>
                      <axis name='descendant' nodeTest='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
                     </fn>
@@ -5739,22 +5758,22 @@
                   </att>
                  </sequence>
                 </choose>
-                <choose line='1628'>
+                <choose line='1629'>
                  <fn name='exists'>
                   <varRef name='Q{}actions' slot='8'/>
                  </fn>
-                 <att line='1629' name='data-action' flags='l'>
+                 <att line='1630' name='data-action' flags='l'>
                   <varRef name='Q{}myid' slot='2'/>
                  </att>
                 </choose>
-                <applyT line='1632' bSlot='8'>
+                <applyT line='1633' bSlot='8'>
                  <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
                  <withParam name='Q{}selectedValue' as='xs:string'>
-                  <choose line='1597'>
+                  <choose line='1598'>
                    <fn name='exists'>
                     <varRef name='Q{}instanceField' slot='7'/>
                    </fn>
-                   <cvUntyped line='1598' to='xs:string' diag='3|0|XTTE0570|selectedValue'>
+                   <cvUntyped line='1599' to='xs:string' diag='3|0|XTTE0570|selectedValue'>
                     <cast as='xs:untypedAtomic' emptiable='0'>
                      <fn name='string'>
                       <convert from='xs:anyAtomicType' to='xs:string'>
@@ -5783,24 +5802,24 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='25' rank='1' minImp='0' slots='1' flags='s' line='2124' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='25' rank='1' minImp='0' slots='1' flags='s' line='2136' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}action)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;action&#39;;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2132' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2133' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2144' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2145' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
       <check card='1' diag='3|0|XTTE0570|action-map'>
        <callT name='Q{}setAction' bSlot='2'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2134' type='element()'/>
+         <dot line='2146' type='element()'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <varRef line='2147' name='Q{}action-map' slot='0'/>
+     <varRef line='2159' name='Q{}action-map' slot='0'/>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='19' rank='1' minImp='0' slots='15' flags='s' line='1753' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='19' rank='1' minImp='0' slots='15' flags='s' line='1754' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1754'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1755'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -5813,7 +5832,7 @@
        </check>
       </treat>
      </param>
-     <param line='1755' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1756' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -5825,7 +5844,7 @@
        </check>
       </treat>
      </param>
-     <param line='1756' name='Q{}recalculate' slot='2' as='xs:boolean'>
+     <param line='1757' name='Q{}recalculate' slot='2' as='xs:boolean'>
       <false role='select'/>
       <treat role='conversion' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='8|0|XTTE0590|recalculate'>
        <check card='1' diag='8|0|XTTE0590|recalculate'>
@@ -5837,7 +5856,7 @@
        </check>
       </treat>
      </param>
-     <param line='1757' name='Q{}refreshRepeats' slot='3' as='xs:boolean'>
+     <param line='1758' name='Q{}refreshRepeats' slot='3' as='xs:boolean'>
       <false role='select'/>
       <treat role='conversion' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='8|0|XTTE0590|refreshRepeats'>
        <check card='1' diag='8|0|XTTE0590|refreshRepeats'>
@@ -5849,7 +5868,7 @@
        </check>
       </treat>
      </param>
-     <let line='1761' var='Q{}myid' as='xs:string' slot='4' eval='16'>
+     <let line='1762' var='Q{}myid' as='xs:string' slot='4' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -5865,7 +5884,7 @@
          <dot type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
         </fn>
         <str val='-'/>
-        <choose line='1759'>
+        <choose line='1760'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -5875,27 +5894,27 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1768'>
+      <sequence line='1770'>
        <choose>
-        <fn name='not'>
-         <varRef name='Q{}recalculate' slot='2'/>
-        </fn>
-        <ifCall line='1784' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <varRef name='Q{}recalculate' slot='2'/>
+        <empty/>
+        <true/>
+        <ifCall line='1789' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
          <str val='setRepeatIndex'/>
          <arrayBlock>
           <varRef name='Q{}myid' slot='4'/>
-          <choose line='1771'>
+          <choose line='1776'>
            <fn name='empty'>
             <axis name='attribute' nodeTest='attribute(Q{}startindex)' jsTest='return item.name===&#39;startindex&#39;'/>
            </fn>
            <dbl val='1'/>
-           <castable line='1774' as='xs:double' emptiable='0'>
+           <castable line='1779' as='xs:double' emptiable='0'>
             <axis name='attribute' nodeTest='attribute(Q{}startindex)' jsTest='return item.name===&#39;startindex&#39;'/>
            </castable>
-           <cvUntyped line='1775' to='xs:double' diag='3|0|XTTE0570|this-index'>
+           <cvUntyped line='1780' to='xs:double' diag='3|0|XTTE0570|this-index'>
             <convert from='xs:double' to='xs:untypedAtomic'>
              <fn name='number'>
               <attVal name='Q{}startindex' chk='0'/>
@@ -5908,67 +5927,67 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1791' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='1792' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='1796' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1797' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
           <callT name='Q{}getBinding' bSlot='9'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='1793' type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
+            <dot line='1798' type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='1798' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='1799' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='1803' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1804' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
              <callT name='Q{}getDataRef' bSlot='10'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='1800' type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
+               <dot line='1805' type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='1801' name='Q{}bindingi' slot='5'/>
+               <varRef line='1806' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='1807' var='Q{}selectedRepeatVar' as='element()*' slot='7' eval='8'>
-          <treat line='1809' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|selectedRepeatVar'>
+         <let line='1812' var='Q{}selectedRepeatVar' as='element()*' slot='7' eval='8'>
+          <treat line='1814' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|selectedRepeatVar'>
            <callT name='Q{}getReferencedInstanceField' bSlot='11'>
             <withParam name='Q{}refi' flags='c' as='xs:string'>
-             <varRef line='1810' name='Q{}refi' slot='6'/>
+             <varRef line='1815' name='Q{}refi' slot='6'/>
             </withParam>
            </callT>
           </treat>
-          <let line='1825' var='Q{}repeat-items' as='element(Q{}div, Q{http://www.w3.org/2001/XMLSchema}untyped)*' slot='8' eval='3'>
-           <let line='1826' var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}repeat)' slot='9' eval='16'>
+          <let line='1830' var='Q{}repeat-items' as='element(Q{}div, Q{http://www.w3.org/2001/XMLSchema}untyped)*' slot='8' eval='3'>
+           <let line='1831' var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}repeat)' slot='9' eval='16'>
             <dot type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
-            <let line='1831' var='Q{http://saxon.sf.net/generated-variable}v0' as='element()*' slot='10' eval='4'>
+            <let line='1836' var='Q{http://saxon.sf.net/generated-variable}v0' as='element()*' slot='10' eval='4'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='9'/>
               <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
              </slash>
-             <forEach line='1827'>
+             <forEach line='1832'>
               <varRef name='Q{}selectedRepeatVar' slot='7'/>
-              <let line='1828' var='Q{}string-position' as='xs:string' slot='11' eval='8'>
+              <let line='1833' var='Q{}string-position' as='xs:string' slot='11' eval='8'>
                <fn name='string'>
                 <fn name='position'/>
                </fn>
-               <elem line='1830' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+               <elem line='1835' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
                 <sequence>
                  <att name='data-repeat-item' flags='l'>
                   <str val='true'/>
                  </att>
-                 <applyT line='1831' bSlot='12'>
+                 <applyT line='1836' bSlot='12'>
                   <varRef role='select' name='Q{http://saxon.sf.net/generated-variable}v0' slot='10'/>
                   <withParam name='Q{}position' as='xs:integer'>
-                   <fn line='1833' name='position'/>
+                   <fn line='1838' name='position'/>
                   </withParam>
                   <withParam name='Q{}context-position' as='xs:string'>
-                   <choose line='1829'>
+                   <choose line='1834'>
                     <varRef name='Q{}context-position' slot='1'/>
                     <fn name='concat'>
                      <varRef name='Q{}context-position' slot='1'/>
@@ -5980,7 +5999,7 @@
                    </choose>
                   </withParam>
                   <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                   <fn line='1832' name='concat'>
+                   <fn line='1837' name='concat'>
                     <varRef name='Q{}refi' slot='6'/>
                     <str val='['/>
                     <fn name='position'/>
@@ -5994,24 +6013,24 @@
              </forEach>
             </let>
            </let>
-           <sequence line='1842'>
+           <sequence line='1847'>
             <choose>
              <varRef name='Q{}refreshRepeats' slot='3'/>
-             <varRef line='1843' name='Q{}repeat-items' slot='8'/>
+             <varRef line='1848' name='Q{}repeat-items' slot='8'/>
              <true/>
-             <elem line='1846' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-              <sequence line='1847'>
+             <elem line='1851' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+              <sequence line='1852'>
                <let var='Q{}element' as='element(Q{http://www.w3.org/2002/xforms}repeat)' slot='12' eval='16'>
                 <dot type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
-                <let line='3064' var='Q{}class' as='xs:string?' slot='13' eval='7'>
-                 <choose line='3065'>
+                <let line='3076' var='Q{}class' as='xs:string?' slot='13' eval='7'>
+                 <choose line='3077'>
                   <fn name='exists'>
                    <slash simple='1'>
                     <varRef name='Q{}element' slot='12'/>
                     <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
                    </slash>
                   </fn>
-                  <cvUntyped line='3066' to='xs:string' diag='3|0|XTTE0570|class'>
+                  <cvUntyped line='3078' to='xs:string' diag='3|0|XTTE0570|class'>
                    <cast as='xs:untypedAtomic' emptiable='0'>
                     <fn name='string'>
                      <convert from='xs:untypedAtomic' to='xs:string'>
@@ -6026,15 +6045,15 @@
                    </cast>
                   </cvUntyped>
                  </choose>
-                 <let line='3069' var='Q{}class-mod' as='xs:string?' slot='14' eval='7'>
-                  <choose line='3071'>
+                 <let line='3081' var='Q{}class-mod' as='xs:string?' slot='14' eval='7'>
+                  <choose line='3083'>
                    <fn name='exists'>
                     <slash simple='1'>
                      <varRef name='Q{}element' slot='12'/>
                      <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
                     </slash>
                    </fn>
-                   <cvUntyped line='3072' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                   <cvUntyped line='3084' to='xs:string' diag='3|0|XTTE0570|class-mod'>
                     <cast as='xs:untypedAtomic' emptiable='0'>
                      <fn name='string-join'>
                       <sequence>
@@ -6046,13 +6065,13 @@
                     </cast>
                    </cvUntyped>
                    <true/>
-                   <varRef line='3075' name='Q{}class' slot='13'/>
+                   <varRef line='3087' name='Q{}class' slot='13'/>
                   </choose>
-                  <choose line='3079'>
+                  <choose line='3091'>
                    <fn name='exists'>
                     <varRef name='Q{}class-mod' slot='14'/>
                    </fn>
-                   <treat line='3080' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                   <treat line='3092' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
                     <att name='class' flags='l'>
                      <varRef name='Q{}class-mod' slot='14'/>
                     </att>
@@ -6061,24 +6080,24 @@
                  </let>
                 </let>
                </let>
-               <att line='1849' name='data-repeatable-context' flags='l'>
+               <att line='1854' name='data-repeatable-context' flags='l'>
                 <varRef name='Q{}refi' slot='6'/>
                </att>
-               <att line='1850' name='data-count' flags='l'>
+               <att line='1855' name='data-count' flags='l'>
                 <convert from='xs:integer' to='xs:string'>
                  <fn name='count'>
                   <varRef name='Q{}selectedRepeatVar' slot='7'/>
                  </fn>
                 </convert>
                </att>
-               <att line='1851' name='id' flags='l'>
+               <att line='1856' name='id' flags='l'>
                 <varRef name='Q{}myid' slot='4'/>
                </att>
-               <varRef line='1853' name='Q{}repeat-items' slot='8'/>
+               <varRef line='1858' name='Q{}repeat-items' slot='8'/>
               </sequence>
              </elem>
             </choose>
-            <choose line='1861'>
+            <choose line='1866'>
              <and op='and'>
               <fn name='not'>
                <varRef name='Q{}recalculate' slot='2'/>
@@ -6090,7 +6109,7 @@
                </slash>
               </fn>
              </and>
-             <ifCall line='1865' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+             <ifCall line='1870' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
               <check card='1' diag='0|0||ixsl:call'>
                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
               </check>
@@ -6101,7 +6120,7 @@
               </arrayBlock>
              </ifCall>
             </choose>
-            <ifCall line='1869' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+            <ifCall line='1874' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
              <check card='1' diag='0|0||ixsl:call'>
               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
              </check>
@@ -6122,9 +6141,9 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='18' rank='1' minImp='0' slots='6' flags='s' line='1709' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='18' rank='1' minImp='0' slots='6' flags='s' line='1710' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}group)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;group&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1710'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1711'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -6137,7 +6156,7 @@
        </check>
       </treat>
      </param>
-     <param line='1711' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1712' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -6149,7 +6168,7 @@
        </check>
       </treat>
      </param>
-     <let line='1715' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='1716' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -6165,7 +6184,7 @@
          <dot type='element(Q{http://www.w3.org/2002/xforms}group)'/>
         </fn>
         <str val='-'/>
-        <choose line='1713'>
+        <choose line='1714'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -6175,13 +6194,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1717'>
+      <sequence line='1718'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}group)' slot='3' eval='16'>
           <dot type='element(Q{http://www.w3.org/2002/xforms}group)'/>
-          <fn line='2998' name='exists'>
-           <sequence line='2973'>
+          <fn line='3010' name='exists'>
+           <sequence line='2985'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -6193,7 +6212,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2976'>
+             <choose role='matching' line='2988'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -6205,7 +6224,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='2985'>
+            <analyzeString line='2997'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -6216,7 +6235,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2988'>
+             <choose role='matching' line='3000'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -6239,37 +6258,14 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='2998' name='exists'>
-             <sequence line='2973'>
+            <fn line='3010' name='exists'>
+             <sequence line='2985'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
                   <varRef name='Q{}this' slot='4'/>
                   <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
-                 </slash>
-                </data>
-               </cvUntyped>
-               <str role='regex' val='\i\c*\('/>
-               <str role='flags' val=''/>
-               <choose role='matching' line='2976'>
-                <vc op='eq' onEmpty='0' comp='CCC'>
-                 <fn name='substring-before'>
-                  <dot type='xs:string'/>
-                  <str val='('/>
-                 </fn>
-                 <str val='index'/>
-                </vc>
-                <str val='i'/>
-               </choose>
-               <empty role='nonMatching'/>
-              </analyzeString>
-              <analyzeString line='2985'>
-               <cvUntyped role='select' to='xs:string'>
-                <data>
-                 <slash simple='1'>
-                  <varRef name='Q{}this' slot='4'/>
-                  <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
                  </slash>
                 </data>
                </cvUntyped>
@@ -6287,13 +6283,36 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
+              <analyzeString line='2997'>
+               <cvUntyped role='select' to='xs:string'>
+                <data>
+                 <slash simple='1'>
+                  <varRef name='Q{}this' slot='4'/>
+                  <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+                 </slash>
+                </data>
+               </cvUntyped>
+               <str role='regex' val='\i\c*\('/>
+               <str role='flags' val=''/>
+               <choose role='matching' line='3000'>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <fn name='substring-before'>
+                  <dot type='xs:string'/>
+                  <str val='('/>
+                 </fn>
+                 <str val='index'/>
+                </vc>
+                <str val='i'/>
+               </choose>
+               <empty role='nonMatching'/>
+              </analyzeString>
              </sequence>
             </fn>
            </let>
           </filter>
          </fn>
         </and>
-        <ifCall line='1718' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1719' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -6304,38 +6323,38 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1721' var='Q{}refi' as='xs:string?' slot='5' eval='7'>
-        <choose line='1723'>
+       <let line='1722' var='Q{}refi' as='xs:string?' slot='5' eval='7'>
+        <choose line='1724'>
          <fn name='exists'>
           <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
          </fn>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
           <attVal name='Q{}nodeset' chk='0'/>
          </cvUntyped>
-         <fn line='1724' name='exists'>
+         <fn line='1725' name='exists'>
           <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
          </fn>
-         <cvUntyped line='1724' to='xs:string' diag='3|0|XTTE0570|refi'>
+         <cvUntyped line='1725' to='xs:string' diag='3|0|XTTE0570|refi'>
           <attVal name='Q{}ref' chk='0'/>
          </cvUntyped>
         </choose>
-        <elem line='1730' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-         <sequence line='1731'>
+        <elem line='1731' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+         <sequence line='1732'>
           <att name='id' flags='l'>
            <varRef name='Q{}myid' slot='2'/>
           </att>
-          <choose line='1732'>
+          <choose line='1733'>
            <fn name='exists'>
             <varRef name='Q{}refi' slot='5'/>
            </fn>
-           <att line='1733' name='data-group-ref' flags='l'>
+           <att line='1734' name='data-group-ref' flags='l'>
             <varRef name='Q{}refi' slot='5'/>
            </att>
           </choose>
-          <applyT line='1735' bSlot='13'>
+          <applyT line='1736' bSlot='13'>
            <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
            <withParam name='Q{}nodeset' flags='t' as='xs:string?'>
-            <choose line='1736'>
+            <choose line='1737'>
              <fn name='exists'>
               <varRef name='Q{}refi' slot='5'/>
              </fn>
@@ -6352,15 +6371,15 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='8' rank='1' minImp='0' slots='0' flags='s' line='1113' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='8' rank='1' minImp='0' slots='0' flags='s' line='1114' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/1999/xhtml}html)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/1999/xhtml&#39;&amp;&amp;q.local===&#39;html&#39;;'/>
-    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1114' name='html' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-     <sequence line='1115'>
+    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1115' name='html' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+     <sequence line='1116'>
       <copyOf flags='vc'>
        <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
       </copyOf>
-      <elem line='1116' name='head' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-       <sequence line='1117'>
+      <elem line='1117' name='head' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+       <sequence line='1118'>
         <copyOf flags='vc'>
          <union op='|'>
           <slash simple='2'>
@@ -6373,7 +6392,7 @@
           </slash>
          </union>
         </copyOf>
-        <elem line='1118' name='meta' nsuri='' flags='l'>
+        <elem line='1119' name='meta' nsuri='' flags='l'>
          <sequence>
           <att name='http-equiv' flags='l'>
            <str val='Content-Type'/>
@@ -6383,7 +6402,7 @@
           </att>
          </sequence>
         </elem>
-        <forEach line='1120'>
+        <forEach line='1121'>
          <union op='|'>
           <filter flags='b'>
            <slash simple='2'>
@@ -6410,19 +6429,19 @@
            </vc>
           </filter>
          </union>
-         <elem line='1121' name='meta' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-          <copyOf line='1122' flags='vc'>
+         <elem line='1122' name='meta' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+          <copyOf line='1123' flags='vc'>
            <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
           </copyOf>
          </elem>
         </forEach>
-        <copyOf line='1127' flags='vc'>
+        <copyOf line='1128' flags='vc'>
          <axis name='child' nodeTest='element(Q{}script)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;script&#39;;'/>
         </copyOf>
        </sequence>
       </elem>
-      <elem line='1129' name='body' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-       <applyT line='1130' bSlot='14'>
+      <elem line='1130' name='body' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+       <applyT line='1131' bSlot='14'>
         <slash role='select' simple='2'>
          <axis name='child' nodeTest='element(Q{}body)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;body&#39;;'/>
          <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
@@ -6432,9 +6451,9 @@
      </sequence>
     </elem>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='9' rank='1' minImp='0' slots='15' flags='s' line='1145' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='9' rank='1' minImp='0' slots='15' flags='s' line='1146' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}output)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;output&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1146'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1147'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -6447,7 +6466,7 @@
        </check>
       </treat>
      </param>
-     <param line='1147' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1148' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -6459,7 +6478,7 @@
        </check>
       </treat>
      </param>
-     <let line='1151' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='1152' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -6475,7 +6494,7 @@
          <dot type='element(Q{http://www.w3.org/2002/xforms}output)'/>
         </fn>
         <str val='-'/>
-        <choose line='1149'>
+        <choose line='1150'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -6485,13 +6504,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1153'>
+      <sequence line='1154'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}output)' slot='3' eval='16'>
           <dot type='element(Q{http://www.w3.org/2002/xforms}output)'/>
-          <fn line='2998' name='exists'>
-           <sequence line='2973'>
+          <fn line='3010' name='exists'>
+           <sequence line='2985'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -6503,7 +6522,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2976'>
+             <choose role='matching' line='2988'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -6515,7 +6534,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='2985'>
+            <analyzeString line='2997'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -6526,7 +6545,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2988'>
+             <choose role='matching' line='3000'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -6549,37 +6568,14 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='2998' name='exists'>
-             <sequence line='2973'>
+            <fn line='3010' name='exists'>
+             <sequence line='2985'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
                   <varRef name='Q{}this' slot='4'/>
                   <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
-                 </slash>
-                </data>
-               </cvUntyped>
-               <str role='regex' val='\i\c*\('/>
-               <str role='flags' val=''/>
-               <choose role='matching' line='2976'>
-                <vc op='eq' onEmpty='0' comp='CCC'>
-                 <fn name='substring-before'>
-                  <dot type='xs:string'/>
-                  <str val='('/>
-                 </fn>
-                 <str val='index'/>
-                </vc>
-                <str val='i'/>
-               </choose>
-               <empty role='nonMatching'/>
-              </analyzeString>
-              <analyzeString line='2985'>
-               <cvUntyped role='select' to='xs:string'>
-                <data>
-                 <slash simple='1'>
-                  <varRef name='Q{}this' slot='4'/>
-                  <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
                  </slash>
                 </data>
                </cvUntyped>
@@ -6597,13 +6593,36 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
+              <analyzeString line='2997'>
+               <cvUntyped role='select' to='xs:string'>
+                <data>
+                 <slash simple='1'>
+                  <varRef name='Q{}this' slot='4'/>
+                  <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+                 </slash>
+                </data>
+               </cvUntyped>
+               <str role='regex' val='\i\c*\('/>
+               <str role='flags' val=''/>
+               <choose role='matching' line='3000'>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <fn name='substring-before'>
+                  <dot type='xs:string'/>
+                  <str val='('/>
+                 </fn>
+                 <str val='index'/>
+                </vc>
+                <str val='i'/>
+               </choose>
+               <empty role='nonMatching'/>
+              </analyzeString>
              </sequence>
             </fn>
            </let>
           </filter>
          </fn>
         </and>
-        <ifCall line='1154' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1155' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -6614,44 +6633,44 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1159' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='1160' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='1160' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1161' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
           <callT name='Q{}getBinding' bSlot='15'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='1161' type='element(Q{http://www.w3.org/2002/xforms}output)'/>
+            <dot line='1162' type='element(Q{http://www.w3.org/2002/xforms}output)'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='1166' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='1167' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='1167' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1168' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
              <callT name='Q{}getDataRef' bSlot='16'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='1168' type='element(Q{http://www.w3.org/2002/xforms}output)'/>
+               <dot line='1169' type='element(Q{http://www.w3.org/2002/xforms}output)'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='1169' name='Q{}bindingi' slot='5'/>
+               <varRef line='1170' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='1174' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
-          <treat line='1175' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+         <let line='1175' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
+          <treat line='1176' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
            <check card='?' diag='3|0|XTTE0570|instanceField'>
             <callT name='Q{}getReferencedInstanceField' bSlot='17'>
              <withParam name='Q{}refi' flags='c' as='xs:string'>
-              <varRef line='1176' name='Q{}refi' slot='6'/>
+              <varRef line='1177' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </check>
           </treat>
-          <let line='1187' var='Q{}namespace-context-item' as='element()' slot='8' eval='16'>
+          <let line='1188' var='Q{}namespace-context-item' as='element()' slot='8' eval='16'>
            <choose>
             <fn name='exists'>
              <varRef name='Q{}instanceField' slot='7'/>
@@ -6686,16 +6705,16 @@
                <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
               </slash>
              </check>
-             <compElem line='3008'>
+             <compElem line='3020'>
               <fn role='name' name='name'>
                <varRef name='Q{}this' slot='9'/>
               </fn>
-              <sequence role='content' line='3009'>
+              <sequence role='content' line='3021'>
                <namespace flags='l'>
                 <str role='name' val='xforms'/>
                 <str role='select' val='http://www.w3.org/2002/xforms'/>
                </namespace>
-               <forEach line='3010'>
+               <forEach line='3022'>
                 <filter flags='b'>
                  <filter flags='b'>
                   <slash simple='1'>
@@ -6734,21 +6753,21 @@
                   </gc>
                  </fn>
                 </filter>
-                <namespace line='3013' flags='l'>
-                 <fn role='name' line='3012' name='substring-before'>
+                <namespace line='3025' flags='l'>
+                 <fn role='name' line='3024' name='substring-before'>
                   <fn name='name'>
                    <dot type='element()'/>
                   </fn>
                   <str val=':'/>
                  </fn>
                  <convert role='select' from='xs:anyURI' to='xs:string'>
-                  <fn line='3011' name='namespace-uri'>
+                  <fn line='3023' name='namespace-uri'>
                    <dot type='element()'/>
                   </fn>
                  </convert>
                 </namespace>
                </forEach>
-               <copyOf line='3015' flags='vc'>
+               <copyOf line='3027' flags='vc'>
                 <sequence>
                  <slash simple='1'>
                   <varRef name='Q{}this' slot='9'/>
@@ -6764,12 +6783,12 @@
              </compElem>
             </let>
            </choose>
-           <let line='1189' var='Q{}valueExecuted' as='xs:string' slot='10' eval='16'>
-            <choose line='1191'>
+           <let line='1190' var='Q{}valueExecuted' as='xs:string' slot='10' eval='16'>
+            <choose line='1192'>
              <fn name='exists'>
               <axis name='attribute' nodeTest='attribute(Q{}value)' jsTest='return item.name===&#39;value&#39;'/>
              </fn>
-             <evaluate line='1192' as='xs:string' dxns=''>
+             <evaluate line='1193' as='xs:string' dxns=''>
               <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='18' eval='16'>
                <check card='1' diag='0|0||xforms:impose'>
                 <cvUntyped to='xs:string'>
@@ -6784,7 +6803,7 @@
               <map role='wp' size='0'/>
              </evaluate>
              <true/>
-             <cvUntyped line='1195' to='xs:string' diag='3|0|XTTE0570|valueExecuted'>
+             <cvUntyped line='1196' to='xs:string' diag='3|0|XTTE0570|valueExecuted'>
               <cast as='xs:untypedAtomic' emptiable='0'>
                <fn name='string'>
                 <convert from='xs:anyAtomicType' to='xs:string'>
@@ -6796,8 +6815,8 @@
               </cast>
              </cvUntyped>
             </choose>
-            <let line='1201' var='Q{}relevantVar' as='xs:boolean' slot='11' eval='16'>
-             <choose line='1203'>
+            <let line='1202' var='Q{}relevantVar' as='xs:boolean' slot='11' eval='16'>
+             <choose line='1204'>
               <and op='and'>
                <and op='and'>
                 <fn name='exists'>
@@ -6814,7 +6833,7 @@
                 <varRef name='Q{}instanceField' slot='7'/>
                </fn>
               </and>
-              <treat line='1204' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantVar'>
+              <treat line='1205' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantVar'>
                <check card='1' diag='3|0|XTTE0570|relevantVar'>
                 <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|relevantVar'>
                  <data>
@@ -6844,20 +6863,20 @@
               <true/>
               <true/>
              </choose>
-             <sequence line='1215'>
+             <sequence line='1216'>
               <elem name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-               <sequence line='1216'>
+               <sequence line='1217'>
                 <let var='Q{}element' as='element(Q{http://www.w3.org/2002/xforms}output)' slot='12' eval='16'>
                  <dot type='element(Q{http://www.w3.org/2002/xforms}output)'/>
-                 <let line='3064' var='Q{}class' as='xs:string?' slot='13' eval='7'>
-                  <choose line='3065'>
+                 <let line='3076' var='Q{}class' as='xs:string?' slot='13' eval='7'>
+                  <choose line='3077'>
                    <fn name='exists'>
                     <slash simple='1'>
                      <varRef name='Q{}element' slot='12'/>
                      <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
                     </slash>
                    </fn>
-                   <cvUntyped line='3066' to='xs:string' diag='3|0|XTTE0570|class'>
+                   <cvUntyped line='3078' to='xs:string' diag='3|0|XTTE0570|class'>
                     <cast as='xs:untypedAtomic' emptiable='0'>
                      <fn name='string'>
                       <convert from='xs:untypedAtomic' to='xs:string'>
@@ -6872,15 +6891,15 @@
                     </cast>
                    </cvUntyped>
                   </choose>
-                  <let line='3069' var='Q{}class-mod' as='xs:string?' slot='14' eval='7'>
-                   <choose line='3071'>
+                  <let line='3081' var='Q{}class-mod' as='xs:string?' slot='14' eval='7'>
+                   <choose line='3083'>
                     <fn name='exists'>
                      <slash simple='1'>
                       <varRef name='Q{}element' slot='12'/>
                       <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
                      </slash>
                     </fn>
-                    <cvUntyped line='3072' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                    <cvUntyped line='3084' to='xs:string' diag='3|0|XTTE0570|class-mod'>
                      <cast as='xs:untypedAtomic' emptiable='0'>
                       <fn name='string-join'>
                        <sequence>
@@ -6892,13 +6911,13 @@
                      </cast>
                     </cvUntyped>
                     <true/>
-                    <varRef line='3075' name='Q{}class' slot='13'/>
+                    <varRef line='3087' name='Q{}class' slot='13'/>
                    </choose>
-                   <choose line='3079'>
+                   <choose line='3091'>
                     <fn name='exists'>
                      <varRef name='Q{}class-mod' slot='14'/>
                     </fn>
-                    <treat line='3080' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                    <treat line='3092' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
                      <att name='class' flags='l'>
                       <varRef name='Q{}class-mod' slot='14'/>
                      </att>
@@ -6907,15 +6926,15 @@
                   </let>
                  </let>
                 </let>
-                <applyT line='1218' bSlot='20'>
+                <applyT line='1219' bSlot='20'>
                  <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
                 </applyT>
-                <elem line='1220' name='span' nsuri='' flags='l'>
-                 <sequence line='1221'>
+                <elem line='1221' name='span' nsuri='' flags='l'>
+                 <sequence line='1222'>
                   <att name='id' flags='l'>
                    <varRef name='Q{}myid' slot='2'/>
                   </att>
-                  <att line='1222' name='style' flags='l'>
+                  <att line='1223' name='style' flags='l'>
                    <choose>
                     <varRef name='Q{}relevantVar' slot='11'/>
                     <str val='display:inline'/>
@@ -6923,42 +6942,42 @@
                     <str val='display:none'/>
                    </choose>
                   </att>
-                  <att line='1223' name='data-ref' flags='l'>
+                  <att line='1224' name='data-ref' flags='l'>
                    <varRef name='Q{}refi' slot='6'/>
                   </att>
-                  <varRef line='1225' name='Q{}valueExecuted' slot='10'/>
+                  <varRef line='1226' name='Q{}valueExecuted' slot='10'/>
                  </sequence>
                 </elem>
                </sequence>
               </elem>
-              <choose line='1230'>
+              <choose line='1231'>
                <fn name='empty'>
                 <slash simple='1'>
                  <dot type='element(Q{http://www.w3.org/2002/xforms}output)'/>
                  <axis name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
                 </slash>
                </fn>
-               <ifCall line='1249' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+               <ifCall line='1250' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                 <check card='1' diag='0|0||ixsl:call'>
                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                 </check>
                 <str val='addOutput'/>
                 <arrayBlock>
                  <varRef name='Q{}myid' slot='2'/>
-                 <ifCall line='1233' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+                 <ifCall line='1234' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
                   <sequence>
                    <choose>
                     <varRef name='Q{}refi' slot='6'/>
-                    <ifCall line='1234' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                    <ifCall line='1235' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                      <str val='@ref'/>
                      <varRef name='Q{}refi' slot='6'/>
                     </ifCall>
                    </choose>
-                   <choose line='1237'>
+                   <choose line='1238'>
                     <fn name='exists'>
                      <axis name='attribute' nodeTest='attribute(Q{}value)' jsTest='return item.name===&#39;value&#39;'/>
                     </fn>
-                    <ifCall line='1238' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                    <ifCall line='1239' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                      <str val='@value'/>
                      <cast as='xs:string' emptiable='1'>
                       <attVal name='Q{}value' chk='0'/>
@@ -6987,34 +7006,34 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='5' rank='1' minImp='0' slots='0' flags='s' line='1077' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='5' rank='1' minImp='0' slots='0' flags='s' line='1078' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
-    <applyT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1078' flags='t' bSlot='21'>
+    <applyT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1079' flags='t' bSlot='21'>
      <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
     </applyT>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='25' part='3' rank='1' minImp='0' slots='1' flags='s' line='2124' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='25' part='3' rank='1' minImp='0' slots='1' flags='s' line='2136' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}hide)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;hide&#39;;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2132' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2133' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2144' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2145' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
       <check card='1' diag='3|0|XTTE0570|action-map'>
        <callT name='Q{}setAction' bSlot='2'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2134' type='element()'/>
+         <dot line='2146' type='element()'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <varRef line='2147' name='Q{}action-map' slot='0'/>
+     <varRef line='2159' name='Q{}action-map' slot='0'/>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='12' rank='1' minImp='0' slots='0' flags='s' line='1534' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='12' rank='1' minImp='0' slots='0' flags='s' line='1535' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}hint)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;hint&#39;;'/>
     <empty role='action'/>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='20' rank='1' minImp='0' slots='2' flags='s' line='1882' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='20' rank='1' minImp='0' slots='2' flags='s' line='1887' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}submit)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;submit&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1883'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1888'>
      <param name='Q{}submissions' slot='0' flags='t' as='map(xs:string, map(*))'>
       <map role='select' size='0'/>
       <treat role='conversion' as='map(xs:string, map(*))' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isMap(item)};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|submissions'>
@@ -7023,31 +7042,31 @@
        </check>
       </treat>
      </param>
-     <let line='1889' var='Q{}innerbody' as='document-node()' slot='1' eval='16'>
-      <doc line='1890' validation='preserve'>
+     <let line='1894' var='Q{}innerbody' as='document-node()' slot='1' eval='16'>
+      <doc line='1895' validation='preserve'>
        <applyT bSlot='22'>
         <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
        </applyT>
       </doc>
-      <choose line='1894'>
+      <choose line='1899'>
        <vc op='eq' onEmpty='0' comp='CCC'>
         <cast as='xs:string' emptiable='1'>
          <attVal name='Q{}appearance' chk='0'/>
         </cast>
         <str val='minimal'/>
        </vc>
-       <elem line='1895' name='a' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-        <copyOf line='1896' flags='vc'>
+       <elem line='1900' name='a' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+        <copyOf line='1901' flags='vc'>
          <varRef name='Q{}innerbody' slot='1'/>
         </copyOf>
        </elem>
        <true/>
-       <elem line='1900' name='button' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+       <elem line='1905' name='button' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
         <sequence>
          <att name='type' flags='l'>
           <str val='button'/>
          </att>
-         <copyOf line='1901' flags='vc'>
+         <copyOf line='1906' flags='vc'>
           <filter flags='b'>
            <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
            <vc op='ne' onEmpty='0' comp='CCC'>
@@ -7058,7 +7077,7 @@
            </vc>
           </filter>
          </copyOf>
-         <choose line='1902'>
+         <choose line='1907'>
           <and op='and'>
            <fn name='exists'>
             <axis name='attribute' nodeTest='attribute(Q{}submission)' jsTest='return item.name===&#39;submission&#39;'/>
@@ -7070,13 +7089,13 @@
             </atomSing>
            </ifCall>
           </and>
-          <att line='1904' name='data-submit' flags='l'>
+          <att line='1909' name='data-submit' flags='l'>
            <convert from='xs:untypedAtomic' to='xs:string'>
             <attVal name='Q{}submission' chk='0'/>
            </convert>
           </att>
          </choose>
-         <copyOf line='1906' flags='vc'>
+         <copyOf line='1911' flags='vc'>
           <varRef name='Q{}innerbody' slot='1'/>
          </copyOf>
         </sequence>
@@ -7085,15 +7104,15 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='8' part='1' rank='1' minImp='0' slots='0' flags='s' line='1113' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='8' part='1' rank='1' minImp='0' slots='0' flags='s' line='1114' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{}html)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;html&#39;;'/>
-    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1114' name='html' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-     <sequence line='1115'>
+    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1115' name='html' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+     <sequence line='1116'>
       <copyOf flags='vc'>
        <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
       </copyOf>
-      <elem line='1116' name='head' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-       <sequence line='1117'>
+      <elem line='1117' name='head' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+       <sequence line='1118'>
         <copyOf flags='vc'>
          <union op='|'>
           <slash simple='2'>
@@ -7106,7 +7125,7 @@
           </slash>
          </union>
         </copyOf>
-        <elem line='1118' name='meta' nsuri='' flags='l'>
+        <elem line='1119' name='meta' nsuri='' flags='l'>
          <sequence>
           <att name='http-equiv' flags='l'>
            <str val='Content-Type'/>
@@ -7116,7 +7135,7 @@
           </att>
          </sequence>
         </elem>
-        <forEach line='1120'>
+        <forEach line='1121'>
          <union op='|'>
           <filter flags='b'>
            <slash simple='2'>
@@ -7143,19 +7162,19 @@
            </vc>
           </filter>
          </union>
-         <elem line='1121' name='meta' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-          <copyOf line='1122' flags='vc'>
+         <elem line='1122' name='meta' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+          <copyOf line='1123' flags='vc'>
            <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
           </copyOf>
          </elem>
         </forEach>
-        <copyOf line='1127' flags='vc'>
+        <copyOf line='1128' flags='vc'>
          <axis name='child' nodeTest='element(Q{}script)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;script&#39;;'/>
         </copyOf>
        </sequence>
       </elem>
-      <elem line='1129' name='body' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-       <applyT line='1130' bSlot='14'>
+      <elem line='1130' name='body' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+       <applyT line='1131' bSlot='14'>
         <slash role='select' simple='2'>
          <axis name='child' nodeTest='element(Q{}body)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;body&#39;;'/>
          <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
@@ -7165,9 +7184,9 @@
      </sequence>
     </elem>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='13' rank='1' minImp='0' slots='12' flags='s' line='1545' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='13' rank='1' minImp='0' slots='12' flags='s' line='1546' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}select1)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;select1&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1546'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1547'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -7180,7 +7199,7 @@
        </check>
       </treat>
      </param>
-     <param line='1547' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1548' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -7192,7 +7211,7 @@
        </check>
       </treat>
      </param>
-     <let line='1551' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='1552' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -7208,7 +7227,7 @@
          <dot type='element()'/>
         </fn>
         <str val='-'/>
-        <choose line='1549'>
+        <choose line='1550'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -7218,13 +7237,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1553'>
+      <sequence line='1554'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element()' slot='3' eval='16'>
           <dot type='element()'/>
-          <fn line='2998' name='exists'>
-           <sequence line='2973'>
+          <fn line='3010' name='exists'>
+           <sequence line='2985'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -7236,7 +7255,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2976'>
+             <choose role='matching' line='2988'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -7248,7 +7267,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='2985'>
+            <analyzeString line='2997'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -7259,7 +7278,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2988'>
+             <choose role='matching' line='3000'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -7282,37 +7301,14 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='2998' name='exists'>
-             <sequence line='2973'>
+            <fn line='3010' name='exists'>
+             <sequence line='2985'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
                   <varRef name='Q{}this' slot='4'/>
                   <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
-                 </slash>
-                </data>
-               </cvUntyped>
-               <str role='regex' val='\i\c*\('/>
-               <str role='flags' val=''/>
-               <choose role='matching' line='2976'>
-                <vc op='eq' onEmpty='0' comp='CCC'>
-                 <fn name='substring-before'>
-                  <dot type='xs:string'/>
-                  <str val='('/>
-                 </fn>
-                 <str val='index'/>
-                </vc>
-                <str val='i'/>
-               </choose>
-               <empty role='nonMatching'/>
-              </analyzeString>
-              <analyzeString line='2985'>
-               <cvUntyped role='select' to='xs:string'>
-                <data>
-                 <slash simple='1'>
-                  <varRef name='Q{}this' slot='4'/>
-                  <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
                  </slash>
                 </data>
                </cvUntyped>
@@ -7330,13 +7326,36 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
+              <analyzeString line='2997'>
+               <cvUntyped role='select' to='xs:string'>
+                <data>
+                 <slash simple='1'>
+                  <varRef name='Q{}this' slot='4'/>
+                  <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+                 </slash>
+                </data>
+               </cvUntyped>
+               <str role='regex' val='\i\c*\('/>
+               <str role='flags' val=''/>
+               <choose role='matching' line='3000'>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <fn name='substring-before'>
+                  <dot type='xs:string'/>
+                  <str val='('/>
+                 </fn>
+                 <str val='index'/>
+                </vc>
+                <str val='i'/>
+               </choose>
+               <empty role='nonMatching'/>
+              </analyzeString>
              </sequence>
             </fn>
            </let>
           </filter>
          </fn>
         </and>
-        <ifCall line='1554' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1555' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -7347,60 +7366,60 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1561' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='1562' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='1562' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1563' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
           <callT name='Q{}getBinding' bSlot='3'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='1563' type='element()'/>
+            <dot line='1564' type='element()'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='1568' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='1569' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='1569' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1570' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
              <callT name='Q{}getDataRef' bSlot='4'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='1570' type='element()'/>
+               <dot line='1571' type='element()'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='1571' name='Q{}bindingi' slot='5'/>
+               <varRef line='1572' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='1576' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
-          <treat line='1577' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+         <let line='1577' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
+          <treat line='1578' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
            <check card='?' diag='3|0|XTTE0570|instanceField'>
             <callT name='Q{}getReferencedInstanceField' bSlot='5'>
              <withParam name='Q{}refi' flags='c' as='xs:string'>
-              <varRef line='1578' name='Q{}refi' slot='6'/>
+              <varRef line='1579' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </check>
           </treat>
-          <let line='1583' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
-           <treat line='1584' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+          <let line='1584' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
+           <treat line='1585' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
             <callT name='Q{}setActions' bSlot='6'>
              <withParam name='Q{}this' flags='c' as='element()'>
-              <dot line='1585' type='element()'/>
+              <dot line='1586' type='element()'/>
              </withParam>
              <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-              <varRef line='1586' name='Q{}refi' slot='6'/>
+              <varRef line='1587' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </treat>
-           <sequence line='1590'>
+           <sequence line='1591'>
             <choose>
              <fn name='exists'>
               <varRef name='Q{}actions' slot='8'/>
              </fn>
-             <ifCall line='1591' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+             <ifCall line='1592' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
               <check card='1' diag='0|0||ixsl:call'>
                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
               </check>
@@ -7411,27 +7430,27 @@
               </arrayBlock>
              </ifCall>
             </choose>
-            <elem line='1608' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+            <elem line='1609' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
              <sequence>
               <att name='class' flags='l'>
                <str val='xforms-select'/>
               </att>
-              <applyT line='1609' bSlot='7'>
+              <applyT line='1610' bSlot='7'>
                <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
               </applyT>
-              <elem line='1611' name='select' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-               <sequence line='1612'>
+              <elem line='1612' name='select' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+               <sequence line='1613'>
                 <let var='Q{}element' as='element()' slot='9' eval='16'>
                  <dot type='element()'/>
-                 <let line='3064' var='Q{}class' as='xs:string?' slot='10' eval='7'>
-                  <choose line='3065'>
+                 <let line='3076' var='Q{}class' as='xs:string?' slot='10' eval='7'>
+                  <choose line='3077'>
                    <fn name='exists'>
                     <slash simple='1'>
                      <varRef name='Q{}element' slot='9'/>
                      <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
                     </slash>
                    </fn>
-                   <cvUntyped line='3066' to='xs:string' diag='3|0|XTTE0570|class'>
+                   <cvUntyped line='3078' to='xs:string' diag='3|0|XTTE0570|class'>
                     <cast as='xs:untypedAtomic' emptiable='0'>
                      <fn name='string'>
                       <convert from='xs:untypedAtomic' to='xs:string'>
@@ -7446,15 +7465,15 @@
                     </cast>
                    </cvUntyped>
                   </choose>
-                  <let line='3069' var='Q{}class-mod' as='xs:string?' slot='11' eval='7'>
-                   <choose line='3071'>
+                  <let line='3081' var='Q{}class-mod' as='xs:string?' slot='11' eval='7'>
+                   <choose line='3083'>
                     <fn name='exists'>
                      <slash simple='1'>
                       <varRef name='Q{}element' slot='9'/>
                       <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
                      </slash>
                     </fn>
-                    <cvUntyped line='3072' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                    <cvUntyped line='3084' to='xs:string' diag='3|0|XTTE0570|class-mod'>
                      <cast as='xs:untypedAtomic' emptiable='0'>
                       <fn name='string-join'>
                        <sequence>
@@ -7466,13 +7485,13 @@
                      </cast>
                     </cvUntyped>
                     <true/>
-                    <varRef line='3075' name='Q{}class' slot='10'/>
+                    <varRef line='3087' name='Q{}class' slot='10'/>
                    </choose>
-                   <choose line='3079'>
+                   <choose line='3091'>
                     <fn name='exists'>
                      <varRef name='Q{}class-mod' slot='11'/>
                     </fn>
-                    <treat line='3080' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                    <treat line='3092' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
                      <att name='class' flags='l'>
                       <varRef name='Q{}class-mod' slot='11'/>
                      </att>
@@ -7481,7 +7500,7 @@
                   </let>
                  </let>
                 </let>
-                <copyOf line='1613' flags='vc'>
+                <copyOf line='1614' flags='vc'>
                  <except op='except'>
                   <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
                   <docOrder intra='1'>
@@ -7493,11 +7512,11 @@
                   </docOrder>
                  </except>
                 </copyOf>
-                <att line='1615' name='data-ref' flags='l'>
+                <att line='1616' name='data-ref' flags='l'>
                  <varRef name='Q{}refi' slot='6'/>
                 </att>
-                <att line='1616' name='data-element' flags='l'>
-                 <lastOf line='1606'>
+                <att line='1617' name='data-element' flags='l'>
+                 <lastOf line='1607'>
                   <fn name='tokenize'>
                    <varRef name='Q{}refi' slot='6'/>
                    <str val='/'/>
@@ -7505,7 +7524,7 @@
                   </fn>
                  </lastOf>
                 </att>
-                <choose line='1618'>
+                <choose line='1619'>
                  <and op='and'>
                   <fn name='exists'>
                    <varRef name='Q{}bindingi' slot='5'/>
@@ -7517,7 +7536,7 @@
                    </slash>
                   </fn>
                  </and>
-                 <att line='1619' name='data-constraint' flags='l'>
+                 <att line='1620' name='data-constraint' flags='l'>
                   <convert from='xs:untypedAtomic' to='xs:string'>
                    <data>
                     <slash simple='1'>
@@ -7528,19 +7547,19 @@
                   </convert>
                  </att>
                 </choose>
-                <choose line='1622'>
+                <choose line='1623'>
                  <vc op='eq' onEmpty='0' comp='CCC'>
                   <fn name='local-name'>
                    <dot type='element()'/>
                   </fn>
                   <str val='select'/>
                  </vc>
-                 <sequence line='1623'>
+                 <sequence line='1624'>
                   <att name='multiple' flags='l'>
                    <str val='true'/>
                   </att>
-                  <att line='1624' name='size' flags='l'>
-                   <convert line='1625' from='xs:integer' to='xs:string'>
+                  <att line='1625' name='size' flags='l'>
+                   <convert line='1626' from='xs:integer' to='xs:string'>
                     <fn name='count'>
                      <axis name='descendant' nodeTest='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
                     </fn>
@@ -7548,22 +7567,22 @@
                   </att>
                  </sequence>
                 </choose>
-                <choose line='1628'>
+                <choose line='1629'>
                  <fn name='exists'>
                   <varRef name='Q{}actions' slot='8'/>
                  </fn>
-                 <att line='1629' name='data-action' flags='l'>
+                 <att line='1630' name='data-action' flags='l'>
                   <varRef name='Q{}myid' slot='2'/>
                  </att>
                 </choose>
-                <applyT line='1632' bSlot='8'>
+                <applyT line='1633' bSlot='8'>
                  <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
                  <withParam name='Q{}selectedValue' as='xs:string'>
-                  <choose line='1597'>
+                  <choose line='1598'>
                    <fn name='exists'>
                     <varRef name='Q{}instanceField' slot='7'/>
                    </fn>
-                   <cvUntyped line='1598' to='xs:string' diag='3|0|XTTE0570|selectedValue'>
+                   <cvUntyped line='1599' to='xs:string' diag='3|0|XTTE0570|selectedValue'>
                     <cast as='xs:untypedAtomic' emptiable='0'>
                      <fn name='string'>
                       <convert from='xs:anyAtomicType' to='xs:string'>
@@ -7592,14 +7611,14 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='16' rank='1' minImp='0' slots='0' flags='s' line='1670' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='16' rank='1' minImp='0' slots='0' flags='s' line='1671' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
-    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1671' name='label' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-     <choose line='1673'>
+    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1672' name='label' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+     <choose line='1674'>
       <fn name='exists'>
        <axis name='child' nodeTest='( element() | text() | comment() | processing-instruction() )' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);'/>
       </fn>
-      <applyT line='1674' bSlot='23'>
+      <applyT line='1675' bSlot='23'>
        <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
       </applyT>
       <true/>
@@ -7609,39 +7628,39 @@
      </choose>
     </elem>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='25' part='5' rank='1' minImp='0' slots='1' flags='s' line='2124' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='25' part='5' rank='1' minImp='0' slots='1' flags='s' line='2136' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}unload)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;unload&#39;;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2132' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2133' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2144' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2145' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
       <check card='1' diag='3|0|XTTE0570|action-map'>
        <callT name='Q{}setAction' bSlot='2'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2134' type='element()'/>
+         <dot line='2146' type='element()'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <varRef line='2147' name='Q{}action-map' slot='0'/>
+     <varRef line='2159' name='Q{}action-map' slot='0'/>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='25' part='2' rank='1' minImp='0' slots='1' flags='s' line='2124' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='25' part='2' rank='1' minImp='0' slots='1' flags='s' line='2136' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}show)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;show&#39;;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2132' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2133' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2144' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2145' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
       <check card='1' diag='3|0|XTTE0570|action-map'>
        <callT name='Q{}setAction' bSlot='2'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2134' type='element()'/>
+         <dot line='2146' type='element()'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <varRef line='2147' name='Q{}action-map' slot='0'/>
+     <varRef line='2159' name='Q{}action-map' slot='0'/>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='10' rank='1' minImp='0' slots='17' flags='s' line='1263' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='10' rank='1' minImp='0' slots='17' flags='s' line='1264' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1264'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1265'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -7654,7 +7673,7 @@
        </check>
       </treat>
      </param>
-     <param line='1265' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1266' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -7666,7 +7685,7 @@
        </check>
       </treat>
      </param>
-     <let line='1267' var='Q{}string-position' as='xs:string' slot='2' eval='16'>
+     <let line='1268' var='Q{}string-position' as='xs:string' slot='2' eval='16'>
       <choose>
        <varRef name='Q{}context-position' slot='1'/>
        <varRef name='Q{}context-position' slot='1'/>
@@ -7675,7 +7694,7 @@
         <varRef name='Q{}position' slot='0'/>
        </fn>
       </choose>
-      <let line='1269' var='Q{}myid' as='xs:string' slot='3' eval='16'>
+      <let line='1270' var='Q{}myid' as='xs:string' slot='3' eval='16'>
        <choose>
         <fn name='exists'>
          <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -7694,13 +7713,13 @@
          <varRef name='Q{}string-position' slot='2'/>
         </fn>
        </choose>
-       <sequence line='1271'>
+       <sequence line='1272'>
         <choose>
          <and op='and'>
           <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}input)' slot='4' eval='16'>
            <dot type='element(Q{http://www.w3.org/2002/xforms}input)'/>
-           <fn line='2998' name='exists'>
-            <sequence line='2973'>
+           <fn line='3010' name='exists'>
+            <sequence line='2985'>
              <analyzeString>
               <cvUntyped role='select' to='xs:string'>
                <data>
@@ -7712,7 +7731,7 @@
               </cvUntyped>
               <str role='regex' val='\i\c*\('/>
               <str role='flags' val=''/>
-              <choose role='matching' line='2976'>
+              <choose role='matching' line='2988'>
                <vc op='eq' onEmpty='0' comp='CCC'>
                 <fn name='substring-before'>
                  <dot type='xs:string'/>
@@ -7724,7 +7743,7 @@
               </choose>
               <empty role='nonMatching'/>
              </analyzeString>
-             <analyzeString line='2985'>
+             <analyzeString line='2997'>
               <cvUntyped role='select' to='xs:string'>
                <data>
                 <slash simple='1'>
@@ -7735,7 +7754,7 @@
               </cvUntyped>
               <str role='regex' val='\i\c*\('/>
               <str role='flags' val=''/>
-              <choose role='matching' line='2988'>
+              <choose role='matching' line='3000'>
                <vc op='eq' onEmpty='0' comp='CCC'>
                 <fn name='substring-before'>
                  <dot type='xs:string'/>
@@ -7758,37 +7777,14 @@
             </slash>
             <let var='Q{}this' as='element()' slot='5' eval='16'>
              <dot type='element()'/>
-             <fn line='2998' name='exists'>
-              <sequence line='2973'>
+             <fn line='3010' name='exists'>
+              <sequence line='2985'>
                <analyzeString>
                 <cvUntyped role='select' to='xs:string'>
                  <data>
                   <slash simple='1'>
                    <varRef name='Q{}this' slot='5'/>
                    <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
-                  </slash>
-                 </data>
-                </cvUntyped>
-                <str role='regex' val='\i\c*\('/>
-                <str role='flags' val=''/>
-                <choose role='matching' line='2976'>
-                 <vc op='eq' onEmpty='0' comp='CCC'>
-                  <fn name='substring-before'>
-                   <dot type='xs:string'/>
-                   <str val='('/>
-                  </fn>
-                  <str val='index'/>
-                 </vc>
-                 <str val='i'/>
-                </choose>
-                <empty role='nonMatching'/>
-               </analyzeString>
-               <analyzeString line='2985'>
-                <cvUntyped role='select' to='xs:string'>
-                 <data>
-                  <slash simple='1'>
-                   <varRef name='Q{}this' slot='5'/>
-                   <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
                   </slash>
                  </data>
                 </cvUntyped>
@@ -7806,13 +7802,36 @@
                 </choose>
                 <empty role='nonMatching'/>
                </analyzeString>
+               <analyzeString line='2997'>
+                <cvUntyped role='select' to='xs:string'>
+                 <data>
+                  <slash simple='1'>
+                   <varRef name='Q{}this' slot='5'/>
+                   <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+                  </slash>
+                 </data>
+                </cvUntyped>
+                <str role='regex' val='\i\c*\('/>
+                <str role='flags' val=''/>
+                <choose role='matching' line='3000'>
+                 <vc op='eq' onEmpty='0' comp='CCC'>
+                  <fn name='substring-before'>
+                   <dot type='xs:string'/>
+                   <str val='('/>
+                  </fn>
+                  <str val='index'/>
+                 </vc>
+                 <str val='i'/>
+                </choose>
+                <empty role='nonMatching'/>
+               </analyzeString>
               </sequence>
              </fn>
             </let>
            </filter>
           </fn>
          </and>
-         <ifCall line='1272' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+         <ifCall line='1273' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
           <check card='1' diag='0|0||ixsl:call'>
            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
           </check>
@@ -7823,45 +7842,45 @@
           </arrayBlock>
          </ifCall>
         </choose>
-        <let line='1280' var='Q{}bindingi' as='node()?' slot='6' eval='7'>
-         <treat line='1281' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+        <let line='1281' var='Q{}bindingi' as='node()?' slot='6' eval='7'>
+         <treat line='1282' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
           <check card='?' diag='3|0|XTTE0570|bindingi'>
            <callT name='Q{}getBinding' bSlot='24'>
             <withParam name='Q{}this' flags='c' as='element()'>
-             <dot line='1282' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
+             <dot line='1283' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
             </withParam>
            </callT>
           </check>
          </treat>
-         <let line='1290' var='Q{}refi' as='xs:string' slot='7' eval='16'>
-          <treat line='1291' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+         <let line='1291' var='Q{}refi' as='xs:string' slot='7' eval='16'>
+          <treat line='1292' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
            <check card='1' diag='3|0|XTTE0570|refi'>
             <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
              <data>
               <callT name='Q{}getDataRef' bSlot='25'>
                <withParam name='Q{}this' flags='c' as='element()'>
-                <dot line='1292' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
+                <dot line='1293' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
                </withParam>
                <withParam name='Q{}bindingi' flags='c' as='node()?'>
-                <varRef line='1293' name='Q{}bindingi' slot='6'/>
+                <varRef line='1294' name='Q{}bindingi' slot='6'/>
                </withParam>
               </callT>
              </data>
             </cvUntyped>
            </check>
           </treat>
-          <let line='1300' var='Q{}instanceField' as='node()?' slot='8' eval='7'>
-           <treat line='1301' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+          <let line='1301' var='Q{}instanceField' as='node()?' slot='8' eval='7'>
+           <treat line='1302' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
             <check card='?' diag='3|0|XTTE0570|instanceField'>
              <callT name='Q{}getReferencedInstanceField' bSlot='26'>
               <withParam name='Q{}refi' flags='c' as='xs:string'>
-               <varRef line='1302' name='Q{}refi' slot='7'/>
+               <varRef line='1303' name='Q{}refi' slot='7'/>
               </withParam>
              </callT>
             </check>
            </treat>
-           <let line='1316' var='Q{}relevantVar' as='xs:boolean' slot='9' eval='16'>
-            <choose line='1318'>
+           <let line='1317' var='Q{}relevantVar' as='xs:boolean' slot='9' eval='16'>
+            <choose line='1319'>
              <and op='and'>
               <and op='and'>
                <fn name='exists'>
@@ -7878,7 +7897,7 @@
                <varRef name='Q{}instanceField' slot='8'/>
               </fn>
              </and>
-             <treat line='1319' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantVar'>
+             <treat line='1320' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantVar'>
               <check card='1' diag='3|0|XTTE0570|relevantVar'>
                <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|relevantVar'>
                 <data>
@@ -7896,7 +7915,7 @@
                    </check>
                   </ufCall>
                   <varRef role='cxt' name='Q{}instanceField' slot='8'/>
-                  <choose role='nsCxt' line='1311'>
+                  <choose role='nsCxt' line='1312'>
                    <fn name='exists'>
                     <varRef name='Q{}instanceField' slot='8'/>
                    </fn>
@@ -7913,16 +7932,16 @@
                       <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
                      </slash>
                     </check>
-                    <compElem line='3008'>
+                    <compElem line='3020'>
                      <fn role='name' name='name'>
                       <varRef name='Q{}this' slot='10'/>
                      </fn>
-                     <sequence role='content' line='3009'>
+                     <sequence role='content' line='3021'>
                       <namespace flags='l'>
                        <str role='name' val='xforms'/>
                        <str role='select' val='http://www.w3.org/2002/xforms'/>
                       </namespace>
-                      <forEach line='3010'>
+                      <forEach line='3022'>
                        <filter flags='b'>
                         <filter flags='b'>
                          <slash simple='1'>
@@ -7961,21 +7980,21 @@
                          </gc>
                         </fn>
                        </filter>
-                       <namespace line='3013' flags='l'>
-                        <fn role='name' line='3012' name='substring-before'>
+                       <namespace line='3025' flags='l'>
+                        <fn role='name' line='3024' name='substring-before'>
                          <fn name='name'>
                           <dot type='element()'/>
                          </fn>
                          <str val=':'/>
                         </fn>
                         <convert role='select' from='xs:anyURI' to='xs:string'>
-                         <fn line='3011' name='namespace-uri'>
+                         <fn line='3023' name='namespace-uri'>
                           <dot type='element()'/>
                          </fn>
                         </convert>
                        </namespace>
                       </forEach>
-                      <copyOf line='3015' flags='vc'>
+                      <copyOf line='3027' flags='vc'>
                        <sequence>
                         <slash simple='1'>
                          <varRef name='Q{}this' slot='10'/>
@@ -8002,23 +8021,23 @@
              <true/>
              <true/>
             </choose>
-            <let line='1329' var='Q{}actions' as='map(*)*' slot='11' eval='8'>
-             <treat line='1330' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+            <let line='1330' var='Q{}actions' as='map(*)*' slot='11' eval='8'>
+             <treat line='1331' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
               <callT name='Q{}setActions' bSlot='28'>
                <withParam name='Q{}this' flags='c' as='element()'>
-                <dot line='1331' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
+                <dot line='1332' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
                </withParam>
                <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                <varRef line='1332' name='Q{}refi' slot='7'/>
+                <varRef line='1333' name='Q{}refi' slot='7'/>
                </withParam>
               </callT>
              </treat>
-             <sequence line='1337'>
+             <sequence line='1338'>
               <choose>
                <fn name='exists'>
                 <varRef name='Q{}actions' slot='11'/>
                </fn>
-               <ifCall line='1338' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+               <ifCall line='1339' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                 <check card='1' diag='0|0||ixsl:call'>
                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                 </check>
@@ -8029,12 +8048,12 @@
                 </arrayBlock>
                </ifCall>
               </choose>
-              <elem line='1343' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+              <elem line='1344' name='div' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
                <sequence>
                 <att name='class' flags='l'>
                  <str val='xforms-input'/>
                 </att>
-                <att line='1344' name='style' flags='l'>
+                <att line='1345' name='style' flags='l'>
                  <choose>
                   <varRef name='Q{}relevantVar' slot='9'/>
                   <str val='display:block'/>
@@ -8042,27 +8061,27 @@
                   <str val='display:none'/>
                  </choose>
                 </att>
-                <applyT line='1346' bSlot='29'>
+                <applyT line='1347' bSlot='29'>
                  <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
                 </applyT>
-                <let line='1348' var='Q{}hints' as='text()*' slot='12' eval='4'>
+                <let line='1349' var='Q{}hints' as='text()*' slot='12' eval='4'>
                  <slash simple='2'>
                   <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}hint)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;hint&#39;;'/>
                   <axis name='child' nodeTest='text()' jsTest='return item.nodeType===3;'/>
                  </slash>
-                 <elem line='1352' name='input' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-                  <sequence line='1353'>
+                 <elem line='1353' name='input' nsuri='' flags='l' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+                  <sequence line='1354'>
                    <let var='Q{}element' as='element(Q{http://www.w3.org/2002/xforms}input)' slot='13' eval='16'>
                     <dot type='element(Q{http://www.w3.org/2002/xforms}input)'/>
-                    <let line='3064' var='Q{}class' as='xs:string?' slot='14' eval='7'>
-                     <choose line='3065'>
+                    <let line='3076' var='Q{}class' as='xs:string?' slot='14' eval='7'>
+                     <choose line='3077'>
                       <fn name='exists'>
                        <slash simple='1'>
                         <varRef name='Q{}element' slot='13'/>
                         <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
                        </slash>
                       </fn>
-                      <cvUntyped line='3066' to='xs:string' diag='3|0|XTTE0570|class'>
+                      <cvUntyped line='3078' to='xs:string' diag='3|0|XTTE0570|class'>
                        <cast as='xs:untypedAtomic' emptiable='0'>
                         <fn name='string'>
                          <convert from='xs:untypedAtomic' to='xs:string'>
@@ -8077,15 +8096,15 @@
                        </cast>
                       </cvUntyped>
                      </choose>
-                     <let line='3069' var='Q{}class-mod' as='xs:string?' slot='15' eval='7'>
-                      <choose line='3071'>
+                     <let line='3081' var='Q{}class-mod' as='xs:string?' slot='15' eval='7'>
+                      <choose line='3083'>
                        <fn name='exists'>
                         <slash simple='1'>
                          <varRef name='Q{}element' slot='13'/>
                          <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
                         </slash>
                        </fn>
-                       <cvUntyped line='3072' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                       <cvUntyped line='3084' to='xs:string' diag='3|0|XTTE0570|class-mod'>
                         <cast as='xs:untypedAtomic' emptiable='0'>
                          <fn name='string-join'>
                           <sequence>
@@ -8097,13 +8116,13 @@
                         </cast>
                        </cvUntyped>
                        <true/>
-                       <varRef line='3075' name='Q{}class' slot='14'/>
+                       <varRef line='3087' name='Q{}class' slot='14'/>
                       </choose>
-                      <choose line='3079'>
+                      <choose line='3091'>
                        <fn name='exists'>
                         <varRef name='Q{}class-mod' slot='15'/>
                        </fn>
-                       <treat line='3080' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                       <treat line='3092' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
                         <att name='class' flags='l'>
                          <varRef name='Q{}class-mod' slot='15'/>
                         </att>
@@ -8112,14 +8131,14 @@
                      </let>
                     </let>
                    </let>
-                   <att line='1354' name='id' flags='l'>
+                   <att line='1355' name='id' flags='l'>
                     <varRef name='Q{}myid' slot='3'/>
                    </att>
-                   <att line='1356' name='data-ref' flags='l'>
+                   <att line='1357' name='data-ref' flags='l'>
                     <varRef name='Q{}refi' slot='7'/>
                    </att>
-                   <att line='1357' name='data-element' flags='l'>
-                    <lastOf line='1350'>
+                   <att line='1358' name='data-element' flags='l'>
+                    <lastOf line='1351'>
                      <fn name='tokenize'>
                       <varRef name='Q{}refi' slot='7'/>
                       <str val='/'/>
@@ -8127,7 +8146,7 @@
                      </fn>
                     </lastOf>
                    </att>
-                   <choose line='1359'>
+                   <choose line='1360'>
                     <and op='and'>
                      <fn name='exists'>
                       <varRef name='Q{}bindingi' slot='6'/>
@@ -8139,7 +8158,7 @@
                       </slash>
                      </fn>
                     </and>
-                    <att line='1360' name='data-required' flags='l'>
+                    <att line='1361' name='data-required' flags='l'>
                      <convert from='xs:untypedAtomic' to='xs:string'>
                       <data>
                        <slash simple='1'>
@@ -8150,7 +8169,7 @@
                      </convert>
                     </att>
                    </choose>
-                   <choose line='1362'>
+                   <choose line='1363'>
                     <and op='and'>
                      <fn name='exists'>
                       <varRef name='Q{}bindingi' slot='6'/>
@@ -8162,7 +8181,7 @@
                       </slash>
                      </fn>
                     </and>
-                    <att line='1363' name='data-constraint' flags='l'>
+                    <att line='1364' name='data-constraint' flags='l'>
                      <convert from='xs:untypedAtomic' to='xs:string'>
                       <data>
                        <slash simple='1'>
@@ -8173,15 +8192,15 @@
                      </convert>
                     </att>
                    </choose>
-                   <choose line='1365'>
+                   <choose line='1366'>
                     <fn name='exists'>
                      <varRef name='Q{}actions' slot='11'/>
                     </fn>
-                    <att line='1366' name='data-action' flags='l'>
+                    <att line='1367' name='data-action' flags='l'>
                      <varRef name='Q{}myid' slot='3'/>
                     </att>
                    </choose>
-                   <choose line='1369'>
+                   <choose line='1370'>
                     <and op='and'>
                      <fn name='exists'>
                       <varRef name='Q{}bindingi' slot='6'/>
@@ -8193,7 +8212,7 @@
                       </slash>
                      </fn>
                     </and>
-                    <att line='1370' name='data-relevant' flags='l'>
+                    <att line='1371' name='data-relevant' flags='l'>
                      <convert from='xs:untypedAtomic' to='xs:string'>
                       <data>
                        <slash simple='1'>
@@ -8204,12 +8223,12 @@
                      </convert>
                     </att>
                    </choose>
-                   <let line='1373' var='Q{}input-value' as='xs:string' slot='16' eval='16'>
-                    <choose line='1375'>
+                   <let line='1374' var='Q{}input-value' as='xs:string' slot='16' eval='16'>
+                    <choose line='1376'>
                      <fn name='exists'>
                       <varRef name='Q{}instanceField' slot='8'/>
                      </fn>
-                     <cvUntyped line='1376' to='xs:string' diag='3|0|XTTE0570|input-value'>
+                     <cvUntyped line='1377' to='xs:string' diag='3|0|XTTE0570|input-value'>
                       <cast as='xs:untypedAtomic' emptiable='0'>
                        <fn name='string'>
                         <convert from='xs:anyAtomicType' to='xs:string'>
@@ -8223,7 +8242,7 @@
                      <true/>
                      <str val=''/>
                     </choose>
-                    <sequence line='1390'>
+                    <sequence line='1391'>
                      <choose>
                       <choose>
                        <fn name='exists'>
@@ -8243,18 +8262,18 @@
                        <true/>
                        <false/>
                       </choose>
-                      <sequence line='1391'>
+                      <sequence line='1392'>
                        <att name='data-type' flags='l'>
                         <str val='date'/>
                        </att>
-                       <att line='1393' name='type' flags='l'>
+                       <att line='1394' name='type' flags='l'>
                         <str val='date'/>
                        </att>
-                       <att line='1395' name='value' flags='l'>
+                       <att line='1396' name='value' flags='l'>
                         <varRef name='Q{}input-value' slot='16'/>
                        </att>
                       </sequence>
-                      <choose line='1402'>
+                      <choose line='1403'>
                        <fn name='exists'>
                         <varRef name='Q{}bindingi' slot='6'/>
                        </fn>
@@ -8272,18 +8291,18 @@
                        <true/>
                        <false/>
                       </choose>
-                      <sequence line='1403'>
+                      <sequence line='1404'>
                        <att name='data-type' flags='l'>
                         <str val='time'/>
                        </att>
-                       <att line='1405' name='type' flags='l'>
+                       <att line='1406' name='type' flags='l'>
                         <str val='time'/>
                        </att>
-                       <att line='1408' name='value' flags='l'>
+                       <att line='1409' name='value' flags='l'>
                         <varRef name='Q{}input-value' slot='16'/>
                        </att>
                       </sequence>
-                      <choose line='1415'>
+                      <choose line='1416'>
                        <fn name='exists'>
                         <varRef name='Q{}bindingi' slot='6'/>
                        </fn>
@@ -8301,48 +8320,48 @@
                        <true/>
                        <false/>
                       </choose>
-                      <sequence line='1416'>
+                      <sequence line='1417'>
                        <att name='data-type' flags='l'>
                         <str val='checkbox'/>
                        </att>
-                       <att line='1418' name='type' flags='l'>
+                       <att line='1419' name='type' flags='l'>
                         <str val='checkbox'/>
                        </att>
-                       <choose line='1423'>
+                       <choose line='1424'>
                         <fn name='exists'>
                          <varRef name='Q{}instanceField' slot='8'/>
                         </fn>
-                        <choose line='1424'>
+                        <choose line='1425'>
                          <and op='and'>
                           <varRef name='Q{}input-value' slot='16'/>
                           <cast as='xs:boolean' emptiable='0'>
                            <varRef name='Q{}input-value' slot='16'/>
                           </cast>
                          </and>
-                         <att line='1425' name='checked' flags='l'>
+                         <att line='1426' name='checked' flags='l'>
                           <varRef name='Q{}input-value' slot='16'/>
                          </att>
                         </choose>
                        </choose>
                       </sequence>
                       <true/>
-                      <sequence line='1431'>
+                      <sequence line='1432'>
                        <choose>
                         <varRef name='Q{}relevantVar' slot='9'/>
-                        <att line='1432' name='type' flags='l'>
+                        <att line='1433' name='type' flags='l'>
                          <str val='text'/>
                         </att>
                        </choose>
-                       <att line='1434' name='value' flags='l'>
+                       <att line='1435' name='value' flags='l'>
                         <varRef name='Q{}input-value' slot='16'/>
                        </att>
                       </sequence>
                      </choose>
-                     <choose line='1438'>
+                     <choose line='1439'>
                       <fn name='exists'>
                        <varRef name='Q{}hints' slot='12'/>
                       </fn>
-                      <att line='1439' name='title' flags='l'>
+                      <att line='1440' name='title' flags='l'>
                        <fn name='string-join'>
                         <convert from='xs:untypedAtomic' to='xs:string'>
                          <data>
@@ -8355,11 +8374,11 @@
                        </fn>
                       </att>
                      </choose>
-                     <choose line='1441'>
+                     <choose line='1442'>
                       <fn name='exists'>
                        <axis name='attribute' nodeTest='attribute(Q{}size)' jsTest='return item.name===&#39;size&#39;'/>
                       </fn>
-                      <att line='1442' name='size' flags='l'>
+                      <att line='1443' name='size' flags='l'>
                        <convert from='xs:untypedAtomic' to='xs:string'>
                         <attVal name='Q{}size' chk='0'/>
                        </convert>
@@ -8383,9 +8402,9 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='2.0' seq='11' rank='3' minImp='0' slots='10' flags='s' line='1460' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='2.0' seq='11' rank='3' minImp='0' slots='10' flags='s' line='1461' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}textarea)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;textarea&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1461'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1462'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -8398,7 +8417,7 @@
        </check>
       </treat>
      </param>
-     <param line='1462' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1463' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -8410,7 +8429,7 @@
        </check>
       </treat>
      </param>
-     <let line='1466' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='1467' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -8426,7 +8445,7 @@
          <dot type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
         </fn>
         <str val='-'/>
-        <choose line='1464'>
+        <choose line='1465'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -8436,13 +8455,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1468'>
+      <sequence line='1469'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}textarea)' slot='3' eval='16'>
           <dot type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
-          <fn line='2998' name='exists'>
-           <sequence line='2973'>
+          <fn line='3010' name='exists'>
+           <sequence line='2985'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -8454,7 +8473,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2976'>
+             <choose role='matching' line='2988'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -8466,7 +8485,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='2985'>
+            <analyzeString line='2997'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -8477,7 +8496,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2988'>
+             <choose role='matching' line='3000'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -8500,37 +8519,14 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='2998' name='exists'>
-             <sequence line='2973'>
+            <fn line='3010' name='exists'>
+             <sequence line='2985'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
                   <varRef name='Q{}this' slot='4'/>
                   <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
-                 </slash>
-                </data>
-               </cvUntyped>
-               <str role='regex' val='\i\c*\('/>
-               <str role='flags' val=''/>
-               <choose role='matching' line='2976'>
-                <vc op='eq' onEmpty='0' comp='CCC'>
-                 <fn name='substring-before'>
-                  <dot type='xs:string'/>
-                  <str val='('/>
-                 </fn>
-                 <str val='index'/>
-                </vc>
-                <str val='i'/>
-               </choose>
-               <empty role='nonMatching'/>
-              </analyzeString>
-              <analyzeString line='2985'>
-               <cvUntyped role='select' to='xs:string'>
-                <data>
-                 <slash simple='1'>
-                  <varRef name='Q{}this' slot='4'/>
-                  <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
                  </slash>
                 </data>
                </cvUntyped>
@@ -8548,13 +8544,36 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
+              <analyzeString line='2997'>
+               <cvUntyped role='select' to='xs:string'>
+                <data>
+                 <slash simple='1'>
+                  <varRef name='Q{}this' slot='4'/>
+                  <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+                 </slash>
+                </data>
+               </cvUntyped>
+               <str role='regex' val='\i\c*\('/>
+               <str role='flags' val=''/>
+               <choose role='matching' line='3000'>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <fn name='substring-before'>
+                  <dot type='xs:string'/>
+                  <str val='('/>
+                 </fn>
+                 <str val='index'/>
+                </vc>
+                <str val='i'/>
+               </choose>
+               <empty role='nonMatching'/>
+              </analyzeString>
              </sequence>
             </fn>
            </let>
           </filter>
          </fn>
         </and>
-        <ifCall line='1469' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1470' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -8565,60 +8584,60 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1473' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='1474' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='1474' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1475' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
           <callT name='Q{}getBinding' bSlot='30'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='1475' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
+            <dot line='1476' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='1480' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='1481' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='1481' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1482' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
              <callT name='Q{}getDataRef' bSlot='31'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='1482' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
+               <dot line='1483' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='1483' name='Q{}bindingi' slot='5'/>
+               <varRef line='1484' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='1488' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
-          <treat line='1489' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+         <let line='1489' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
+          <treat line='1490' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
            <check card='?' diag='3|0|XTTE0570|instanceField'>
             <callT name='Q{}getReferencedInstanceField' bSlot='32'>
              <withParam name='Q{}refi' flags='c' as='xs:string'>
-              <varRef line='1490' name='Q{}refi' slot='6'/>
+              <varRef line='1491' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </check>
           </treat>
-          <let line='1495' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
-           <treat line='1496' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+          <let line='1496' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
+           <treat line='1497' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
             <callT name='Q{}setActions' bSlot='33'>
              <withParam name='Q{}this' flags='c' as='element()'>
-              <dot line='1497' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
+              <dot line='1498' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
              </withParam>
              <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-              <varRef line='1498' name='Q{}refi' slot='6'/>
+              <varRef line='1499' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </treat>
-           <sequence line='1502'>
+           <sequence line='1503'>
             <choose>
              <fn name='exists'>
               <varRef name='Q{}actions' slot='8'/>
              </fn>
-             <ifCall line='1503' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+             <ifCall line='1504' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
               <check card='1' diag='0|0||ixsl:call'>
                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
               </check>
@@ -8629,13 +8648,13 @@
               </arrayBlock>
              </ifCall>
             </choose>
-            <let line='1508' var='Q{}hints' as='text()*' slot='9' eval='4'>
+            <let line='1509' var='Q{}hints' as='text()*' slot='9' eval='4'>
              <slash simple='2'>
               <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}hint)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;hint&#39;;'/>
               <axis name='child' nodeTest='text()' jsTest='return item.nodeType===3;'/>
              </slash>
-             <elem line='1510' name='textarea' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
-              <sequence line='1511'>
+             <elem line='1511' name='textarea' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+              <sequence line='1512'>
                <copyOf flags='vc'>
                 <filter flags='b'>
                  <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
@@ -8647,8 +8666,8 @@
                  </vc>
                 </filter>
                </copyOf>
-               <att line='1512' name='data-element' flags='l'>
-                <lastOf line='1506'>
+               <att line='1513' name='data-element' flags='l'>
+                <lastOf line='1507'>
                  <fn name='tokenize'>
                   <varRef name='Q{}refi' slot='6'/>
                   <str val='/'/>
@@ -8656,14 +8675,14 @@
                  </fn>
                 </lastOf>
                </att>
-               <att line='1513' name='data-ref' flags='l'>
+               <att line='1514' name='data-ref' flags='l'>
                 <varRef name='Q{}refi' slot='6'/>
                </att>
-               <choose line='1515'>
+               <choose line='1516'>
                 <fn name='exists'>
                  <varRef name='Q{}instanceField' slot='7'/>
                 </fn>
-                <valueOf line='1516' flags='l'>
+                <valueOf line='1517' flags='l'>
                  <convert from='xs:anyAtomicType' to='xs:string'>
                   <data>
                    <varRef name='Q{}instanceField' slot='7'/>
@@ -8671,7 +8690,7 @@
                  </convert>
                 </valueOf>
                 <true/>
-                <sequence line='1518'>
+                <sequence line='1519'>
                  <valueOf flags='Sl'>
                   <str val=''/>
                  </valueOf>
@@ -8680,11 +8699,11 @@
                  </valueOf>
                 </sequence>
                </choose>
-               <choose line='1521'>
+               <choose line='1522'>
                 <fn name='exists'>
                  <varRef name='Q{}hints' slot='9'/>
                 </fn>
-                <att line='1522' name='title' flags='l'>
+                <att line='1523' name='title' flags='l'>
                  <fn name='string-join'>
                   <convert from='xs:untypedAtomic' to='xs:string'>
                    <data>
@@ -8709,9 +8728,9 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='24' rank='1' minImp='0' slots='9' flags='s' line='2042' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='24' rank='1' minImp='0' slots='9' flags='s' line='2054' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}trigger)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;trigger&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2043'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2055'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -8724,7 +8743,7 @@
        </check>
       </treat>
      </param>
-     <param line='2044' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='2056' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -8736,7 +8755,7 @@
        </check>
       </treat>
      </param>
-     <let line='2048' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='2060' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -8752,7 +8771,7 @@
          <dot type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
         </fn>
         <str val='-'/>
-        <choose line='2046'>
+        <choose line='2058'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -8762,13 +8781,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='2050'>
+      <sequence line='2062'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}trigger)' slot='3' eval='16'>
           <dot type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
-          <fn line='2998' name='exists'>
-           <sequence line='2973'>
+          <fn line='3010' name='exists'>
+           <sequence line='2985'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -8780,7 +8799,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2976'>
+             <choose role='matching' line='2988'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -8792,7 +8811,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='2985'>
+            <analyzeString line='2997'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -8803,7 +8822,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2988'>
+             <choose role='matching' line='3000'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -8826,37 +8845,14 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='2998' name='exists'>
-             <sequence line='2973'>
+            <fn line='3010' name='exists'>
+             <sequence line='2985'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
                   <varRef name='Q{}this' slot='4'/>
                   <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
-                 </slash>
-                </data>
-               </cvUntyped>
-               <str role='regex' val='\i\c*\('/>
-               <str role='flags' val=''/>
-               <choose role='matching' line='2976'>
-                <vc op='eq' onEmpty='0' comp='CCC'>
-                 <fn name='substring-before'>
-                  <dot type='xs:string'/>
-                  <str val='('/>
-                 </fn>
-                 <str val='index'/>
-                </vc>
-                <str val='i'/>
-               </choose>
-               <empty role='nonMatching'/>
-              </analyzeString>
-              <analyzeString line='2985'>
-               <cvUntyped role='select' to='xs:string'>
-                <data>
-                 <slash simple='1'>
-                  <varRef name='Q{}this' slot='4'/>
-                  <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
                  </slash>
                 </data>
                </cvUntyped>
@@ -8874,13 +8870,36 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
+              <analyzeString line='2997'>
+               <cvUntyped role='select' to='xs:string'>
+                <data>
+                 <slash simple='1'>
+                  <varRef name='Q{}this' slot='4'/>
+                  <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+                 </slash>
+                </data>
+               </cvUntyped>
+               <str role='regex' val='\i\c*\('/>
+               <str role='flags' val=''/>
+               <choose role='matching' line='3000'>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <fn name='substring-before'>
+                  <dot type='xs:string'/>
+                  <str val='('/>
+                 </fn>
+                 <str val='index'/>
+                </vc>
+                <str val='i'/>
+               </choose>
+               <empty role='nonMatching'/>
+              </analyzeString>
              </sequence>
             </fn>
            </let>
           </filter>
          </fn>
         </and>
-        <ifCall line='2051' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='2063' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -8891,50 +8910,50 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='2055' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='2056' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='2067' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='2068' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
           <callT name='Q{}getBinding' bSlot='34'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='2057' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
+            <dot line='2069' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='2062' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='2063' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='2074' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='2075' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
              <callT name='Q{}getDataRef' bSlot='35'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='2064' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
+               <dot line='2076' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='2065' name='Q{}bindingi' slot='5'/>
+               <varRef line='2077' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='2072' var='Q{}actions' as='map(*)*' slot='7' eval='8'>
-          <treat line='2073' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+         <let line='2084' var='Q{}actions' as='map(*)*' slot='7' eval='8'>
+          <treat line='2085' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
            <callT name='Q{}setActions' bSlot='36'>
             <withParam name='Q{}this' flags='c' as='element()'>
-             <dot line='2074' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
+             <dot line='2086' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
             </withParam>
             <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-             <varRef line='2075' name='Q{}refi' slot='6'/>
+             <varRef line='2087' name='Q{}refi' slot='6'/>
             </withParam>
            </callT>
           </treat>
-          <sequence line='2079'>
+          <sequence line='2091'>
            <choose>
             <fn name='exists'>
              <varRef name='Q{}actions' slot='7'/>
             </fn>
-            <ifCall line='2080' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+            <ifCall line='2092' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
              <check card='1' diag='0|0||ixsl:call'>
               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
              </check>
@@ -8945,28 +8964,28 @@
              </arrayBlock>
             </ifCall>
            </choose>
-           <let line='2083' var='Q{}innerbody' as='document-node()' slot='8' eval='16'>
-            <doc line='2085' validation='preserve'>
+           <let line='2095' var='Q{}innerbody' as='document-node()' slot='8' eval='16'>
+            <doc line='2097' validation='preserve'>
              <choose>
               <fn name='exists'>
                <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
               </fn>
-              <applyT line='2086' bSlot='37'>
+              <applyT line='2098' bSlot='37'>
                <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
               </applyT>
               <true/>
-              <valueOf line='2088' flags='l'>
+              <valueOf line='2100' flags='l'>
                <str val=' '/>
               </valueOf>
              </choose>
             </doc>
-            <elem line='2092' name='span' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+            <elem line='2104' name='span' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
              <sequence>
               <att name='style' flags='l'>
                <str val='display:&#39;inline&#39;'/>
               </att>
-              <compElem line='2103' flags='l'>
-               <choose role='name' line='2095'>
+              <compElem line='2115' flags='l'>
+               <choose role='name' line='2107'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <cast as='xs:string' emptiable='1'>
                   <attVal name='Q{}appearance' chk='0'/>
@@ -8977,7 +8996,7 @@
                 <true/>
                 <str val='button'/>
                </choose>
-               <sequence role='content' line='2104'>
+               <sequence role='content' line='2116'>
                 <choose>
                  <vc op='eq' onEmpty='0' comp='CCC'>
                   <cast as='xs:string' emptiable='1'>
@@ -8985,17 +9004,17 @@
                   </cast>
                   <str val='minimal'/>
                  </vc>
-                 <att line='2105' name='type' flags='l'>
+                 <att line='2117' name='type' flags='l'>
                   <str val='button'/>
                  </att>
                 </choose>
-                <att line='2108' name='data-ref' flags='l'>
+                <att line='2120' name='data-ref' flags='l'>
                  <varRef name='Q{}refi' slot='6'/>
                 </att>
-                <att line='2109' name='data-action' flags='l'>
+                <att line='2121' name='data-action' flags='l'>
                  <varRef name='Q{}myid' slot='2'/>
                 </att>
-                <copyOf line='2110' flags='vc'>
+                <copyOf line='2122' flags='vc'>
                  <varRef name='Q{}innerbody' slot='8'/>
                 </copyOf>
                </sequence>
@@ -9011,13 +9030,13 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='6' rank='1' minImp='0' slots='0' flags='s' line='1087' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='6' rank='1' minImp='0' slots='0' flags='s' line='1088' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
     <empty role='action'/>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='17' rank='1' minImp='0' slots='1' flags='s' line='1688' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='17' rank='1' minImp='0' slots='1' flags='s' line='1689' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1689'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1690'>
      <param name='Q{}selectedValue' slot='0' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|selectedValue'>
@@ -9030,7 +9049,7 @@
        </check>
       </treat>
      </param>
-     <elem line='1691' name='option' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
+     <elem line='1692' name='option' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
       <sequence>
        <att name='value' flags='l'>
         <fn name='string-join'>
@@ -9042,7 +9061,7 @@
          <str val=' '/>
         </fn>
        </att>
-       <choose line='1692'>
+       <choose line='1693'>
         <vc op='eq' onEmpty='0' comp='CCC'>
          <varRef name='Q{}selectedValue' slot='0'/>
          <cast as='xs:string' emptiable='1'>
@@ -9054,11 +9073,11 @@
           </atomSing>
          </cast>
         </vc>
-        <att line='1693' name='selected' flags='l'>
+        <att line='1694' name='selected' flags='l'>
          <varRef name='Q{}selectedValue' slot='0'/>
         </att>
        </choose>
-       <valueOf line='1696' flags='l'>
+       <valueOf line='1697' flags='l'>
         <fn name='string-join'>
          <convert from='xs:untypedAtomic' to='xs:string'>
           <data>
@@ -9072,24 +9091,24 @@
      </elem>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='25' part='4' rank='1' minImp='0' slots='1' flags='s' line='2124' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='25' part='4' rank='1' minImp='0' slots='1' flags='s' line='2136' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}script)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;script&#39;;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2132' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2133' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2144' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2145' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
       <check card='1' diag='3|0|XTTE0570|action-map'>
        <callT name='Q{}setAction' bSlot='2'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2134' type='element()'/>
+         <dot line='2146' type='element()'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <varRef line='2147' name='Q{}action-map' slot='0'/>
+     <varRef line='2159' name='Q{}action-map' slot='0'/>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='-0.5' seq='14' part='1' rank='0' minImp='0' slots='0' flags='s' line='1649' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='14' part='1' rank='0' minImp='0' slots='0' flags='s' line='1650' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
-    <copy role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1651' flags='cin'>
+    <copy role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1652' flags='cin'>
      <applyT role='content' bSlot='38'>
       <sequence role='select'>
        <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
@@ -9098,16 +9117,16 @@
      </applyT>
     </copy>
    </templateRule>
-   <templateRule prec='0' prio='0.5' seq='15' rank='2' minImp='0' slots='0' flags='s' line='1660' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.5' seq='15' rank='2' minImp='0' slots='0' flags='s' line='1661' module='saxon-xforms.xsl'>
     <p.withPredicate role='match'>
      <p.nodeTest test='text()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===3;'/>
-     <axis ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1660' name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
+     <axis ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1661' name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
     </p.withPredicate>
     <empty role='action'/>
    </templateRule>
-   <templateRule prec='0' prio='-0.5' seq='14' rank='0' minImp='0' slots='0' flags='s' line='1649' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='14' rank='0' minImp='0' slots='0' flags='s' line='1650' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='( element() | text() | comment() | processing-instruction() )' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);'/>
-    <copy role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1651' flags='cin'>
+    <copy role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1652' flags='cin'>
      <applyT role='content' bSlot='38'>
       <sequence role='select'>
        <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
@@ -9119,8 +9138,8 @@
   </mode>
  </co>
  <co id='62' binds='61'>
-  <template name='Q{}getDataRef' flags='os' line='3326' module='saxon-xforms.xsl' slots='16'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3327'>
+  <template name='Q{}getDataRef' flags='os' line='3338' module='saxon-xforms.xsl' slots='16'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3339'>
     <param name='Q{}this' slot='0' flags='r' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
       <check card='1' diag='8|0|XTTE0590|this'>
@@ -9128,7 +9147,7 @@
       </check>
      </treat>
     </param>
-    <param line='3328' name='Q{}nodeset' slot='1' flags='t' as='xs:string'>
+    <param line='3340' name='Q{}nodeset' slot='1' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -9140,7 +9159,7 @@
       </check>
      </treat>
     </param>
-    <param line='3329' name='Q{}bindingi' slot='2' as='node()?'>
+    <param line='3341' name='Q{}bindingi' slot='2' as='node()?'>
      <empty role='select'/>
      <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|bindingi'>
       <check card='?' diag='8|0|XTTE0590|bindingi'>
@@ -9148,7 +9167,7 @@
       </check>
      </treat>
     </param>
-    <let line='3337' var='Q{}this-ref' as='xs:string?' slot='3' eval='7'>
+    <let line='3349' var='Q{}this-ref' as='xs:string?' slot='3' eval='7'>
      <choose>
       <fn name='exists'>
        <slash simple='1'>
@@ -9183,12 +9202,12 @@
        </cast>
       </fn>
      </choose>
-     <let line='3344' var='Q{}this-binding-ref' as='xs:string?' slot='4' eval='7'>
-      <choose line='3346'>
+     <let line='3356' var='Q{}this-binding-ref' as='xs:string?' slot='4' eval='7'>
+      <choose line='3358'>
        <fn name='exists'>
         <varRef name='Q{}bindingi' slot='2'/>
        </fn>
-       <cvUntyped line='3357' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
+       <cvUntyped line='3369' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
         <cast as='xs:untypedAtomic' emptiable='0'>
          <choose>
           <fn name='exists'>
@@ -9222,23 +9241,23 @@
         </cast>
        </cvUntyped>
        <true/>
-       <let line='3361' var='Q{}this-binding' as='node()?' slot='5' eval='7'>
-        <treat line='3362' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|this-binding'>
+       <let line='3373' var='Q{}this-binding' as='node()?' slot='5' eval='7'>
+        <treat line='3374' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|this-binding'>
          <check card='?' diag='3|0|XTTE0570|this-binding'>
           <callT name='Q{}getBinding' bSlot='0'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <treat line='3363' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+            <treat line='3375' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
              <dot flags='a'/>
             </treat>
            </withParam>
           </callT>
          </check>
         </treat>
-        <choose line='3366'>
+        <choose line='3378'>
          <fn name='exists'>
           <varRef name='Q{}this-binding' slot='5'/>
          </fn>
-         <cvUntyped line='3373' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
+         <cvUntyped line='3385' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
           <cast as='xs:untypedAtomic' emptiable='0'>
            <choose>
             <fn name='exists'>
@@ -9274,11 +9293,11 @@
         </choose>
        </let>
       </choose>
-      <choose line='3383'>
+      <choose line='3395'>
        <fn name='exists'>
         <varRef name='Q{}bindingi' slot='2'/>
        </fn>
-       <let line='3385' var='Q{}relative' as='xs:string' slot='6' eval='16'>
+       <let line='3397' var='Q{}relative' as='xs:string' slot='6' eval='16'>
         <check card='1' diag='0|1||xforms:resolveXPathStrings'>
          <varRef name='Q{}this-binding-ref' slot='4'/>
         </check>
@@ -9297,7 +9316,7 @@
          <varRef line='845' name='Q{}relative' slot='6'/>
         </choose>
        </let>
-       <and line='3387' op='and'>
+       <and line='3399' op='and'>
         <fn name='exists'>
          <varRef name='Q{}this-ref' slot='3'/>
         </fn>
@@ -9305,7 +9324,7 @@
          <varRef name='Q{}nodeset' slot='1'/>
         </fn>
        </and>
-       <let line='3342' var='Q{}base' as='xs:string' slot='7' eval='16'>
+       <let line='3354' var='Q{}base' as='xs:string' slot='7' eval='16'>
         <choose>
          <fn name='exists'>
           <slash simple='1'>
@@ -9326,7 +9345,7 @@
          <true/>
          <str val='.'/>
         </choose>
-        <let line='3388' var='Q{}relative' as='xs:string' slot='8' eval='16'>
+        <let line='3400' var='Q{}relative' as='xs:string' slot='8' eval='16'>
          <check card='1' diag='0|1||xforms:resolveXPathStrings'>
           <varRef name='Q{}this-ref' slot='3'/>
          </check>
@@ -9460,10 +9479,10 @@
          </choose>
         </let>
        </let>
-       <fn line='3390' name='exists'>
+       <fn line='3402' name='exists'>
         <varRef name='Q{}this-ref' slot='3'/>
        </fn>
-       <let line='3392' var='Q{}relative' as='xs:string' slot='12' eval='16'>
+       <let line='3404' var='Q{}relative' as='xs:string' slot='12' eval='16'>
         <check card='1' diag='0|1||xforms:resolveXPathStrings'>
          <varRef name='Q{}this-ref' slot='3'/>
         </check>
@@ -9478,7 +9497,7 @@
           <str val='instance('/>
          </fn>
          <varRef line='842' name='Q{}relative' slot='12'/>
-         <fn line='3392' name='not'>
+         <fn line='3404' name='not'>
           <varRef name='Q{}nodeset' slot='1'/>
          </fn>
          <varRef line='845' name='Q{}relative' slot='12'/>
@@ -9491,7 +9510,7 @@
            <str val='.'/>
           </vc>
          </or>
-         <varRef line='3392' name='Q{}nodeset' slot='1'/>
+         <varRef line='3404' name='Q{}nodeset' slot='1'/>
          <true/>
          <let line='852' var='Q{}parentCallCount' as='xs:integer' slot='13' eval='16'>
           <choose>
@@ -9522,13 +9541,13 @@
           </choose>
           <let line='855' var='Q{}slashes' as='xs:integer*' slot='14' eval='4'>
            <choose>
-            <fn line='3392' name='contains'>
+            <fn line='3404' name='contains'>
              <varRef name='Q{}nodeset' slot='1'/>
              <str val='/'/>
             </fn>
             <fn name='index-of'>
              <fn name='string-to-codepoints'>
-              <varRef line='3392' name='Q{}nodeset' slot='1'/>
+              <varRef line='3404' name='Q{}nodeset' slot='1'/>
              </fn>
              <int val='47'/>
             </fn>
@@ -9541,7 +9560,7 @@
             </compareToInt>
             <fn line='891' name='concat'>
              <fn name='substring'>
-              <varRef line='3392' name='Q{}nodeset' slot='1'/>
+              <varRef line='3404' name='Q{}nodeset' slot='1'/>
               <int val='1'/>
               <choose line='866'>
                <and op='and'>
@@ -9586,7 +9605,7 @@
              </fn>
             </fn>
             <true/>
-            <fn line='3392' name='concat'>
+            <fn line='3404' name='concat'>
              <varRef name='Q{}nodeset' slot='1'/>
              <str val='/'/>
              <varRef line='894' name='Q{}relative' slot='12'/>
@@ -9596,8 +9615,8 @@
          </let>
         </choose>
        </let>
-       <varRef line='3394' name='Q{}nodeset' slot='1'/>
-       <choose line='3397'>
+       <varRef line='3406' name='Q{}nodeset' slot='1'/>
+       <choose line='3409'>
         <fn name='starts-with'>
          <varRef name='Q{}nodeset' slot='1'/>
          <str val='/'/>
@@ -9612,7 +9631,7 @@
         <varRef name='Q{}nodeset' slot='1'/>
        </choose>
        <true/>
-       <cvUntyped line='3401' to='xs:string' diag='3|0|XTTE0570|data-ref'>
+       <cvUntyped line='3413' to='xs:string' diag='3|0|XTTE0570|data-ref'>
         <cast as='xs:untypedAtomic' emptiable='0'>
          <varRef name='Q{}nodeset' slot='1'/>
         </cast>
@@ -9624,17 +9643,17 @@
   </template>
  </co>
  <co id='5' binds='23'>
-  <function name='Q{http://www.w3.org/2002/xforms}setInstance-JS' line='3235' module='saxon-xforms.xsl' eval='7' flags='pU' as='empty-sequence()' slots='2'>
+  <function name='Q{http://www.w3.org/2002/xforms}setInstance-JS' line='3247' module='saxon-xforms.xsl' eval='7' flags='pU' as='empty-sequence()' slots='2'>
    <arg name='Q{}ref' as='xs:string'/>
    <arg name='Q{}updatedInstance' as='element()'/>
-   <check role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3243' card='°' diag='5|0|XTTE0780|xforms:setInstance-JS#2'>
+   <check role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3255' card='°' diag='5|0|XTTE0780|xforms:setInstance-JS#2'>
     <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
      <check card='1' diag='0|0||ixsl:call'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
      </check>
      <str val='setInstance'/>
      <arrayBlock>
-      <check line='3241' card='1' diag='3|0|XTTE0570|this-instance-id'>
+      <check line='3253' card='1' diag='3|0|XTTE0570|this-instance-id'>
        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
         <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='0' eval='6'>
          <varRef name='Q{}ref' slot='0'/>
@@ -9649,14 +9668,14 @@
   </function>
  </co>
  <co id='34' binds='2 23'>
-  <function name='Q{http://www.w3.org/2002/xforms}getInstance-JS' line='3208' module='saxon-xforms.xsl' eval='7' flags='pU' as='element()?' slots='1'>
+  <function name='Q{http://www.w3.org/2002/xforms}getInstance-JS' line='3220' module='saxon-xforms.xsl' eval='7' flags='pU' as='element()?' slots='1'>
    <arg name='Q{}ref' as='xs:string'/>
-   <tailCallLoop role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3212'>
+   <tailCallLoop role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3224'>
     <choose>
      <fn name='not'>
       <varRef name='Q{}ref' slot='0'/>
      </fn>
-     <treat line='3213' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='5|0|XTTE0780|xforms:getInstance-JS#1'>
+     <treat line='3225' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='5|0|XTTE0780|xforms:getInstance-JS#1'>
       <message>
        <valueOf role='select'>
         <str val='[xforms:getInstance-JS] Empty ref supplied, no instance will be returned'/>
@@ -9666,8 +9685,8 @@
       </message>
      </treat>
      <true/>
-     <ufCall line='3218' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='foreign' bSlot='0' eval='16'>
-      <check line='3216' card='1' diag='3|0|XTTE0570|this-instance-id'>
+     <ufCall line='3230' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='foreign' bSlot='0' eval='16'>
+      <check line='3228' card='1' diag='3|0|XTTE0570|this-instance-id'>
        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
         <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='1' eval='6'>
          <varRef name='Q{}ref' slot='0'/>
@@ -9681,53 +9700,53 @@
   </function>
  </co>
  <co id='23' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}getInstanceMap' line='3105' module='saxon-xforms.xsl' eval='8' flags='pU' as='map(xs:string, xs:string)' slots='3'>
+  <function name='Q{http://www.w3.org/2002/xforms}getInstanceMap' line='3117' module='saxon-xforms.xsl' eval='8' flags='pU' as='map(xs:string, xs:string)' slots='3'>
    <arg name='Q{}nodeset' as='xs:string'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3126' var='Q{http://saxon.sf.net/generated-variable}v0' as='map(xs:string, xs:string)+' slot='1' eval='4'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3138' var='Q{http://saxon.sf.net/generated-variable}v0' as='map(xs:string, xs:string)+' slot='1' eval='4'>
     <sequence>
      <map size='1'>
       <str val='instance-id'/>
       <str val='saxon-forms-default'/>
      </map>
-     <ifCall line='3127' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+     <ifCall line='3139' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
       <str val='xpath'/>
       <fn name='normalize-space'>
        <varRef name='Q{}nodeset' slot='0'/>
       </fn>
      </ifCall>
     </sequence>
-    <ifCall line='3110' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+    <ifCall line='3122' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
      <analyzeString>
       <fn role='select' name='normalize-space'>
        <varRef name='Q{}nodeset' slot='0'/>
       </fn>
       <str role='regex' val='^instance\s*\(\s*&#39;([^&#39;]+)&#39;\s*\)\s*(/\s*(.*)|)$'/>
       <str role='flags' val=''/>
-      <let role='matching' line='3112' var='Q{}xpath' as='xs:string' slot='2' eval='16'>
-       <choose line='3114'>
+      <let role='matching' line='3124' var='Q{}xpath' as='xs:string' slot='2' eval='16'>
+       <choose line='3126'>
         <fn name='regex-group'>
          <int val='2'/>
         </fn>
-        <fn line='3115' name='regex-group'>
+        <fn line='3127' name='regex-group'>
          <int val='3'/>
         </fn>
         <true/>
         <str val='.'/>
        </choose>
-       <sequence line='3122'>
+       <sequence line='3134'>
         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
          <str val='instance-id'/>
          <fn name='regex-group'>
           <int val='1'/>
          </fn>
         </ifCall>
-        <ifCall line='3123' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+        <ifCall line='3135' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
          <str val='xpath'/>
          <varRef name='Q{}xpath' slot='2'/>
         </ifCall>
        </sequence>
       </let>
-      <varRef role='nonMatching' line='3126' name='Q{http://saxon.sf.net/generated-variable}v0' slot='1'/>
+      <varRef role='nonMatching' line='3138' name='Q{http://saxon.sf.net/generated-variable}v0' slot='1'/>
      </analyzeString>
      <map size='2'>
       <str val='duplicates'/>
@@ -9740,13 +9759,13 @@
   </function>
  </co>
  <co id='1' binds='23'>
-  <function name='Q{http://www.w3.org/2002/xforms}getInstanceId' line='3092' module='saxon-xforms.xsl' eval='8' flags='pU' as='xs:string' slots='1'>
+  <function name='Q{http://www.w3.org/2002/xforms}getInstanceId' line='3104' module='saxon-xforms.xsl' eval='8' flags='pU' as='xs:string' slots='1'>
    <arg name='Q{}nodeset' as='xs:string'/>
-   <cvUntyped role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3095' to='xs:string' diag='5|0|XTTE0780|xforms:getInstanceId#1'>
+   <cvUntyped role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3107' to='xs:string' diag='5|0|XTTE0780|xforms:getInstanceId#1'>
     <cast as='xs:untypedAtomic' emptiable='0'>
      <fn name='string'>
       <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-       <ufCall line='3094' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='0' eval='6'>
+       <ufCall line='3106' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='0' eval='6'>
         <varRef name='Q{}nodeset' slot='0'/>
        </ufCall>
        <str val='instance-id'/>
@@ -9756,17 +9775,17 @@
    </cvUntyped>
   </function>
  </co>
- <co id='46' binds='44'>
-  <globalVariable name='Q{http://saxon.sf.net/generated-variable}gg1399833911' type='element()*' line='4247' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='function test(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};if (test(val)) {return val;} else {throw SaxonJS.XError(&#39;Conversion failed&#39;, &#39;XTTE0590&#39;);}' jsCardCheck='function c() {return true;};'>
-   <slash ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4247' simple='1'>
-    <gVarRef name='Q{}xforms-doc' bSlot='0'/>
-    <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-   </slash>
-  </globalVariable>
- </co>
  <co id='64' binds=''>
   <globalVariable name='Q{}debugMode' type='xs:boolean' line='75' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.boolean.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
    <true/>
+  </globalVariable>
+ </co>
+ <co id='46' binds='44'>
+  <globalVariable name='Q{http://saxon.sf.net/generated-variable}gg1090039905' type='element()*' line='4274' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='function test(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};if (test(val)) {return val;} else {throw SaxonJS.XError(&#39;Conversion failed&#39;, &#39;XTTE0590&#39;);}' jsCardCheck='function c() {return true;};'>
+   <slash ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4274' simple='1'>
+    <gVarRef name='Q{}xforms-doc' bSlot='0'/>
+    <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+   </slash>
   </globalVariable>
  </co>
  <co id='65' binds=''>
@@ -9812,8 +9831,8 @@
   </function>
  </co>
  <co id='66' binds='1 2 3 15 19 20'>
-  <template name='Q{}DOMActivate' flags='os' line='4488' module='saxon-xforms.xsl' slots='9'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4489'>
+  <template name='Q{}DOMActivate' flags='os' line='4515' module='saxon-xforms.xsl' slots='9'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4516'>
     <param name='Q{}form-control' slot='0' flags='i' as='node()'>
      <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|form-control'>
       <check card='1' diag='8|0|XTTE0590|form-control'>
@@ -9821,7 +9840,7 @@
       </check>
      </treat>
     </param>
-    <let line='4491' var='Q{}actions' as='map(*)?' slot='1' eval='7'>
+    <let line='4518' var='Q{}actions' as='map(*)?' slot='1' eval='7'>
      <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
@@ -9838,12 +9857,12 @@
        </arrayBlock>
       </ifCall>
      </treat>
-     <let line='4493' var='Q{}refi' as='attribute(Q{}data-ref)?' slot='2' eval='8'>
+     <let line='4520' var='Q{}refi' as='attribute(Q{}data-ref)?' slot='2' eval='8'>
       <slash simple='1'>
        <varRef name='Q{}form-control' slot='0'/>
        <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
       </slash>
-      <let line='4495' var='Q{}instance-id' as='xs:string' slot='3' eval='16'>
+      <let line='4522' var='Q{}instance-id' as='xs:string' slot='3' eval='16'>
        <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='16'>
         <check card='1' diag='0|0||xforms:getInstanceId'>
          <cvUntyped to='xs:string'>
@@ -9853,12 +9872,12 @@
          </cvUntyped>
         </check>
        </ufCall>
-       <let line='4508' var='Q{}instanceXML' as='element()?' slot='4' eval='7'>
+       <let line='4535' var='Q{}instanceXML' as='element()?' slot='4' eval='7'>
         <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='6'>
          <varRef name='Q{}instance-id' slot='3'/>
         </ufCall>
-        <let line='4510' var='Q{}updatedInstanceXML' as='element()?' slot='5' eval='7'>
-         <choose line='4512'>
+        <let line='4537' var='Q{}updatedInstanceXML' as='element()?' slot='5' eval='7'>
+         <choose line='4539'>
           <and op='and'>
            <fn name='exists'>
             <varRef name='Q{}refi' slot='2'/>
@@ -9867,8 +9886,8 @@
             <varRef name='Q{}instanceXML' slot='4'/>
            </fn>
           </and>
-          <let line='4513' var='Q{}updatedNode' as='node()' slot='6' eval='16'>
-           <treat line='4514' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|updatedNode'>
+          <let line='4540' var='Q{}updatedNode' as='node()' slot='6' eval='16'>
+           <treat line='4541' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|updatedNode'>
             <check card='1' diag='3|0|XTTE0570|updatedNode'>
              <evaluate dxns=''>
               <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
@@ -9890,8 +9909,8 @@
              </evaluate>
             </check>
            </treat>
-           <let line='4516' var='Q{}new-value' as='xs:string' slot='7' eval='16'>
-            <treat line='4517' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-value'>
+           <let line='4543' var='Q{}new-value' as='xs:string' slot='7' eval='16'>
+            <treat line='4544' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-value'>
              <check card='1' diag='3|0|XTTE0570|new-value'>
               <cvUntyped to='xs:string' diag='3|0|XTTE0570|new-value'>
                <data>
@@ -9902,18 +9921,18 @@
               </cvUntyped>
              </check>
             </treat>
-            <treat line='4519' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+            <treat line='4546' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
              <check card='?' diag='3|0|XTTE0570|updatedInstanceXML'>
               <applyT mode='Q{}recalculate' bSlot='4'>
                <varRef role='select' name='Q{}instanceXML' slot='4'/>
                <withParam name='Q{}instance-id' as='xs:string'>
-                <varRef line='4520' name='Q{}instance-id' slot='3'/>
+                <varRef line='4547' name='Q{}instance-id' slot='3'/>
                </withParam>
                <withParam name='Q{}updated-nodes' flags='t' as='node()'>
-                <varRef line='4521' name='Q{}updatedNode' slot='6'/>
+                <varRef line='4548' name='Q{}updatedNode' slot='6'/>
                </withParam>
                <withParam name='Q{}updated-values' flags='t' as='xs:string'>
-                <varRef line='4522' name='Q{}new-value' slot='7'/>
+                <varRef line='4549' name='Q{}new-value' slot='7'/>
                </withParam>
               </applyT>
              </check>
@@ -9921,18 +9940,18 @@
            </let>
           </let>
           <true/>
-          <varRef line='4526' name='Q{}instanceXML' slot='4'/>
+          <varRef line='4553' name='Q{}instanceXML' slot='4'/>
          </choose>
-         <forEach line='4533'>
+         <forEach line='4560'>
           <varRef name='Q{}actions' slot='1'/>
-          <let line='4534' var='Q{}action-map' as='map(*)' slot='8' eval='16'>
+          <let line='4561' var='Q{}action-map' as='map(*)' slot='8' eval='16'>
            <dot type='map(*)'/>
-           <choose line='4537'>
+           <choose line='4564'>
             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
              <varRef name='Q{}action-map' slot='8'/>
              <str val='@event'/>
             </ifCall>
-            <choose line='4538'>
+            <choose line='4565'>
              <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
               <data>
                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
@@ -9942,12 +9961,12 @@
               </data>
               <str val='DOMActivate'/>
              </gc>
-             <callT line='4539' name='Q{}applyActions' bSlot='5' flags='t'>
+             <callT line='4566' name='Q{}applyActions' bSlot='5' flags='t'>
               <withParam name='Q{}action-map' flags='t' as='item()'>
-               <varRef line='4540' name='Q{}action-map' slot='8'/>
+               <varRef line='4567' name='Q{}action-map' slot='8'/>
               </withParam>
               <withParam name='Q{}instanceXML' flags='t' as='element()?'>
-               <varRef line='4541' name='Q{}updatedInstanceXML' slot='5'/>
+               <varRef line='4568' name='Q{}updatedInstanceXML' slot='5'/>
               </withParam>
              </callT>
             </choose>
@@ -9963,8 +9982,8 @@
   </template>
  </co>
  <co id='63' binds='43'>
-  <template name='Q{}setActions' flags='os' line='3654' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3655'>
+  <template name='Q{}setActions' flags='os' line='3666' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3667'>
     <param name='Q{}this' slot='0' flags='i' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
       <check card='1' diag='8|0|XTTE0590|this'>
@@ -9972,7 +9991,7 @@
       </check>
      </treat>
     </param>
-    <applyT line='3657' flags='t' bSlot='0'>
+    <applyT line='3669' flags='t' bSlot='0'>
      <union role='select' op='|'>
       <union op='|'>
        <union op='|'>
@@ -10036,8 +10055,8 @@
   </template>
  </co>
  <co id='67' binds=''>
-  <template name='Q{}serverError' flags='os' line='1066' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1067'>
+  <template name='Q{}serverError' flags='os' line='1067' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1068'>
     <param name='Q{}responseMap' slot='0' flags='i' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|responseMap'>
       <check card='1' diag='8|0|XTTE0590|responseMap'>
@@ -10045,7 +10064,7 @@
       </check>
      </treat>
     </param>
-    <message line='1068'>
+    <message line='1069'>
      <sequence role='select'>
       <valueOf>
        <str val='Server side error HTTP response - '/>
@@ -10075,8 +10094,8 @@
   </template>
  </co>
  <co id='60' binds='61 62 43'>
-  <template name='Q{}setAction' flags='os' line='3821' module='saxon-xforms.xsl' slots='15'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3822'>
+  <template name='Q{}setAction' flags='os' line='3846' module='saxon-xforms.xsl' slots='20'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3847'>
     <param name='Q{}this' slot='0' flags='i' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
       <check card='1' diag='8|0|XTTE0590|this'>
@@ -10084,42 +10103,42 @@
       </check>
      </treat>
     </param>
-    <param line='3823' name='Q{}nodeset' slot='1' flags='t'>
+    <param line='3848' name='Q{}nodeset' slot='1' flags='t'>
      <str role='select' val=''/>
      <supplied role='conversion' slot='1'/>
     </param>
-    <let line='3826' var='Q{}bindingi' as='node()?' slot='2' eval='7'>
-     <treat line='3827' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+    <let line='3851' var='Q{}bindingi' as='node()?' slot='2' eval='7'>
+     <treat line='3852' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
       <check card='?' diag='3|0|XTTE0570|bindingi'>
        <callT name='Q{}getBinding' bSlot='0'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <treat line='3828' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+         <treat line='3853' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
           <dot flags='a'/>
          </treat>
         </withParam>
        </callT>
       </check>
      </treat>
-     <let line='3833' var='Q{}refi' as='xs:string' slot='3' eval='16'>
-      <treat line='3834' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+     <let line='3858' var='Q{}refi' as='xs:string' slot='3' eval='16'>
+      <treat line='3859' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
        <check card='1' diag='3|0|XTTE0570|refi'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
          <data>
           <callT name='Q{}getDataRef' bSlot='1'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <treat line='3835' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+            <treat line='3860' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
              <dot flags='a'/>
             </treat>
            </withParam>
            <withParam name='Q{}bindingi' flags='c' as='node()?'>
-            <varRef line='3836' name='Q{}bindingi' slot='2'/>
+            <varRef line='3861' name='Q{}bindingi' slot='2'/>
            </withParam>
           </callT>
          </data>
         </cvUntyped>
        </check>
       </treat>
-      <ifCall line='3844' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+      <ifCall line='3869' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
        <sequence>
         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
          <str val='name'/>
@@ -10129,14 +10148,14 @@
           </treat>
          </fn>
         </ifCall>
-        <choose line='3846'>
+        <choose line='3871'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}value)' jsTest='return item.name===&#39;value&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3847' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3872' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@value'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10146,7 +10165,7 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3849'>
+        <choose line='3874'>
          <and op='and'>
           <fn name='empty'>
            <slash simple='1'>
@@ -10163,25 +10182,25 @@
            </slash>
           </fn>
          </and>
-         <ifCall line='3850' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3875' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='value'/>
           <fn name='string'>
            <dot flags='a'/>
           </fn>
          </ifCall>
         </choose>
-        <ifCall line='3853' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+        <ifCall line='3878' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
          <str val='@ref'/>
          <varRef name='Q{}refi' slot='3'/>
         </ifCall>
-        <choose line='3859'>
+        <choose line='3884'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}position)' jsTest='return item.name===&#39;position&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3860' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3885' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@position'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10191,14 +10210,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3862'>
+        <choose line='3887'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}at)' jsTest='return item.name===&#39;at&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3863' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3888' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@at'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10208,14 +10227,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3867'>
+        <choose line='3892'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}if)' jsTest='return item.name===&#39;if&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3868' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3893' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@if'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10225,14 +10244,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3872'>
+        <choose line='3897'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}while)' jsTest='return item.name===&#39;while&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3873' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3898' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@while'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10242,14 +10261,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3876'>
+        <choose line='3901'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='@*:event' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===2&amp;&amp;q.local===&#39;event&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3877' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3902' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@event'/>
           <fn name='string'>
            <check card='?' diag='0|0||fn:string'>
@@ -10261,14 +10280,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3879'>
+        <choose line='3904'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}submission)' jsTest='return item.name===&#39;submission&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3880' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3905' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@submission'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10278,14 +10297,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3883'>
+        <choose line='3908'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}model)' jsTest='return item.name===&#39;model&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3884' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3909' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@model'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10295,14 +10314,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3887'>
+        <choose line='3912'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}control)' jsTest='return item.name===&#39;control&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3888' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3913' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@control'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10312,14 +10331,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3891'>
+        <choose line='3916'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}repeat)' jsTest='return item.name===&#39;repeat&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3892' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3917' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@repeat'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10329,14 +10348,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3895'>
+        <choose line='3920'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}index)' jsTest='return item.name===&#39;index&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3896' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3921' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@index'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10346,16 +10365,16 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3901'>
+        <choose line='3924'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}origin)' jsTest='return item.name===&#39;origin&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3909' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3932' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@origin'/>
-          <let line='3905' var='Q{}base' as='xs:string' slot='4' eval='16'>
+          <let line='3928' var='Q{}base' as='xs:string' slot='4' eval='16'>
            <choose>
             <fn name='exists'>
              <slash simple='1'>
@@ -10525,7 +10544,7 @@
              </check>
             </treat>
            </choose>
-           <let line='3907' var='Q{}relative' as='xs:string' slot='10' eval='16'>
+           <let line='3930' var='Q{}relative' as='xs:string' slot='10' eval='16'>
             <check card='1' diag='0|1||xforms:resolveXPathStrings'>
              <cvUntyped to='xs:string'>
               <data>
@@ -10668,29 +10687,191 @@
           </let>
          </ifCall>
         </choose>
-        <choose line='3913'>
+        <choose line='3935'>
+         <fn name='exists'>
+          <slash simple='1'>
+           <varRef name='Q{}this' slot='0'/>
+           <axis name='attribute' nodeTest='attribute(Q{}context)' jsTest='return item.name===&#39;context&#39;'/>
+          </slash>
+         </fn>
+         <ifCall line='3936' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <str val='@context'/>
+          <let var='Q{}base' as='xs:string' slot='14' eval='16'>
+           <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:resolveXPathStrings'>
+            <check card='1' diag='0|0||xforms:resolveXPathStrings'>
+             <cvUntyped to='xs:string'>
+              <data>
+               <varRef name='Q{}nodeset' slot='1'/>
+              </data>
+             </cvUntyped>
+            </check>
+           </treat>
+           <let var='Q{}relative' as='xs:string' slot='15' eval='16'>
+            <check card='1' diag='0|1||xforms:resolveXPathStrings'>
+             <cvUntyped to='xs:string'>
+              <data>
+               <slash simple='1'>
+                <varRef name='Q{}this' slot='0'/>
+                <axis name='attribute' nodeTest='attribute(Q{}context)' jsTest='return item.name===&#39;context&#39;'/>
+               </slash>
+              </data>
+             </cvUntyped>
+            </check>
+            <choose line='838'>
+             <fn name='starts-with'>
+              <varRef name='Q{}relative' slot='15'/>
+              <str val='/'/>
+             </fn>
+             <varRef line='839' name='Q{}relative' slot='15'/>
+             <fn line='841' name='starts-with'>
+              <varRef name='Q{}relative' slot='15'/>
+              <str val='instance('/>
+             </fn>
+             <varRef line='842' name='Q{}relative' slot='15'/>
+             <fn line='844' name='not'>
+              <varRef name='Q{}base' slot='14'/>
+             </fn>
+             <varRef line='845' name='Q{}relative' slot='15'/>
+             <or line='847' op='or'>
+              <fn name='not'>
+               <varRef name='Q{}relative' slot='15'/>
+              </fn>
+              <vc op='eq' onEmpty='0' comp='CCC'>
+               <varRef name='Q{}relative' slot='15'/>
+               <str val='.'/>
+              </vc>
+             </or>
+             <varRef line='848' name='Q{}base' slot='14'/>
+             <true/>
+             <let line='852' var='Q{}parentCallCount' as='xs:integer' slot='16' eval='16'>
+              <choose>
+               <fn name='contains'>
+                <varRef name='Q{}relative' slot='15'/>
+                <str val='/'/>
+               </fn>
+               <fn name='count'>
+                <filter flags='b'>
+                 <fn name='tokenize'>
+                  <varRef name='Q{}relative' slot='15'/>
+                  <str val='/'/>
+                  <str val=''/>
+                 </fn>
+                 <vc op='eq' onEmpty='0' comp='CCC'>
+                  <dot type='xs:string'/>
+                  <str val='..'/>
+                 </vc>
+                </filter>
+               </fn>
+               <fn name='contains'>
+                <varRef name='Q{}relative' slot='15'/>
+                <str val='..'/>
+               </fn>
+               <int val='1'/>
+               <true/>
+               <int val='0'/>
+              </choose>
+              <let line='855' var='Q{}slashes' as='xs:integer*' slot='17' eval='4'>
+               <choose>
+                <fn name='contains'>
+                 <varRef name='Q{}base' slot='14'/>
+                 <str val='/'/>
+                </fn>
+                <fn name='index-of'>
+                 <fn name='string-to-codepoints'>
+                  <varRef name='Q{}base' slot='14'/>
+                 </fn>
+                 <int val='47'/>
+                </fn>
+                <true/>
+                <int val='0'/>
+               </choose>
+               <choose line='887'>
+                <compareToInt op='gt' val='0'>
+                 <varRef name='Q{}parentCallCount' slot='16'/>
+                </compareToInt>
+                <fn line='891' name='concat'>
+                 <fn name='substring'>
+                  <varRef name='Q{}base' slot='14'/>
+                  <int val='1'/>
+                  <choose line='866'>
+                   <and op='and'>
+                    <vc op='ge' onEmpty='0' comp='CAVC'>
+                     <fn name='count'>
+                      <varRef name='Q{}slashes' slot='17'/>
+                     </fn>
+                     <varRef name='Q{}parentCallCount' slot='16'/>
+                    </vc>
+                    <compareToInt op='gt' val='0'>
+                     <varRef name='Q{}parentCallCount' slot='16'/>
+                    </compareToInt>
+                   </and>
+                   <let line='867' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='18' eval='13'>
+                    <arith op='-' calc='i-i'>
+                     <varRef name='Q{}parentCallCount' slot='16'/>
+                     <int val='1'/>
+                    </arith>
+                    <check card='1' diag='3|0|XTTE0570|parentSlash'>
+                     <filter flags='p'>
+                      <varRef name='Q{}slashes' slot='17'/>
+                      <arith op='-' calc='i-i'>
+                       <fn name='last'/>
+                       <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='18'/>
+                      </arith>
+                     </filter>
+                    </check>
+                   </let>
+                   <true/>
+                   <check line='870' card='1' diag='3|0|XTTE0570|parentSlash'>
+                    <lastOf>
+                     <varRef name='Q{}slashes' slot='17'/>
+                    </lastOf>
+                   </check>
+                  </choose>
+                 </fn>
+                 <fn name='replace'>
+                  <varRef name='Q{}relative' slot='15'/>
+                  <str val='\.\./'/>
+                  <str val=''/>
+                  <str val=''/>
+                 </fn>
+                </fn>
+                <true/>
+                <fn line='894' name='concat'>
+                 <varRef name='Q{}base' slot='14'/>
+                 <str val='/'/>
+                 <varRef name='Q{}relative' slot='15'/>
+                </fn>
+               </choose>
+              </let>
+             </let>
+            </choose>
+           </let>
+          </let>
+         </ifCall>
+        </choose>
+        <choose line='3940'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
           </slash>
          </fn>
-         <ifCall line='3914' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3941' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='nested-actions'/>
-          <let line='3915' var='Q{}array' as='map(*)*' slot='14' eval='3'>
-           <treat line='3916' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|array'>
+          <let line='3942' var='Q{}array' as='map(*)*' slot='19' eval='3'>
+           <treat line='3943' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|array'>
             <forEach>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
              </slash>
-             <applyT line='3917' bSlot='2'>
+             <applyT line='3944' bSlot='2'>
               <dot role='select' type='element()'/>
              </applyT>
             </forEach>
            </treat>
-           <ifCall line='3920' name='Q{http://www.w3.org/2005/xpath-functions/array}_from-sequence' type='array(*)'>
-            <varRef name='Q{}array' slot='14'/>
+           <ifCall line='3947' name='Q{http://www.w3.org/2005/xpath-functions/array}_from-sequence' type='array(*)'>
+            <varRef name='Q{}array' slot='19'/>
            </ifCall>
           </let>
          </ifCall>
@@ -10877,16 +11058,16 @@
             <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
            </slash>
           </check>
-          <compElem line='3008'>
+          <compElem line='3020'>
            <fn role='name' name='name'>
             <varRef name='Q{}this' slot='9'/>
            </fn>
-           <sequence role='content' line='3009'>
+           <sequence role='content' line='3021'>
             <namespace flags='l'>
              <str role='name' val='xforms'/>
              <str role='select' val='http://www.w3.org/2002/xforms'/>
             </namespace>
-            <forEach line='3010'>
+            <forEach line='3022'>
              <filter flags='b'>
               <filter flags='b'>
                <slash simple='1'>
@@ -10925,21 +11106,21 @@
                </gc>
               </fn>
              </filter>
-             <namespace line='3013' flags='l'>
-              <fn role='name' line='3012' name='substring-before'>
+             <namespace line='3025' flags='l'>
+              <fn role='name' line='3024' name='substring-before'>
                <fn name='name'>
                 <dot type='element()'/>
                </fn>
                <str val=':'/>
               </fn>
               <convert role='select' from='xs:anyURI' to='xs:string'>
-               <fn line='3011' name='namespace-uri'>
+               <fn line='3023' name='namespace-uri'>
                 <dot type='element()'/>
                </fn>
               </convert>
              </namespace>
             </forEach>
-            <copyOf line='3015' flags='vc'>
+            <copyOf line='3027' flags='vc'>
              <sequence>
               <slash simple='1'>
                <varRef name='Q{}this' slot='9'/>
@@ -11386,7 +11567,7 @@
                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
                    <axis name='descendant' nodeTest='element(Q{}head)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;head&#39;;'/>
                   </slash>
-                  <resultDoc line='295' global='#&#xA;#Sun Feb 23 16:30:38 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sun Feb 23 16:30:38 GMT 2020&#xA;'>
+                  <resultDoc line='295' global='#&#xD;&#xA;#Fri Mar 13 14:41:49 GMT 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Fri Mar 13 14:41:49 GMT 2020&#xD;&#xA;'>
                    <str role='href' val='?.'/>
                    <elem role='content' line='296' name='script' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
                     <sequence>
@@ -11585,7 +11766,7 @@
                    </arrayBlock>
                   </ifCall>
                  </forEach>
-                 <resultDoc line='619' global='#&#xA;#Sun Feb 23 16:30:38 GMT 2020&#xA;indent=no&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xA;encoding=utf-8&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xA;omit-xml-declaration=no&#xA;method=html&#xA;' local='#&#xA;#Sun Feb 23 16:30:38 GMT 2020&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xA;'>
+                 <resultDoc line='619' global='#&#xD;&#xA;#Fri Mar 13 14:41:49 GMT 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Fri Mar 13 14:41:49 GMT 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
                   <fn role='href' name='concat'>
                    <str val='#'/>
                    <varRef name='Q{}xFormsId' slot='4'/>
@@ -11627,15 +11808,15 @@
  </co>
  <co id='70' binds='70'>
   <mode name='Q{}namespace-fix' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='31' rank='0' minImp='0' slots='1' flags='s' line='2845' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='31' rank='0' minImp='0' slots='1' flags='s' line='2857' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2846' var='Q{}current-namespace' as='xs:anyURI' slot='0' eval='8'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2858' var='Q{}current-namespace' as='xs:anyURI' slot='0' eval='8'>
      <fn name='namespace-uri'>
       <dot type='element()'/>
      </fn>
-     <compElem line='2848'>
+     <compElem line='2860'>
       <convert role='name' from='xs:QName' to='xs:string'>
-       <fn line='2847' name='QName'>
+       <fn line='2859' name='QName'>
         <convert from='xs:anyURI' to='xs:string'>
          <varRef name='Q{}current-namespace' slot='0'/>
         </convert>
@@ -11647,12 +11828,12 @@
       <convert role='namespace' from='xs:anyURI' to='xs:string'>
        <varRef name='Q{}current-namespace' slot='0'/>
       </convert>
-      <sequence role='content' line='2849'>
+      <sequence role='content' line='2861'>
        <namespace flags='l'>
         <str role='name' val='xforms'/>
         <str role='select' val='http://www.w3.org/2002/xforms'/>
        </namespace>
-       <applyT line='2851' mode='Q{}namespace-fix' bSlot='0'>
+       <applyT line='2863' mode='Q{}namespace-fix' bSlot='0'>
         <sequence role='select'>
          <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
          <axis name='child' nodeTest='( element() | text() | comment() | processing-instruction() )' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);'/>
@@ -11709,55 +11890,54 @@
       <varRef name='Q{}instance-id' slot='0'/>
       <str val='&#39;)/'/>
      </fn>
-     <let line='1025' var='Q{}responseXML' as='document-node()' slot='4' eval='16'>
-      <treat as='document-node()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);' diag='3|0|XTTE0570|responseXML'>
-       <check card='1' diag='3|0|XTTE0570|responseXML'>
-        <lookup>
-         <dot type='map(*)'/>
-         <str val='body'/>
-        </lookup>
-       </check>
-      </treat>
-      <sequence line='1027'>
-       <message>
-        <sequence role='select'>
-         <valueOf>
-          <str val='[HTTPsubmit] Response body: '/>
-         </valueOf>
-         <fn name='serialize'>
-          <varRef name='Q{}responseXML' slot='4'/>
-         </fn>
-        </sequence>
-        <str role='terminate' val='no'/>
-        <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-       </message>
-       <choose line='1030'>
-        <fn name='empty'>
-         <varRef name='Q{}responseXML' slot='4'/>
-        </fn>
-        <callT line='1031' name='Q{}serverError' bSlot='0' flags='t'>
-         <withParam name='Q{}responseMap' flags='c' as='map(*)'>
-          <dot line='1032' type='map(*)'/>
-         </withParam>
-        </callT>
-        <vc line='1044' op='eq' onEmpty='0' comp='CCC'>
+     <let line='1026' var='Q{}response' as='item()' slot='4' eval='16'>
+      <check card='1' diag='3|0|XTTE0570|response'>
+       <lookup>
+        <dot type='map(*)'/>
+        <str val='body'/>
+       </lookup>
+      </check>
+      <choose line='1031'>
+       <fn name='empty'>
+        <varRef name='Q{}response' slot='4'/>
+       </fn>
+       <callT line='1032' name='Q{}serverError' bSlot='0' flags='t'>
+        <withParam name='Q{}responseMap' flags='c' as='map(*)'>
+         <dot line='1033' type='map(*)'/>
+        </withParam>
+       </callT>
+       <and line='1045' op='and'>
+        <vc op='eq' onEmpty='0' comp='CCC'>
          <varRef name='Q{}replace' slot='2'/>
          <str val='instance'/>
         </vc>
-        <sequence line='1045'>
-         <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='1' eval='6 16'>
-          <varRef name='Q{}refi' slot='3'/>
-          <check card='1' diag='0|1||xforms:setInstance-JS'>
-           <slash simple='1'>
-            <varRef name='Q{}responseXML' slot='4'/>
-            <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-           </slash>
-          </check>
-         </ufCall>
-         <callT line='1047' name='Q{}xforms-recalculate' bSlot='2' flags='t'/>
-        </sequence>
-       </choose>
-      </sequence>
+        <filter flags='b'>
+         <varRef name='Q{}response' slot='4'/>
+         <fn name='exists'>
+          <slash simple='1'>
+           <treat as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='14|12|XPTY0020|'>
+            <dot/>
+           </treat>
+           <axis name='self' nodeTest='document-node()' jsTest='return (item.nodeType===9||item.nodeType===11);'/>
+          </slash>
+         </fn>
+        </filter>
+       </and>
+       <sequence line='1046'>
+        <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='1' eval='6 16'>
+         <varRef name='Q{}refi' slot='3'/>
+         <check card='1' diag='0|1||xforms:setInstance-JS'>
+          <slash simple='1'>
+           <treat as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='1|0|XPTY0019|/'>
+            <varRef name='Q{}response' slot='4'/>
+           </treat>
+           <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+          </slash>
+         </check>
+        </ufCall>
+        <callT line='1048' name='Q{}xforms-recalculate' bSlot='2' flags='t'/>
+       </sequence>
+      </choose>
      </let>
     </let>
    </sequence>
@@ -11877,16 +12057,16 @@
      </sequence>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.5' seq='23' rank='0' minImp='0' slots='0' flags='s' line='2024' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.5' seq='23' rank='0' minImp='0' slots='0' flags='s' line='2036' module='saxon-xforms.xsl'>
     <p.withPredicate role='match'>
      <p.nodeTest test='element(Q{}button)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;button&#39;;'/>
-     <fn ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2024' name='exists'>
+     <fn ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2036' name='exists'>
       <axis name='attribute' nodeTest='attribute(Q{}data-action)' jsTest='return item.name===&#39;data-action&#39;'/>
      </fn>
     </p.withPredicate>
-    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2026' name='Q{}DOMActivate' bSlot='1' flags='t'>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2038' name='Q{}DOMActivate' bSlot='1' flags='t'>
      <withParam name='Q{}form-control' flags='c' as='node()'>
-      <dot line='2027' type='element(Q{}button)'/>
+      <dot line='2039' type='element(Q{}button)'/>
      </withParam>
     </callT>
    </templateRule>
@@ -11908,8 +12088,8 @@
   </mode>
  </co>
  <co id='71' binds='61 62 63'>
-  <template name='Q{}setSubmission' flags='os' line='3938' module='saxon-xforms.xsl' slots='5'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3939'>
+  <template name='Q{}setSubmission' flags='os' line='3965' module='saxon-xforms.xsl' slots='5'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3966'>
     <param name='Q{}this' slot='0' flags='i' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
       <check card='1' diag='8|0|XTTE0590|this'>
@@ -11917,7 +12097,7 @@
       </check>
      </treat>
     </param>
-    <param line='3940' name='Q{}submission-id' slot='1' flags='i' as='xs:string'>
+    <param line='3967' name='Q{}submission-id' slot='1' flags='i' as='xs:string'>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|submission-id'>
       <check card='1' diag='8|0|XTTE0590|submission-id'>
        <cvUntyped to='xs:string' diag='8|0|XTTE0590|submission-id'>
@@ -11928,52 +12108,52 @@
       </check>
      </treat>
     </param>
-    <let line='3943' var='Q{}bindingi' as='node()?' slot='2' eval='7'>
-     <treat line='3944' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+    <let line='3970' var='Q{}bindingi' as='node()?' slot='2' eval='7'>
+     <treat line='3971' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
       <check card='?' diag='3|0|XTTE0570|bindingi'>
        <callT name='Q{}getBinding' bSlot='0'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <varRef line='3945' name='Q{}this' slot='0'/>
+         <varRef line='3972' name='Q{}this' slot='0'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <let line='3950' var='Q{}refi' as='xs:string' slot='3' eval='16'>
-      <treat line='3951' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+     <let line='3977' var='Q{}refi' as='xs:string' slot='3' eval='16'>
+      <treat line='3978' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
        <check card='1' diag='3|0|XTTE0570|refi'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
          <data>
           <callT name='Q{}getDataRef' bSlot='1'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <varRef line='3952' name='Q{}this' slot='0'/>
+            <varRef line='3979' name='Q{}this' slot='0'/>
            </withParam>
            <withParam name='Q{}bindingi' flags='c' as='node()?'>
-            <varRef line='3953' name='Q{}bindingi' slot='2'/>
+            <varRef line='3980' name='Q{}bindingi' slot='2'/>
            </withParam>
           </callT>
          </data>
         </cvUntyped>
        </check>
       </treat>
-      <let line='3958' var='Q{}actions' as='map(*)*' slot='4' eval='8'>
-       <treat line='3959' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+      <let line='3985' var='Q{}actions' as='map(*)*' slot='4' eval='8'>
+       <treat line='3986' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
         <callT name='Q{}setActions' bSlot='2'>
          <withParam name='Q{}this' flags='c' as='element()'>
-          <treat line='3960' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+          <treat line='3987' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
            <dot flags='a'/>
           </treat>
          </withParam>
          <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-          <varRef line='3961' name='Q{}refi' slot='3'/>
+          <varRef line='3988' name='Q{}refi' slot='3'/>
          </withParam>
         </callT>
        </treat>
-       <sequence line='3965'>
+       <sequence line='3992'>
         <choose>
          <fn name='exists'>
           <varRef name='Q{}actions' slot='4'/>
          </fn>
-         <ifCall line='3966' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+         <ifCall line='3993' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
           <check card='1' diag='0|0||ixsl:call'>
            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
           </check>
@@ -11984,20 +12164,20 @@
           </arrayBlock>
          </ifCall>
         </choose>
-        <ifCall line='3971' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+        <ifCall line='3998' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
          <sequence>
-          <ifCall line='3972' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <ifCall line='3999' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
            <str val='@ref'/>
            <varRef name='Q{}refi' slot='3'/>
           </ifCall>
-          <choose line='3975'>
+          <choose line='4002'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}resource)' jsTest='return item.name===&#39;resource&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3976' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4003' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@resource'/>
             <cast as='xs:string' emptiable='1'>
              <data>
@@ -12009,14 +12189,14 @@
             </cast>
            </ifCall>
           </choose>
-          <choose line='3978'>
+          <choose line='4005'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}mode)' jsTest='return item.name===&#39;mode&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3979' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4006' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@mode'/>
             <cast as='xs:string' emptiable='1'>
              <data>
@@ -12028,16 +12208,16 @@
             </cast>
            </ifCall>
           </choose>
-          <ifCall line='3982' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <ifCall line='4009' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
            <str val='@method'/>
-           <choose line='3984'>
+           <choose line='4011'>
             <fn name='exists'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='attribute' nodeTest='attribute(Q{}method)' jsTest='return item.name===&#39;method&#39;'/>
              </slash>
             </fn>
-            <fn line='3985' name='string'>
+            <fn line='4012' name='string'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='attribute' nodeTest='attribute(Q{}method)' jsTest='return item.name===&#39;method&#39;'/>
@@ -12047,14 +12227,14 @@
             <str val='POST'/>
            </choose>
           </ifCall>
-          <choose line='3994'>
+          <choose line='4021'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}validate)' jsTest='return item.name===&#39;validate&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3995' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4022' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@validate'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12064,14 +12244,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='3997'>
+          <choose line='4024'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}relevant)' jsTest='return item.name===&#39;relevant&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3998' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4025' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@relevant'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12081,14 +12261,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='4000'>
+          <choose line='4027'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}serialization)' jsTest='return item.name===&#39;serialization&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4001' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4028' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@serialization'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12098,14 +12278,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='4003'>
+          <choose line='4030'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}version)' jsTest='return item.name===&#39;version&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4004' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4031' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@version'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12115,14 +12295,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='4006'>
+          <choose line='4033'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}indent)' jsTest='return item.name===&#39;indent&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4007' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4034' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@indent'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12132,16 +12312,16 @@
             </fn>
            </ifCall>
           </choose>
-          <ifCall line='4011' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <ifCall line='4038' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
            <str val='@mediatype'/>
-           <choose line='4013'>
+           <choose line='4040'>
             <fn name='exists'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='attribute' nodeTest='attribute(Q{}mediatype)' jsTest='return item.name===&#39;mediatype&#39;'/>
              </slash>
             </fn>
-            <fn line='4014' name='string'>
+            <fn line='4041' name='string'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='attribute' nodeTest='attribute(Q{}mediatype)' jsTest='return item.name===&#39;mediatype&#39;'/>
@@ -12151,14 +12331,14 @@
             <str val='text/plain'/>
            </choose>
           </ifCall>
-          <choose line='4024'>
+          <choose line='4051'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}encoding)' jsTest='return item.name===&#39;encoding&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4025' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4052' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@encoding'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12168,14 +12348,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='4027'>
+          <choose line='4054'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}omit-xml-declaration)' jsTest='return item.name===&#39;omit-xml-declaration&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4028' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4055' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@omit-xml-declaration'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12185,14 +12365,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='4030'>
+          <choose line='4057'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}standalone)' jsTest='return item.name===&#39;standalone&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4031' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4058' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@standalone'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12202,14 +12382,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='4033'>
+          <choose line='4060'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}cdata-section-elements)' jsTest='return item.name===&#39;cdata-section-elements&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4034' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4061' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@cdata-section-elements'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12219,16 +12399,16 @@
             </fn>
            </ifCall>
           </choose>
-          <ifCall line='4037' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <ifCall line='4064' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
            <str val='@replace'/>
-           <choose line='4039'>
+           <choose line='4066'>
             <fn name='exists'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='attribute' nodeTest='attribute(Q{}replace)' jsTest='return item.name===&#39;replace&#39;'/>
              </slash>
             </fn>
-            <fn line='4040' name='string'>
+            <fn line='4067' name='string'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='attribute' nodeTest='attribute(Q{}replace)' jsTest='return item.name===&#39;replace&#39;'/>
@@ -12238,14 +12418,14 @@
             <str val='all'/>
            </choose>
           </ifCall>
-          <choose line='4051'>
+          <choose line='4078'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}instance)' jsTest='return item.name===&#39;instance&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4052' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4079' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@instance'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12255,14 +12435,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='4054'>
+          <choose line='4081'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}targetref)' jsTest='return item.name===&#39;targetref&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4055' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4082' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@targetref'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12272,14 +12452,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='4057'>
+          <choose line='4084'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}separator)' jsTest='return item.name===&#39;separator&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4058' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4085' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@separator'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12289,14 +12469,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='4060'>
+          <choose line='4087'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}includenamespaceprefixes)' jsTest='return item.name===&#39;includenamespaceprefixes&#39;'/>
             </slash>
            </fn>
-           <ifCall line='4061' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='4088' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@includenamespaceprefixes'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12332,7 +12512,7 @@
         <data>
          <slash simple='1'>
           <dot type='element(Q{}input)'/>
-          <axis line='3044' name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
+          <axis line='3056' name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
          </slash>
         </data>
        </cvUntyped>
@@ -12349,8 +12529,8 @@
   </mode>
  </co>
  <co id='61' binds=''>
-  <template name='Q{}getBinding' flags='os' line='3282' module='saxon-xforms.xsl' slots='4'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3283'>
+  <template name='Q{}getBinding' flags='os' line='3294' module='saxon-xforms.xsl' slots='4'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3295'>
     <param name='Q{}this' slot='0' flags='r' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
       <check card='1' diag='8|0|XTTE0590|this'>
@@ -12358,7 +12538,7 @@
       </check>
      </treat>
     </param>
-    <param line='3284' name='Q{}bindings' slot='1' flags='t' as='map(xs:string, node())'>
+    <param line='3296' name='Q{}bindings' slot='1' flags='t' as='map(xs:string, node())'>
      <map role='select' size='0'/>
      <treat role='conversion' as='map(xs:string, node())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|bindings'>
       <check card='1' diag='8|0|XTTE0590|bindings'>
@@ -12366,7 +12546,7 @@
       </check>
      </treat>
     </param>
-    <let line='3293' var='Q{}ref-binding' as='xs:string' slot='2' eval='16'>
+    <let line='3305' var='Q{}ref-binding' as='xs:string' slot='2' eval='16'>
      <choose>
       <fn name='exists'>
        <slash simple='1'>
@@ -12403,8 +12583,8 @@
       <true/>
       <str val=''/>
      </choose>
-     <let line='3295' var='Q{}binding' as='element()?' slot='3' eval='7'>
-      <choose line='3300'>
+     <let line='3307' var='Q{}binding' as='element()?' slot='3' eval='7'>
+      <choose line='3312'>
        <fn name='empty'>
         <varRef name='Q{}ref-binding' slot='2'/>
        </fn>
@@ -12417,12 +12597,12 @@
         </ifCall>
        </treat>
       </choose>
-      <sequence line='3303'>
+      <sequence line='3315'>
        <choose>
         <fn name='exists'>
          <varRef name='Q{}binding' slot='3'/>
         </fn>
-        <message line='3309'>
+        <message line='3321'>
          <sequence role='select'>
           <valueOf>
            <str val='[getBinding for '/>
@@ -12445,7 +12625,7 @@
          <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
         </message>
        </choose>
-       <varRef line='3313' name='Q{}binding' slot='3'/>
+       <varRef line='3325' name='Q{}binding' slot='3'/>
       </sequence>
      </let>
     </let>
@@ -12463,10 +12643,10 @@
   </globalVariable>
  </co>
  <co id='45' binds='61'>
-  <function name='Q{http://www.w3.org/2002/xforms}getDataRef' line='3141' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:string' slots='11'>
+  <function name='Q{http://www.w3.org/2002/xforms}getDataRef' line='3153' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:string' slots='11'>
    <arg name='Q{}this' as='element()'/>
    <arg name='Q{}nodeset' as='xs:string?'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3150' var='Q{}this-ref' as='xs:string?' slot='2' eval='7'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3162' var='Q{}this-ref' as='xs:string?' slot='2' eval='7'>
     <choose>
      <fn name='exists'>
       <slash simple='1'>
@@ -12501,27 +12681,27 @@
       </cast>
      </fn>
     </choose>
-    <let line='3153' var='Q{}this-binding' as='node()?' slot='3' eval='7'>
-     <treat line='3154' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|this-binding'>
+    <let line='3165' var='Q{}this-binding' as='node()?' slot='3' eval='7'>
+     <treat line='3166' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|this-binding'>
       <check card='?' diag='3|0|XTTE0570|this-binding'>
        <callT name='Q{}getBinding' bSlot='0'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <varRef line='3155' name='Q{}this' slot='0'/>
+         <varRef line='3167' name='Q{}this' slot='0'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <choose line='3180'>
+     <choose line='3192'>
       <fn name='exists'>
        <varRef name='Q{}this-binding' slot='3'/>
       </fn>
-      <let line='3161' var='Q{}relative' as='xs:string' slot='4' eval='16'>
+      <let line='3173' var='Q{}relative' as='xs:string' slot='4' eval='16'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
         <choose>
          <fn name='exists'>
           <varRef name='Q{}this-binding' slot='3'/>
          </fn>
-         <cvUntyped line='3172' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
+         <cvUntyped line='3184' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
           <cast as='xs:untypedAtomic' emptiable='0'>
            <choose>
             <fn name='exists'>
@@ -12571,10 +12751,10 @@
         <varRef line='845' name='Q{}relative' slot='4'/>
        </choose>
       </let>
-      <fn line='3183' name='exists'>
+      <fn line='3195' name='exists'>
        <varRef name='Q{}this-ref' slot='2'/>
       </fn>
-      <let line='3184' var='Q{}base' as='xs:string' slot='5' eval='16'>
+      <let line='3196' var='Q{}base' as='xs:string' slot='5' eval='16'>
        <check card='1' diag='0|0||xforms:resolveXPathStrings'>
         <varRef name='Q{}nodeset' slot='1'/>
        </check>
@@ -12712,8 +12892,8 @@
         </choose>
        </let>
       </let>
-      <varRef line='3186' name='Q{}nodeset' slot='1'/>
-      <let line='3187' var='Q{}relative' as='xs:string' slot='10' eval='16'>
+      <varRef line='3198' name='Q{}nodeset' slot='1'/>
+      <let line='3199' var='Q{}relative' as='xs:string' slot='10' eval='16'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
         <varRef name='Q{}nodeset' slot='1'/>
        </check>
@@ -12741,16 +12921,16 @@
  </co>
  <co id='19' binds='19 19'>
   <mode name='Q{}recalculate' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='28' rank='0' minImp='0' slots='5' flags='s' line='2754' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='28' rank='0' minImp='0' slots='5' flags='s' line='2766' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2755'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2767'>
      <param name='Q{}updated-nodes' slot='0' flags='t' as='node()*'>
       <empty role='select'/>
       <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|updated-nodes'>
        <supplied slot='0'/>
       </treat>
      </param>
-     <param line='2756' name='Q{}updated-values' slot='1' flags='t' as='xs:string*'>
+     <param line='2768' name='Q{}updated-values' slot='1' flags='t' as='xs:string*'>
       <empty role='select'/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|updated-values'>
        <cvUntyped to='xs:string' diag='8|0|XTTE0590|updated-values'>
@@ -12760,14 +12940,14 @@
        </cvUntyped>
       </treat>
      </param>
-     <copy line='2761' flags='cin'>
+     <copy line='2773' flags='cin'>
       <sequence role='content'>
        <applyT mode='Q{}recalculate' bSlot='0'>
         <axis role='select' name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
        </applyT>
-       <choose line='2764'>
+       <choose line='2776'>
         <fn name='exists'>
-         <let line='2758' var='Q{http://saxon.sf.net/generated-variable}current887200931' as='element()' slot='2' eval='16'>
+         <let line='2770' var='Q{http://saxon.sf.net/generated-variable}current1588085169' as='element()' slot='2' eval='16'>
           <dot type='element()'/>
           <treat as='element()' jsTest='return item.nodeType===1;' diag='3|0|XTTE0570|updated-node'>
            <check card='?' diag='3|0|XTTE0570|updated-node'>
@@ -12775,15 +12955,15 @@
              <varRef name='Q{}updated-nodes' slot='0'/>
              <is op='is'>
               <dot type='node()'/>
-              <varRef name='Q{http://saxon.sf.net/generated-variable}current887200931' slot='2'/>
+              <varRef name='Q{http://saxon.sf.net/generated-variable}current1588085169' slot='2'/>
              </is>
             </filter>
            </check>
           </treat>
          </let>
         </fn>
-        <let line='2765' var='Q{}updated-node-position' as='xs:integer' slot='3' eval='16'>
-         <let var='Q{http://saxon.sf.net/generated-variable}current80799437' as='element()' slot='4' eval='16'>
+        <let line='2777' var='Q{}updated-node-position' as='xs:integer' slot='3' eval='16'>
+         <let var='Q{http://saxon.sf.net/generated-variable}current-90465281' as='element()' slot='4' eval='16'>
           <dot type='element()'/>
           <check card='1' diag='3|0|XTTE0570|updated-node-position'>
            <slash>
@@ -12791,20 +12971,20 @@
              <varRef name='Q{}updated-nodes' slot='0'/>
              <is op='is'>
               <dot type='node()'/>
-              <varRef name='Q{http://saxon.sf.net/generated-variable}current80799437' slot='4'/>
+              <varRef name='Q{http://saxon.sf.net/generated-variable}current-90465281' slot='4'/>
              </is>
             </filter>
             <fn name='position'/>
            </slash>
           </check>
          </let>
-         <subscript line='2766'>
+         <subscript line='2778'>
           <varRef name='Q{}updated-values' slot='1'/>
           <varRef name='Q{}updated-node-position' slot='3'/>
          </subscript>
         </let>
         <true/>
-        <applyT line='2769' mode='Q{}recalculate' bSlot='1'>
+        <applyT line='2781' mode='Q{}recalculate' bSlot='1'>
          <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
         </applyT>
        </choose>
@@ -12812,16 +12992,16 @@
      </copy>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='-0.5' seq='29' rank='0' minImp='0' slots='5' flags='s' line='2782' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='29' rank='0' minImp='0' slots='5' flags='s' line='2794' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2783'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2795'>
      <param name='Q{}updated-nodes' slot='0' flags='t' as='node()*'>
       <empty role='select'/>
       <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|updated-nodes'>
        <supplied slot='0'/>
       </treat>
      </param>
-     <param line='2784' name='Q{}updated-values' slot='1' flags='t' as='xs:string*'>
+     <param line='2796' name='Q{}updated-values' slot='1' flags='t' as='xs:string*'>
       <empty role='select'/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|updated-values'>
        <cvUntyped to='xs:string' diag='8|0|XTTE0590|updated-values'>
@@ -12831,9 +13011,9 @@
        </cvUntyped>
       </treat>
      </param>
-     <choose line='2789'>
+     <choose line='2801'>
       <fn name='exists'>
-       <let line='2786' var='Q{http://saxon.sf.net/generated-variable}current887200928' as='attribute()' slot='2' eval='16'>
+       <let line='2798' var='Q{http://saxon.sf.net/generated-variable}current1588085170' as='attribute()' slot='2' eval='16'>
         <dot type='attribute()'/>
         <treat as='attribute()' jsTest='return SaxonJS.U.isAttr(item)' diag='3|0|XTTE0570|updated-node'>
          <check card='?' diag='3|0|XTTE0570|updated-node'>
@@ -12841,15 +13021,15 @@
            <varRef name='Q{}updated-nodes' slot='0'/>
            <is op='is'>
             <dot type='node()'/>
-            <varRef name='Q{http://saxon.sf.net/generated-variable}current887200928' slot='2'/>
+            <varRef name='Q{http://saxon.sf.net/generated-variable}current1588085170' slot='2'/>
            </is>
           </filter>
          </check>
         </treat>
        </let>
       </fn>
-      <let line='2790' var='Q{}updated-node-position' as='xs:integer' slot='3' eval='16'>
-       <let var='Q{http://saxon.sf.net/generated-variable}current80799437' as='attribute()' slot='4' eval='16'>
+      <let line='2802' var='Q{}updated-node-position' as='xs:integer' slot='3' eval='16'>
+       <let var='Q{http://saxon.sf.net/generated-variable}current-90465281' as='attribute()' slot='4' eval='16'>
         <dot type='attribute()'/>
         <check card='1' diag='3|0|XTTE0570|updated-node-position'>
          <slash>
@@ -12857,14 +13037,14 @@
            <varRef name='Q{}updated-nodes' slot='0'/>
            <is op='is'>
             <dot type='node()'/>
-            <varRef name='Q{http://saxon.sf.net/generated-variable}current80799437' slot='4'/>
+            <varRef name='Q{http://saxon.sf.net/generated-variable}current-90465281' slot='4'/>
            </is>
           </filter>
           <fn name='position'/>
          </slash>
         </check>
        </let>
-       <compAtt line='2791'>
+       <compAtt line='2803'>
         <fn role='name' name='name'>
          <dot type='attribute()'/>
         </fn>
@@ -12875,7 +13055,7 @@
        </compAtt>
       </let>
       <true/>
-      <copyOf line='2794' flags='vc'>
+      <copyOf line='2806' flags='vc'>
        <dot type='attribute()'/>
       </copyOf>
      </choose>
@@ -12884,8 +13064,8 @@
   </mode>
  </co>
  <co id='24' binds=''>
-  <template name='Q{}getInstance' flags='os' as='element()?' line='3256' module='saxon-xforms.xsl' slots='2'>
-   <check role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3257' card='?' diag='7|0|XTTE0505|getInstance'>
+  <template name='Q{}getInstance' flags='os' as='element()?' line='3268' module='saxon-xforms.xsl' slots='2'>
+   <check role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3269' card='?' diag='7|0|XTTE0505|getInstance'>
     <sequence>
      <param name='Q{}instance-id' slot='0' as='xs:string'>
       <str role='select' val=''/>
@@ -12899,21 +13079,21 @@
        </check>
       </treat>
      </param>
-     <param line='3258' name='Q{}instances' slot='1' flags='ti' as='map(xs:string, element())'>
+     <param line='3270' name='Q{}instances' slot='1' flags='ti' as='map(xs:string, element())'>
       <treat role='conversion' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|instances'>
        <check card='1' diag='8|0|XTTE0590|instances'>
         <supplied slot='1'/>
        </check>
       </treat>
      </param>
-     <choose line='3262'>
+     <choose line='3274'>
       <varRef name='Q{}instance-id' slot='0'/>
-      <ifCall line='3263' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+      <ifCall line='3275' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
        <varRef name='Q{}instances' slot='1'/>
        <varRef name='Q{}instance-id' slot='0'/>
       </ifCall>
       <true/>
-      <copyOf line='3267' flags='vc'>
+      <copyOf line='3279' flags='vc'>
        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
         <varRef name='Q{}instances' slot='1'/>
         <str val='saxon-forms-default'/>
@@ -12936,4 +13116,4 @@
  </output>
  <decimalFormat/>
 </package>
-<?Σ 966b6e1b?>
+<?Σ 238b9aac?>

--- a/sef/saxon-xforms.sef.xml
+++ b/sef/saxon-xforms.sef.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns='http://ns.saxonica.com/xslt/export' xmlns:fn='http://www.w3.org/2005/xpath-functions' xmlns:xs='http://www.w3.org/2001/XMLSchema' xmlns:vv='http://saxon.sf.net/generated-variable' xmlns:java-type='http://saxon.sf.net/java-type' when='2020-03-13T14:41:49.557Z' id='0' version='30' packageVersion='1' saxonVersion='9.9.1.5' target='JS' targetVersion='1' relocatable='true' implicit='true'>
+<package xmlns='http://ns.saxonica.com/xslt/export' xmlns:fn='http://www.w3.org/2005/xpath-functions' xmlns:xs='http://www.w3.org/2001/XMLSchema' xmlns:vv='http://saxon.sf.net/generated-variable' xmlns:java-type='http://saxon.sf.net/java-type' when='2020-03-13T15:05:29.385Z' id='0' version='30' packageVersion='1' saxonVersion='9.9.1.5' target='JS' targetVersion='1' relocatable='true' implicit='true'>
  <co id='0' binds='1 2 1 2 3 3 3 4 5 6 3 7'>
-  <template name='Q{}action-insert' flags='os' line='4673' module='saxon-xforms.xsl' slots='21'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4674'>
+  <template name='Q{}action-insert' flags='os' line='4679' module='saxon-xforms.xsl' slots='21'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4680'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -10,7 +10,7 @@
       </check>
      </treat>
     </param>
-    <param line='4675' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
+    <param line='4681' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
      <empty role='select'/>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|instanceXML'>
       <check card='?' diag='8|0|XTTE0590|instanceXML'>
@@ -18,7 +18,7 @@
       </check>
      </treat>
     </param>
-    <param line='4676' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
+    <param line='4682' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -30,7 +30,7 @@
       </check>
      </treat>
     </param>
-    <let line='4678' var='Q{}ref' as='xs:string' slot='3' eval='16'>
+    <let line='4684' var='Q{}ref' as='xs:string' slot='3' eval='16'>
      <let var='Q{}relative' as='xs:string' slot='4' eval='16'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|1||xforms:resolveXPathStrings'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
@@ -55,7 +55,7 @@
         <str val='instance('/>
        </fn>
        <varRef line='842' name='Q{}relative' slot='4'/>
-       <fn line='4678' name='not'>
+       <fn line='4684' name='not'>
         <varRef name='Q{}nodeset' slot='2'/>
        </fn>
        <varRef line='845' name='Q{}relative' slot='4'/>
@@ -68,7 +68,7 @@
          <str val='.'/>
         </vc>
        </or>
-       <varRef line='4678' name='Q{}nodeset' slot='2'/>
+       <varRef line='4684' name='Q{}nodeset' slot='2'/>
        <true/>
        <let line='852' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
         <choose>
@@ -99,13 +99,13 @@
         </choose>
         <let line='855' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
          <choose>
-          <fn line='4678' name='contains'>
+          <fn line='4684' name='contains'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
           </fn>
           <fn name='index-of'>
            <fn name='string-to-codepoints'>
-            <varRef line='4678' name='Q{}nodeset' slot='2'/>
+            <varRef line='4684' name='Q{}nodeset' slot='2'/>
            </fn>
            <int val='47'/>
           </fn>
@@ -118,7 +118,7 @@
           </compareToInt>
           <fn line='891' name='concat'>
            <fn name='substring'>
-            <varRef line='4678' name='Q{}nodeset' slot='2'/>
+            <varRef line='4684' name='Q{}nodeset' slot='2'/>
             <int val='1'/>
             <choose line='866'>
              <and op='and'>
@@ -163,7 +163,7 @@
            </fn>
           </fn>
           <true/>
-          <fn line='4678' name='concat'>
+          <fn line='4684' name='concat'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
            <varRef line='894' name='Q{}relative' slot='4'/>
@@ -173,7 +173,7 @@
        </let>
       </choose>
      </let>
-     <let line='4679' var='Q{}at' as='xs:string?' slot='8' eval='7'>
+     <let line='4685' var='Q{}at' as='xs:string?' slot='8' eval='7'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|at'>
        <check card='?' diag='3|0|XTTE0570|at'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|at'>
@@ -186,7 +186,7 @@
         </cvUntyped>
        </check>
       </treat>
-      <let line='4680' var='Q{}position' as='xs:string?' slot='9' eval='7'>
+      <let line='4686' var='Q{}position' as='xs:string?' slot='9' eval='7'>
        <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|position'>
         <check card='?' diag='3|0|XTTE0570|position'>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|position'>
@@ -199,7 +199,7 @@
          </cvUntyped>
         </check>
        </treat>
-       <let line='4681' var='Q{}origin-ref' as='xs:string?' slot='10' eval='7'>
+       <let line='4687' var='Q{}origin-ref' as='xs:string?' slot='10' eval='7'>
         <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|origin-ref'>
          <check card='?' diag='3|0|XTTE0570|origin-ref'>
           <cvUntyped to='xs:string' diag='3|0|XTTE0570|origin-ref'>
@@ -212,12 +212,12 @@
           </cvUntyped>
          </check>
         </treat>
-        <let line='4695' var='Q{}instance-id' as='xs:string' slot='11' eval='16'>
+        <let line='4701' var='Q{}instance-id' as='xs:string' slot='11' eval='16'>
          <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='6'>
           <varRef name='Q{}ref' slot='3'/>
          </ufCall>
-         <let line='4697' var='Q{}instanceXML2' as='element()' slot='12' eval='16'>
-          <choose line='4699'>
+         <let line='4703' var='Q{}instanceXML2' as='element()' slot='12' eval='16'>
+          <choose line='4705'>
            <and op='and'>
             <vc op='eq' onEmpty='0' comp='CCC'>
              <varRef name='Q{}instance-id' slot='11'/>
@@ -227,24 +227,24 @@
              <varRef name='Q{}instanceXML' slot='1'/>
             </fn>
            </and>
-           <check line='4700' card='1' diag='3|0|XTTE0570|instanceXML2'>
+           <check line='4706' card='1' diag='3|0|XTTE0570|instanceXML2'>
             <varRef name='Q{}instanceXML' slot='1'/>
            </check>
            <true/>
-           <check line='4703' card='1' diag='3|0|XTTE0570|instanceXML2'>
+           <check line='4709' card='1' diag='3|0|XTTE0570|instanceXML2'>
             <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='6'>
              <varRef name='Q{}instance-id' slot='11'/>
             </ufCall>
            </check>
           </choose>
-          <let line='4716' var='Q{}instance-id-origin' as='xs:string' slot='13' eval='16'>
+          <let line='4722' var='Q{}instance-id-origin' as='xs:string' slot='13' eval='16'>
            <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='2' eval='16'>
             <check card='1' diag='0|0||xforms:getInstanceId'>
              <varRef name='Q{}origin-ref' slot='10'/>
             </check>
            </ufCall>
-           <let line='4718' var='Q{}instanceXML-origin' as='element()' slot='14' eval='16'>
-            <choose line='4720'>
+           <let line='4724' var='Q{}instanceXML-origin' as='element()' slot='14' eval='16'>
+            <choose line='4726'>
              <and op='and'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <varRef name='Q{}instance-id-origin' slot='13'/>
@@ -254,18 +254,18 @@
                <varRef name='Q{}instanceXML' slot='1'/>
               </fn>
              </and>
-             <check line='4721' card='1' diag='3|0|XTTE0570|instanceXML-origin'>
+             <check line='4727' card='1' diag='3|0|XTTE0570|instanceXML-origin'>
               <varRef name='Q{}instanceXML' slot='1'/>
              </check>
              <true/>
-             <check line='4724' card='1' diag='3|0|XTTE0570|instanceXML-origin'>
+             <check line='4730' card='1' diag='3|0|XTTE0570|instanceXML-origin'>
               <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='3' eval='6'>
                <varRef name='Q{}instance-id-origin' slot='13'/>
               </ufCall>
              </check>
             </choose>
-            <let line='4729' var='Q{}origin-node' as='node()?' slot='15' eval='7'>
-             <treat line='4730' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|origin-node'>
+            <let line='4735' var='Q{}origin-node' as='node()?' slot='15' eval='7'>
+             <treat line='4736' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|origin-node'>
               <check card='?' diag='3|0|XTTE0570|origin-node'>
                <evaluate dxns=''>
                 <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='4' eval='16'>
@@ -281,13 +281,13 @@
                </evaluate>
               </check>
              </treat>
-             <let line='4733' var='Q{}insert-node-location' as='node()?' slot='16' eval='7'>
-              <treat line='4734' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|insert-node-location'>
+             <let line='4739' var='Q{}insert-node-location' as='node()?' slot='16' eval='7'>
+              <treat line='4740' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|insert-node-location'>
                <check card='?' diag='3|0|XTTE0570|insert-node-location'>
                 <evaluate dxns=''>
                  <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='5' eval='16'>
                   <check card='1' diag='0|0||xforms:impose'>
-                   <choose line='4693'>
+                   <choose line='4699'>
                     <vc op='ne' onEmpty='0' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
                      <varRef name='Q{}ref' slot='3'/>
                      <str val=''/>
@@ -316,14 +316,14 @@
                 </evaluate>
                </check>
               </treat>
-              <let line='4737' var='Q{}context-node' as='node()' slot='17' eval='16'>
-               <treat line='4738' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|context-node'>
+              <let line='4743' var='Q{}context-node' as='node()' slot='17' eval='16'>
+               <treat line='4744' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|context-node'>
                 <check card='1' diag='3|0|XTTE0570|context-node'>
                  <evaluate dxns=''>
                   <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='6' eval='16'>
-                   <treat line='4682' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|context'>
-                    <check line='4738' card='1' diag='0|0||xforms:impose'>
-                     <check line='4682' card='?' diag='3|0|XTTE0570|context'>
+                   <treat line='4688' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|context'>
+                    <check line='4744' card='1' diag='0|0||xforms:impose'>
+                     <check line='4688' card='?' diag='3|0|XTTE0570|context'>
                       <cvUntyped to='xs:string' diag='3|0|XTTE0570|context'>
                        <data>
                         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
@@ -344,13 +344,13 @@
                  </evaluate>
                 </check>
                </treat>
-               <let line='4755' var='Q{}instance-with-insert' as='element()' slot='18' eval='16'>
-                <treat line='4756' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-insert'>
+               <let line='4761' var='Q{}instance-with-insert' as='element()' slot='18' eval='16'>
+                <treat line='4762' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-insert'>
                  <check card='1' diag='3|0|XTTE0570|instance-with-insert'>
                   <applyT mode='Q{}insert-node' bSlot='7'>
                    <varRef role='select' name='Q{}instanceXML2' slot='12'/>
                    <withParam name='Q{}insert-node-location' flags='t' as='node()?'>
-                    <choose line='4757'>
+                    <choose line='4763'>
                      <fn name='exists'>
                       <varRef name='Q{}insert-node-location' slot='16'/>
                      </fn>
@@ -360,21 +360,21 @@
                     </choose>
                    </withParam>
                    <withParam name='Q{}node-to-insert' flags='t' as='node()?'>
-                    <choose line='4744'>
+                    <choose line='4750'>
                      <fn name='exists'>
                       <varRef name='Q{}origin-node' slot='15'/>
                      </fn>
-                     <copyOf line='4745' flags='vc'>
+                     <copyOf line='4751' flags='vc'>
                       <varRef name='Q{}origin-node' slot='15'/>
                      </copyOf>
                      <true/>
-                     <copyOf line='4748' flags='vc'>
+                     <copyOf line='4754' flags='vc'>
                       <varRef name='Q{}insert-node-location' slot='16'/>
                      </copyOf>
                     </choose>
                    </withParam>
                    <withParam name='Q{}position-relative' flags='t' as='xs:string?'>
-                    <choose line='4759'>
+                    <choose line='4765'>
                      <fn name='exists'>
                       <varRef name='Q{}insert-node-location' slot='16'/>
                      </fn>
@@ -386,25 +386,25 @@
                   </applyT>
                  </check>
                 </treat>
-                <sequence line='4765'>
+                <sequence line='4771'>
                  <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='8' eval='6 6'>
                   <varRef name='Q{}ref' slot='3'/>
                   <varRef name='Q{}instance-with-insert' slot='18'/>
                  </ufCall>
-                 <choose line='4769'>
+                 <choose line='4775'>
                   <fn name='matches'>
                    <varRef name='Q{}at' slot='8'/>
                    <str val='index\s*\('/>
                    <str val=''/>
                   </fn>
-                  <let line='4770' var='Q{}repeat-id' as='xs:string?' slot='19' eval='7'>
+                  <let line='4776' var='Q{}repeat-id' as='xs:string?' slot='19' eval='7'>
                    <ufCall name='Q{http://www.w3.org/2002/xforms}getRepeatID' tailCall='false' bSlot='9' eval='16'>
                     <check card='1' diag='0|0||xforms:getRepeatID'>
                      <varRef name='Q{}at' slot='8'/>
                     </check>
                    </ufCall>
-                   <let line='4771' var='Q{}at-position' as='xs:integer' slot='20' eval='16'>
-                    <treat line='4772' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|at-position'>
+                   <let line='4777' var='Q{}at-position' as='xs:integer' slot='20' eval='16'>
+                    <treat line='4778' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|at-position'>
                      <check card='1' diag='3|0|XTTE0570|at-position'>
                       <cvUntyped to='xs:integer' diag='3|0|XTTE0570|at-position'>
                        <data>
@@ -423,16 +423,16 @@
                       </cvUntyped>
                      </check>
                     </treat>
-                    <choose line='4777'>
+                    <choose line='4783'>
                      <fn name='exists'>
                       <varRef name='Q{}repeat-id' slot='19'/>
                      </fn>
-                     <choose line='4779'>
+                     <choose line='4785'>
                       <vc op='eq' onEmpty='0' comp='CCC'>
                        <varRef name='Q{}position' slot='9'/>
                        <str val='before'/>
                       </vc>
-                      <ifCall line='4780' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                      <ifCall line='4786' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                        <check card='1' diag='0|0||ixsl:call'>
                         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                        </check>
@@ -443,7 +443,7 @@
                        </arrayBlock>
                       </ifCall>
                       <true/>
-                      <ifCall line='4783' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                      <ifCall line='4789' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                        <check card='1' diag='0|0||ixsl:call'>
                         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                        </check>
@@ -461,7 +461,7 @@
                    </let>
                   </let>
                  </choose>
-                 <callT line='4793' name='Q{}xforms-recalculate' bSlot='11' flags='t'/>
+                 <callT line='4799' name='Q{}xforms-recalculate' bSlot='11' flags='t'/>
                 </sequence>
                </let>
               </let>
@@ -479,8 +479,8 @@
   </template>
  </co>
  <co id='8' binds='1 2 3 3 9 5 7'>
-  <template name='Q{}action-delete' flags='os' line='4805' module='saxon-xforms.xsl' slots='16'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4806'>
+  <template name='Q{}action-delete' flags='os' line='4811' module='saxon-xforms.xsl' slots='16'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4812'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -488,14 +488,14 @@
       </check>
      </treat>
     </param>
-    <param line='4807' name='Q{}instanceXML' slot='1' flags='ti' as='element()'>
+    <param line='4813' name='Q{}instanceXML' slot='1' flags='ti' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|instanceXML'>
       <check card='1' diag='8|0|XTTE0590|instanceXML'>
        <supplied slot='1'/>
       </check>
      </treat>
     </param>
-    <param line='4808' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
+    <param line='4814' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -507,7 +507,7 @@
       </check>
      </treat>
     </param>
-    <let line='4810' var='Q{}ref' as='xs:string' slot='3' eval='16'>
+    <let line='4816' var='Q{}ref' as='xs:string' slot='3' eval='16'>
      <let var='Q{}relative' as='xs:string' slot='4' eval='16'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|1||xforms:resolveXPathStrings'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
@@ -532,7 +532,7 @@
         <str val='instance('/>
        </fn>
        <varRef line='842' name='Q{}relative' slot='4'/>
-       <fn line='4810' name='not'>
+       <fn line='4816' name='not'>
         <varRef name='Q{}nodeset' slot='2'/>
        </fn>
        <varRef line='845' name='Q{}relative' slot='4'/>
@@ -545,7 +545,7 @@
          <str val='.'/>
         </vc>
        </or>
-       <varRef line='4810' name='Q{}nodeset' slot='2'/>
+       <varRef line='4816' name='Q{}nodeset' slot='2'/>
        <true/>
        <let line='852' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
         <choose>
@@ -576,13 +576,13 @@
         </choose>
         <let line='855' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
          <choose>
-          <fn line='4810' name='contains'>
+          <fn line='4816' name='contains'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
           </fn>
           <fn name='index-of'>
            <fn name='string-to-codepoints'>
-            <varRef line='4810' name='Q{}nodeset' slot='2'/>
+            <varRef line='4816' name='Q{}nodeset' slot='2'/>
            </fn>
            <int val='47'/>
           </fn>
@@ -595,7 +595,7 @@
           </compareToInt>
           <fn line='891' name='concat'>
            <fn name='substring'>
-            <varRef line='4810' name='Q{}nodeset' slot='2'/>
+            <varRef line='4816' name='Q{}nodeset' slot='2'/>
             <int val='1'/>
             <choose line='866'>
              <and op='and'>
@@ -640,7 +640,7 @@
            </fn>
           </fn>
           <true/>
-          <fn line='4810' name='concat'>
+          <fn line='4816' name='concat'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
            <varRef line='894' name='Q{}relative' slot='4'/>
@@ -650,7 +650,7 @@
        </let>
       </choose>
      </let>
-     <let line='4811' var='Q{}at' as='xs:string?' slot='8' eval='7'>
+     <let line='4817' var='Q{}at' as='xs:string?' slot='8' eval='7'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|at'>
        <check card='?' diag='3|0|XTTE0570|at'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|at'>
@@ -663,7 +663,7 @@
         </cvUntyped>
        </check>
       </treat>
-      <let line='4821' var='Q{}ref-qualified' as='xs:string' slot='9' eval='16'>
+      <let line='4827' var='Q{}ref-qualified' as='xs:string' slot='9' eval='16'>
        <choose>
         <fn name='exists'>
          <varRef name='Q{}at' slot='8'/>
@@ -677,28 +677,28 @@
         <true/>
         <varRef name='Q{}ref' slot='3'/>
        </choose>
-       <let line='4823' var='Q{}instance-id' as='xs:string' slot='10' eval='16'>
+       <let line='4829' var='Q{}instance-id' as='xs:string' slot='10' eval='16'>
         <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='6'>
          <varRef name='Q{}ref' slot='3'/>
         </ufCall>
-        <let line='4825' var='Q{}instanceXML2' as='element()' slot='11' eval='16'>
-         <choose line='4827'>
+        <let line='4831' var='Q{}instanceXML2' as='element()' slot='11' eval='16'>
+         <choose line='4833'>
           <vc op='eq' onEmpty='0' comp='CCC'>
            <varRef name='Q{}instance-id' slot='10'/>
            <str val='saxon-forms-default'/>
           </vc>
-          <varRef line='4828' name='Q{}instanceXML' slot='1'/>
+          <varRef line='4834' name='Q{}instanceXML' slot='1'/>
           <true/>
-          <check line='4831' card='1' diag='3|0|XTTE0570|instanceXML2'>
+          <check line='4837' card='1' diag='3|0|XTTE0570|instanceXML2'>
            <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='6'>
             <varRef name='Q{}instance-id' slot='10'/>
            </ufCall>
           </check>
          </choose>
-         <let line='4836' var='Q{}ifVar' as='xs:string?' slot='12' eval='7'>
+         <let line='4842' var='Q{}ifVar' as='xs:string?' slot='12' eval='7'>
           <choose line='793'>
            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
-            <varRef line='4836' name='Q{}action-map' slot='0'/>
+            <varRef line='4842' name='Q{}action-map' slot='0'/>
             <str val='@if'/>
            </ifCall>
            <treat line='794' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
@@ -706,7 +706,7 @@
              <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
               <data>
                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                <varRef line='4836' name='Q{}action-map' slot='0'/>
+                <varRef line='4842' name='Q{}action-map' slot='0'/>
                 <str val='@if'/>
                </ifCall>
               </data>
@@ -714,8 +714,8 @@
             </check>
            </treat>
           </choose>
-          <let line='4839' var='Q{}delete-node' as='node()*' slot='13' eval='8'>
-           <choose line='4841'>
+          <let line='4845' var='Q{}delete-node' as='node()*' slot='13' eval='8'>
+           <choose line='4847'>
             <and op='and'>
              <fn name='exists'>
               <varRef name='Q{}ref-qualified' slot='9'/>
@@ -725,7 +725,7 @@
               <str val=''/>
              </vc>
             </and>
-            <treat line='4842' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|delete-node'>
+            <treat line='4848' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|delete-node'>
              <evaluate dxns=''>
               <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
                <check card='1' diag='0|0||xforms:impose'>
@@ -740,12 +740,12 @@
              </evaluate>
             </treat>
            </choose>
-           <let line='4847' var='Q{}ifExecuted' as='xs:boolean' slot='14' eval='16'>
-            <choose line='4849'>
+           <let line='4853' var='Q{}ifExecuted' as='xs:boolean' slot='14' eval='16'>
+            <choose line='4855'>
              <fn name='exists'>
               <varRef name='Q{}ifVar' slot='12'/>
              </fn>
-             <treat line='4850' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|ifExecuted'>
+             <treat line='4856' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|ifExecuted'>
               <check card='1' diag='3|0|XTTE0570|ifExecuted'>
                <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|ifExecuted'>
                 <data>
@@ -772,25 +772,25 @@
              <true/>
              <true/>
             </choose>
-            <choose line='4858'>
+            <choose line='4864'>
              <varRef name='Q{}ifExecuted' slot='14'/>
-             <let line='4859' var='Q{}instance-with-delete' as='element()' slot='15' eval='16'>
-              <treat line='4860' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-delete'>
+             <let line='4865' var='Q{}instance-with-delete' as='element()' slot='15' eval='16'>
+              <treat line='4866' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-delete'>
                <check card='1' diag='3|0|XTTE0570|instance-with-delete'>
                 <applyT mode='Q{}delete-node' bSlot='4'>
                  <varRef role='select' name='Q{}instanceXML2' slot='11'/>
                  <withParam name='Q{}delete-node' flags='t' as='node()*'>
-                  <varRef line='4861' name='Q{}delete-node' slot='13'/>
+                  <varRef line='4867' name='Q{}delete-node' slot='13'/>
                  </withParam>
                 </applyT>
                </check>
               </treat>
-              <sequence line='4867'>
+              <sequence line='4873'>
                <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='5' eval='6 6'>
                 <varRef name='Q{}ref' slot='3'/>
                 <varRef name='Q{}instance-with-delete' slot='15'/>
                </ufCall>
-               <callT line='4896' name='Q{}xforms-recalculate' bSlot='6' flags='t'/>
+               <callT line='4902' name='Q{}xforms-recalculate' bSlot='6' flags='t'/>
               </sequence>
              </let>
             </choose>
@@ -806,8 +806,8 @@
   </template>
  </co>
  <co id='10' binds='11'>
-  <template name='Q{}action-send' flags='os' line='4941' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4942'>
+  <template name='Q{}action-send' flags='os' line='4947' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4948'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -815,9 +815,9 @@
       </check>
      </treat>
     </param>
-    <callT line='4948' name='Q{}xforms-submit' bSlot='0' flags='t'>
+    <callT line='4954' name='Q{}xforms-submit' bSlot='0' flags='t'>
      <withParam name='Q{}submission' flags='c' as='xs:string'>
-      <treat line='4946' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|submission'>
+      <treat line='4952' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|submission'>
        <check card='1' diag='3|0|XTTE0570|submission'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|submission'>
          <data>
@@ -1510,8 +1510,8 @@
   </function>
  </co>
  <co id='17' binds=''>
-  <template name='Q{}action-reset' flags='os' line='4988' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4989'>
+  <template name='Q{}action-reset' flags='os' line='4994' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4995'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -1519,7 +1519,7 @@
       </check>
      </treat>
     </param>
-    <message line='4991'>
+    <message line='4997'>
      <valueOf role='select'>
       <str val='[action-reset] Reset triggered!'/>
      </valueOf>
@@ -1530,8 +1530,8 @@
   </template>
  </co>
  <co id='18' binds='1 2 3 15 19 5 20 7 21'>
-  <template name='Q{}xforms-value-changed' flags='os' line='4198' module='saxon-xforms.xsl' slots='9'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4199'>
+  <template name='Q{}xforms-value-changed' flags='os' line='4204' module='saxon-xforms.xsl' slots='9'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4205'>
     <param name='Q{}form-control' slot='0' flags='i' as='node()'>
      <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|form-control'>
       <check card='1' diag='8|0|XTTE0590|form-control'>
@@ -1539,12 +1539,12 @@
       </check>
      </treat>
     </param>
-    <let line='4201' var='Q{}refi' as='attribute(Q{}data-ref)?' slot='1' eval='8'>
+    <let line='4207' var='Q{}refi' as='attribute(Q{}data-ref)?' slot='1' eval='8'>
      <slash simple='1'>
       <varRef name='Q{}form-control' slot='0'/>
       <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
      </slash>
-     <let line='4204' var='Q{}instance-id' as='xs:string' slot='2' eval='16'>
+     <let line='4210' var='Q{}instance-id' as='xs:string' slot='2' eval='16'>
       <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='16'>
        <check card='1' diag='0|0||xforms:getInstanceId'>
         <cvUntyped to='xs:string'>
@@ -1554,7 +1554,7 @@
         </cvUntyped>
        </check>
       </ufCall>
-      <let line='4205' var='Q{}actions' as='item()?' slot='3' eval='8'>
+      <let line='4211' var='Q{}actions' as='item()?' slot='3' eval='8'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
         <check card='1' diag='0|0||ixsl:call'>
          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -1569,14 +1569,14 @@
          </fn>
         </arrayBlock>
        </ifCall>
-       <let line='4216' var='Q{}instanceXML' as='element()' slot='4' eval='16'>
+       <let line='4222' var='Q{}instanceXML' as='element()' slot='4' eval='16'>
         <check card='1' diag='3|0|XTTE0570|instanceXML'>
          <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='6'>
           <varRef name='Q{}instance-id' slot='2'/>
          </ufCall>
         </check>
-        <let line='4217' var='Q{}updatedNode' as='node()' slot='5' eval='16'>
-         <treat line='4218' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|updatedNode'>
+        <let line='4223' var='Q{}updatedNode' as='node()' slot='5' eval='16'>
+         <treat line='4224' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|updatedNode'>
           <check card='1' diag='3|0|XTTE0570|updatedNode'>
            <evaluate dxns=''>
             <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
@@ -1596,8 +1596,8 @@
            </evaluate>
           </check>
          </treat>
-         <let line='4220' var='Q{}new-value' as='xs:string' slot='6' eval='16'>
-          <treat line='4221' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-value'>
+         <let line='4226' var='Q{}new-value' as='xs:string' slot='6' eval='16'>
+          <treat line='4227' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-value'>
            <check card='1' diag='3|0|XTTE0570|new-value'>
             <cvUntyped to='xs:string' diag='3|0|XTTE0570|new-value'>
              <data>
@@ -1608,24 +1608,24 @@
             </cvUntyped>
            </check>
           </treat>
-          <let line='4223' var='Q{}updatedInstanceXML' as='element()' slot='7' eval='16'>
-           <treat line='4224' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+          <let line='4229' var='Q{}updatedInstanceXML' as='element()' slot='7' eval='16'>
+           <treat line='4230' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
             <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
              <applyT mode='Q{}recalculate' bSlot='4'>
               <varRef role='select' name='Q{}instanceXML' slot='4'/>
               <withParam name='Q{}instance-id' as='xs:string'>
-               <varRef line='4225' name='Q{}instance-id' slot='2'/>
+               <varRef line='4231' name='Q{}instance-id' slot='2'/>
               </withParam>
               <withParam name='Q{}updated-nodes' flags='t' as='node()'>
-               <varRef line='4226' name='Q{}updatedNode' slot='5'/>
+               <varRef line='4232' name='Q{}updatedNode' slot='5'/>
               </withParam>
               <withParam name='Q{}updated-values' flags='t' as='xs:string'>
-               <varRef line='4227' name='Q{}new-value' slot='6'/>
+               <varRef line='4233' name='Q{}new-value' slot='6'/>
               </withParam>
              </applyT>
             </check>
            </treat>
-           <sequence line='4234'>
+           <sequence line='4240'>
             <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='5' eval='16 6'>
              <check card='1' diag='0|0||xforms:setInstance-JS'>
               <cvUntyped to='xs:string'>
@@ -1636,40 +1636,40 @@
              </check>
              <varRef name='Q{}updatedInstanceXML' slot='7'/>
             </ufCall>
-            <ifCall line='4241' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+            <ifCall line='4247' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
              <check card='1' diag='0|0||ixsl:call'>
               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
              </check>
              <str val='setPendingUpdates'/>
              <arrayBlock>
-              <treat line='4238' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||pendingInstanceUpdates'>
+              <treat line='4244' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||pendingInstanceUpdates'>
                <map size='0'/>
               </treat>
              </arrayBlock>
             </ifCall>
-            <ifCall line='4242' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+            <ifCall line='4248' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
              <check card='1' diag='0|0||ixsl:call'>
               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
              </check>
              <str val='setUpdates'/>
              <arrayBlock>
-              <treat line='4239' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||instanceUpdates'>
+              <treat line='4245' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||instanceUpdates'>
                <map size='0'/>
               </treat>
              </arrayBlock>
             </ifCall>
-            <forEach line='4244'>
+            <forEach line='4250'>
              <varRef name='Q{}actions' slot='3'/>
-             <let line='4245' var='Q{}action-map' as='item()' slot='8' eval='16'>
+             <let line='4251' var='Q{}action-map' as='item()' slot='8' eval='16'>
               <dot/>
-              <choose line='4247'>
+              <choose line='4253'>
                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
                 <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:contains'>
                  <varRef name='Q{}action-map' slot='8'/>
                 </treat>
                 <str val='@event'/>
                </ifCall>
-               <choose line='4248'>
+               <choose line='4254'>
                 <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
                  <data>
                   <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
@@ -1681,12 +1681,12 @@
                  </data>
                  <str val='xforms-value-changed'/>
                 </gc>
-                <callT line='4250' name='Q{}applyActions' bSlot='6'>
+                <callT line='4256' name='Q{}applyActions' bSlot='6'>
                  <withParam name='Q{}action-map' flags='t' as='item()'>
-                  <varRef line='4251' name='Q{}action-map' slot='8'/>
+                  <varRef line='4257' name='Q{}action-map' slot='8'/>
                  </withParam>
                  <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                  <check line='4252' card='1' diag='8|0|XTTE0590|nodeset'>
+                  <check line='4258' card='1' diag='8|0|XTTE0590|nodeset'>
                    <cvUntyped to='xs:string' diag='8|0|XTTE0590|nodeset'>
                     <data>
                      <varRef name='Q{}refi' slot='1'/>
@@ -1695,19 +1695,19 @@
                   </check>
                  </withParam>
                  <withParam name='Q{}instanceXML' flags='t' as='element()'>
-                  <varRef line='4253' name='Q{}updatedInstanceXML' slot='7'/>
+                  <varRef line='4259' name='Q{}updatedInstanceXML' slot='7'/>
                  </withParam>
                 </callT>
                </choose>
               </choose>
              </let>
             </forEach>
-            <callT line='4259' name='Q{}xforms-recalculate' bSlot='7'/>
-            <ufCall line='4261' name='Q{http://www.w3.org/2002/xforms}checkRelevantFields' tailCall='false' bSlot='8' eval='16'>
+            <callT line='4265' name='Q{}xforms-recalculate' bSlot='7'/>
+            <ufCall line='4267' name='Q{http://www.w3.org/2002/xforms}checkRelevantFields' tailCall='false' bSlot='8' eval='16'>
              <check card='1' diag='0|0||xforms:checkRelevantFields'>
               <cvUntyped to='xs:string'>
                <data>
-                <slash line='4202' simple='1'>
+                <slash line='4208' simple='1'>
                  <varRef name='Q{}form-control' slot='0'/>
                  <axis name='attribute' nodeTest='attribute(Q{}data-element)' jsTest='return item.name===&#39;data-element&#39;'/>
                 </slash>
@@ -1796,8 +1796,8 @@
   </template>
  </co>
  <co id='25' binds=''>
-  <template name='Q{}action-message' flags='os' line='4908' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4909'>
+  <template name='Q{}action-message' flags='os' line='4914' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4915'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -1805,13 +1805,13 @@
       </check>
      </treat>
     </param>
-    <message line='4913'>
+    <message line='4919'>
      <sequence role='select'>
       <valueOf>
        <str val='[action-message] Message reads "'/>
       </valueOf>
       <valueOf>
-       <treat line='4911' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|message-value'>
+       <treat line='4917' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|message-value'>
         <check card='1' diag='3|0|XTTE0570|message-value'>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|message-value'>
           <data>
@@ -2011,8 +2011,8 @@
   </function>
  </co>
  <co id='29' binds='3'>
-  <template name='Q{}action-setindex' flags='os' line='4961' module='saxon-xforms.xsl' slots='2'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4962'>
+  <template name='Q{}action-setindex' flags='os' line='4967' module='saxon-xforms.xsl' slots='2'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4968'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -2020,14 +2020,14 @@
       </check>
      </treat>
     </param>
-    <let line='4968' var='Q{}new-index' as='xs:integer' slot='1' eval='16'>
-     <treat line='4969' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|new-index'>
+    <let line='4974' var='Q{}new-index' as='xs:integer' slot='1' eval='16'>
+     <treat line='4975' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|new-index'>
       <check card='1' diag='3|0|XTTE0570|new-index'>
        <cvUntyped to='xs:integer' diag='3|0|XTTE0570|new-index'>
         <data>
          <evaluate dxns=''>
           <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='0' eval='16'>
-           <treat line='4965' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-index-ref'>
+           <treat line='4971' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-index-ref'>
             <check card='1' diag='3|0|XTTE0570|new-index-ref'>
              <cvUntyped to='xs:string' diag='3|0|XTTE0570|new-index-ref'>
               <data>
@@ -2049,13 +2049,13 @@
        </cvUntyped>
       </check>
      </treat>
-     <ifCall line='4974' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+     <ifCall line='4980' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
       <check card='1' diag='0|0||ixsl:call'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
       </check>
       <str val='setRepeatIndex'/>
       <arrayBlock>
-       <treat line='4964' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|repeatID'>
+       <treat line='4970' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|repeatID'>
         <check card='1' diag='3|0|XTTE0570|repeatID'>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|repeatID'>
           <data>
@@ -2075,8 +2075,8 @@
   </template>
  </co>
  <co id='30' binds='31'>
-  <template name='Q{}action-setfocus' flags='os' line='4923' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4924'>
+  <template name='Q{}action-setfocus' flags='os' line='4929' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4930'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -2084,9 +2084,9 @@
       </check>
      </treat>
     </param>
-    <callT line='4928' name='Q{}xforms-focus' bSlot='0' flags='t'>
+    <callT line='4934' name='Q{}xforms-focus' bSlot='0' flags='t'>
      <withParam name='Q{}control' flags='c' as='xs:string'>
-      <treat line='4926' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|control'>
+      <treat line='4932' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|control'>
        <check card='1' diag='3|0|XTTE0570|control'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|control'>
          <data>
@@ -2104,8 +2104,8 @@
   </template>
  </co>
  <co id='32' binds='1 3 3 33 16 34 5 35'>
-  <template name='Q{}action-setvalue' flags='os' line='4585' module='saxon-xforms.xsl' slots='14'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4586'>
+  <template name='Q{}action-setvalue' flags='os' line='4591' module='saxon-xforms.xsl' slots='14'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4592'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -2113,7 +2113,7 @@
       </check>
      </treat>
     </param>
-    <param line='4587' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
+    <param line='4593' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
      <empty role='select'/>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|instanceXML'>
       <check card='?' diag='8|0|XTTE0590|instanceXML'>
@@ -2121,7 +2121,7 @@
       </check>
      </treat>
     </param>
-    <param line='4588' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
+    <param line='4594' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -2133,7 +2133,7 @@
       </check>
      </treat>
     </param>
-    <let line='4592' var='Q{}refz' as='xs:string' slot='3' eval='16'>
+    <let line='4598' var='Q{}refz' as='xs:string' slot='3' eval='16'>
      <let var='Q{}relative' as='xs:string' slot='4' eval='16'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|1||xforms:resolveXPathStrings'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
@@ -2158,7 +2158,7 @@
         <str val='instance('/>
        </fn>
        <varRef line='842' name='Q{}relative' slot='4'/>
-       <fn line='4592' name='not'>
+       <fn line='4598' name='not'>
         <varRef name='Q{}nodeset' slot='2'/>
        </fn>
        <varRef line='845' name='Q{}relative' slot='4'/>
@@ -2171,7 +2171,7 @@
          <str val='.'/>
         </vc>
        </or>
-       <varRef line='4592' name='Q{}nodeset' slot='2'/>
+       <varRef line='4598' name='Q{}nodeset' slot='2'/>
        <true/>
        <let line='852' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
         <choose>
@@ -2202,13 +2202,13 @@
         </choose>
         <let line='855' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
          <choose>
-          <fn line='4592' name='contains'>
+          <fn line='4598' name='contains'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
           </fn>
           <fn name='index-of'>
            <fn name='string-to-codepoints'>
-            <varRef line='4592' name='Q{}nodeset' slot='2'/>
+            <varRef line='4598' name='Q{}nodeset' slot='2'/>
            </fn>
            <int val='47'/>
           </fn>
@@ -2221,7 +2221,7 @@
           </compareToInt>
           <fn line='891' name='concat'>
            <fn name='substring'>
-            <varRef line='4592' name='Q{}nodeset' slot='2'/>
+            <varRef line='4598' name='Q{}nodeset' slot='2'/>
             <int val='1'/>
             <choose line='866'>
              <and op='and'>
@@ -2266,7 +2266,7 @@
            </fn>
           </fn>
           <true/>
-          <fn line='4592' name='concat'>
+          <fn line='4598' name='concat'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
            <varRef line='894' name='Q{}relative' slot='4'/>
@@ -2276,19 +2276,19 @@
        </let>
       </choose>
      </let>
-     <let line='4594' var='Q{}instance-id' as='xs:string' slot='8' eval='16'>
+     <let line='4600' var='Q{}instance-id' as='xs:string' slot='8' eval='16'>
       <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='6'>
        <varRef name='Q{}refz' slot='3'/>
       </ufCall>
-      <let line='4607' var='Q{}valuez' as='document-node()' slot='9' eval='16'>
-       <doc line='4609' validation='preserve'>
+      <let line='4613' var='Q{}valuez' as='document-node()' slot='9' eval='16'>
+       <doc line='4615' validation='preserve'>
         <choose>
          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
           <varRef name='Q{}action-map' slot='0'/>
           <str val='@value'/>
          </ifCall>
-         <let line='4610' var='Q{}contexti' as='node()' slot='10' eval='8'>
-          <evaluate line='4611' as='node()' dxns=''>
+         <let line='4616' var='Q{}contexti' as='node()' slot='10' eval='8'>
+          <evaluate line='4617' as='node()' dxns=''>
            <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='1' eval='6'>
             <varRef name='Q{}nodeset' slot='2'/>
            </ufCall>
@@ -2300,7 +2300,7 @@
            <map role='options' size='0'/>
            <map role='wp' size='0'/>
           </evaluate>
-          <evaluate line='4614' dxns=''>
+          <evaluate line='4620' dxns=''>
            <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
             <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:impose'>
              <check card='1' diag='0|0||xforms:impose'>
@@ -2322,13 +2322,13 @@
            <map role='wp' size='0'/>
           </evaluate>
          </let>
-         <ifCall line='4617' name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+         <ifCall line='4623' name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
           <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:contains'>
            <dot flags='a'/>
           </treat>
           <str val='value'/>
          </ifCall>
-         <ifCall line='4618' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+         <ifCall line='4624' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
           <varRef name='Q{}action-map' slot='0'/>
           <str val='value'/>
          </ifCall>
@@ -2336,8 +2336,8 @@
          <str val=''/>
         </choose>
        </doc>
-       <sequence line='4628'>
-        <let line='4630' var='Q{}associated-form-control' as='element()?' slot='11' eval='7'>
+       <sequence line='4634'>
+        <let line='4636' var='Q{}associated-form-control' as='element()?' slot='11' eval='7'>
          <check card='?' diag='3|0|XTTE0570|associated-form-control'>
           <filter flags='b'>
            <slash simple='1'>
@@ -2352,22 +2352,22 @@
            </vc>
           </filter>
          </check>
-         <choose line='4632'>
+         <choose line='4638'>
           <fn name='exists'>
            <varRef name='Q{}associated-form-control' slot='11'/>
           </fn>
-          <sequence line='4633'>
+          <sequence line='4639'>
            <applyT mode='Q{}set-field' bSlot='3'>
             <varRef role='select' name='Q{}associated-form-control' slot='11'/>
             <withParam name='Q{}value' flags='t' as='xs:string'>
-             <cast line='4634' as='xs:string' emptiable='0'>
+             <cast line='4640' as='xs:string' emptiable='0'>
               <data>
                <varRef name='Q{}valuez' slot='9'/>
               </data>
              </cast>
             </withParam>
            </applyT>
-           <ifCall line='4636' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+           <ifCall line='4642' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
             <check card='1' diag='0|0||ixsl:call'>
              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
             </check>
@@ -2396,7 +2396,7 @@
            </ifCall>
           </sequence>
           <true/>
-          <ifCall line='4639' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+          <ifCall line='4645' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
            <check card='1' diag='0|0||ixsl:call'>
             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
            </check>
@@ -2425,12 +2425,12 @@
           </ifCall>
          </choose>
         </let>
-        <choose line='4645'>
+        <choose line='4651'>
          <vc op='ne' onEmpty='1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
           <varRef name='Q{}refz' slot='3'/>
           <str val=''/>
          </vc>
-         <let line='4647' var='Q{}pendingUpdates' as='map(xs:string, xs:string)?' slot='12' eval='7'>
+         <let line='4653' var='Q{}pendingUpdates' as='map(xs:string, xs:string)?' slot='12' eval='7'>
           <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|pendingUpdates'>
            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
             <check card='1' diag='0|0||ixsl:call'>
@@ -2440,11 +2440,11 @@
             <array size='0'/>
            </ifCall>
           </treat>
-          <let line='4649' var='Q{}updatedInstanceXML' as='element()' slot='13' eval='16'>
-           <treat line='4650' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+          <let line='4655' var='Q{}updatedInstanceXML' as='element()' slot='13' eval='16'>
+           <treat line='4656' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
             <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
              <applyT mode='Q{}form-check-initial' bSlot='4'>
-              <choose role='select' line='4598'>
+              <choose role='select' line='4604'>
                <and op='and'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <varRef name='Q{}instance-id' slot='8'/>
@@ -2454,31 +2454,31 @@
                  <varRef name='Q{}instanceXML' slot='1'/>
                 </fn>
                </and>
-               <check line='4599' card='1' diag='3|0|XTTE0570|instanceXML2'>
+               <check line='4605' card='1' diag='3|0|XTTE0570|instanceXML2'>
                 <varRef name='Q{}instanceXML' slot='1'/>
                </check>
                <true/>
-               <check line='4602' card='1' diag='3|0|XTTE0570|instanceXML2'>
+               <check line='4608' card='1' diag='3|0|XTTE0570|instanceXML2'>
                 <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='5' eval='6'>
                  <varRef name='Q{}refz' slot='3'/>
                 </ufCall>
                </check>
               </choose>
               <withParam name='Q{}instance-id' as='xs:string'>
-               <varRef line='4651' name='Q{}instance-id' slot='8'/>
+               <varRef line='4657' name='Q{}instance-id' slot='8'/>
               </withParam>
               <withParam name='Q{}pendingUpdates' flags='t' as='map(xs:string, xs:string)?'>
-               <varRef line='4652' name='Q{}pendingUpdates' slot='12'/>
+               <varRef line='4658' name='Q{}pendingUpdates' slot='12'/>
               </withParam>
              </applyT>
             </check>
            </treat>
-           <sequence line='4657'>
+           <sequence line='4663'>
             <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='6' eval='6 6'>
              <varRef name='Q{}refz' slot='3'/>
              <varRef name='Q{}updatedInstanceXML' slot='13'/>
             </ufCall>
-            <callT line='4658' name='Q{}refreshOutputs-JS' bSlot='7' flags='t'/>
+            <callT line='4664' name='Q{}refreshOutputs-JS' bSlot='7' flags='t'/>
            </sequence>
           </let>
          </let>
@@ -3247,7 +3247,7 @@
                  </map>
                 </ifCall>
                </treat>
-               <resultDoc line='3601' global='#&#xD;&#xA;#Fri Mar 13 14:41:49 GMT 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Fri Mar 13 14:41:49 GMT 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
+               <resultDoc line='3601' global='#&#xD;&#xA;#Fri Mar 13 15:05:29 GMT 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Fri Mar 13 15:05:29 GMT 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
                 <fn role='href' name='concat'>
                  <str val='#'/>
                  <varRef name='Q{}this-key' slot='1'/>
@@ -3483,7 +3483,7 @@
                <fn name='exists'>
                 <varRef name='Q{}associated-form-control' slot='7'/>
                </fn>
-               <resultDoc line='3544' global='#&#xD;&#xA;#Fri Mar 13 14:41:49 GMT 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Fri Mar 13 14:41:49 GMT 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
+               <resultDoc line='3544' global='#&#xD;&#xA;#Fri Mar 13 15:05:29 GMT 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Fri Mar 13 15:05:29 GMT 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
                 <fn role='href' name='concat'>
                  <str val='#'/>
                  <varRef name='Q{}this-key' slot='1'/>
@@ -3507,8 +3507,8 @@
   </template>
  </co>
  <co id='31' binds='46'>
-  <template name='Q{}xforms-focus' flags='os' line='4272' module='saxon-xforms.xsl' slots='5'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4273'>
+  <template name='Q{}xforms-focus' flags='os' line='4278' module='saxon-xforms.xsl' slots='5'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4279'>
     <param name='Q{}control' slot='0' flags='i' as='xs:string'>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|control'>
       <check card='1' diag='8|0|XTTE0590|control'>
@@ -3520,10 +3520,10 @@
       </check>
      </treat>
     </param>
-    <let line='4274' var='Q{}xforms-control' as='element()' slot='1' eval='16'>
+    <let line='4280' var='Q{}xforms-control' as='element()' slot='1' eval='16'>
      <check card='1' diag='3|0|XTTE0570|xforms-control'>
       <filter flags='b'>
-       <gVarRef name='Q{http://saxon.sf.net/generated-variable}gg1090039905' bSlot='0'/>
+       <gVarRef name='Q{http://saxon.sf.net/generated-variable}gg841391920' bSlot='0'/>
        <vc op='eq' onEmpty='0' comp='CCC'>
         <cast as='xs:string' emptiable='1'>
          <attVal name='Q{}id' chk='0'/>
@@ -3532,19 +3532,19 @@
        </vc>
       </filter>
      </check>
-     <choose line='4279'>
+     <choose line='4285'>
       <fn name='exists'>
        <slash simple='1'>
         <varRef name='Q{}xforms-control' slot='1'/>
         <axis name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
        </slash>
       </fn>
-      <let line='4283' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='2' eval='13'>
+      <let line='4289' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='2' eval='13'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
        </check>
-       <let line='4280' var='Q{}context-indexes' as='xs:double*' slot='3' eval='8'>
-        <convert line='4281' from='xs:anyAtomicType' to='xs:double' flags='p' diag='3|0|XTTE0570|context-indexes'>
+       <let line='4286' var='Q{}context-indexes' as='xs:double*' slot='3' eval='8'>
+        <convert line='4287' from='xs:anyAtomicType' to='xs:double' flags='p' diag='3|0|XTTE0570|context-indexes'>
          <cvUntyped to='xs:double' diag='3|0|XTTE0570|context-indexes'>
           <data>
            <forEach>
@@ -3555,7 +3555,7 @@
                <axis name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
               </fn>
              </slash>
-             <sortKey line='4282' comp='DESC|NC11'>
+             <sortKey line='4288' comp='DESC|NC11'>
               <fn role='select' name='position'/>
               <str role='order' val='descending'/>
               <str role='dataType' val='number'/>
@@ -3565,7 +3565,7 @@
               <str role='collation' val='http://www.w3.org/2005/xpath-functions/collation/codepoint'/>
              </sortKey>
             </sort>
-            <ifCall line='4283' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+            <ifCall line='4289' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
              <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='2'/>
              <str val='getRepeatIndex'/>
              <arrayBlock>
@@ -3578,12 +3578,12 @@
           </data>
          </cvUntyped>
         </convert>
-        <let line='4287' var='Q{}control-index' as='xs:string' slot='4' eval='8'>
+        <let line='4293' var='Q{}control-index' as='xs:string' slot='4' eval='8'>
          <fn name='string-join'>
           <varRef name='Q{}context-indexes' slot='3'/>
           <str val='.'/>
          </fn>
-         <sequence line='4288'>
+         <sequence line='4294'>
           <message>
            <sequence role='select'>
             <valueOf>
@@ -3601,7 +3601,7 @@
            <str role='terminate' val='no'/>
            <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
           </message>
-          <ifCall line='4289' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+          <ifCall line='4295' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
            <check card='1' diag='0|0||ixsl:call'>
             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
            </check>
@@ -3619,7 +3619,7 @@
        </let>
       </let>
       <true/>
-      <ifCall line='4292' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+      <ifCall line='4298' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
        </check>
@@ -3919,7 +3919,7 @@
  </co>
  <co id='7' binds='1 2 3 3 19 35 42 49'>
   <template name='Q{}xforms-recalculate' flags='os' line='4132' module='saxon-xforms.xsl' slots='11'>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4179' var='Q{http://saxon.sf.net/generated-variable}v1' as='item()' slot='0' eval='13'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4185' var='Q{http://saxon.sf.net/generated-variable}v1' as='item()' slot='0' eval='13'>
     <check card='1' diag='0|0||ixsl:call'>
      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
     </check>
@@ -3970,7 +3970,24 @@
             <check card='1' diag='0|0||map:entry'>
              <currentGroupingKey/>
             </check>
-            <currentGroup/>
+            <forEach line='4141'>
+             <currentGroup/>
+             <ifCall line='4143' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+               <dot type='xs:anyAtomicType'/>
+               <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                <varRef name='Q{}calculationMap' slot='2'/>
+                <dot type='xs:anyAtomicType'/>
+               </ifCall>
+              </ifCall>
+              <map size='2'>
+               <str val='duplicates'/>
+               <str val='reject'/>
+               <str val='duplicates-error-code'/>
+               <str val='XTDE3365'/>
+              </map>
+             </ifCall>
+            </forEach>
            </ifCall>
           </forEachGroup>
           <map size='2'>
@@ -3981,12 +3998,12 @@
           </map>
          </ifCall>
         </treat>
-        <sequence line='4145'>
+        <sequence line='4151'>
          <forEach>
           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
            <varRef name='Q{}instances-with-calculations' slot='3'/>
           </ifCall>
-          <let line='4146' var='Q{}instanceXML' as='element()' slot='4' eval='16'>
+          <let line='4152' var='Q{}instanceXML' as='element()' slot='4' eval='16'>
            <check card='1' diag='3|0|XTTE0570|instanceXML'>
             <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='16'>
              <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:instance'>
@@ -3996,26 +4013,26 @@
              </treat>
             </ufCall>
            </check>
-           <let line='4148' var='Q{}calculations' as='map(xs:string, xs:string)*' slot='5' eval='4'>
+           <let line='4154' var='Q{}calculations' as='map(xs:string, xs:string)*' slot='5' eval='4'>
             <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|calculations'>
              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
               <varRef name='Q{}instances-with-calculations' slot='3'/>
               <dot type='xs:anyAtomicType'/>
              </ifCall>
             </treat>
-            <let line='4162' var='Q{http://saxon.sf.net/generated-variable}v0' as='map(xs:string, xs:string)' slot='6' eval='13'>
+            <let line='4168' var='Q{http://saxon.sf.net/generated-variable}v0' as='map(xs:string, xs:string)' slot='6' eval='13'>
              <check card='1' diag='0|0||map:get'>
               <varRef name='Q{}calculations' slot='5'/>
              </check>
-             <let line='4151' var='Q{}calculated-nodes' as='node()*' slot='7' eval='8'>
-              <treat line='4152' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|calculated-nodes'>
+             <let line='4157' var='Q{}calculated-nodes' as='node()*' slot='7' eval='8'>
+              <treat line='4158' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|calculated-nodes'>
                <forEach>
                 <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
                  <check card='1' diag='0|0||map:keys'>
                   <varRef name='Q{}calculations' slot='5'/>
                  </check>
                 </ifCall>
-                <evaluate line='4153' dxns=''>
+                <evaluate line='4159' dxns=''>
                  <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
                   <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:impose'>
                    <cvUntyped to='xs:string'>
@@ -4031,15 +4048,15 @@
                 </evaluate>
                </forEach>
               </treat>
-              <let line='4158' var='Q{}calculated-values' as='xs:string*' slot='8' eval='8'>
-               <forEach line='4159'>
+              <let line='4164' var='Q{}calculated-values' as='xs:string*' slot='8' eval='8'>
+               <forEach line='4165'>
                 <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
                  <check card='1' diag='0|0||map:keys'>
                   <varRef name='Q{}calculations' slot='5'/>
                  </check>
                 </ifCall>
-                <let line='4161' var='Q{}value' as='xs:string?' slot='9' eval='7'>
-                 <treat line='4162' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|value'>
+                <let line='4167' var='Q{}value' as='xs:string?' slot='9' eval='7'>
+                 <treat line='4168' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|value'>
                   <check card='?' diag='3|0|XTTE0570|value'>
                    <cvUntyped to='xs:string' diag='3|0|XTTE0570|value'>
                     <data>
@@ -4062,7 +4079,7 @@
                    </cvUntyped>
                   </check>
                  </treat>
-                 <first line='4168'>
+                 <first line='4174'>
                   <sequence>
                    <varRef name='Q{}value' slot='9'/>
                    <str val=''/>
@@ -4070,21 +4087,21 @@
                  </first>
                 </let>
                </forEach>
-               <let line='4172' var='Q{}updatedInstanceXML' as='element()' slot='10' eval='16'>
-                <treat line='4173' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+               <let line='4178' var='Q{}updatedInstanceXML' as='element()' slot='10' eval='16'>
+                <treat line='4179' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
                  <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
                   <applyT mode='Q{}recalculate' bSlot='4'>
                    <varRef role='select' name='Q{}instanceXML' slot='4'/>
                    <withParam name='Q{}updated-nodes' as='node()*'>
-                    <varRef line='4174' name='Q{}calculated-nodes' slot='7'/>
+                    <varRef line='4180' name='Q{}calculated-nodes' slot='7'/>
                    </withParam>
                    <withParam name='Q{}updated-values' as='xs:string*'>
-                    <varRef line='4175' name='Q{}calculated-values' slot='8'/>
+                    <varRef line='4181' name='Q{}calculated-values' slot='8'/>
                    </withParam>
                   </applyT>
                  </check>
                 </treat>
-                <ifCall line='4179' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                <ifCall line='4185' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                  <varRef name='Q{http://saxon.sf.net/generated-variable}v1' slot='0'/>
                  <str val='setInstance'/>
                  <arrayBlock>
@@ -4099,9 +4116,9 @@
            </let>
           </let>
          </forEach>
-         <callT line='4183' name='Q{}refreshOutputs-JS' bSlot='5'/>
-         <callT line='4184' name='Q{}refreshRepeats-JS' bSlot='6'/>
-         <callT line='4185' name='Q{}refreshElementsUsingIndexFunction-JS' bSlot='7' flags='t'/>
+         <callT line='4189' name='Q{}refreshOutputs-JS' bSlot='5'/>
+         <callT line='4190' name='Q{}refreshRepeats-JS' bSlot='6'/>
+         <callT line='4191' name='Q{}refreshElementsUsingIndexFunction-JS' bSlot='7' flags='t'/>
         </sequence>
        </let>
       </let>
@@ -4214,8 +4231,8 @@
   </function>
  </co>
  <co id='11' binds='2 1 3 15 19 52 3 53 20'>
-  <template name='Q{}xforms-submit' flags='os' line='4305' module='saxon-xforms.xsl' slots='20'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4306'>
+  <template name='Q{}xforms-submit' flags='os' line='4311' module='saxon-xforms.xsl' slots='20'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4312'>
     <param name='Q{}submission' slot='0' flags='i' as='xs:string'>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|submission'>
       <check card='1' diag='8|0|XTTE0590|submission'>
@@ -4227,7 +4244,7 @@
       </check>
      </treat>
     </param>
-    <let line='4308' var='Q{}submission-map' as='map(*)' slot='1' eval='16'>
+    <let line='4314' var='Q{}submission-map' as='map(*)' slot='1' eval='16'>
      <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|submission-map'>
       <check card='1' diag='3|0|XTTE0570|submission-map'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
@@ -4241,7 +4258,7 @@
        </ifCall>
       </check>
      </treat>
-     <let line='4309' var='Q{}actions' as='map(*)?' slot='2' eval='7'>
+     <let line='4315' var='Q{}actions' as='map(*)?' slot='2' eval='7'>
       <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
         <check card='1' diag='0|0||ixsl:call'>
@@ -4253,7 +4270,7 @@
         </arrayBlock>
        </ifCall>
       </treat>
-      <let line='4313' var='Q{}refi' as='xs:string?' slot='3' eval='7'>
+      <let line='4319' var='Q{}refi' as='xs:string?' slot='3' eval='7'>
        <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
         <check card='?' diag='3|0|XTTE0570|refi'>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
@@ -4266,13 +4283,13 @@
          </cvUntyped>
         </check>
        </treat>
-       <let line='4315' var='Q{}instance-id' as='xs:string' slot='4' eval='16'>
-        <choose line='4317'>
+       <let line='4321' var='Q{}instance-id' as='xs:string' slot='4' eval='16'>
+        <choose line='4323'>
          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
           <varRef name='Q{}submission-map' slot='1'/>
           <str val='@instance'/>
          </ifCall>
-         <treat line='4318' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|instance-id'>
+         <treat line='4324' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|instance-id'>
           <check card='1' diag='3|0|XTTE0570|instance-id'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|instance-id'>
             <data>
@@ -4287,13 +4304,13 @@
          <true/>
          <str val='saxon-forms-default'/>
         </choose>
-        <let line='4339' var='Q{}instanceXML' as='element()' slot='5' eval='16'>
+        <let line='4345' var='Q{}instanceXML' as='element()' slot='5' eval='16'>
          <check card='1' diag='3|0|XTTE0570|instanceXML'>
           <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='0' eval='6'>
            <varRef name='Q{}instance-id' slot='4'/>
           </ufCall>
          </check>
-         <let line='4340' var='Q{}data-fields' as='element()*' slot='6' eval='8'>
+         <let line='4346' var='Q{}data-fields' as='element()*' slot='6' eval='8'>
           <filter flags='b'>
            <filter flags='b'>
             <filter flags='b'>
@@ -4330,11 +4347,11 @@
             <varRef name='Q{}instance-id' slot='4'/>
            </vc>
           </filter>
-          <let line='4343' var='Q{}calculated-nodes' as='node()*' slot='7' eval='8'>
-           <treat line='4344' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|calculated-nodes'>
+          <let line='4349' var='Q{}calculated-nodes' as='node()*' slot='7' eval='8'>
+           <treat line='4350' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|calculated-nodes'>
             <forEach>
              <varRef name='Q{}data-fields' slot='6'/>
-             <evaluate line='4345' dxns=''>
+             <evaluate line='4351' dxns=''>
               <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
                <fn name='string'>
                 <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
@@ -4348,11 +4365,11 @@
              </evaluate>
             </forEach>
            </treat>
-           <let line='4350' var='Q{}calculated-values' as='xs:string*' slot='8' eval='3'>
-            <forEach line='4351'>
+           <let line='4356' var='Q{}calculated-values' as='xs:string*' slot='8' eval='3'>
+            <forEach line='4357'>
              <varRef name='Q{}data-fields' slot='6'/>
-             <let line='4353' var='Q{}value' as='xs:string' slot='9' eval='8'>
-              <cvUntyped line='4355' to='xs:string' diag='3|0|XTTE0570|value'>
+             <let line='4359' var='Q{}value' as='xs:string' slot='9' eval='8'>
+              <cvUntyped line='4361' to='xs:string' diag='3|0|XTTE0570|value'>
                <cast as='xs:untypedAtomic' emptiable='0'>
                 <fn name='string-join'>
                  <convert from='xs:anyAtomicType' to='xs:string'>
@@ -4368,7 +4385,7 @@
                 </fn>
                </cast>
               </cvUntyped>
-              <first line='4362'>
+              <first line='4368'>
                <sequence>
                 <varRef name='Q{}value' slot='9'/>
                 <str val=''/>
@@ -4376,21 +4393,21 @@
               </first>
              </let>
             </forEach>
-            <let line='4366' var='Q{}updatedInstanceXML' as='element()' slot='10' eval='16'>
-             <treat line='4367' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+            <let line='4372' var='Q{}updatedInstanceXML' as='element()' slot='10' eval='16'>
+             <treat line='4373' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
               <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
                <applyT mode='Q{}recalculate' bSlot='4'>
                 <varRef role='select' name='Q{}instanceXML' slot='5'/>
                 <withParam name='Q{}updated-nodes' as='node()*'>
-                 <varRef line='4368' name='Q{}calculated-nodes' slot='7'/>
+                 <varRef line='4374' name='Q{}calculated-nodes' slot='7'/>
                 </withParam>
                 <withParam name='Q{}updated-values' as='xs:string*'>
-                 <varRef line='4369' name='Q{}calculated-values' slot='8'/>
+                 <varRef line='4375' name='Q{}calculated-values' slot='8'/>
                 </withParam>
                </applyT>
               </check>
              </treat>
-             <let line='4374' var='Q{}required-fieldsi' as='element()*' slot='11' eval='8'>
+             <let line='4380' var='Q{}required-fieldsi' as='element()*' slot='11' eval='8'>
               <filter flags='b'>
                <slash simple='1'>
                 <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
@@ -4400,18 +4417,18 @@
                 <axis name='attribute' nodeTest='attribute(Q{}data-required)' jsTest='return item.name===&#39;data-required&#39;'/>
                </fn>
               </filter>
-              <let line='4376' var='Q{}required-fields-check' as='element()*' slot='12' eval='3'>
+              <let line='4382' var='Q{}required-fields-check' as='element()*' slot='12' eval='3'>
                <ufCall name='Q{http://www.w3.org/2002/xforms}check-required-fields' tailCall='false' bSlot='5' eval='6'>
                 <varRef name='Q{}updatedInstanceXML' slot='10'/>
                </ufCall>
-               <choose line='4382'>
+               <choose line='4388'>
                 <fn name='empty'>
                  <varRef name='Q{}required-fields-check' slot='12'/>
                 </fn>
-                <let line='4383' var='Q{}requestBody' as='node()' slot='13' eval='16'>
-                 <choose line='4385'>
+                <let line='4389' var='Q{}requestBody' as='node()' slot='13' eval='16'>
+                 <choose line='4391'>
                   <varRef name='Q{}refi' slot='3'/>
-                  <treat line='4386' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|requestBody'>
+                  <treat line='4392' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|requestBody'>
                    <check card='1' diag='3|0|XTTE0570|requestBody'>
                     <evaluate dxns=''>
                      <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='6' eval='16'>
@@ -4428,10 +4445,10 @@
                    </check>
                   </treat>
                   <true/>
-                  <varRef line='4389' name='Q{}instanceXML' slot='5'/>
+                  <varRef line='4395' name='Q{}instanceXML' slot='5'/>
                  </choose>
-                 <let line='4394' var='Q{}requestBodyDoc' as='document-node()?' slot='14' eval='7'>
-                  <choose line='4395'>
+                 <let line='4400' var='Q{}requestBodyDoc' as='document-node()?' slot='14' eval='7'>
+                  <choose line='4401'>
                    <fn name='exists'>
                     <filter flags='b'>
                      <varRef name='Q{}requestBody' slot='13'/>
@@ -4440,11 +4457,11 @@
                      </fn>
                     </filter>
                    </fn>
-                   <doc line='4396'>
-                    <varRef line='4397' name='Q{}requestBody' slot='13'/>
+                   <doc line='4402'>
+                    <varRef line='4403' name='Q{}requestBody' slot='13'/>
                    </doc>
                   </choose>
-                  <let line='4402' var='Q{}method' as='xs:string' slot='15' eval='16'>
+                  <let line='4408' var='Q{}method' as='xs:string' slot='15' eval='16'>
                    <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|method'>
                     <check card='1' diag='3|0|XTTE0570|method'>
                      <cvUntyped to='xs:string' diag='3|0|XTTE0570|method'>
@@ -4457,7 +4474,7 @@
                      </cvUntyped>
                     </check>
                    </treat>
-                   <let line='4404' var='Q{}serialization' as='xs:string?' slot='16' eval='7'>
+                   <let line='4410' var='Q{}serialization' as='xs:string?' slot='16' eval='7'>
                     <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|serialization'>
                      <check card='?' diag='3|0|XTTE0570|serialization'>
                       <cvUntyped to='xs:string' diag='3|0|XTTE0570|serialization'>
@@ -4470,8 +4487,8 @@
                       </cvUntyped>
                      </check>
                     </treat>
-                    <let line='4406' var='Q{}query-parameters' as='xs:string?' slot='17' eval='7'>
-                     <choose line='4407'>
+                    <let line='4412' var='Q{}query-parameters' as='xs:string?' slot='17' eval='7'>
+                     <choose line='4413'>
                       <and op='and'>
                        <fn name='exists'>
                         <varRef name='Q{}serialization' slot='16'/>
@@ -4481,17 +4498,17 @@
                         <str val='application/x-www-form-urlencoded'/>
                        </vc>
                       </and>
-                      <fn line='4425' name='string-join'>
-                       <choose line='4411'>
+                      <fn line='4431' name='string-join'>
+                       <choose line='4417'>
                         <fn name='exists'>
                          <varRef name='Q{}requestBodyDoc' slot='14'/>
                         </fn>
-                        <forEach line='4412'>
+                        <forEach line='4418'>
                          <slash simple='1'>
                           <varRef name='Q{}requestBody' slot='13'/>
                           <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
                          </slash>
-                         <fn line='4413' name='concat'>
+                         <fn line='4419' name='concat'>
                           <fn name='local-name'>
                            <dot type='element()'/>
                           </fn>
@@ -4505,7 +4522,7 @@
                        <str val='&amp;'/>
                       </fn>
                      </choose>
-                     <let line='4429' var='Q{}href-base' as='xs:string' slot='18' eval='16'>
+                     <let line='4435' var='Q{}href-base' as='xs:string' slot='18' eval='16'>
                       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|href-base'>
                        <check card='1' diag='3|0|XTTE0570|href-base'>
                         <cvUntyped to='xs:string' diag='3|0|XTTE0570|href-base'>
@@ -4518,16 +4535,16 @@
                         </cvUntyped>
                        </check>
                       </treat>
-                      <sequence line='4473'>
+                      <sequence line='4479'>
                        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}schedule-action' type='item()*'>
                         <int val='0'/>
                         <empty/>
                         <callT name='Q{}HTTPsubmit' bSlot='7'>
                          <withParam name='Q{}instance-id' flags='c' as='xs:string'>
-                          <varRef line='4474' name='Q{}instance-id' slot='4'/>
+                          <varRef line='4480' name='Q{}instance-id' slot='4'/>
                          </withParam>
                          <withParam name='Q{}targetref' flags='c' as='xs:string?'>
-                          <treat line='4475' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|targetref'>
+                          <treat line='4481' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|targetref'>
                            <check card='?' diag='8|0|XTTE0590|targetref'>
                             <cvUntyped to='xs:string' diag='8|0|XTTE0590|targetref'>
                              <data>
@@ -4541,7 +4558,7 @@
                           </treat>
                          </withParam>
                          <withParam name='Q{}replace' flags='c' as='xs:string?'>
-                          <treat line='4476' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|replace'>
+                          <treat line='4482' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|replace'>
                            <check card='?' diag='8|0|XTTE0590|replace'>
                             <cvUntyped to='xs:string' diag='8|0|XTTE0590|replace'>
                              <data>
@@ -4555,7 +4572,7 @@
                           </treat>
                          </withParam>
                         </callT>
-                        <ifCall line='4450' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+                        <ifCall line='4456' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
                          <sequence>
                           <choose>
                            <vc op='ne' onEmpty='1' comp='CCC'>
@@ -4564,37 +4581,37 @@
                             </fn>
                             <str val='GET'/>
                            </vc>
-                           <choose line='4452'>
+                           <choose line='4458'>
                             <fn name='exists'>
                              <varRef name='Q{}requestBodyDoc' slot='14'/>
                             </fn>
-                            <ifCall line='4453' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                            <ifCall line='4459' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                              <str val='body'/>
                              <varRef name='Q{}requestBodyDoc' slot='14'/>
                             </ifCall>
                             <true/>
-                            <ifCall line='4456' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                            <ifCall line='4462' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                              <str val='body'/>
                              <varRef name='Q{}requestBody' slot='13'/>
                             </ifCall>
                            </choose>
                           </choose>
-                          <ifCall line='4461' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                          <ifCall line='4467' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                            <str val='method'/>
                            <varRef name='Q{}method' slot='15'/>
                           </ifCall>
-                          <ifCall line='4462' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                          <ifCall line='4468' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                            <str val='href'/>
-                           <choose line='4433'>
+                           <choose line='4439'>
                             <fn name='exists'>
                              <varRef name='Q{}query-parameters' slot='17'/>
                             </fn>
-                            <fn line='4434' name='concat'>
+                            <fn line='4440' name='concat'>
                              <varRef name='Q{}href-base' slot='18'/>
                              <str val='?'/>
                              <varRef name='Q{}query-parameters' slot='17'/>
                             </fn>
-                            <fn line='4436' name='exists'>
+                            <fn line='4442' name='exists'>
                              <filter flags='b'>
                               <varRef name='Q{}requestBody' slot='13'/>
                               <fn name='exists'>
@@ -4602,7 +4619,7 @@
                               </fn>
                              </filter>
                             </fn>
-                            <fn line='4437' name='concat'>
+                            <fn line='4443' name='concat'>
                              <varRef name='Q{}href-base' slot='18'/>
                              <str val='/'/>
                              <data>
@@ -4610,12 +4627,12 @@
                              </data>
                             </fn>
                             <true/>
-                            <varRef line='4440' name='Q{}href-base' slot='18'/>
+                            <varRef line='4446' name='Q{}href-base' slot='18'/>
                            </choose>
                           </ifCall>
-                          <ifCall line='4463' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                          <ifCall line='4469' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                            <str val='media-type'/>
-                           <treat line='4445' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|mediatype'>
+                           <treat line='4451' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|mediatype'>
                             <check card='1' diag='3|0|XTTE0570|mediatype'>
                              <cvUntyped to='xs:string' diag='3|0|XTTE0570|mediatype'>
                               <data>
@@ -4637,16 +4654,16 @@
                          </map>
                         </ifCall>
                        </ifCall>
-                       <forEach line='4480'>
+                       <forEach line='4486'>
                         <varRef name='Q{}actions' slot='2'/>
-                        <let line='4481' var='Q{}action-map' as='map(*)' slot='19' eval='16'>
+                        <let line='4487' var='Q{}action-map' as='map(*)' slot='19' eval='16'>
                          <dot type='map(*)'/>
-                         <choose line='4484'>
+                         <choose line='4490'>
                           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
                            <varRef name='Q{}action-map' slot='19'/>
                            <str val='@event'/>
                           </ifCall>
-                          <choose line='4485'>
+                          <choose line='4491'>
                            <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
                             <data>
                              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
@@ -4656,17 +4673,17 @@
                             </data>
                             <str val='xforms-submit-done'/>
                            </gc>
-                           <callT line='4486' name='Q{}applyActions' bSlot='8' flags='t'>
+                           <callT line='4492' name='Q{}applyActions' bSlot='8' flags='t'>
                             <withParam name='Q{}action-map' flags='t' as='item()'>
-                             <varRef line='4487' name='Q{}action-map' slot='19'/>
+                             <varRef line='4493' name='Q{}action-map' slot='19'/>
                             </withParam>
                             <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                             <check line='4488' card='1' diag='8|0|XTTE0590|nodeset'>
+                             <check line='4494' card='1' diag='8|0|XTTE0590|nodeset'>
                               <varRef name='Q{}refi' slot='3'/>
                              </check>
                             </withParam>
                             <withParam name='Q{}instanceXML' flags='t' as='element()'>
-                             <varRef line='4489' name='Q{}instanceXML' slot='5'/>
+                             <varRef line='4495' name='Q{}instanceXML' slot='5'/>
                             </withParam>
                            </callT>
                           </choose>
@@ -4681,23 +4698,23 @@
                  </let>
                 </let>
                 <true/>
-                <ifCall line='4502' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                <ifCall line='4508' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                  <check card='1' diag='0|0||ixsl:call'>
                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                  </check>
                  <str val='alert'/>
                  <arrayBlock>
                   <fn name='serialize'>
-                   <doc line='4497' flags='t' validation='preserve'>
+                   <doc line='4503' flags='t' validation='preserve'>
                     <forEach>
                      <varRef name='Q{}required-fields-check' slot='12'/>
-                     <valueOf line='4499' flags='l'>
+                     <valueOf line='4505' flags='l'>
                       <fn name='concat'>
                        <str val='Value error see: '/>
                        <fn name='serialize'>
-                        <slash line='4498' simple='1'>
+                        <slash line='4504' simple='1'>
                          <dot type='element()'/>
-                         <axis line='4499' name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
+                         <axis line='4505' name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
                         </slash>
                        </fn>
                        <str val='&#xA;'/>
@@ -4994,7 +5011,7 @@
               </data>
              </cvUntyped>
             </choose>
-            <resultDoc line='3648' global='#&#xD;&#xA;#Fri Mar 13 14:41:49 GMT 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Fri Mar 13 14:41:49 GMT 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
+            <resultDoc line='3648' global='#&#xD;&#xA;#Fri Mar 13 15:05:29 GMT 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Fri Mar 13 15:05:29 GMT 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
              <fn role='href' name='concat'>
               <str val='#'/>
               <varRef name='Q{}this-key' slot='3'/>
@@ -5135,6 +5152,14 @@
      <axis name='child' nodeTest='element(Q{}random)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;random&#39;;'/>
     </slash>
    </sequence>
+  </globalVariable>
+ </co>
+ <co id='46' binds='44'>
+  <globalVariable name='Q{http://saxon.sf.net/generated-variable}gg841391920' type='element()*' line='4280' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='function test(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};if (test(val)) {return val;} else {throw SaxonJS.XError(&#39;Conversion failed&#39;, &#39;XTTE0590&#39;);}' jsCardCheck='function c() {return true;};'>
+   <slash ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4280' simple='1'>
+    <gVarRef name='Q{}xforms-doc' bSlot='0'/>
+    <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+   </slash>
   </globalVariable>
  </co>
  <co id='52' binds=''>
@@ -9780,14 +9805,6 @@
    <true/>
   </globalVariable>
  </co>
- <co id='46' binds='44'>
-  <globalVariable name='Q{http://saxon.sf.net/generated-variable}gg1090039905' type='element()*' line='4274' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='function test(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};if (test(val)) {return val;} else {throw SaxonJS.XError(&#39;Conversion failed&#39;, &#39;XTTE0590&#39;);}' jsCardCheck='function c() {return true;};'>
-   <slash ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4274' simple='1'>
-    <gVarRef name='Q{}xforms-doc' bSlot='0'/>
-    <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-   </slash>
-  </globalVariable>
- </co>
  <co id='65' binds=''>
   <function name='Q{http://www.w3.org/2002/xforms}getWhileStatement' line='809' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
    <arg name='Q{}map' as='map(*)'/>
@@ -9831,8 +9848,8 @@
   </function>
  </co>
  <co id='66' binds='1 2 3 15 19 20'>
-  <template name='Q{}DOMActivate' flags='os' line='4515' module='saxon-xforms.xsl' slots='9'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4516'>
+  <template name='Q{}DOMActivate' flags='os' line='4521' module='saxon-xforms.xsl' slots='9'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4522'>
     <param name='Q{}form-control' slot='0' flags='i' as='node()'>
      <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|form-control'>
       <check card='1' diag='8|0|XTTE0590|form-control'>
@@ -9840,7 +9857,7 @@
       </check>
      </treat>
     </param>
-    <let line='4518' var='Q{}actions' as='map(*)?' slot='1' eval='7'>
+    <let line='4524' var='Q{}actions' as='map(*)?' slot='1' eval='7'>
      <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
@@ -9857,12 +9874,12 @@
        </arrayBlock>
       </ifCall>
      </treat>
-     <let line='4520' var='Q{}refi' as='attribute(Q{}data-ref)?' slot='2' eval='8'>
+     <let line='4526' var='Q{}refi' as='attribute(Q{}data-ref)?' slot='2' eval='8'>
       <slash simple='1'>
        <varRef name='Q{}form-control' slot='0'/>
        <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
       </slash>
-      <let line='4522' var='Q{}instance-id' as='xs:string' slot='3' eval='16'>
+      <let line='4528' var='Q{}instance-id' as='xs:string' slot='3' eval='16'>
        <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='16'>
         <check card='1' diag='0|0||xforms:getInstanceId'>
          <cvUntyped to='xs:string'>
@@ -9872,12 +9889,12 @@
          </cvUntyped>
         </check>
        </ufCall>
-       <let line='4535' var='Q{}instanceXML' as='element()?' slot='4' eval='7'>
+       <let line='4541' var='Q{}instanceXML' as='element()?' slot='4' eval='7'>
         <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='6'>
          <varRef name='Q{}instance-id' slot='3'/>
         </ufCall>
-        <let line='4537' var='Q{}updatedInstanceXML' as='element()?' slot='5' eval='7'>
-         <choose line='4539'>
+        <let line='4543' var='Q{}updatedInstanceXML' as='element()?' slot='5' eval='7'>
+         <choose line='4545'>
           <and op='and'>
            <fn name='exists'>
             <varRef name='Q{}refi' slot='2'/>
@@ -9886,8 +9903,8 @@
             <varRef name='Q{}instanceXML' slot='4'/>
            </fn>
           </and>
-          <let line='4540' var='Q{}updatedNode' as='node()' slot='6' eval='16'>
-           <treat line='4541' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|updatedNode'>
+          <let line='4546' var='Q{}updatedNode' as='node()' slot='6' eval='16'>
+           <treat line='4547' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|updatedNode'>
             <check card='1' diag='3|0|XTTE0570|updatedNode'>
              <evaluate dxns=''>
               <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
@@ -9909,8 +9926,8 @@
              </evaluate>
             </check>
            </treat>
-           <let line='4543' var='Q{}new-value' as='xs:string' slot='7' eval='16'>
-            <treat line='4544' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-value'>
+           <let line='4549' var='Q{}new-value' as='xs:string' slot='7' eval='16'>
+            <treat line='4550' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-value'>
              <check card='1' diag='3|0|XTTE0570|new-value'>
               <cvUntyped to='xs:string' diag='3|0|XTTE0570|new-value'>
                <data>
@@ -9921,18 +9938,18 @@
               </cvUntyped>
              </check>
             </treat>
-            <treat line='4546' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+            <treat line='4552' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
              <check card='?' diag='3|0|XTTE0570|updatedInstanceXML'>
               <applyT mode='Q{}recalculate' bSlot='4'>
                <varRef role='select' name='Q{}instanceXML' slot='4'/>
                <withParam name='Q{}instance-id' as='xs:string'>
-                <varRef line='4547' name='Q{}instance-id' slot='3'/>
+                <varRef line='4553' name='Q{}instance-id' slot='3'/>
                </withParam>
                <withParam name='Q{}updated-nodes' flags='t' as='node()'>
-                <varRef line='4548' name='Q{}updatedNode' slot='6'/>
+                <varRef line='4554' name='Q{}updatedNode' slot='6'/>
                </withParam>
                <withParam name='Q{}updated-values' flags='t' as='xs:string'>
-                <varRef line='4549' name='Q{}new-value' slot='7'/>
+                <varRef line='4555' name='Q{}new-value' slot='7'/>
                </withParam>
               </applyT>
              </check>
@@ -9940,18 +9957,18 @@
            </let>
           </let>
           <true/>
-          <varRef line='4553' name='Q{}instanceXML' slot='4'/>
+          <varRef line='4559' name='Q{}instanceXML' slot='4'/>
          </choose>
-         <forEach line='4560'>
+         <forEach line='4566'>
           <varRef name='Q{}actions' slot='1'/>
-          <let line='4561' var='Q{}action-map' as='map(*)' slot='8' eval='16'>
+          <let line='4567' var='Q{}action-map' as='map(*)' slot='8' eval='16'>
            <dot type='map(*)'/>
-           <choose line='4564'>
+           <choose line='4570'>
             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
              <varRef name='Q{}action-map' slot='8'/>
              <str val='@event'/>
             </ifCall>
-            <choose line='4565'>
+            <choose line='4571'>
              <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
               <data>
                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
@@ -9961,12 +9978,12 @@
               </data>
               <str val='DOMActivate'/>
              </gc>
-             <callT line='4566' name='Q{}applyActions' bSlot='5' flags='t'>
+             <callT line='4572' name='Q{}applyActions' bSlot='5' flags='t'>
               <withParam name='Q{}action-map' flags='t' as='item()'>
-               <varRef line='4567' name='Q{}action-map' slot='8'/>
+               <varRef line='4573' name='Q{}action-map' slot='8'/>
               </withParam>
               <withParam name='Q{}instanceXML' flags='t' as='element()?'>
-               <varRef line='4568' name='Q{}updatedInstanceXML' slot='5'/>
+               <varRef line='4574' name='Q{}updatedInstanceXML' slot='5'/>
               </withParam>
              </callT>
             </choose>
@@ -11497,8 +11514,20 @@
                 </map>
                </ifCall>
               </treat>
-              <sequence line='270'>
-               <choose>
+              <sequence line='264'>
+               <message>
+                <sequence role='select'>
+                 <valueOf>
+                  <str val='[xformsjs-main] CalculationBindings = '/>
+                 </valueOf>
+                 <fn name='serialize'>
+                  <varRef name='Q{}CalculationBindings' slot='18'/>
+                 </fn>
+                </sequence>
+                <str role='terminate' val='no'/>
+                <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+               </message>
+               <choose line='270'>
                 <gc op='=' card='M:N' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
                  <data>
                   <slash simple='2'>
@@ -11567,7 +11596,7 @@
                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
                    <axis name='descendant' nodeTest='element(Q{}head)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;head&#39;;'/>
                   </slash>
-                  <resultDoc line='295' global='#&#xD;&#xA;#Fri Mar 13 14:41:49 GMT 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Fri Mar 13 14:41:49 GMT 2020&#xD;&#xA;'>
+                  <resultDoc line='295' global='#&#xD;&#xA;#Fri Mar 13 15:05:29 GMT 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Fri Mar 13 15:05:29 GMT 2020&#xD;&#xA;'>
                    <str role='href' val='?.'/>
                    <elem role='content' line='296' name='script' nsuri='' namespaces='xd rdf xhtml js sfp in fn map array ev'>
                     <sequence>
@@ -11766,7 +11795,7 @@
                    </arrayBlock>
                   </ifCall>
                  </forEach>
-                 <resultDoc line='619' global='#&#xD;&#xA;#Fri Mar 13 14:41:49 GMT 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Fri Mar 13 14:41:49 GMT 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
+                 <resultDoc line='619' global='#&#xD;&#xA;#Fri Mar 13 15:05:29 GMT 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Fri Mar 13 15:05:29 GMT 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
                   <fn role='href' name='concat'>
                    <str val='#'/>
                    <varRef name='Q{}xFormsId' slot='4'/>
@@ -13116,4 +13145,4 @@
  </output>
  <decimalFormat/>
 </package>
-<?Σ 238b9aac?>
+<?Σ 775d27e1?>

--- a/src/saxon-xforms.xsl
+++ b/src/saxon-xforms.xsl
@@ -261,7 +261,7 @@
             </xsl:map>  
         </xsl:variable>
         
-<!--        <xsl:message use-when="$debugMode">[xformsjs-main] CalculationBindings = <xsl:sequence select="serialize($CalculationBindings)"/></xsl:message>-->
+        <!--<xsl:message use-when="$debugMode">[xformsjs-main] CalculationBindings = <xsl:sequence select="serialize($CalculationBindings)"/></xsl:message>-->
         
         
         <!-- copy xform-doc to HTML page -->
@@ -4137,7 +4137,13 @@
         <xsl:variable name="instances-with-calculations" as="map(xs:string,map(*)*)">
             <xsl:map>
                 <xsl:for-each-group select="map:keys($calculationMap)" group-by="xforms:getInstanceId(.)">
-                    <xsl:map-entry key="fn:current-grouping-key()" select="fn:current-group()"/>
+                    <xsl:map-entry key="fn:current-grouping-key()">
+                        <xsl:for-each select="fn:current-group()">
+                            <xsl:map>
+                                <xsl:map-entry key="." select="map:get($calculationMap,.)"/>
+                            </xsl:map>
+                        </xsl:for-each>
+                    </xsl:map-entry>
                 </xsl:for-each-group>
             </xsl:map>
         </xsl:variable>


### PR DESCRIPTION
From the XForms 1.1 spec: "If the Node Set Binding node-set is not specified or empty, then the insert location node provided by the context attribute is intended to be the parent of the cloned node."

Updated the repeat demo to include an example that tests this.

(Plus a bug fix)