### PR TITLE
Fix samples

### DIFF
--- a/demos/demo-input-select-output.html
+++ b/demos/demo-input-select-output.html
@@ -13,9 +13,6 @@
         SaxonJS.transform({
            "stylesheetLocation":"../sef/saxon-xforms.sef.xml",
            "sourceLocation":"xml/demo-input-select-output-xform.xml",
-           "stylesheetParams": {
-              "xforms-file": "xml/demo-input-select-output-xform.xml",
-           }
         })
       }     
       </script>
@@ -33,6 +30,8 @@
                <li>Binding input for feeding time to a data type (XForms <a href="https://www.w3.org/TR/xforms11/#structure-bind-element" class="xforms-spec-link">&lt;bind&gt;</a>)</li>
                <li>Select from drop-down menu (XForms <a href="https://www.w3.org/TR/xforms11/#ui-selectOne" class="xforms-spec-link">&lt;select1&gt;</a>)</li>
                <li>Output (XForms <a href="https://www.w3.org/TR/xforms11/#ui-output" class="xforms-spec-link">&lt;output&gt;</a>)</li>
+               <li>Trigger (XForms <a href="https://www.w3.org/TR/xforms11/#ui-trigger" class="xforms-spec-link">&lt;trigger&gt;</a>)</li>
+               <li>Message (WIP) (XForms <a href="https://www.w3.org/TR/xforms11/#action-message" class="xforms-spec-link">&lt;message&gt;</a>)</li>
            </ul>
        </div>
       

--- a/demos/demo-repeat.html
+++ b/demos/demo-repeat.html
@@ -12,9 +12,6 @@
         SaxonJS.transform({
            "stylesheetLocation":"../sef/saxon-xforms.sef.xml",
            "sourceLocation":"xml/demo-repeat-xform.xml",
-           "stylesheetParams": {
-              "xforms-file": "../demos/xml/demo-repeat-xform.xml",
-           }
         })
       }     
       </script>

--- a/samples/sample1/sample1.html
+++ b/samples/sample1/sample1.html
@@ -2,21 +2,21 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 
    <head>
-      <title>Booking Form</title>
+      <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+         <title>Booking Form</title>
       <link rel="stylesheet" href="style.css" type="text/css" />
-      <script src="Saxon-JS-1.0.0/SaxonJS.js"></script>
+      <script src="../../Saxon-JS-1.1.0/SaxonJS.js"></script>
 
       <script>
       window.onload = function() {
         SaxonJS.transform({
-           "stylesheetLocation":"saxon-xforms.sef.xml",
+           "stylesheetLocation":"../../sef/saxon-xforms.sef.xml",
            "sourceLocation":"sampleBookingForm.xml",
-           "stylesheetParams": {"xforms-file":"sampleBookingForm.xml"}
            })
       }     
       </script>
       <script src="saxonRequests.js"></script>
-      <script type="application/json" id="xforms-jinstance"></script>
+<!--      <script type="application/json" id="xforms-jinstance"></script>-->
    </head>
 
    <body>

--- a/samples/sample2/sample2.html
+++ b/samples/sample2/sample2.html
@@ -2,15 +2,17 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 
    <head>
-      <title>Booking Form</title>
+      <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+         <title>Booking Form</title>
       <link rel="stylesheet" href="style.css" type="text/css" />
-      <script src="SaxonJS.js"></script>
+      <script src="../../Saxon-JS-1.1.0/SaxonJS.js"></script>
 
       <script>
       window.onload = function() {
         SaxonJS.transform({
-           "stylesheetLocation":"sample2.sef.xml",
-           "initialTemplate":"main"
+           "stylesheetLocation":"../../sef/saxon-xforms.sef.xml",
+           "initialTemplate":"xformsjs-main",
+           "stylesheetParams": {"xforms-file":"../samples/sample1/sampleBookingForm.xml"}
            })
       }     
       </script>

--- a/samples/sample3/sample3.html
+++ b/samples/sample3/sample3.html
@@ -10,9 +10,9 @@
       <script>
       window.onload = function() {
         SaxonJS.transform({
-           "stylesheetLocation":"sef/sample3.sef.xml",
-           "initialTemplate":"main"
-           })
+           "stylesheetLocation":"../../sef/saxon-xforms.sef.xml",
+           "sourceLocation":"xml/sample3form.xml"
+            })
       }     
       </script>
    </head>

--- a/samples/sample3/xml/sample3form.xml
+++ b/samples/sample3/xml/sample3form.xml
@@ -40,7 +40,7 @@
         
         <!-- <xf:bind nodeset="EventTime" type="xf:time"/>-->
 <!--        <xf:submission ref="submit_model_records" action="http://dunn.local/Saxon-Forms/samples/sample3/php/test.php" />-->
-        <xf:submission ref="submit_model_records" action="php/test.php" />
+        <xf:submission id="submit_model_records" ref="instance('event')" mediatype="application/xml" resource="php/test.php" method="GET"/>
     </xf:model>
     
     
@@ -207,7 +207,7 @@
     </xf:input>
     <br/>-->
     
-    <xf:submit id="submit_model_records">
+    <xf:submit submission="submit_model_records">
         <xf:label>Submit Booking</xf:label>
     </xf:submit>
     

--- a/sef/logger.sef.xml
+++ b/sef/logger.sef.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns='http://ns.saxonica.com/xslt/export' xmlns:fn='http://www.w3.org/2005/xpath-functions' xmlns:xs='http://www.w3.org/2001/XMLSchema' xmlns:vv='http://saxon.sf.net/generated-variable' xmlns:java-type='http://saxon.sf.net/java-type' when='2020-03-14T10:24:10.083Z' id='0' name='http://saxon.sf.net/packages/logger.xsl' version='30' declaredModes='1' packageVersion='1' saxonVersion='9.9.1.5' target='JS' targetVersion='1' relocatable='true' implicit='false'>
+<package xmlns='http://ns.saxonica.com/xslt/export' xmlns:fn='http://www.w3.org/2005/xpath-functions' xmlns:xs='http://www.w3.org/2001/XMLSchema' xmlns:vv='http://saxon.sf.net/generated-variable' xmlns:java-type='http://saxon.sf.net/java-type' when='2020-03-24T21:48:02.667Z' id='0' name='http://saxon.sf.net/packages/logger.xsl' version='30' declaredModes='1' packageVersion='1' saxonVersion='9.9.1.5' target='JS' targetVersion='1' relocatable='true' implicit='false'>
  <co id='0' vis='PUBLIC' binds='1'>
   <globalVariable name='Q{http://saxon.sf.net/ns/packages}LOGLEVEL' type='xs:integer' line='73' module='logger.xsl' visibility='PUBLIC' jsAcceptor='return SaxonJS.U.Atomic.integer.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
    <gVarRef ns='xsl=~ xs=~ xd=http://www.oxygenxml.com/ns/doc/xsl sfp=http://saxon.sf.net/ns/packages' line='73' name='Q{http://saxon.sf.net/ns/packages}LOGLEVEL_NOTSET' bSlot='0'/>
@@ -384,4 +384,4 @@
  </output>
  <decimalFormat/>
 </package>
-<?Σ 9cdcacbb?>
+<?Σ 9cdc0c8b?>

--- a/sef/saxon-xforms.sef.xml
+++ b/sef/saxon-xforms.sef.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns='http://ns.saxonica.com/xslt/export' xmlns:fn='http://www.w3.org/2005/xpath-functions' xmlns:xs='http://www.w3.org/2001/XMLSchema' xmlns:vv='http://saxon.sf.net/generated-variable' xmlns:java-type='http://saxon.sf.net/java-type' when='2020-03-14T13:02:55.16Z' id='0' version='30' packageVersion='1' saxonVersion='9.9.1.5' target='JS' targetVersion='1' relocatable='true' implicit='true'>
+<package xmlns='http://ns.saxonica.com/xslt/export' xmlns:fn='http://www.w3.org/2005/xpath-functions' xmlns:xs='http://www.w3.org/2001/XMLSchema' xmlns:vv='http://saxon.sf.net/generated-variable' xmlns:java-type='http://saxon.sf.net/java-type' when='2020-03-24T21:48:26.172Z' id='0' version='30' packageVersion='1' saxonVersion='9.9.1.5' target='JS' targetVersion='1' relocatable='true' implicit='true'>
  <package id='1' name='http://saxon.sf.net/packages/logger.xsl' version='30' declaredModes='1' packageVersion='1' saxonVersion='9.9.1.5' target='JS' targetVersion='1' relocatable='false' implicit='false'>
   <schema ns='http://ns.saxonica.com/anonymous-type'/>
   <co id='0' vis='PUBLIC' binds='1'>
@@ -387,8 +387,8 @@
   <decimalFormat/>
  </package>
  <co id='20' binds='21 22 21 22 23 23 23 24 25 26 23 27'>
-  <template name='Q{}action-insert' flags='os' line='4182' module='saxon-xforms.xsl' slots='21'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4183'>
+  <template name='Q{}action-insert' flags='os' line='4188' module='saxon-xforms.xsl' slots='21'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4189'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -396,7 +396,7 @@
       </check>
      </treat>
     </param>
-    <param line='4184' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
+    <param line='4190' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
      <empty role='select'/>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|instanceXML'>
       <check card='?' diag='8|0|XTTE0590|instanceXML'>
@@ -404,7 +404,7 @@
       </check>
      </treat>
     </param>
-    <param line='4185' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
+    <param line='4191' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -416,7 +416,7 @@
       </check>
      </treat>
     </param>
-    <let line='4187' var='Q{}ref' as='xs:string' slot='3' eval='16'>
+    <let line='4193' var='Q{}ref' as='xs:string' slot='3' eval='16'>
      <let var='Q{}relative' as='xs:string' slot='4' eval='16'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|1||xforms:resolveXPathStrings'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
@@ -430,22 +430,22 @@
         </cvUntyped>
        </check>
       </treat>
-      <choose line='811'>
+      <choose line='815'>
        <fn name='starts-with'>
         <varRef name='Q{}relative' slot='4'/>
         <str val='/'/>
        </fn>
-       <varRef line='812' name='Q{}relative' slot='4'/>
-       <fn line='814' name='starts-with'>
+       <varRef line='816' name='Q{}relative' slot='4'/>
+       <fn line='818' name='starts-with'>
         <varRef name='Q{}relative' slot='4'/>
         <str val='instance('/>
        </fn>
-       <varRef line='815' name='Q{}relative' slot='4'/>
-       <fn line='4187' name='not'>
+       <varRef line='819' name='Q{}relative' slot='4'/>
+       <fn line='4193' name='not'>
         <varRef name='Q{}nodeset' slot='2'/>
        </fn>
-       <varRef line='818' name='Q{}relative' slot='4'/>
-       <or line='820' op='or'>
+       <varRef line='822' name='Q{}relative' slot='4'/>
+       <or line='824' op='or'>
         <fn name='not'>
          <varRef name='Q{}relative' slot='4'/>
         </fn>
@@ -454,9 +454,9 @@
          <str val='.'/>
         </vc>
        </or>
-       <varRef line='4187' name='Q{}nodeset' slot='2'/>
+       <varRef line='4193' name='Q{}nodeset' slot='2'/>
        <true/>
-       <let line='825' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
+       <let line='829' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
         <choose>
          <fn name='contains'>
           <varRef name='Q{}relative' slot='4'/>
@@ -483,30 +483,30 @@
          <true/>
          <int val='0'/>
         </choose>
-        <let line='828' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
+        <let line='832' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
          <choose>
-          <fn line='4187' name='contains'>
+          <fn line='4193' name='contains'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
           </fn>
           <fn name='index-of'>
            <fn name='string-to-codepoints'>
-            <varRef line='4187' name='Q{}nodeset' slot='2'/>
+            <varRef line='4193' name='Q{}nodeset' slot='2'/>
            </fn>
            <int val='47'/>
           </fn>
           <true/>
           <int val='0'/>
          </choose>
-         <choose line='860'>
+         <choose line='864'>
           <compareToInt op='gt' val='0'>
            <varRef name='Q{}parentCallCount' slot='5'/>
           </compareToInt>
-          <fn line='864' name='concat'>
+          <fn line='868' name='concat'>
            <fn name='substring'>
-            <varRef line='4187' name='Q{}nodeset' slot='2'/>
+            <varRef line='4193' name='Q{}nodeset' slot='2'/>
             <int val='1'/>
-            <choose line='839'>
+            <choose line='843'>
              <and op='and'>
               <vc op='ge' onEmpty='0' comp='CAVC'>
                <fn name='count'>
@@ -518,7 +518,7 @@
                <varRef name='Q{}parentCallCount' slot='5'/>
               </compareToInt>
              </and>
-             <let line='840' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='7' eval='13'>
+             <let line='844' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='7' eval='13'>
               <arith op='-' calc='i-i'>
                <varRef name='Q{}parentCallCount' slot='5'/>
                <int val='1'/>
@@ -534,7 +534,7 @@
               </check>
              </let>
              <true/>
-             <check line='843' card='1' diag='3|0|XTTE0570|parentSlash'>
+             <check line='847' card='1' diag='3|0|XTTE0570|parentSlash'>
               <lastOf>
                <varRef name='Q{}slashes' slot='6'/>
               </lastOf>
@@ -549,17 +549,17 @@
            </fn>
           </fn>
           <true/>
-          <fn line='4187' name='concat'>
+          <fn line='4193' name='concat'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
-           <varRef line='867' name='Q{}relative' slot='4'/>
+           <varRef line='871' name='Q{}relative' slot='4'/>
           </fn>
          </choose>
         </let>
        </let>
       </choose>
      </let>
-     <let line='4188' var='Q{}at' as='xs:string?' slot='8' eval='7'>
+     <let line='4194' var='Q{}at' as='xs:string?' slot='8' eval='7'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|at'>
        <check card='?' diag='3|0|XTTE0570|at'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|at'>
@@ -572,7 +572,7 @@
         </cvUntyped>
        </check>
       </treat>
-      <let line='4189' var='Q{}position' as='xs:string?' slot='9' eval='7'>
+      <let line='4195' var='Q{}position' as='xs:string?' slot='9' eval='7'>
        <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|position'>
         <check card='?' diag='3|0|XTTE0570|position'>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|position'>
@@ -585,7 +585,7 @@
          </cvUntyped>
         </check>
        </treat>
-       <let line='4190' var='Q{}origin-ref' as='xs:string?' slot='10' eval='7'>
+       <let line='4196' var='Q{}origin-ref' as='xs:string?' slot='10' eval='7'>
         <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|origin-ref'>
          <check card='?' diag='3|0|XTTE0570|origin-ref'>
           <cvUntyped to='xs:string' diag='3|0|XTTE0570|origin-ref'>
@@ -598,12 +598,12 @@
           </cvUntyped>
          </check>
         </treat>
-        <let line='4204' var='Q{}instance-id' as='xs:string' slot='11' eval='16'>
+        <let line='4210' var='Q{}instance-id' as='xs:string' slot='11' eval='16'>
          <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='6'>
           <varRef name='Q{}ref' slot='3'/>
          </ufCall>
-         <let line='4206' var='Q{}instanceXML2' as='element()' slot='12' eval='16'>
-          <choose line='4208'>
+         <let line='4212' var='Q{}instanceXML2' as='element()' slot='12' eval='16'>
+          <choose line='4214'>
            <and op='and'>
             <vc op='eq' onEmpty='0' comp='CCC'>
              <varRef name='Q{}instance-id' slot='11'/>
@@ -613,24 +613,24 @@
              <varRef name='Q{}instanceXML' slot='1'/>
             </fn>
            </and>
-           <check line='4209' card='1' diag='3|0|XTTE0570|instanceXML2'>
+           <check line='4215' card='1' diag='3|0|XTTE0570|instanceXML2'>
             <varRef name='Q{}instanceXML' slot='1'/>
            </check>
            <true/>
-           <check line='4212' card='1' diag='3|0|XTTE0570|instanceXML2'>
+           <check line='4218' card='1' diag='3|0|XTTE0570|instanceXML2'>
             <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='6'>
              <varRef name='Q{}instance-id' slot='11'/>
             </ufCall>
            </check>
           </choose>
-          <let line='4225' var='Q{}instance-id-origin' as='xs:string' slot='13' eval='16'>
+          <let line='4231' var='Q{}instance-id-origin' as='xs:string' slot='13' eval='16'>
            <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='2' eval='16'>
             <check card='1' diag='0|0||xforms:getInstanceId'>
              <varRef name='Q{}origin-ref' slot='10'/>
             </check>
            </ufCall>
-           <let line='4227' var='Q{}instanceXML-origin' as='element()' slot='14' eval='16'>
-            <choose line='4229'>
+           <let line='4233' var='Q{}instanceXML-origin' as='element()' slot='14' eval='16'>
+            <choose line='4235'>
              <and op='and'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <varRef name='Q{}instance-id-origin' slot='13'/>
@@ -640,18 +640,18 @@
                <varRef name='Q{}instanceXML' slot='1'/>
               </fn>
              </and>
-             <check line='4230' card='1' diag='3|0|XTTE0570|instanceXML-origin'>
+             <check line='4236' card='1' diag='3|0|XTTE0570|instanceXML-origin'>
               <varRef name='Q{}instanceXML' slot='1'/>
              </check>
              <true/>
-             <check line='4233' card='1' diag='3|0|XTTE0570|instanceXML-origin'>
+             <check line='4239' card='1' diag='3|0|XTTE0570|instanceXML-origin'>
               <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='3' eval='6'>
                <varRef name='Q{}instance-id-origin' slot='13'/>
               </ufCall>
              </check>
             </choose>
-            <let line='4238' var='Q{}origin-node' as='node()?' slot='15' eval='7'>
-             <treat line='4239' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|origin-node'>
+            <let line='4244' var='Q{}origin-node' as='node()?' slot='15' eval='7'>
+             <treat line='4245' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|origin-node'>
               <check card='?' diag='3|0|XTTE0570|origin-node'>
                <evaluate dxns=''>
                 <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='4' eval='16'>
@@ -667,13 +667,13 @@
                </evaluate>
               </check>
              </treat>
-             <let line='4242' var='Q{}insert-node-location' as='node()?' slot='16' eval='7'>
-              <treat line='4243' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|insert-node-location'>
+             <let line='4248' var='Q{}insert-node-location' as='node()?' slot='16' eval='7'>
+              <treat line='4249' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|insert-node-location'>
                <check card='?' diag='3|0|XTTE0570|insert-node-location'>
                 <evaluate dxns=''>
                  <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='5' eval='16'>
                   <check card='1' diag='0|0||xforms:impose'>
-                   <choose line='4202'>
+                   <choose line='4208'>
                     <vc op='ne' onEmpty='0' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
                      <varRef name='Q{}ref' slot='3'/>
                      <str val=''/>
@@ -702,14 +702,14 @@
                 </evaluate>
                </check>
               </treat>
-              <let line='4246' var='Q{}context-node' as='node()' slot='17' eval='16'>
-               <treat line='4247' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|context-node'>
+              <let line='4252' var='Q{}context-node' as='node()' slot='17' eval='16'>
+               <treat line='4253' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|context-node'>
                 <check card='1' diag='3|0|XTTE0570|context-node'>
                  <evaluate dxns=''>
                   <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='6' eval='16'>
-                   <treat line='4191' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|context'>
-                    <check line='4247' card='1' diag='0|0||xforms:impose'>
-                     <check line='4191' card='?' diag='3|0|XTTE0570|context'>
+                   <treat line='4197' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|context'>
+                    <check line='4253' card='1' diag='0|0||xforms:impose'>
+                     <check line='4197' card='?' diag='3|0|XTTE0570|context'>
                       <cvUntyped to='xs:string' diag='3|0|XTTE0570|context'>
                        <data>
                         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
@@ -730,13 +730,13 @@
                  </evaluate>
                 </check>
                </treat>
-               <let line='4264' var='Q{}instance-with-insert' as='element()' slot='18' eval='16'>
-                <treat line='4265' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-insert'>
+               <let line='4270' var='Q{}instance-with-insert' as='element()' slot='18' eval='16'>
+                <treat line='4271' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-insert'>
                  <check card='1' diag='3|0|XTTE0570|instance-with-insert'>
                   <applyT mode='Q{}insert-node' bSlot='7'>
                    <varRef role='select' name='Q{}instanceXML2' slot='12'/>
                    <withParam name='Q{}insert-node-location' flags='t' as='node()?'>
-                    <choose line='4266'>
+                    <choose line='4272'>
                      <fn name='exists'>
                       <varRef name='Q{}insert-node-location' slot='16'/>
                      </fn>
@@ -746,21 +746,21 @@
                     </choose>
                    </withParam>
                    <withParam name='Q{}node-to-insert' flags='t' as='node()?'>
-                    <choose line='4253'>
+                    <choose line='4259'>
                      <fn name='exists'>
                       <varRef name='Q{}origin-node' slot='15'/>
                      </fn>
-                     <copyOf line='4254' flags='vc'>
+                     <copyOf line='4260' flags='vc'>
                       <varRef name='Q{}origin-node' slot='15'/>
                      </copyOf>
                      <true/>
-                     <copyOf line='4257' flags='vc'>
+                     <copyOf line='4263' flags='vc'>
                       <varRef name='Q{}insert-node-location' slot='16'/>
                      </copyOf>
                     </choose>
                    </withParam>
                    <withParam name='Q{}position-relative' flags='t' as='xs:string?'>
-                    <choose line='4268'>
+                    <choose line='4274'>
                      <fn name='exists'>
                       <varRef name='Q{}insert-node-location' slot='16'/>
                      </fn>
@@ -772,25 +772,25 @@
                   </applyT>
                  </check>
                 </treat>
-                <sequence line='4274'>
+                <sequence line='4280'>
                  <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='8' eval='6 6'>
                   <varRef name='Q{}ref' slot='3'/>
                   <varRef name='Q{}instance-with-insert' slot='18'/>
                  </ufCall>
-                 <choose line='4278'>
+                 <choose line='4284'>
                   <fn name='matches'>
                    <varRef name='Q{}at' slot='8'/>
                    <str val='index\s*\('/>
                    <str val=''/>
                   </fn>
-                  <let line='4279' var='Q{}repeat-id' as='xs:string?' slot='19' eval='7'>
+                  <let line='4285' var='Q{}repeat-id' as='xs:string?' slot='19' eval='7'>
                    <ufCall name='Q{http://www.w3.org/2002/xforms}getRepeatID' tailCall='false' bSlot='9' eval='16'>
                     <check card='1' diag='0|0||xforms:getRepeatID'>
                      <varRef name='Q{}at' slot='8'/>
                     </check>
                    </ufCall>
-                   <let line='4280' var='Q{}at-position' as='xs:integer' slot='20' eval='16'>
-                    <treat line='4281' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|at-position'>
+                   <let line='4286' var='Q{}at-position' as='xs:integer' slot='20' eval='16'>
+                    <treat line='4287' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|at-position'>
                      <check card='1' diag='3|0|XTTE0570|at-position'>
                       <cvUntyped to='xs:integer' diag='3|0|XTTE0570|at-position'>
                        <data>
@@ -809,16 +809,16 @@
                       </cvUntyped>
                      </check>
                     </treat>
-                    <choose line='4286'>
+                    <choose line='4292'>
                      <fn name='exists'>
                       <varRef name='Q{}repeat-id' slot='19'/>
                      </fn>
-                     <choose line='4288'>
+                     <choose line='4294'>
                       <vc op='eq' onEmpty='0' comp='CCC'>
                        <varRef name='Q{}position' slot='9'/>
                        <str val='before'/>
                       </vc>
-                      <ifCall line='4289' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                      <ifCall line='4295' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                        <check card='1' diag='0|0||ixsl:call'>
                         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                        </check>
@@ -829,7 +829,7 @@
                        </arrayBlock>
                       </ifCall>
                       <true/>
-                      <ifCall line='4292' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                      <ifCall line='4298' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                        <check card='1' diag='0|0||ixsl:call'>
                         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                        </check>
@@ -847,7 +847,7 @@
                    </let>
                   </let>
                  </choose>
-                 <callT line='4302' name='Q{}xforms-recalculate' bSlot='11' flags='t'/>
+                 <callT line='4308' name='Q{}xforms-recalculate' bSlot='11' flags='t'/>
                 </sequence>
                </let>
               </let>
@@ -865,8 +865,8 @@
   </template>
  </co>
  <co id='28' binds='21 22 23 23 29 25 27'>
-  <template name='Q{}action-delete' flags='os' line='4314' module='saxon-xforms.xsl' slots='16'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4315'>
+  <template name='Q{}action-delete' flags='os' line='4320' module='saxon-xforms.xsl' slots='16'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4321'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -874,14 +874,14 @@
       </check>
      </treat>
     </param>
-    <param line='4316' name='Q{}instanceXML' slot='1' flags='ti' as='element()'>
+    <param line='4322' name='Q{}instanceXML' slot='1' flags='ti' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|instanceXML'>
       <check card='1' diag='8|0|XTTE0590|instanceXML'>
        <supplied slot='1'/>
       </check>
      </treat>
     </param>
-    <param line='4317' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
+    <param line='4323' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -893,7 +893,7 @@
       </check>
      </treat>
     </param>
-    <let line='4319' var='Q{}ref' as='xs:string' slot='3' eval='16'>
+    <let line='4325' var='Q{}ref' as='xs:string' slot='3' eval='16'>
      <let var='Q{}relative' as='xs:string' slot='4' eval='16'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|1||xforms:resolveXPathStrings'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
@@ -907,22 +907,22 @@
         </cvUntyped>
        </check>
       </treat>
-      <choose line='811'>
+      <choose line='815'>
        <fn name='starts-with'>
         <varRef name='Q{}relative' slot='4'/>
         <str val='/'/>
        </fn>
-       <varRef line='812' name='Q{}relative' slot='4'/>
-       <fn line='814' name='starts-with'>
+       <varRef line='816' name='Q{}relative' slot='4'/>
+       <fn line='818' name='starts-with'>
         <varRef name='Q{}relative' slot='4'/>
         <str val='instance('/>
        </fn>
-       <varRef line='815' name='Q{}relative' slot='4'/>
-       <fn line='4319' name='not'>
+       <varRef line='819' name='Q{}relative' slot='4'/>
+       <fn line='4325' name='not'>
         <varRef name='Q{}nodeset' slot='2'/>
        </fn>
-       <varRef line='818' name='Q{}relative' slot='4'/>
-       <or line='820' op='or'>
+       <varRef line='822' name='Q{}relative' slot='4'/>
+       <or line='824' op='or'>
         <fn name='not'>
          <varRef name='Q{}relative' slot='4'/>
         </fn>
@@ -931,9 +931,9 @@
          <str val='.'/>
         </vc>
        </or>
-       <varRef line='4319' name='Q{}nodeset' slot='2'/>
+       <varRef line='4325' name='Q{}nodeset' slot='2'/>
        <true/>
-       <let line='825' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
+       <let line='829' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
         <choose>
          <fn name='contains'>
           <varRef name='Q{}relative' slot='4'/>
@@ -960,30 +960,30 @@
          <true/>
          <int val='0'/>
         </choose>
-        <let line='828' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
+        <let line='832' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
          <choose>
-          <fn line='4319' name='contains'>
+          <fn line='4325' name='contains'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
           </fn>
           <fn name='index-of'>
            <fn name='string-to-codepoints'>
-            <varRef line='4319' name='Q{}nodeset' slot='2'/>
+            <varRef line='4325' name='Q{}nodeset' slot='2'/>
            </fn>
            <int val='47'/>
           </fn>
           <true/>
           <int val='0'/>
          </choose>
-         <choose line='860'>
+         <choose line='864'>
           <compareToInt op='gt' val='0'>
            <varRef name='Q{}parentCallCount' slot='5'/>
           </compareToInt>
-          <fn line='864' name='concat'>
+          <fn line='868' name='concat'>
            <fn name='substring'>
-            <varRef line='4319' name='Q{}nodeset' slot='2'/>
+            <varRef line='4325' name='Q{}nodeset' slot='2'/>
             <int val='1'/>
-            <choose line='839'>
+            <choose line='843'>
              <and op='and'>
               <vc op='ge' onEmpty='0' comp='CAVC'>
                <fn name='count'>
@@ -995,7 +995,7 @@
                <varRef name='Q{}parentCallCount' slot='5'/>
               </compareToInt>
              </and>
-             <let line='840' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='7' eval='13'>
+             <let line='844' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='7' eval='13'>
               <arith op='-' calc='i-i'>
                <varRef name='Q{}parentCallCount' slot='5'/>
                <int val='1'/>
@@ -1011,7 +1011,7 @@
               </check>
              </let>
              <true/>
-             <check line='843' card='1' diag='3|0|XTTE0570|parentSlash'>
+             <check line='847' card='1' diag='3|0|XTTE0570|parentSlash'>
               <lastOf>
                <varRef name='Q{}slashes' slot='6'/>
               </lastOf>
@@ -1026,17 +1026,17 @@
            </fn>
           </fn>
           <true/>
-          <fn line='4319' name='concat'>
+          <fn line='4325' name='concat'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
-           <varRef line='867' name='Q{}relative' slot='4'/>
+           <varRef line='871' name='Q{}relative' slot='4'/>
           </fn>
          </choose>
         </let>
        </let>
       </choose>
      </let>
-     <let line='4320' var='Q{}at' as='xs:string?' slot='8' eval='7'>
+     <let line='4326' var='Q{}at' as='xs:string?' slot='8' eval='7'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|at'>
        <check card='?' diag='3|0|XTTE0570|at'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|at'>
@@ -1049,7 +1049,7 @@
         </cvUntyped>
        </check>
       </treat>
-      <let line='4330' var='Q{}ref-qualified' as='xs:string' slot='9' eval='16'>
+      <let line='4336' var='Q{}ref-qualified' as='xs:string' slot='9' eval='16'>
        <choose>
         <fn name='exists'>
          <varRef name='Q{}at' slot='8'/>
@@ -1063,36 +1063,36 @@
         <true/>
         <varRef name='Q{}ref' slot='3'/>
        </choose>
-       <let line='4332' var='Q{}instance-id' as='xs:string' slot='10' eval='16'>
+       <let line='4338' var='Q{}instance-id' as='xs:string' slot='10' eval='16'>
         <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='6'>
          <varRef name='Q{}ref' slot='3'/>
         </ufCall>
-        <let line='4334' var='Q{}instanceXML2' as='element()' slot='11' eval='16'>
-         <choose line='4336'>
+        <let line='4340' var='Q{}instanceXML2' as='element()' slot='11' eval='16'>
+         <choose line='4342'>
           <vc op='eq' onEmpty='0' comp='CCC'>
            <varRef name='Q{}instance-id' slot='10'/>
            <str val='saxon-forms-default'/>
           </vc>
-          <varRef line='4337' name='Q{}instanceXML' slot='1'/>
+          <varRef line='4343' name='Q{}instanceXML' slot='1'/>
           <true/>
-          <check line='4340' card='1' diag='3|0|XTTE0570|instanceXML2'>
+          <check line='4346' card='1' diag='3|0|XTTE0570|instanceXML2'>
            <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='6'>
             <varRef name='Q{}instance-id' slot='10'/>
            </ufCall>
           </check>
          </choose>
-         <let line='4345' var='Q{}ifVar' as='xs:string?' slot='12' eval='7'>
-          <choose line='766'>
+         <let line='4351' var='Q{}ifVar' as='xs:string?' slot='12' eval='7'>
+          <choose line='770'>
            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
-            <varRef line='4345' name='Q{}action-map' slot='0'/>
+            <varRef line='4351' name='Q{}action-map' slot='0'/>
             <str val='@if'/>
            </ifCall>
-           <treat line='767' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
+           <treat line='771' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
             <check card='?' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
              <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
               <data>
                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                <varRef line='4345' name='Q{}action-map' slot='0'/>
+                <varRef line='4351' name='Q{}action-map' slot='0'/>
                 <str val='@if'/>
                </ifCall>
               </data>
@@ -1100,8 +1100,8 @@
             </check>
            </treat>
           </choose>
-          <let line='4348' var='Q{}delete-node' as='node()*' slot='13' eval='8'>
-           <choose line='4350'>
+          <let line='4354' var='Q{}delete-node' as='node()*' slot='13' eval='8'>
+           <choose line='4356'>
             <and op='and'>
              <fn name='exists'>
               <varRef name='Q{}ref-qualified' slot='9'/>
@@ -1111,7 +1111,7 @@
               <str val=''/>
              </vc>
             </and>
-            <treat line='4351' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|delete-node'>
+            <treat line='4357' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|delete-node'>
              <evaluate dxns=''>
               <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
                <check card='1' diag='0|0||xforms:impose'>
@@ -1126,12 +1126,12 @@
              </evaluate>
             </treat>
            </choose>
-           <let line='4356' var='Q{}ifExecuted' as='xs:boolean' slot='14' eval='16'>
-            <choose line='4358'>
+           <let line='4362' var='Q{}ifExecuted' as='xs:boolean' slot='14' eval='16'>
+            <choose line='4364'>
              <fn name='exists'>
               <varRef name='Q{}ifVar' slot='12'/>
              </fn>
-             <treat line='4359' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|ifExecuted'>
+             <treat line='4365' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|ifExecuted'>
               <check card='1' diag='3|0|XTTE0570|ifExecuted'>
                <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|ifExecuted'>
                 <data>
@@ -1158,25 +1158,25 @@
              <true/>
              <true/>
             </choose>
-            <choose line='4367'>
+            <choose line='4373'>
              <varRef name='Q{}ifExecuted' slot='14'/>
-             <let line='4368' var='Q{}instance-with-delete' as='element()' slot='15' eval='16'>
-              <treat line='4369' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-delete'>
+             <let line='4374' var='Q{}instance-with-delete' as='element()' slot='15' eval='16'>
+              <treat line='4375' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-delete'>
                <check card='1' diag='3|0|XTTE0570|instance-with-delete'>
                 <applyT mode='Q{}delete-node' bSlot='4'>
                  <varRef role='select' name='Q{}instanceXML2' slot='11'/>
                  <withParam name='Q{}delete-node' flags='t' as='node()*'>
-                  <varRef line='4370' name='Q{}delete-node' slot='13'/>
+                  <varRef line='4376' name='Q{}delete-node' slot='13'/>
                  </withParam>
                 </applyT>
                </check>
               </treat>
-              <sequence line='4376'>
+              <sequence line='4382'>
                <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='5' eval='6 6'>
                 <varRef name='Q{}ref' slot='3'/>
                 <varRef name='Q{}instance-with-delete' slot='15'/>
                </ufCall>
-               <callT line='4405' name='Q{}xforms-recalculate' bSlot='6' flags='t'/>
+               <callT line='4411' name='Q{}xforms-recalculate' bSlot='6' flags='t'/>
               </sequence>
              </let>
             </choose>
@@ -1192,8 +1192,8 @@
   </template>
  </co>
  <co id='30' binds='31'>
-  <template name='Q{}action-send' flags='os' line='4464' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4465'>
+  <template name='Q{}action-send' flags='os' line='4470' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4471'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -1201,9 +1201,9 @@
       </check>
      </treat>
     </param>
-    <callT line='4471' name='Q{}xforms-submit' bSlot='0' flags='t'>
+    <callT line='4477' name='Q{}xforms-submit' bSlot='0' flags='t'>
      <withParam name='Q{}submission' flags='c' as='xs:string'>
-      <treat line='4469' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|submission'>
+      <treat line='4475' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|submission'>
        <check card='1' diag='3|0|XTTE0570|submission'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|submission'>
          <data>
@@ -1221,10 +1221,10 @@
   </template>
  </co>
  <co id='32' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}usesIndexFunction' line='2496' module='saxon-xforms.xsl' eval='8' flags='pU' as='xs:boolean' slots='1'>
+  <function name='Q{http://www.w3.org/2002/xforms}usesIndexFunction' line='2500' module='saxon-xforms.xsl' eval='8' flags='pU' as='xs:boolean' slots='1'>
    <arg name='Q{}this' as='element()'/>
-   <fn role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2532' name='exists'>
-    <sequence line='2507'>
+   <fn role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2536' name='exists'>
+    <sequence line='2511'>
      <analyzeString>
       <cvUntyped role='select' to='xs:string'>
        <data>
@@ -1236,7 +1236,7 @@
       </cvUntyped>
       <str role='regex' val='\i\c*\('/>
       <str role='flags' val=''/>
-      <choose role='matching' line='2510'>
+      <choose role='matching' line='2514'>
        <vc op='eq' onEmpty='0' comp='CCC'>
         <fn name='substring-before'>
          <dot type='xs:string'/>
@@ -1248,7 +1248,7 @@
       </choose>
       <empty role='nonMatching'/>
      </analyzeString>
-     <analyzeString line='2519'>
+     <analyzeString line='2523'>
       <cvUntyped role='select' to='xs:string'>
        <data>
         <slash simple='1'>
@@ -1259,7 +1259,7 @@
       </cvUntyped>
       <str role='regex' val='\i\c*\('/>
       <str role='flags' val=''/>
-      <choose role='matching' line='2522'>
+      <choose role='matching' line='2526'>
        <vc op='eq' onEmpty='0' comp='CCC'>
         <fn name='substring-before'>
          <dot type='xs:string'/>
@@ -1277,18 +1277,18 @@
  </co>
  <co id='33' binds='34 33 34 35 33 33 35'>
   <mode name='Q{}form-check' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='27' rank='0' minImp='0' slots='12' flags='s' line='2152' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='27' rank='0' minImp='0' slots='12' flags='s' line='2156' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2153'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2157'>
      <param name='Q{}curPath' slot='0'>
       <str role='select' val=''/>
       <supplied role='conversion' slot='0'/>
      </param>
-     <param line='2154' name='Q{}position' slot='1'>
+     <param line='2158' name='Q{}position' slot='1'>
       <int role='select' val='0'/>
       <supplied role='conversion' slot='1'/>
      </param>
-     <param line='2155' name='Q{}pendingUpdates' slot='2' flags='t' as='map(xs:string, xs:string)?'>
+     <param line='2159' name='Q{}pendingUpdates' slot='2' flags='t' as='map(xs:string, xs:string)?'>
       <empty role='select'/>
       <treat role='conversion' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|pendingUpdates'>
        <check card='?' diag='8|0|XTTE0590|pendingUpdates'>
@@ -1296,7 +1296,7 @@
        </check>
       </treat>
      </param>
-     <param line='2156' name='Q{}updated-node' slot='3' flags='t' as='node()?'>
+     <param line='2160' name='Q{}updated-node' slot='3' flags='t' as='node()?'>
       <empty role='select'/>
       <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|updated-node'>
        <check card='?' diag='8|0|XTTE0590|updated-node'>
@@ -1304,7 +1304,7 @@
        </check>
       </treat>
      </param>
-     <param line='2157' name='Q{}value' slot='4' flags='t' as='xs:string?'>
+     <param line='2161' name='Q{}value' slot='4' flags='t' as='xs:string?'>
       <empty role='select'/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|value'>
        <check card='?' diag='8|0|XTTE0590|value'>
@@ -1316,7 +1316,7 @@
        </check>
       </treat>
      </param>
-     <let line='2178' var='Q{}updatedPath' as='xs:string' slot='5' eval='16'>
+     <let line='2182' var='Q{}updatedPath' as='xs:string' slot='5' eval='16'>
       <choose>
        <gc op='&gt;' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
         <data>
@@ -1347,7 +1347,7 @@
         </fn>
        </fn>
       </choose>
-      <sequence line='2184'>
+      <sequence line='2188'>
        <message>
         <sequence role='select'>
          <valueOf>
@@ -1361,7 +1361,7 @@
         <str role='terminate' val='no'/>
         <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
        </message>
-       <forEach line='2185'>
+       <forEach line='2189'>
         <filter flags='b'>
          <slash simple='1'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
@@ -1381,7 +1381,7 @@
           </fn>
          </or>
         </filter>
-        <sequence line='2186'>
+        <sequence line='2190'>
          <message>
           <sequence role='select'>
            <valueOf>
@@ -1401,7 +1401,7 @@
           <str role='terminate' val='no'/>
           <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
          </message>
-         <message line='2187'>
+         <message line='2191'>
           <sequence role='select'>
            <valueOf>
             <str val='[form-check] resolved @data-ref = &#39;'/>
@@ -1422,18 +1422,18 @@
          </message>
         </sequence>
        </forEach>
-       <copy line='2192' flags='cin'>
+       <copy line='2196' flags='cin'>
         <sequence role='content'>
          <applyT mode='Q{}form-check' bSlot='1'>
           <axis role='select' name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
           <withParam name='Q{}curPath' as='xs:string'>
-           <fn line='2193' name='concat'>
+           <fn line='2197' name='concat'>
             <varRef name='Q{}updatedPath' slot='5'/>
             <str val='/'/>
            </fn>
           </withParam>
          </applyT>
-         <let line='2199' var='Q{}associated-form-control' as='element()*' slot='6' eval='8'>
+         <let line='2203' var='Q{}associated-form-control' as='element()*' slot='6' eval='8'>
           <filter flags='b'>
            <filter flags='b'>
             <slash simple='1'>
@@ -1465,14 +1465,14 @@
             <varRef name='Q{}updatedPath' slot='5'/>
            </vc>
           </filter>
-          <sequence line='2201'>
+          <sequence line='2205'>
            <choose>
             <fn name='exists'>
              <tail start='2'>
               <varRef name='Q{}associated-form-control' slot='6'/>
              </tail>
             </fn>
-            <message line='2202'>
+            <message line='2206'>
              <sequence role='select'>
               <valueOf>
                <str val='[form-check] More than one form element controls the value of XForm node at '/>
@@ -1488,12 +1488,12 @@
              <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
             </message>
            </choose>
-           <choose line='2206'>
+           <choose line='2210'>
             <is op='is'>
              <varRef name='Q{}updated-node' slot='3'/>
              <dot type='element()'/>
             </is>
-            <sequence line='2207'>
+            <sequence line='2211'>
              <message>
               <valueOf role='select'>
                <str val='&#xA;                        [form-check] Matched node!!&#xA;                    '/>
@@ -1501,14 +1501,14 @@
               <str role='terminate' val='no'/>
               <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
              </message>
-             <valueOf line='2210' flags='l'>
+             <valueOf line='2214' flags='l'>
               <varRef name='Q{}value' slot='4'/>
              </valueOf>
             </sequence>
-            <fn line='2212' name='exists'>
+            <fn line='2216' name='exists'>
              <varRef name='Q{}associated-form-control' slot='6'/>
             </fn>
-            <valueOf line='2216' flags='l'>
+            <valueOf line='2220' flags='l'>
              <fn name='string-join'>
               <convert from='xs:anyAtomicType' to='xs:string'>
                <data>
@@ -1524,7 +1524,7 @@
               <str val=''/>
              </fn>
             </valueOf>
-            <and line='2219' op='and'>
+            <and line='2223' op='and'>
              <fn name='exists'>
               <varRef name='Q{}pendingUpdates' slot='2'/>
              </fn>
@@ -1535,7 +1535,7 @@
               <varRef name='Q{}updatedPath' slot='5'/>
              </ifCall>
             </and>
-            <valueOf line='2227' flags='l'>
+            <valueOf line='2231' flags='l'>
              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
               <check card='1' diag='0|0||map:get'>
                <varRef name='Q{}pendingUpdates' slot='2'/>
@@ -1544,7 +1544,7 @@
              </ifCall>
             </valueOf>
             <true/>
-            <valueOf line='2236' flags='l'>
+            <valueOf line='2240' flags='l'>
              <fn name='normalize-space'>
               <fn name='string-join'>
                <data>
@@ -1555,13 +1555,13 @@
              </fn>
             </valueOf>
            </choose>
-           <forEachGroup line='2241' algorithm='by'>
+           <forEachGroup line='2245' algorithm='by'>
             <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
             <fn role='key' name='local-name'>
              <dot type='element()'/>
             </fn>
             <str role='collation' val='http://www.w3.org/2005/xpath-functions/collation/codepoint'/>
-            <let role='content' line='2243' var='Q{}updatedChildPath' as='xs:string' slot='7' eval='8'>
+            <let role='content' line='2247' var='Q{}updatedChildPath' as='xs:string' slot='7' eval='8'>
              <fn name='concat'>
               <varRef name='Q{}updatedPath' slot='5'/>
               <str val='/'/>
@@ -1569,7 +1569,7 @@
                <currentGroupingKey/>
               </check>
              </fn>
-             <let line='2248' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='8' eval='13'>
+             <let line='2252' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='8' eval='13'>
               <fn name='concat'>
                <varRef name='Q{}updatedChildPath' slot='7'/>
                <str val='['/>
@@ -1587,7 +1587,7 @@
                  <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='8'/>
                 </fn>
                </filter>
-               <choose line='2251'>
+               <choose line='2255'>
                 <or op='or'>
                  <fn name='exists'>
                   <tail start='2'>
@@ -1598,36 +1598,36 @@
                   <varRef name='Q{}dataRefWithFilter' slot='9'/>
                  </fn>
                 </or>
-                <let line='2254' var='Q{http://saxon.sf.net/generated-variable}v1' as='xs:string' slot='10' eval='13'>
+                <let line='2258' var='Q{http://saxon.sf.net/generated-variable}v1' as='xs:string' slot='10' eval='13'>
                  <fn name='concat'>
                   <varRef name='Q{}updatedPath' slot='5'/>
                   <str val='/'/>
                  </fn>
-                 <forEach line='2252'>
+                 <forEach line='2256'>
                   <currentGroup/>
-                  <applyT line='2253' mode='Q{}form-check' bSlot='4'>
+                  <applyT line='2257' mode='Q{}form-check' bSlot='4'>
                    <dot role='select'/>
                    <withParam name='Q{}curPath' as='xs:string'>
-                    <varRef line='2254' name='Q{http://saxon.sf.net/generated-variable}v1' slot='10'/>
+                    <varRef line='2258' name='Q{http://saxon.sf.net/generated-variable}v1' slot='10'/>
                    </withParam>
                    <withParam name='Q{}position' as='xs:integer'>
-                    <fn line='2255' name='position'/>
+                    <fn line='2259' name='position'/>
                    </withParam>
                   </applyT>
                  </forEach>
                 </let>
                 <true/>
-                <let line='2263' var='Q{http://saxon.sf.net/generated-variable}v2' as='xs:string' slot='11' eval='13'>
+                <let line='2267' var='Q{http://saxon.sf.net/generated-variable}v2' as='xs:string' slot='11' eval='13'>
                  <fn name='concat'>
                   <varRef name='Q{}updatedPath' slot='5'/>
                   <str val='/'/>
                  </fn>
-                 <forEach line='2261'>
+                 <forEach line='2265'>
                   <currentGroup/>
-                  <applyT line='2262' mode='Q{}form-check' bSlot='5'>
+                  <applyT line='2266' mode='Q{}form-check' bSlot='5'>
                    <dot role='select'/>
                    <withParam name='Q{}curPath' as='xs:string'>
-                    <varRef line='2263' name='Q{http://saxon.sf.net/generated-variable}v2' slot='11'/>
+                    <varRef line='2267' name='Q{http://saxon.sf.net/generated-variable}v2' slot='11'/>
                    </withParam>
                   </applyT>
                  </forEach>
@@ -1645,14 +1645,14 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='-0.5' seq='30' rank='0' minImp='0' slots='4' flags='s' line='2339' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='30' rank='0' minImp='0' slots='4' flags='s' line='2343' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2340'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2344'>
      <param name='Q{}curPath' slot='0'>
       <str role='select' val=''/>
       <supplied role='conversion' slot='0'/>
      </param>
-     <param line='2341' name='Q{}pendingUpdates' slot='1' flags='t' as='map(xs:string, xs:string)?'>
+     <param line='2345' name='Q{}pendingUpdates' slot='1' flags='t' as='map(xs:string, xs:string)?'>
       <empty role='select'/>
       <treat role='conversion' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|pendingUpdates'>
        <check card='?' diag='8|0|XTTE0590|pendingUpdates'>
@@ -1660,7 +1660,7 @@
        </check>
       </treat>
      </param>
-     <let line='2342' var='Q{}updatedPath' as='xs:string' slot='2' eval='8'>
+     <let line='2346' var='Q{}updatedPath' as='xs:string' slot='2' eval='8'>
       <fn name='concat'>
        <atomSing card='?' diag='0|0||fn:concat'>
         <varRef name='Q{}curPath' slot='0'/>
@@ -1670,7 +1670,7 @@
         <dot type='attribute()'/>
        </fn>
       </fn>
-      <let line='2351' var='Q{}associated-form-control' as='element()*' slot='3' eval='8'>
+      <let line='2355' var='Q{}associated-form-control' as='element()*' slot='3' eval='8'>
        <filter flags='b'>
         <slash simple='1'>
          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
@@ -1683,15 +1683,15 @@
          <varRef name='Q{}updatedPath' slot='2'/>
         </vc>
        </filter>
-       <choose line='2354'>
+       <choose line='2358'>
         <fn name='exists'>
          <varRef name='Q{}associated-form-control' slot='3'/>
         </fn>
-        <compAtt line='2357'>
+        <compAtt line='2361'>
          <fn role='name' name='local-name'>
           <dot type='attribute()'/>
          </fn>
-         <fn role='select' line='2358' name='string-join'>
+         <fn role='select' line='2362' name='string-join'>
           <convert from='xs:anyAtomicType' to='xs:string'>
            <data>
             <mergeAdj>
@@ -1704,7 +1704,7 @@
           <str val=''/>
          </fn>
         </compAtt>
-        <and line='2361' op='and'>
+        <and line='2365' op='and'>
          <fn name='exists'>
           <varRef name='Q{}pendingUpdates' slot='1'/>
          </fn>
@@ -1715,11 +1715,11 @@
           <varRef name='Q{}updatedPath' slot='2'/>
          </ifCall>
         </and>
-        <compAtt line='2362'>
+        <compAtt line='2366'>
          <fn role='name' name='local-name'>
           <dot type='attribute()'/>
          </fn>
-         <ifCall role='select' line='2363' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+         <ifCall role='select' line='2367' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
           <check card='1' diag='0|0||map:get'>
            <varRef name='Q{}pendingUpdates' slot='1'/>
           </check>
@@ -1727,7 +1727,7 @@
          </ifCall>
         </compAtt>
         <true/>
-        <forEach line='2367'>
+        <forEach line='2371'>
          <dot type='attribute()'/>
          <copyOf flags='vsc'>
           <dot type='attribute()'/>
@@ -1742,9 +1742,9 @@
  </co>
  <co id='36' binds='33 33'>
   <mode name='Q{}form-check-initial' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='26' rank='0' minImp='0' slots='6' flags='s' line='2090' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='26' rank='0' minImp='0' slots='6' flags='s' line='2094' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2091'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2095'>
      <param name='Q{}instance-id' slot='0' as='xs:string'>
       <str role='select' val='saxon-forms-default'/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|instance-id'>
@@ -1757,7 +1757,7 @@
        </check>
       </treat>
      </param>
-     <param line='2092' name='Q{}pendingUpdates' slot='1' flags='t' as='map(xs:string, xs:string)?'>
+     <param line='2096' name='Q{}pendingUpdates' slot='1' flags='t' as='map(xs:string, xs:string)?'>
       <empty role='select'/>
       <treat role='conversion' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|pendingUpdates'>
        <check card='?' diag='8|0|XTTE0590|pendingUpdates'>
@@ -1765,15 +1765,15 @@
        </check>
       </treat>
      </param>
-     <let line='2098' var='Q{}curPath' as='xs:string' slot='2' eval='16'>
-      <choose line='2100'>
+     <let line='2102' var='Q{}curPath' as='xs:string' slot='2' eval='16'>
+      <choose line='2104'>
        <vc op='eq' onEmpty='0' comp='CCC'>
         <varRef name='Q{}instance-id' slot='0'/>
         <str val='saxon-forms-default'/>
        </vc>
        <str val=''/>
        <true/>
-       <cvUntyped line='2104' to='xs:string' diag='3|0|XTTE0570|curPath'>
+       <cvUntyped line='2108' to='xs:string' diag='3|0|XTTE0570|curPath'>
         <cast as='xs:untypedAtomic' emptiable='0'>
          <fn name='concat'>
           <str val='instance(&#39;'/>
@@ -1783,21 +1783,21 @@
         </cast>
        </cvUntyped>
       </choose>
-      <copy line='2111' flags='cin'>
+      <copy line='2115' flags='cin'>
        <forEachGroup role='content' algorithm='by'>
         <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
         <fn role='key' name='local-name'>
          <dot type='element()'/>
         </fn>
         <str role='collation' val='http://www.w3.org/2005/xpath-functions/collation/codepoint'/>
-        <let role='content' line='2113' var='Q{}updatedChildPath' as='xs:string' slot='3' eval='8'>
+        <let role='content' line='2117' var='Q{}updatedChildPath' as='xs:string' slot='3' eval='8'>
          <fn name='concat'>
           <varRef name='Q{}curPath' slot='2'/>
           <check card='?' diag='0|1||fn:concat'>
            <currentGroupingKey/>
           </check>
          </fn>
-         <let line='2118' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='4' eval='13'>
+         <let line='2122' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='4' eval='13'>
           <fn name='concat'>
            <varRef name='Q{}updatedChildPath' slot='3'/>
            <str val='['/>
@@ -1815,7 +1815,7 @@
              <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='4'/>
             </fn>
            </filter>
-           <choose line='2120'>
+           <choose line='2124'>
             <or op='or'>
              <fn name='exists'>
               <tail start='2'>
@@ -1826,25 +1826,25 @@
               <varRef name='Q{}dataRefWithFilter' slot='5'/>
              </fn>
             </or>
-            <forEach line='2121'>
+            <forEach line='2125'>
              <currentGroup/>
-             <applyT line='2122' mode='Q{}form-check' bSlot='0'>
+             <applyT line='2126' mode='Q{}form-check' bSlot='0'>
               <dot role='select'/>
               <withParam name='Q{}curPath' as='xs:string'>
-               <varRef line='2123' name='Q{}curPath' slot='2'/>
+               <varRef line='2127' name='Q{}curPath' slot='2'/>
               </withParam>
               <withParam name='Q{}position' as='xs:integer'>
-               <fn line='2124' name='position'/>
+               <fn line='2128' name='position'/>
               </withParam>
              </applyT>
             </forEach>
             <true/>
-            <forEach line='2130'>
+            <forEach line='2134'>
              <currentGroup/>
-             <applyT line='2131' mode='Q{}form-check' bSlot='1'>
+             <applyT line='2135' mode='Q{}form-check' bSlot='1'>
               <dot role='select'/>
               <withParam name='Q{}curPath' as='xs:string'>
-               <varRef line='2132' name='Q{}curPath' slot='2'/>
+               <varRef line='2136' name='Q{}curPath' slot='2'/>
               </withParam>
              </applyT>
             </forEach>
@@ -1860,9 +1860,9 @@
   </mode>
  </co>
  <co id='26' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}getRepeatID' line='739' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
+  <function name='Q{http://www.w3.org/2002/xforms}getRepeatID' line='743' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
    <arg name='Q{}string-to-parse' as='xs:string'/>
-   <treat role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='742' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getRepeatID#1'>
+   <treat role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='746' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getRepeatID#1'>
     <check card='?' diag='5|0|XTTE0780|xforms:getRepeatID#1'>
      <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getRepeatID#1'>
       <data>
@@ -1870,10 +1870,10 @@
         <varRef role='select' name='Q{}string-to-parse' slot='0'/>
         <str role='regex' val='^.*index\s*\(\s*&#39;([^&#39;]+)&#39;\s*\).*$'/>
         <str role='flags' val=''/>
-        <fn role='matching' line='744' name='regex-group'>
+        <fn role='matching' line='748' name='regex-group'>
          <int val='1'/>
         </fn>
-        <message role='nonMatching' line='747'>
+        <message role='nonMatching' line='751'>
          <sequence role='select'>
           <valueOf>
            <str val='[xforms:getRepeatID] No repeat identifiable from value &#39;'/>
@@ -1896,8 +1896,8 @@
   </function>
  </co>
  <co id='37' binds=''>
-  <template name='Q{}action-reset' flags='os' line='4511' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4512'>
+  <template name='Q{}action-reset' flags='os' line='4517' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4518'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -1905,7 +1905,7 @@
       </check>
      </treat>
     </param>
-    <message line='4514'>
+    <message line='4520'>
      <valueOf role='select'>
       <str val='[action-reset] Reset triggered!'/>
      </valueOf>
@@ -1915,9 +1915,9 @@
    </sequence>
   </template>
  </co>
- <co id='38' binds='21 22 23 35 39 25 40 27 41'>
-  <template name='Q{}xforms-value-changed' flags='os' line='3699' module='saxon-xforms.xsl' slots='9'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3700'>
+ <co id='38' binds='21 39 22 23 35 40 25 41 27 42'>
+  <template name='Q{}xforms-value-changed' flags='os' line='3703' module='saxon-xforms.xsl' slots='9'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3704'>
     <param name='Q{}form-control' slot='0' flags='i' as='node()'>
      <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|form-control'>
       <check card='1' diag='8|0|XTTE0590|form-control'>
@@ -1925,12 +1925,12 @@
       </check>
      </treat>
     </param>
-    <let line='3702' var='Q{}refi' as='attribute(Q{}data-ref)?' slot='1' eval='8'>
+    <let line='3706' var='Q{}refi' as='attribute(Q{}data-ref)?' slot='1' eval='8'>
      <slash simple='1'>
       <varRef name='Q{}form-control' slot='0'/>
       <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
      </slash>
-     <let line='3705' var='Q{}instance-id' as='xs:string' slot='2' eval='16'>
+     <let line='3709' var='Q{}instance-id' as='xs:string' slot='2' eval='16'>
       <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='16'>
        <check card='1' diag='0|0||xforms:getInstanceId'>
         <cvUntyped to='xs:string'>
@@ -1940,7 +1940,7 @@
         </cvUntyped>
        </check>
       </ufCall>
-      <let line='3706' var='Q{}actions' as='item()?' slot='3' eval='8'>
+      <let line='3710' var='Q{}actions' as='item()?' slot='3' eval='8'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
         <check card='1' diag='0|0||ixsl:call'>
          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -1955,166 +1955,176 @@
          </fn>
         </arrayBlock>
        </ifCall>
-       <let line='3717' var='Q{}instanceXML' as='element()' slot='4' eval='16'>
-        <check card='1' diag='3|0|XTTE0570|instanceXML'>
-         <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='6'>
-          <varRef name='Q{}instance-id' slot='2'/>
-         </ufCall>
-        </check>
-        <let line='3718' var='Q{}updatedNode' as='node()' slot='5' eval='16'>
-         <treat line='3719' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|updatedNode'>
-          <check card='1' diag='3|0|XTTE0570|updatedNode'>
-           <evaluate dxns=''>
-            <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
-             <check card='1' diag='0|0||xforms:impose'>
-              <cvUntyped to='xs:string'>
-               <data>
-                <varRef name='Q{}refi' slot='1'/>
-               </data>
-              </cvUntyped>
-             </check>
-            </ufCall>
-            <varRef role='cxt' name='Q{}instanceXML' slot='4'/>
-            <varRef role='nsCxt' name='Q{}instanceXML' slot='4'/>
-            <str role='sa' val='no'/>
-            <map role='options' size='0'/>
-            <map role='wp' size='0'/>
-           </evaluate>
-          </check>
-         </treat>
-         <let line='3721' var='Q{}new-value' as='xs:string' slot='6' eval='16'>
-          <treat line='3722' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-value'>
-           <check card='1' diag='3|0|XTTE0570|new-value'>
-            <cvUntyped to='xs:string' diag='3|0|XTTE0570|new-value'>
-             <data>
-              <applyT mode='Q{}get-field' bSlot='3'>
-               <varRef role='select' name='Q{}form-control' slot='0'/>
-              </applyT>
-             </data>
-            </cvUntyped>
+       <sequence line='3720'>
+        <ufCall name='Q{http://saxon.sf.net/ns/packages}logInfo' tailCall='false' bSlot='1' eval='16'>
+         <fn name='concat'>
+          <str val='[xforms-value-changed] Evaluating data ref: '/>
+          <data>
+           <varRef name='Q{}refi' slot='1'/>
+          </data>
+         </fn>
+        </ufCall>
+        <let line='3723' var='Q{}instanceXML' as='element()' slot='4' eval='16'>
+         <check card='1' diag='3|0|XTTE0570|instanceXML'>
+          <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='2' eval='6'>
+           <varRef name='Q{}instance-id' slot='2'/>
+          </ufCall>
+         </check>
+         <let line='3724' var='Q{}updatedNode' as='node()' slot='5' eval='16'>
+          <treat line='3725' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|updatedNode'>
+           <check card='1' diag='3|0|XTTE0570|updatedNode'>
+            <evaluate dxns=''>
+             <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='3' eval='16'>
+              <check card='1' diag='0|0||xforms:impose'>
+               <cvUntyped to='xs:string'>
+                <data>
+                 <varRef name='Q{}refi' slot='1'/>
+                </data>
+               </cvUntyped>
+              </check>
+             </ufCall>
+             <varRef role='cxt' name='Q{}instanceXML' slot='4'/>
+             <varRef role='nsCxt' name='Q{}instanceXML' slot='4'/>
+             <str role='sa' val='no'/>
+             <map role='options' size='0'/>
+             <map role='wp' size='0'/>
+            </evaluate>
            </check>
           </treat>
-          <let line='3724' var='Q{}updatedInstanceXML' as='element()' slot='7' eval='16'>
-           <treat line='3725' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
-            <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
-             <applyT mode='Q{}recalculate' bSlot='4'>
-              <varRef role='select' name='Q{}instanceXML' slot='4'/>
-              <withParam name='Q{}instance-id' as='xs:string'>
-               <varRef line='3726' name='Q{}instance-id' slot='2'/>
-              </withParam>
-              <withParam name='Q{}updated-nodes' flags='t' as='node()'>
-               <varRef line='3727' name='Q{}updatedNode' slot='5'/>
-              </withParam>
-              <withParam name='Q{}updated-values' flags='t' as='xs:string'>
-               <varRef line='3728' name='Q{}new-value' slot='6'/>
-              </withParam>
-             </applyT>
+          <let line='3727' var='Q{}new-value' as='xs:string' slot='6' eval='16'>
+           <treat line='3728' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-value'>
+            <check card='1' diag='3|0|XTTE0570|new-value'>
+             <cvUntyped to='xs:string' diag='3|0|XTTE0570|new-value'>
+              <data>
+               <applyT mode='Q{}get-field' bSlot='4'>
+                <varRef role='select' name='Q{}form-control' slot='0'/>
+               </applyT>
+              </data>
+             </cvUntyped>
             </check>
            </treat>
-           <sequence line='3735'>
-            <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='5' eval='16 6'>
-             <check card='1' diag='0|0||xforms:setInstance-JS'>
-              <cvUntyped to='xs:string'>
-               <data>
-                <varRef name='Q{}refi' slot='1'/>
-               </data>
-              </cvUntyped>
+           <let line='3730' var='Q{}updatedInstanceXML' as='element()' slot='7' eval='16'>
+            <treat line='3731' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+             <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
+              <applyT mode='Q{}recalculate' bSlot='5'>
+               <varRef role='select' name='Q{}instanceXML' slot='4'/>
+               <withParam name='Q{}instance-id' as='xs:string'>
+                <varRef line='3732' name='Q{}instance-id' slot='2'/>
+               </withParam>
+               <withParam name='Q{}updated-nodes' flags='t' as='node()'>
+                <varRef line='3733' name='Q{}updatedNode' slot='5'/>
+               </withParam>
+               <withParam name='Q{}updated-values' flags='t' as='xs:string'>
+                <varRef line='3734' name='Q{}new-value' slot='6'/>
+               </withParam>
+              </applyT>
              </check>
-             <varRef name='Q{}updatedInstanceXML' slot='7'/>
-            </ufCall>
-            <ifCall line='3742' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-             <check card='1' diag='0|0||ixsl:call'>
-              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-             </check>
-             <str val='setPendingUpdates'/>
-             <arrayBlock>
-              <treat line='3739' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||pendingInstanceUpdates'>
-               <map size='0'/>
-              </treat>
-             </arrayBlock>
-            </ifCall>
-            <ifCall line='3743' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-             <check card='1' diag='0|0||ixsl:call'>
-              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-             </check>
-             <str val='setUpdates'/>
-             <arrayBlock>
-              <treat line='3740' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||instanceUpdates'>
-               <map size='0'/>
-              </treat>
-             </arrayBlock>
-            </ifCall>
-            <forEach line='3745'>
-             <varRef name='Q{}actions' slot='3'/>
-             <let line='3746' var='Q{}action-map' as='item()' slot='8' eval='16'>
-              <dot/>
-              <choose line='3748'>
-               <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
-                <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:contains'>
-                 <varRef name='Q{}action-map' slot='8'/>
-                </treat>
-                <str val='@event'/>
-               </ifCall>
-               <choose line='3749'>
-                <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
-                 <data>
-                  <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                   <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:get'>
-                    <varRef name='Q{}action-map' slot='8'/>
-                   </treat>
-                   <str val='@event'/>
-                  </ifCall>
-                 </data>
-                 <str val='xforms-value-changed'/>
-                </gc>
-                <callT line='3751' name='Q{}applyActions' bSlot='6'>
-                 <withParam name='Q{}action-map' flags='t' as='item()'>
-                  <varRef line='3752' name='Q{}action-map' slot='8'/>
-                 </withParam>
-                 <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                  <check line='3753' card='1' diag='8|0|XTTE0590|nodeset'>
-                   <cvUntyped to='xs:string' diag='8|0|XTTE0590|nodeset'>
-                    <data>
-                     <varRef name='Q{}refi' slot='1'/>
-                    </data>
-                   </cvUntyped>
-                  </check>
-                 </withParam>
-                 <withParam name='Q{}instanceXML' flags='t' as='element()'>
-                  <varRef line='3754' name='Q{}updatedInstanceXML' slot='7'/>
-                 </withParam>
-                </callT>
+            </treat>
+            <sequence line='3741'>
+             <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='6' eval='16 6'>
+              <check card='1' diag='0|0||xforms:setInstance-JS'>
+               <cvUntyped to='xs:string'>
+                <data>
+                 <varRef name='Q{}refi' slot='1'/>
+                </data>
+               </cvUntyped>
+              </check>
+              <varRef name='Q{}updatedInstanceXML' slot='7'/>
+             </ufCall>
+             <ifCall line='3748' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+              <check card='1' diag='0|0||ixsl:call'>
+               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+              </check>
+              <str val='setPendingUpdates'/>
+              <arrayBlock>
+               <treat line='3745' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||pendingInstanceUpdates'>
+                <map size='0'/>
+               </treat>
+              </arrayBlock>
+             </ifCall>
+             <ifCall line='3749' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+              <check card='1' diag='0|0||ixsl:call'>
+               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+              </check>
+              <str val='setUpdates'/>
+              <arrayBlock>
+               <treat line='3746' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||instanceUpdates'>
+                <map size='0'/>
+               </treat>
+              </arrayBlock>
+             </ifCall>
+             <forEach line='3751'>
+              <varRef name='Q{}actions' slot='3'/>
+              <let line='3752' var='Q{}action-map' as='item()' slot='8' eval='16'>
+               <dot/>
+               <choose line='3754'>
+                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+                 <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:contains'>
+                  <varRef name='Q{}action-map' slot='8'/>
+                 </treat>
+                 <str val='@event'/>
+                </ifCall>
+                <choose line='3755'>
+                 <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+                  <data>
+                   <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                    <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:get'>
+                     <varRef name='Q{}action-map' slot='8'/>
+                    </treat>
+                    <str val='@event'/>
+                   </ifCall>
+                  </data>
+                  <str val='xforms-value-changed'/>
+                 </gc>
+                 <callT line='3757' name='Q{}applyActions' bSlot='7'>
+                  <withParam name='Q{}action-map' flags='t' as='item()'>
+                   <varRef line='3758' name='Q{}action-map' slot='8'/>
+                  </withParam>
+                  <withParam name='Q{}nodeset' flags='t' as='xs:string'>
+                   <check line='3759' card='1' diag='8|0|XTTE0590|nodeset'>
+                    <cvUntyped to='xs:string' diag='8|0|XTTE0590|nodeset'>
+                     <data>
+                      <varRef name='Q{}refi' slot='1'/>
+                     </data>
+                    </cvUntyped>
+                   </check>
+                  </withParam>
+                  <withParam name='Q{}instanceXML' flags='t' as='element()'>
+                   <varRef line='3760' name='Q{}updatedInstanceXML' slot='7'/>
+                  </withParam>
+                 </callT>
+                </choose>
                </choose>
-              </choose>
-             </let>
-            </forEach>
-            <callT line='3760' name='Q{}xforms-recalculate' bSlot='7'/>
-            <ufCall line='3762' name='Q{http://www.w3.org/2002/xforms}checkRelevantFields' tailCall='false' bSlot='8' eval='16'>
-             <check card='1' diag='0|0||xforms:checkRelevantFields'>
-              <cvUntyped to='xs:string'>
-               <data>
-                <slash line='3703' simple='1'>
-                 <varRef name='Q{}form-control' slot='0'/>
-                 <axis name='attribute' nodeTest='attribute(Q{}data-element)' jsTest='return item.name===&#39;data-element&#39;'/>
-                </slash>
-               </data>
-              </cvUntyped>
-             </check>
-            </ufCall>
-           </sequence>
+              </let>
+             </forEach>
+             <callT line='3766' name='Q{}xforms-recalculate' bSlot='8'/>
+             <ufCall line='3768' name='Q{http://www.w3.org/2002/xforms}checkRelevantFields' tailCall='false' bSlot='9' eval='16'>
+              <check card='1' diag='0|0||xforms:checkRelevantFields'>
+               <cvUntyped to='xs:string'>
+                <data>
+                 <slash line='3707' simple='1'>
+                  <varRef name='Q{}form-control' slot='0'/>
+                  <axis name='attribute' nodeTest='attribute(Q{}data-element)' jsTest='return item.name===&#39;data-element&#39;'/>
+                 </slash>
+                </data>
+               </cvUntyped>
+              </check>
+             </ufCall>
+            </sequence>
+           </let>
           </let>
          </let>
         </let>
-       </let>
+       </sequence>
       </let>
      </let>
     </let>
    </sequence>
   </template>
  </co>
- <co id='42' binds='43 22 23 44 22'>
-  <template name='Q{}getReferencedInstanceField' flags='os' line='2930' module='saxon-xforms.xsl' slots='4'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2931'>
+ <co id='43' binds='44 22 23 45 22'>
+  <template name='Q{}getReferencedInstanceField' flags='os' line='2934' module='saxon-xforms.xsl' slots='4'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2935'>
     <param name='Q{}refi' slot='0' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|refi'>
@@ -2127,29 +2137,29 @@
       </check>
      </treat>
     </param>
-    <let line='2933' var='Q{}field' as='node()*' slot='1' eval='8'>
-     <choose line='2935'>
+    <let line='2937' var='Q{}field' as='node()*' slot='1' eval='8'>
+     <choose line='2939'>
       <varRef name='Q{}refi' slot='0'/>
-      <let line='2936' var='Q{}instance-map' as='map(xs:string, xs:string)' slot='2' eval='16'>
+      <let line='2940' var='Q{}instance-map' as='map(xs:string, xs:string)' slot='2' eval='16'>
        <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='0' eval='6'>
         <varRef name='Q{}refi' slot='0'/>
        </ufCall>
-       <let line='2939' var='Q{}this-instance' as='element()?' slot='3' eval='7'>
+       <let line='2943' var='Q{}this-instance' as='element()?' slot='3' eval='7'>
         <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='16'>
-         <check line='2938' card='1' diag='3|0|XTTE0570|this-instance-id'>
+         <check line='2942' card='1' diag='3|0|XTTE0570|this-instance-id'>
           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
            <varRef name='Q{}instance-map' slot='2'/>
            <str val='instance-id'/>
           </ifCall>
          </check>
         </ufCall>
-        <choose line='2943'>
+        <choose line='2947'>
          <fn name='exists'>
           <varRef name='Q{}this-instance' slot='3'/>
          </fn>
-         <treat line='2945' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|field'>
+         <treat line='2949' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|field'>
           <evaluate dxns=''>
-           <ufCall role='xpath' line='2944' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
+           <ufCall role='xpath' line='2948' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
             <check card='1' diag='0|0||xforms:impose'>
              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
               <varRef name='Q{}instance-map' slot='2'/>
@@ -2167,10 +2177,10 @@
           </evaluate>
          </treat>
          <true/>
-         <treat line='2948' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|field'>
+         <treat line='2952' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|field'>
           <callT name='Q{}logToPage' bSlot='3'>
            <withParam name='Q{}message' flags='c' as='xs:string'>
-            <fn line='2949' name='concat'>
+            <fn line='2953' name='concat'>
              <str val='[getReferencedInstanceField] Unable to locate XForms instance relating to reference '/>
              <varRef name='Q{}refi' slot='0'/>
             </fn>
@@ -2184,18 +2194,18 @@
        </let>
       </let>
       <true/>
-      <ufCall line='2958' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='4' eval='0'>
+      <ufCall line='2962' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='4' eval='0'>
        <str val='saxon-forms-default'/>
       </ufCall>
      </choose>
-     <varRef line='2963' name='Q{}field' slot='1'/>
+     <varRef line='2967' name='Q{}field' slot='1'/>
     </let>
    </sequence>
   </template>
  </co>
- <co id='45' binds='44'>
-  <template name='Q{}action-message' flags='os' line='4418' module='saxon-xforms.xsl' slots='3'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4419'>
+ <co id='46' binds='45'>
+  <template name='Q{}action-message' flags='os' line='4424' module='saxon-xforms.xsl' slots='3'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4425'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -2203,7 +2213,7 @@
       </check>
      </treat>
     </param>
-    <let line='4421' var='Q{}message-value' as='xs:string' slot='1' eval='16'>
+    <let line='4427' var='Q{}message-value' as='xs:string' slot='1' eval='16'>
      <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|message-value'>
       <check card='1' diag='3|0|XTTE0570|message-value'>
        <cvUntyped to='xs:string' diag='3|0|XTTE0570|message-value'>
@@ -2216,7 +2226,7 @@
        </cvUntyped>
       </check>
      </treat>
-     <let line='4423' var='Q{}message-level' as='xs:string' slot='2' eval='16'>
+     <let line='4429' var='Q{}message-level' as='xs:string' slot='2' eval='16'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|message-level'>
        <check card='1' diag='3|0|XTTE0570|message-level'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|message-level'>
@@ -2234,7 +2244,7 @@
         </cvUntyped>
        </check>
       </treat>
-      <sequence line='4425'>
+      <sequence line='4431'>
        <message>
         <sequence role='select'>
          <valueOf>
@@ -2256,14 +2266,14 @@
         <str role='terminate' val='no'/>
         <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
        </message>
-       <choose line='4429'>
+       <choose line='4435'>
         <vc op='eq' onEmpty='0' comp='CCC'>
          <varRef name='Q{}message-level' slot='2'/>
          <str val='ephemeral'/>
         </vc>
-        <callT line='4430' name='Q{}logToPage' bSlot='0' flags='t'>
+        <callT line='4436' name='Q{}logToPage' bSlot='0' flags='t'>
          <withParam name='Q{}message' flags='c' as='xs:string'>
-          <varRef line='4431' name='Q{}message-value' slot='1'/>
+          <varRef line='4437' name='Q{}message-value' slot='1'/>
          </withParam>
         </callT>
        </choose>
@@ -2273,26 +2283,26 @@
    </sequence>
   </template>
  </co>
- <co id='46' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}resolveXPathStrings' line='804' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:string' slots='5'>
+ <co id='47' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}resolveXPathStrings' line='808' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:string' slots='5'>
    <arg name='Q{}base' as='xs:string'/>
    <arg name='Q{}relative' as='xs:string'/>
-   <choose role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='811'>
+   <choose role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='815'>
     <fn name='starts-with'>
      <varRef name='Q{}relative' slot='1'/>
      <str val='/'/>
     </fn>
-    <varRef line='812' name='Q{}relative' slot='1'/>
-    <fn line='814' name='starts-with'>
+    <varRef line='816' name='Q{}relative' slot='1'/>
+    <fn line='818' name='starts-with'>
      <varRef name='Q{}relative' slot='1'/>
      <str val='instance('/>
     </fn>
-    <varRef line='815' name='Q{}relative' slot='1'/>
-    <fn line='817' name='not'>
+    <varRef line='819' name='Q{}relative' slot='1'/>
+    <fn line='821' name='not'>
      <varRef name='Q{}base' slot='0'/>
     </fn>
-    <varRef line='818' name='Q{}relative' slot='1'/>
-    <or line='820' op='or'>
+    <varRef line='822' name='Q{}relative' slot='1'/>
+    <or line='824' op='or'>
      <fn name='not'>
       <varRef name='Q{}relative' slot='1'/>
      </fn>
@@ -2301,9 +2311,9 @@
       <str val='.'/>
      </vc>
     </or>
-    <varRef line='821' name='Q{}base' slot='0'/>
+    <varRef line='825' name='Q{}base' slot='0'/>
     <true/>
-    <let line='825' var='Q{}parentCallCount' as='xs:integer' slot='2' eval='16'>
+    <let line='829' var='Q{}parentCallCount' as='xs:integer' slot='2' eval='16'>
      <choose>
       <fn name='contains'>
        <varRef name='Q{}relative' slot='1'/>
@@ -2330,7 +2340,7 @@
       <true/>
       <int val='0'/>
      </choose>
-     <let line='828' var='Q{}slashes' as='xs:integer*' slot='3' eval='4'>
+     <let line='832' var='Q{}slashes' as='xs:integer*' slot='3' eval='4'>
       <choose>
        <fn name='contains'>
         <varRef name='Q{}base' slot='0'/>
@@ -2345,15 +2355,15 @@
        <true/>
        <int val='0'/>
       </choose>
-      <choose line='860'>
+      <choose line='864'>
        <compareToInt op='gt' val='0'>
         <varRef name='Q{}parentCallCount' slot='2'/>
        </compareToInt>
-       <fn line='864' name='concat'>
+       <fn line='868' name='concat'>
         <fn name='substring'>
          <varRef name='Q{}base' slot='0'/>
          <int val='1'/>
-         <choose line='839'>
+         <choose line='843'>
           <and op='and'>
            <vc op='ge' onEmpty='0' comp='CAVC'>
             <fn name='count'>
@@ -2365,7 +2375,7 @@
             <varRef name='Q{}parentCallCount' slot='2'/>
            </compareToInt>
           </and>
-          <let line='840' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='4' eval='13'>
+          <let line='844' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='4' eval='13'>
            <arith op='-' calc='i-i'>
             <varRef name='Q{}parentCallCount' slot='2'/>
             <int val='1'/>
@@ -2381,7 +2391,7 @@
            </check>
           </let>
           <true/>
-          <check line='843' card='1' diag='3|0|XTTE0570|parentSlash'>
+          <check line='847' card='1' diag='3|0|XTTE0570|parentSlash'>
            <lastOf>
             <varRef name='Q{}slashes' slot='3'/>
            </lastOf>
@@ -2396,7 +2406,7 @@
         </fn>
        </fn>
        <true/>
-       <fn line='867' name='concat'>
+       <fn line='871' name='concat'>
         <varRef name='Q{}base' slot='0'/>
         <str val='/'/>
         <varRef name='Q{}relative' slot='1'/>
@@ -2407,9 +2417,9 @@
    </choose>
   </function>
  </co>
- <co id='47' binds=''>
-  <function name='Q{http://saxonica.com/ns/forms-local}current-date' line='118' module='xforms-function-library.xsl' eval='16' flags='pU' as='xs:string' slots='0'>
-   <treat role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='119' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|today'>
+ <co id='48' binds=''>
+  <function name='Q{http://saxonica.com/ns/forms-local}current-date' line='119' module='xforms-function-library.xsl' eval='16' flags='pU' as='xs:string' slots='0'>
+   <treat role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='120' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|today'>
     <check card='1' diag='3|0|XTTE0570|today'>
      <cvUntyped to='xs:string' diag='3|0|XTTE0570|today'>
       <data>
@@ -2426,32 +2436,32 @@
    </treat>
   </function>
  </co>
- <co id='34' binds='48'>
-  <function name='Q{http://www.w3.org/2002/xforms}resolve-index' line='72' module='xforms-function-library.xsl' eval='8' flags='pU' as='xs:string' slots='2'>
+ <co id='34' binds='49'>
+  <function name='Q{http://www.w3.org/2002/xforms}resolve-index' line='73' module='xforms-function-library.xsl' eval='8' flags='pU' as='xs:string' slots='2'>
    <arg name='Q{}input' as='xs:string'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='74' var='Q{}parts' as='xs:string*' slot='1' eval='8'>
-    <analyzeString line='75'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='75' var='Q{}parts' as='xs:string*' slot='1' eval='8'>
+    <analyzeString line='76'>
      <varRef role='select' name='Q{}input' slot='0'/>
      <str role='regex' val='index\s*\(\s*&#39;([^&#39;]+)&#39;\s*\)'/>
      <str role='flags' val=''/>
-     <cast role='matching' line='78' as='xs:string' emptiable='0'>
+     <cast role='matching' line='79' as='xs:string' emptiable='0'>
       <ufCall name='Q{http://www.w3.org/2002/xforms}index' tailCall='false' bSlot='0' eval='16'>
        <fn name='regex-group'>
         <int val='1'/>
        </fn>
       </ufCall>
      </cast>
-     <dot role='nonMatching' line='81' type='xs:string'/>
+     <dot role='nonMatching' line='82' type='xs:string'/>
     </analyzeString>
-    <fn line='87' name='string-join'>
+    <fn line='88' name='string-join'>
      <varRef name='Q{}parts' slot='1'/>
     </fn>
    </let>
   </function>
  </co>
- <co id='49' binds='23'>
-  <template name='Q{}action-setindex' flags='os' line='4484' module='saxon-xforms.xsl' slots='2'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4485'>
+ <co id='50' binds='23'>
+  <template name='Q{}action-setindex' flags='os' line='4490' module='saxon-xforms.xsl' slots='2'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4491'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -2459,14 +2469,14 @@
       </check>
      </treat>
     </param>
-    <let line='4491' var='Q{}new-index' as='xs:integer' slot='1' eval='16'>
-     <treat line='4492' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|new-index'>
+    <let line='4497' var='Q{}new-index' as='xs:integer' slot='1' eval='16'>
+     <treat line='4498' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|new-index'>
       <check card='1' diag='3|0|XTTE0570|new-index'>
        <cvUntyped to='xs:integer' diag='3|0|XTTE0570|new-index'>
         <data>
          <evaluate dxns=''>
           <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='0' eval='16'>
-           <treat line='4488' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-index-ref'>
+           <treat line='4494' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-index-ref'>
             <check card='1' diag='3|0|XTTE0570|new-index-ref'>
              <cvUntyped to='xs:string' diag='3|0|XTTE0570|new-index-ref'>
               <data>
@@ -2488,13 +2498,13 @@
        </cvUntyped>
       </check>
      </treat>
-     <ifCall line='4497' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+     <ifCall line='4503' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
       <check card='1' diag='0|0||ixsl:call'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
       </check>
       <str val='setRepeatIndex'/>
       <arrayBlock>
-       <treat line='4487' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|repeatID'>
+       <treat line='4493' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|repeatID'>
         <check card='1' diag='3|0|XTTE0570|repeatID'>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|repeatID'>
           <data>
@@ -2513,9 +2523,9 @@
    </sequence>
   </template>
  </co>
- <co id='50' binds='51'>
-  <template name='Q{}action-setfocus' flags='os' line='4446' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4447'>
+ <co id='51' binds='52'>
+  <template name='Q{}action-setfocus' flags='os' line='4452' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4453'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -2523,9 +2533,9 @@
       </check>
      </treat>
     </param>
-    <callT line='4451' name='Q{}xforms-focus' bSlot='0' flags='t'>
+    <callT line='4457' name='Q{}xforms-focus' bSlot='0' flags='t'>
      <withParam name='Q{}control' flags='c' as='xs:string'>
-      <treat line='4449' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|control'>
+      <treat line='4455' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|control'>
        <check card='1' diag='3|0|XTTE0570|control'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|control'>
          <data>
@@ -2542,9 +2552,9 @@
    </sequence>
   </template>
  </co>
- <co id='52' binds='21 23 23 53 36 54 25 55'>
-  <template name='Q{}action-setvalue' flags='os' line='4094' module='saxon-xforms.xsl' slots='14'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4095'>
+ <co id='53' binds='21 23 23 54 36 55 25 56'>
+  <template name='Q{}action-setvalue' flags='os' line='4100' module='saxon-xforms.xsl' slots='14'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4101'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -2552,7 +2562,7 @@
       </check>
      </treat>
     </param>
-    <param line='4096' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
+    <param line='4102' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
      <empty role='select'/>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|instanceXML'>
       <check card='?' diag='8|0|XTTE0590|instanceXML'>
@@ -2560,7 +2570,7 @@
       </check>
      </treat>
     </param>
-    <param line='4097' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
+    <param line='4103' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -2572,7 +2582,7 @@
       </check>
      </treat>
     </param>
-    <let line='4101' var='Q{}refz' as='xs:string' slot='3' eval='16'>
+    <let line='4107' var='Q{}refz' as='xs:string' slot='3' eval='16'>
      <let var='Q{}relative' as='xs:string' slot='4' eval='16'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|1||xforms:resolveXPathStrings'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
@@ -2586,22 +2596,22 @@
         </cvUntyped>
        </check>
       </treat>
-      <choose line='811'>
+      <choose line='815'>
        <fn name='starts-with'>
         <varRef name='Q{}relative' slot='4'/>
         <str val='/'/>
        </fn>
-       <varRef line='812' name='Q{}relative' slot='4'/>
-       <fn line='814' name='starts-with'>
+       <varRef line='816' name='Q{}relative' slot='4'/>
+       <fn line='818' name='starts-with'>
         <varRef name='Q{}relative' slot='4'/>
         <str val='instance('/>
        </fn>
-       <varRef line='815' name='Q{}relative' slot='4'/>
-       <fn line='4101' name='not'>
+       <varRef line='819' name='Q{}relative' slot='4'/>
+       <fn line='4107' name='not'>
         <varRef name='Q{}nodeset' slot='2'/>
        </fn>
-       <varRef line='818' name='Q{}relative' slot='4'/>
-       <or line='820' op='or'>
+       <varRef line='822' name='Q{}relative' slot='4'/>
+       <or line='824' op='or'>
         <fn name='not'>
          <varRef name='Q{}relative' slot='4'/>
         </fn>
@@ -2610,9 +2620,9 @@
          <str val='.'/>
         </vc>
        </or>
-       <varRef line='4101' name='Q{}nodeset' slot='2'/>
+       <varRef line='4107' name='Q{}nodeset' slot='2'/>
        <true/>
-       <let line='825' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
+       <let line='829' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
         <choose>
          <fn name='contains'>
           <varRef name='Q{}relative' slot='4'/>
@@ -2639,30 +2649,30 @@
          <true/>
          <int val='0'/>
         </choose>
-        <let line='828' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
+        <let line='832' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
          <choose>
-          <fn line='4101' name='contains'>
+          <fn line='4107' name='contains'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
           </fn>
           <fn name='index-of'>
            <fn name='string-to-codepoints'>
-            <varRef line='4101' name='Q{}nodeset' slot='2'/>
+            <varRef line='4107' name='Q{}nodeset' slot='2'/>
            </fn>
            <int val='47'/>
           </fn>
           <true/>
           <int val='0'/>
          </choose>
-         <choose line='860'>
+         <choose line='864'>
           <compareToInt op='gt' val='0'>
            <varRef name='Q{}parentCallCount' slot='5'/>
           </compareToInt>
-          <fn line='864' name='concat'>
+          <fn line='868' name='concat'>
            <fn name='substring'>
-            <varRef line='4101' name='Q{}nodeset' slot='2'/>
+            <varRef line='4107' name='Q{}nodeset' slot='2'/>
             <int val='1'/>
-            <choose line='839'>
+            <choose line='843'>
              <and op='and'>
               <vc op='ge' onEmpty='0' comp='CAVC'>
                <fn name='count'>
@@ -2674,7 +2684,7 @@
                <varRef name='Q{}parentCallCount' slot='5'/>
               </compareToInt>
              </and>
-             <let line='840' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='7' eval='13'>
+             <let line='844' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='7' eval='13'>
               <arith op='-' calc='i-i'>
                <varRef name='Q{}parentCallCount' slot='5'/>
                <int val='1'/>
@@ -2690,7 +2700,7 @@
               </check>
              </let>
              <true/>
-             <check line='843' card='1' diag='3|0|XTTE0570|parentSlash'>
+             <check line='847' card='1' diag='3|0|XTTE0570|parentSlash'>
               <lastOf>
                <varRef name='Q{}slashes' slot='6'/>
               </lastOf>
@@ -2705,29 +2715,29 @@
            </fn>
           </fn>
           <true/>
-          <fn line='4101' name='concat'>
+          <fn line='4107' name='concat'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
-           <varRef line='867' name='Q{}relative' slot='4'/>
+           <varRef line='871' name='Q{}relative' slot='4'/>
           </fn>
          </choose>
         </let>
        </let>
       </choose>
      </let>
-     <let line='4103' var='Q{}instance-id' as='xs:string' slot='8' eval='16'>
+     <let line='4109' var='Q{}instance-id' as='xs:string' slot='8' eval='16'>
       <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='6'>
        <varRef name='Q{}refz' slot='3'/>
       </ufCall>
-      <let line='4116' var='Q{}valuez' as='document-node()' slot='9' eval='16'>
-       <doc line='4118' validation='preserve'>
+      <let line='4122' var='Q{}valuez' as='document-node()' slot='9' eval='16'>
+       <doc line='4124' validation='preserve'>
         <choose>
          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
           <varRef name='Q{}action-map' slot='0'/>
           <str val='@value'/>
          </ifCall>
-         <let line='4119' var='Q{}contexti' as='node()' slot='10' eval='8'>
-          <evaluate line='4120' as='node()' dxns=''>
+         <let line='4125' var='Q{}contexti' as='node()' slot='10' eval='8'>
+          <evaluate line='4126' as='node()' dxns=''>
            <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='1' eval='6'>
             <varRef name='Q{}nodeset' slot='2'/>
            </ufCall>
@@ -2739,7 +2749,7 @@
            <map role='options' size='0'/>
            <map role='wp' size='0'/>
           </evaluate>
-          <evaluate line='4123' dxns=''>
+          <evaluate line='4129' dxns=''>
            <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
             <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:impose'>
              <check card='1' diag='0|0||xforms:impose'>
@@ -2761,13 +2771,13 @@
            <map role='wp' size='0'/>
           </evaluate>
          </let>
-         <ifCall line='4126' name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+         <ifCall line='4132' name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
           <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:contains'>
            <dot flags='a'/>
           </treat>
           <str val='value'/>
          </ifCall>
-         <ifCall line='4127' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+         <ifCall line='4133' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
           <varRef name='Q{}action-map' slot='0'/>
           <str val='value'/>
          </ifCall>
@@ -2775,8 +2785,8 @@
          <str val=''/>
         </choose>
        </doc>
-       <sequence line='4137'>
-        <let line='4139' var='Q{}associated-form-control' as='element()?' slot='11' eval='7'>
+       <sequence line='4143'>
+        <let line='4145' var='Q{}associated-form-control' as='element()?' slot='11' eval='7'>
          <check card='?' diag='3|0|XTTE0570|associated-form-control'>
           <filter flags='b'>
            <slash simple='1'>
@@ -2791,22 +2801,22 @@
            </vc>
           </filter>
          </check>
-         <choose line='4141'>
+         <choose line='4147'>
           <fn name='exists'>
            <varRef name='Q{}associated-form-control' slot='11'/>
           </fn>
-          <sequence line='4142'>
+          <sequence line='4148'>
            <applyT mode='Q{}set-field' bSlot='3'>
             <varRef role='select' name='Q{}associated-form-control' slot='11'/>
             <withParam name='Q{}value' flags='t' as='xs:string'>
-             <cast line='4143' as='xs:string' emptiable='0'>
+             <cast line='4149' as='xs:string' emptiable='0'>
               <data>
                <varRef name='Q{}valuez' slot='9'/>
               </data>
              </cast>
             </withParam>
            </applyT>
-           <ifCall line='4145' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+           <ifCall line='4151' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
             <check card='1' diag='0|0||ixsl:call'>
              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
             </check>
@@ -2835,7 +2845,7 @@
            </ifCall>
           </sequence>
           <true/>
-          <ifCall line='4148' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+          <ifCall line='4154' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
            <check card='1' diag='0|0||ixsl:call'>
             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
            </check>
@@ -2864,12 +2874,12 @@
           </ifCall>
          </choose>
         </let>
-        <choose line='4154'>
+        <choose line='4160'>
          <vc op='ne' onEmpty='1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
           <varRef name='Q{}refz' slot='3'/>
           <str val=''/>
          </vc>
-         <let line='4156' var='Q{}pendingUpdates' as='map(xs:string, xs:string)?' slot='12' eval='7'>
+         <let line='4162' var='Q{}pendingUpdates' as='map(xs:string, xs:string)?' slot='12' eval='7'>
           <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|pendingUpdates'>
            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
             <check card='1' diag='0|0||ixsl:call'>
@@ -2879,11 +2889,11 @@
             <array size='0'/>
            </ifCall>
           </treat>
-          <let line='4158' var='Q{}updatedInstanceXML' as='element()' slot='13' eval='16'>
-           <treat line='4159' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+          <let line='4164' var='Q{}updatedInstanceXML' as='element()' slot='13' eval='16'>
+           <treat line='4165' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
             <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
              <applyT mode='Q{}form-check-initial' bSlot='4'>
-              <choose role='select' line='4107'>
+              <choose role='select' line='4113'>
                <and op='and'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <varRef name='Q{}instance-id' slot='8'/>
@@ -2893,31 +2903,31 @@
                  <varRef name='Q{}instanceXML' slot='1'/>
                 </fn>
                </and>
-               <check line='4108' card='1' diag='3|0|XTTE0570|instanceXML2'>
+               <check line='4114' card='1' diag='3|0|XTTE0570|instanceXML2'>
                 <varRef name='Q{}instanceXML' slot='1'/>
                </check>
                <true/>
-               <check line='4111' card='1' diag='3|0|XTTE0570|instanceXML2'>
+               <check line='4117' card='1' diag='3|0|XTTE0570|instanceXML2'>
                 <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='5' eval='6'>
                  <varRef name='Q{}refz' slot='3'/>
                 </ufCall>
                </check>
               </choose>
               <withParam name='Q{}instance-id' as='xs:string'>
-               <varRef line='4160' name='Q{}instance-id' slot='8'/>
+               <varRef line='4166' name='Q{}instance-id' slot='8'/>
               </withParam>
               <withParam name='Q{}pendingUpdates' flags='t' as='map(xs:string, xs:string)?'>
-               <varRef line='4161' name='Q{}pendingUpdates' slot='12'/>
+               <varRef line='4167' name='Q{}pendingUpdates' slot='12'/>
               </withParam>
              </applyT>
             </check>
            </treat>
-           <sequence line='4166'>
+           <sequence line='4172'>
             <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='6' eval='6 6'>
              <varRef name='Q{}refz' slot='3'/>
              <varRef name='Q{}updatedInstanceXML' slot='13'/>
             </ufCall>
-            <callT line='4167' name='Q{}refreshOutputs-JS' bSlot='7' flags='t'/>
+            <callT line='4173' name='Q{}refreshOutputs-JS' bSlot='7' flags='t'/>
            </sequence>
           </let>
          </let>
@@ -2929,14 +2939,14 @@
    </sequence>
   </template>
  </co>
- <co id='56' binds=''>
+ <co id='57' binds=''>
   <globalVariable name='Q{}default-submission-id' type='xs:string' line='82' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
    <str val='saxon-forms-default-submission'/>
   </globalVariable>
  </co>
- <co id='40' binds='21 54 23 23 23 52 20 28 49 50 57 27 37 30 45 40'>
-  <template name='Q{}applyActions' flags='os' line='3175' module='saxon-xforms.xsl' slots='15'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3176'>
+ <co id='41' binds='21 55 23 23 23 53 20 28 50 51 58 27 37 30 46 41'>
+  <template name='Q{}applyActions' flags='os' line='3179' module='saxon-xforms.xsl' slots='15'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3180'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -2944,7 +2954,7 @@
       </check>
      </treat>
     </param>
-    <param line='3177' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
+    <param line='3181' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
      <empty role='select'/>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|instanceXML'>
       <check card='?' diag='8|0|XTTE0590|instanceXML'>
@@ -2952,7 +2962,7 @@
       </check>
      </treat>
     </param>
-    <param line='3178' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
+    <param line='3182' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -2964,7 +2974,7 @@
       </check>
      </treat>
     </param>
-    <let line='3180' var='Q{}ref' as='xs:string?' slot='3' eval='7'>
+    <let line='3184' var='Q{}ref' as='xs:string?' slot='3' eval='7'>
      <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|ref'>
       <check card='?' diag='3|0|XTTE0570|ref'>
        <cvUntyped to='xs:string' diag='3|0|XTTE0570|ref'>
@@ -2977,7 +2987,7 @@
        </cvUntyped>
       </check>
      </treat>
-     <let line='3181' var='Q{}at' as='xs:string?' slot='4' eval='7'>
+     <let line='3185' var='Q{}at' as='xs:string?' slot='4' eval='7'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|at'>
        <check card='?' diag='3|0|XTTE0570|at'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|at'>
@@ -2990,7 +3000,7 @@
         </cvUntyped>
        </check>
       </treat>
-      <let line='3183' var='Q{}context' as='xs:string?' slot='5' eval='7'>
+      <let line='3187' var='Q{}context' as='xs:string?' slot='5' eval='7'>
        <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|context'>
         <check card='?' diag='3|0|XTTE0570|context'>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|context'>
@@ -3003,7 +3013,7 @@
          </cvUntyped>
         </check>
        </treat>
-       <let line='3194' var='Q{}ref-qualified' as='xs:string?' slot='6' eval='7'>
+       <let line='3198' var='Q{}ref-qualified' as='xs:string?' slot='6' eval='7'>
         <choose>
          <and op='and'>
           <fn name='exists'>
@@ -3025,14 +3035,14 @@
           <varRef name='Q{}ref' slot='3'/>
          </choose>
         </choose>
-        <let line='3196' var='Q{}instance-id' as='xs:string' slot='7' eval='16'>
+        <let line='3200' var='Q{}instance-id' as='xs:string' slot='7' eval='16'>
          <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='16'>
           <check card='1' diag='0|0||xforms:getInstanceId'>
            <varRef name='Q{}ref' slot='3'/>
           </check>
          </ufCall>
-         <let line='3198' var='Q{}instanceXML2' as='element()?' slot='8' eval='7'>
-          <choose line='3200'>
+         <let line='3202' var='Q{}instanceXML2' as='element()?' slot='8' eval='7'>
+          <choose line='3204'>
            <and op='and'>
             <vc op='eq' onEmpty='0' comp='CCC'>
              <varRef name='Q{}instance-id' slot='7'/>
@@ -3042,18 +3052,18 @@
              <varRef name='Q{}instanceXML' slot='1'/>
             </fn>
            </and>
-           <varRef line='3201' name='Q{}instanceXML' slot='1'/>
-           <fn line='3203' name='exists'>
+           <varRef line='3205' name='Q{}instanceXML' slot='1'/>
+           <fn line='3207' name='exists'>
             <varRef name='Q{}ref-qualified' slot='6'/>
            </fn>
-           <ufCall line='3204' name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='1' eval='16'>
+           <ufCall line='3208' name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='1' eval='16'>
             <check card='1' diag='0|0||xforms:getInstance-JS'>
              <varRef name='Q{}ref-qualified' slot='6'/>
             </check>
            </ufCall>
           </choose>
-          <let line='3212' var='Q{}ref-node' as='node()*' slot='9' eval='8'>
-           <choose line='3214'>
+          <let line='3216' var='Q{}ref-node' as='node()*' slot='9' eval='8'>
+           <choose line='3218'>
             <and op='and'>
              <and op='and'>
               <fn name='exists'>
@@ -3068,7 +3078,7 @@
               <varRef name='Q{}instanceXML2' slot='8'/>
              </fn>
             </and>
-            <treat line='3215' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|ref-node'>
+            <treat line='3219' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|ref-node'>
              <evaluate dxns=''>
               <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
                <check card='1' diag='0|0||xforms:impose'>
@@ -3085,8 +3095,8 @@
              </evaluate>
             </treat>
            </choose>
-           <let line='3220' var='Q{}context-node' as='node()?' slot='10' eval='7'>
-            <choose line='3222'>
+           <let line='3224' var='Q{}context-node' as='node()?' slot='10' eval='7'>
+            <choose line='3226'>
              <and op='and'>
               <and op='and'>
                <fn name='exists'>
@@ -3101,7 +3111,7 @@
                <varRef name='Q{}instanceXML2' slot='8'/>
               </fn>
              </and>
-             <treat line='3223' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|context-node'>
+             <treat line='3227' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|context-node'>
               <check card='?' diag='3|0|XTTE0570|context-node'>
                <evaluate dxns=''>
                 <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='3' eval='16'>
@@ -3120,7 +3130,7 @@
               </check>
              </treat>
             </choose>
-            <let line='3228' var='Q{}context' as='node()?' slot='11' eval='7'>
+            <let line='3232' var='Q{}context' as='node()?' slot='11' eval='7'>
              <first>
               <sequence>
                <varRef name='Q{}context-node' slot='10'/>
@@ -3128,18 +3138,18 @@
                <varRef name='Q{}instanceXML2' slot='8'/>
               </sequence>
              </first>
-             <let line='3234' var='Q{}ifVar' as='xs:string?' slot='12' eval='7'>
-              <choose line='766'>
+             <let line='3238' var='Q{}ifVar' as='xs:string?' slot='12' eval='7'>
+              <choose line='770'>
                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
-                <varRef line='3234' name='Q{}action-map' slot='0'/>
+                <varRef line='3238' name='Q{}action-map' slot='0'/>
                 <str val='@if'/>
                </ifCall>
-               <treat line='767' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
+               <treat line='771' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
                 <check card='?' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
                  <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
                   <data>
                    <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                    <varRef line='3234' name='Q{}action-map' slot='0'/>
+                    <varRef line='3238' name='Q{}action-map' slot='0'/>
                     <str val='@if'/>
                    </ifCall>
                   </data>
@@ -3147,8 +3157,8 @@
                 </check>
                </treat>
               </choose>
-              <let line='3238' var='Q{}ifExecuted' as='xs:boolean' slot='13' eval='16'>
-               <choose line='3240'>
+              <let line='3242' var='Q{}ifExecuted' as='xs:boolean' slot='13' eval='16'>
+               <choose line='3244'>
                 <and op='and'>
                  <fn name='exists'>
                   <varRef name='Q{}ifVar' slot='12'/>
@@ -3157,7 +3167,7 @@
                   <varRef name='Q{}context' slot='11'/>
                  </fn>
                 </and>
-                <treat line='3241' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|ifExecuted'>
+                <treat line='3245' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|ifExecuted'>
                  <check card='1' diag='3|0|XTTE0570|ifExecuted'>
                   <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|ifExecuted'>
                    <data>
@@ -3182,9 +3192,9 @@
                 <true/>
                 <true/>
                </choose>
-               <choose line='3251'>
+               <choose line='3255'>
                 <varRef name='Q{}ifExecuted' slot='13'/>
-                <let line='3252' var='Q{}action-name' as='xs:string' slot='14' eval='16'>
+                <let line='3256' var='Q{}action-name' as='xs:string' slot='14' eval='16'>
                  <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|action-name'>
                   <check card='1' diag='3|0|XTTE0570|action-name'>
                    <cvUntyped to='xs:string' diag='3|0|XTTE0570|action-name'>
@@ -3197,98 +3207,98 @@
                    </cvUntyped>
                   </check>
                  </treat>
-                 <sequence line='3255'>
+                 <sequence line='3259'>
                   <choose>
                    <vc op='eq' onEmpty='0' comp='CCC'>
                     <varRef name='Q{}action-name' slot='14'/>
                     <str val='action'/>
                    </vc>
                    <empty/>
-                   <vc line='3258' op='eq' onEmpty='0' comp='CCC'>
+                   <vc line='3262' op='eq' onEmpty='0' comp='CCC'>
                     <varRef name='Q{}action-name' slot='14'/>
                     <str val='setvalue'/>
                    </vc>
-                   <callT line='3259' name='Q{}action-setvalue' bSlot='5'>
+                   <callT line='3263' name='Q{}action-setvalue' bSlot='5'>
                     <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                     <check line='3260' card='1' diag='8|0|XTTE0590|nodeset'>
+                     <check line='3264' card='1' diag='8|0|XTTE0590|nodeset'>
                       <varRef name='Q{}ref' slot='3'/>
                      </check>
                     </withParam>
                     <withParam name='Q{}instanceXML' flags='t' as='element()'>
-                     <check line='3261' card='1' diag='8|0|XTTE0590|instanceXML'>
+                     <check line='3265' card='1' diag='8|0|XTTE0590|instanceXML'>
                       <varRef name='Q{}instanceXML2' slot='8'/>
                      </check>
                     </withParam>
                    </callT>
-                   <vc line='3264' op='eq' onEmpty='0' comp='CCC'>
+                   <vc line='3268' op='eq' onEmpty='0' comp='CCC'>
                     <varRef name='Q{}action-name' slot='14'/>
                     <str val='insert'/>
                    </vc>
-                   <callT line='3265' name='Q{}action-insert' bSlot='6'>
+                   <callT line='3269' name='Q{}action-insert' bSlot='6'>
                     <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                     <check line='3266' card='1' diag='8|0|XTTE0590|nodeset'>
+                     <check line='3270' card='1' diag='8|0|XTTE0590|nodeset'>
                       <varRef name='Q{}ref-qualified' slot='6'/>
                      </check>
                     </withParam>
                     <withParam name='Q{}instanceXML' flags='t' as='element()'>
-                     <check line='3267' card='1' diag='8|0|XTTE0590|instanceXML'>
+                     <check line='3271' card='1' diag='8|0|XTTE0590|instanceXML'>
                       <varRef name='Q{}instanceXML2' slot='8'/>
                      </check>
                     </withParam>
                    </callT>
-                   <vc line='3270' op='eq' onEmpty='0' comp='CCC'>
+                   <vc line='3274' op='eq' onEmpty='0' comp='CCC'>
                     <varRef name='Q{}action-name' slot='14'/>
                     <str val='delete'/>
                    </vc>
-                   <callT line='3271' name='Q{}action-delete' bSlot='7'>
+                   <callT line='3275' name='Q{}action-delete' bSlot='7'>
                     <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                     <check line='3272' card='1' diag='8|0|XTTE0590|nodeset'>
+                     <check line='3276' card='1' diag='8|0|XTTE0590|nodeset'>
                       <varRef name='Q{}ref-qualified' slot='6'/>
                      </check>
                     </withParam>
                     <withParam name='Q{}instanceXML' flags='t' as='element()'>
-                     <check line='3273' card='1' diag='8|0|XTTE0590|instanceXML'>
+                     <check line='3277' card='1' diag='8|0|XTTE0590|instanceXML'>
                       <varRef name='Q{}instanceXML2' slot='8'/>
                      </check>
                     </withParam>
                    </callT>
-                   <vc line='3276' op='eq' onEmpty='0' comp='CCC'>
+                   <vc line='3280' op='eq' onEmpty='0' comp='CCC'>
                     <varRef name='Q{}action-name' slot='14'/>
                     <str val='setindex'/>
                    </vc>
-                   <callT line='3277' name='Q{}action-setindex' bSlot='8'/>
-                   <vc line='3282' op='eq' onEmpty='0' comp='CCC'>
+                   <callT line='3281' name='Q{}action-setindex' bSlot='8'/>
+                   <vc line='3286' op='eq' onEmpty='0' comp='CCC'>
                     <varRef name='Q{}action-name' slot='14'/>
                     <str val='setfocus'/>
                    </vc>
-                   <callT line='3283' name='Q{}action-setfocus' bSlot='9'/>
-                   <vc line='3288' op='eq' onEmpty='0' comp='CCC'>
+                   <callT line='3287' name='Q{}action-setfocus' bSlot='9'/>
+                   <vc line='3292' op='eq' onEmpty='0' comp='CCC'>
                     <varRef name='Q{}action-name' slot='14'/>
                     <str val='rebuild'/>
                    </vc>
-                   <callT line='3289' name='Q{}xforms-rebuild' bSlot='10'/>
-                   <vc line='3291' op='eq' onEmpty='0' comp='CCC'>
+                   <callT line='3293' name='Q{}xforms-rebuild' bSlot='10'/>
+                   <vc line='3295' op='eq' onEmpty='0' comp='CCC'>
                     <varRef name='Q{}action-name' slot='14'/>
                     <str val='recalculate'/>
                    </vc>
-                   <callT line='3292' name='Q{}xforms-recalculate' bSlot='11'/>
-                   <vc line='3300' op='eq' onEmpty='0' comp='CCC'>
+                   <callT line='3296' name='Q{}xforms-recalculate' bSlot='11'/>
+                   <vc line='3304' op='eq' onEmpty='0' comp='CCC'>
                     <varRef name='Q{}action-name' slot='14'/>
                     <str val='reset'/>
                    </vc>
-                   <callT line='3301' name='Q{}action-reset' bSlot='12'/>
-                   <vc line='3306' op='eq' onEmpty='0' comp='CCC'>
+                   <callT line='3305' name='Q{}action-reset' bSlot='12'/>
+                   <vc line='3310' op='eq' onEmpty='0' comp='CCC'>
                     <varRef name='Q{}action-name' slot='14'/>
                     <str val='send'/>
                    </vc>
-                   <callT line='3307' name='Q{}action-send' bSlot='13'/>
-                   <vc line='3309' op='eq' onEmpty='0' comp='CCC'>
+                   <callT line='3311' name='Q{}action-send' bSlot='13'/>
+                   <vc line='3313' op='eq' onEmpty='0' comp='CCC'>
                     <varRef name='Q{}action-name' slot='14'/>
                     <str val='message'/>
                    </vc>
-                   <callT line='3310' name='Q{}action-message' bSlot='14'/>
+                   <callT line='3314' name='Q{}action-message' bSlot='14'/>
                    <true/>
-                   <message line='3313'>
+                   <message line='3317'>
                     <sequence role='select'>
                      <valueOf>
                       <str val='[applyActions] action &#39;'/>
@@ -3304,8 +3314,8 @@
                     <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
                    </message>
                   </choose>
-                  <forEach line='3322'>
-                   <ifCall line='3318' name='Q{http://www.w3.org/2005/xpath-functions/array}flatten' type='item()*'>
+                  <forEach line='3326'>
+                   <ifCall line='3322' name='Q{http://www.w3.org/2005/xpath-functions/array}flatten' type='item()*'>
                     <treat as='array(map(*))' jsTest='function v(item) {return SaxonJS.U.isMap(item)};function c(n) {return n==1;};return SaxonJS.U.isArray(item) &amp;&amp; SaxonJS.U.ForArray(item.value).every(function(seq){return c(seq.length) &amp;&amp; SaxonJS.U.ForArray(seq).every(v)});' diag='3|0|XTTE0570|nested-actions-array'>
                      <check card='?' diag='3|0|XTTE0570|nested-actions-array'>
                       <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
@@ -3315,9 +3325,9 @@
                      </check>
                     </treat>
                    </ifCall>
-                   <callT line='3323' name='Q{}applyActions' bSlot='15'>
+                   <callT line='3327' name='Q{}applyActions' bSlot='15'>
                     <withParam name='Q{}action-map' flags='t' as='item()'>
-                     <dot line='3324'/>
+                     <dot line='3328'/>
                     </withParam>
                    </callT>
                   </forEach>
@@ -3340,9 +3350,9 @@
  </co>
  <co id='24' binds='24'>
   <mode name='Q{}insert-node' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='21' rank='0' minImp='0' slots='3' flags='s' line='1901' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='21' rank='0' minImp='0' slots='3' flags='s' line='1905' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1902'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1906'>
      <param name='Q{}insert-node-location' slot='0' flags='ti' as='node()'>
       <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|insert-node-location'>
        <check card='1' diag='8|0|XTTE0590|insert-node-location'>
@@ -3350,14 +3360,14 @@
        </check>
       </treat>
      </param>
-     <param line='1903' name='Q{}node-to-insert' slot='1' flags='ti' as='node()'>
+     <param line='1907' name='Q{}node-to-insert' slot='1' flags='ti' as='node()'>
       <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|node-to-insert'>
        <check card='1' diag='8|0|XTTE0590|node-to-insert'>
         <supplied slot='1'/>
        </check>
       </treat>
      </param>
-     <param line='1904' name='Q{}position-relative' slot='2' flags='t' as='xs:string?'>
+     <param line='1908' name='Q{}position-relative' slot='2' flags='t' as='xs:string?'>
       <str role='select' val='after'/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|position-relative'>
        <check card='?' diag='8|0|XTTE0590|position-relative'>
@@ -3369,7 +3379,7 @@
        </check>
       </treat>
      </param>
-     <choose line='1907'>
+     <choose line='1911'>
       <and op='and'>
        <is op='is'>
         <dot type='element()'/>
@@ -3380,16 +3390,16 @@
         <str val='before'/>
        </vc>
       </and>
-      <copyOf line='1909' flags='vc'>
+      <copyOf line='1913' flags='vc'>
        <varRef name='Q{}node-to-insert' slot='1'/>
       </copyOf>
      </choose>
-     <copy line='1912' flags='cin'>
+     <copy line='1916' flags='cin'>
       <sequence role='content'>
        <copyOf flags='vc'>
         <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
        </copyOf>
-       <choose line='1917'>
+       <choose line='1921'>
         <and op='and'>
          <is op='is'>
           <dot type='element()'/>
@@ -3400,16 +3410,16 @@
           <str val='child'/>
          </vc>
         </and>
-        <copyOf line='1918' flags='vc'>
+        <copyOf line='1922' flags='vc'>
          <varRef name='Q{}node-to-insert' slot='1'/>
         </copyOf>
        </choose>
-       <applyT line='1920' mode='Q{}insert-node' bSlot='0'>
+       <applyT line='1924' mode='Q{}insert-node' bSlot='0'>
         <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
        </applyT>
       </sequence>
      </copy>
-     <choose line='1922'>
+     <choose line='1926'>
       <and op='and'>
        <is op='is'>
         <dot type='element()'/>
@@ -3420,7 +3430,7 @@
         <str val='after'/>
        </vc>
       </and>
-      <copyOf line='1923' flags='vc'>
+      <copyOf line='1927' flags='vc'>
        <varRef name='Q{}node-to-insert' slot='1'/>
       </copyOf>
      </choose>
@@ -3428,11 +3438,11 @@
    </templateRule>
   </mode>
  </co>
- <co id='58' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}hasClass' line='2580' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:boolean' slots='2'>
+ <co id='59' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}hasClass' line='2584' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:boolean' slots='2'>
    <arg name='Q{}element' as='element()'/>
    <arg name='Q{}string' as='xs:string'/>
-   <gc role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2584' op='=' card='N:1' comp='CCC'>
+   <gc role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2588' op='=' card='N:1' comp='CCC'>
     <fn name='tokenize'>
      <cvUntyped to='xs:string' diag='3|0|XTTE0570|class'>
       <data>
@@ -3443,24 +3453,24 @@
       </data>
      </cvUntyped>
     </fn>
-    <varRef line='2587' name='Q{}string' slot='1'/>
+    <varRef line='2591' name='Q{}string' slot='1'/>
    </gc>
   </function>
  </co>
- <co id='59' binds=''>
+ <co id='60' binds=''>
   <globalParam name='Q{}xforms-instance-id' type='xs:string' line='69' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
    <str val='xforms-jinstance'/>
   </globalParam>
  </co>
- <co id='60' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}getIfStatement' line='763' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
+ <co id='61' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}getIfStatement' line='767' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
    <arg name='Q{}map' as='map(*)'/>
-   <choose role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='766'>
+   <choose role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='770'>
     <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
      <varRef name='Q{}map' slot='0'/>
      <str val='@if'/>
     </ifCall>
-    <treat line='767' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
+    <treat line='771' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
      <check card='?' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
       <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
        <data>
@@ -3475,18 +3485,18 @@
    </choose>
   </function>
  </co>
- <co id='61' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}getClass' line='2601' module='saxon-xforms.xsl' eval='7' flags='pU' as='attribute(Q{}class)?' slots='3'>
+ <co id='62' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}getClass' line='2605' module='saxon-xforms.xsl' eval='7' flags='pU' as='attribute(Q{}class)?' slots='3'>
    <arg name='Q{}element' as='element()'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2604' var='Q{}class' as='xs:string?' slot='1' eval='7'>
-    <choose line='2605'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2608' var='Q{}class' as='xs:string?' slot='1' eval='7'>
+    <choose line='2609'>
      <fn name='exists'>
       <slash simple='1'>
        <varRef name='Q{}element' slot='0'/>
        <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
       </slash>
      </fn>
-     <cvUntyped line='2606' to='xs:string' diag='3|0|XTTE0570|class'>
+     <cvUntyped line='2610' to='xs:string' diag='3|0|XTTE0570|class'>
       <cast as='xs:untypedAtomic' emptiable='0'>
        <fn name='string'>
         <convert from='xs:untypedAtomic' to='xs:string'>
@@ -3501,15 +3511,15 @@
       </cast>
      </cvUntyped>
     </choose>
-    <let line='2609' var='Q{}class-mod' as='xs:string?' slot='2' eval='7'>
-     <choose line='2611'>
+    <let line='2613' var='Q{}class-mod' as='xs:string?' slot='2' eval='7'>
+     <choose line='2615'>
       <fn name='exists'>
        <slash simple='1'>
         <varRef name='Q{}element' slot='0'/>
         <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
        </slash>
       </fn>
-      <cvUntyped line='2612' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+      <cvUntyped line='2616' to='xs:string' diag='3|0|XTTE0570|class-mod'>
        <cast as='xs:untypedAtomic' emptiable='0'>
         <fn name='string-join'>
          <sequence>
@@ -3521,13 +3531,13 @@
        </cast>
       </cvUntyped>
       <true/>
-      <varRef line='2615' name='Q{}class' slot='1'/>
+      <varRef line='2619' name='Q{}class' slot='1'/>
      </choose>
-     <choose line='2619'>
+     <choose line='2623'>
       <fn name='exists'>
        <varRef name='Q{}class-mod' slot='2'/>
       </fn>
-      <treat line='2620' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+      <treat line='2624' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
        <att name='class'>
         <varRef name='Q{}class-mod' slot='2'/>
        </att>
@@ -3537,9 +3547,9 @@
    </let>
   </function>
  </co>
- <co id='62' binds='22 43 63 64 65'>
-  <template name='Q{}refreshRepeats-JS' flags='os' line='3051' module='saxon-xforms.xsl' slots='8'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3053'>
+ <co id='63' binds='22 44 64 65 66'>
+  <template name='Q{}refreshRepeats-JS' flags='os' line='3055' module='saxon-xforms.xsl' slots='8'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3057'>
     <message>
      <valueOf role='select'>
       <str val='[refreshRepeats-JS] START refreshRepeats'/>
@@ -3547,7 +3557,7 @@
      <str role='terminate' val='no'/>
      <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
     </message>
-    <let line='3056' var='Q{}repeat-keys' as='item()?' slot='0' eval='8'>
+    <let line='3060' var='Q{}repeat-keys' as='item()?' slot='0' eval='8'>
      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
       <check card='1' diag='0|0||ixsl:call'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -3555,9 +3565,9 @@
       <str val='getRepeatKeys'/>
       <array size='0'/>
      </ifCall>
-     <forEach line='3058'>
+     <forEach line='3062'>
       <varRef name='Q{}repeat-keys' slot='0'/>
-      <let line='3059' var='Q{}this-key' as='xs:string' slot='1' eval='16'>
+      <let line='3063' var='Q{}this-key' as='xs:string' slot='1' eval='16'>
        <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|this-key'>
         <check card='1' diag='3|0|XTTE0570|this-key'>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|this-key'>
@@ -3567,7 +3577,7 @@
          </cvUntyped>
         </check>
        </treat>
-       <let line='3060' var='Q{}this-repeat-nodeset' as='xs:string' slot='2' eval='16'>
+       <let line='3064' var='Q{}this-repeat-nodeset' as='xs:string' slot='2' eval='16'>
         <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|this-repeat-nodeset'>
          <check card='1' diag='3|0|XTTE0570|this-repeat-nodeset'>
           <cvUntyped to='xs:string' diag='3|0|XTTE0570|this-repeat-nodeset'>
@@ -3585,7 +3595,7 @@
           </cvUntyped>
          </check>
         </treat>
-        <sequence line='3062'>
+        <sequence line='3066'>
          <message>
           <sequence role='select'>
            <valueOf>
@@ -3599,9 +3609,9 @@
           <str role='terminate' val='no'/>
           <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
          </message>
-         <let line='3073' var='Q{}contexti' as='element()?' slot='3' eval='7'>
-          <ufCall line='3074' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='0' eval='16'>
-           <check line='3066' card='1' diag='3|0|XTTE0570|this-instance-id'>
+         <let line='3077' var='Q{}contexti' as='element()?' slot='3' eval='7'>
+          <ufCall line='3078' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='0' eval='16'>
+           <check line='3070' card='1' diag='3|0|XTTE0570|this-instance-id'>
             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
              <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='1' eval='6'>
               <varRef name='Q{}this-repeat-nodeset' slot='2'/>
@@ -3610,7 +3620,7 @@
             </ifCall>
            </check>
           </ufCall>
-          <let line='3081' var='Q{}namespace-context-item' as='element()' slot='4' eval='16'>
+          <let line='3085' var='Q{}namespace-context-item' as='element()' slot='4' eval='16'>
            <choose>
             <fn name='exists'>
              <varRef name='Q{}contexti' slot='3'/>
@@ -3631,7 +3641,7 @@
              </check>
             </treat>
            </choose>
-           <let line='3083' var='Q{}page-element' as='element()?' slot='5' eval='7'>
+           <let line='3087' var='Q{}page-element' as='element()?' slot='5' eval='7'>
             <check card='?' diag='3|0|XTTE0570|page-element'>
              <filter flags='b'>
               <slash simple='1'>
@@ -3646,11 +3656,11 @@
               </vc>
              </filter>
             </check>
-            <choose line='3086'>
+            <choose line='3090'>
              <fn name='exists'>
               <varRef name='Q{}page-element' slot='5'/>
              </fn>
-             <let line='3087' var='Q{}instance-keys' as='item()?' slot='6' eval='8'>
+             <let line='3091' var='Q{}instance-keys' as='item()?' slot='6' eval='8'>
               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                <check card='1' diag='0|0||ixsl:call'>
                 <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -3658,12 +3668,12 @@
                <str val='getInstanceKeys'/>
                <array size='0'/>
               </ifCall>
-              <let line='3088' var='Q{}instances' as='map(xs:string, element())' slot='7' eval='16'>
-               <treat line='3090' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances'>
+              <let line='3092' var='Q{}instances' as='map(xs:string, element())' slot='7' eval='16'>
+               <treat line='3094' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances'>
                 <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
                  <forEach>
                   <varRef name='Q{}instance-keys' slot='6'/>
-                  <ifCall line='3091' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                  <ifCall line='3095' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                    <atomSing diag='0|0||map:entry'>
                     <dot/>
                    </atomSing>
@@ -3686,12 +3696,12 @@
                  </map>
                 </ifCall>
                </treat>
-               <resultDoc line='3095' global='#&#xD;&#xA;#Sat Mar 14 13:02:55 GMT 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Sat Mar 14 13:02:55 GMT 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
+               <resultDoc line='3099' global='#&#xD;&#xA;#Tue Mar 24 21:48:26 GMT 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Tue Mar 24 21:48:26 GMT 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
                 <fn role='href' name='concat'>
                  <str val='#'/>
                  <varRef name='Q{}this-key' slot='1'/>
                 </fn>
-                <applyT role='content' line='3096' bSlot='2'>
+                <applyT role='content' line='3100' bSlot='2'>
                  <filter role='select' flags='b'>
                   <slash simple='1'>
                    <gVarRef name='Q{}xforms-doc' bSlot='3'/>
@@ -3712,7 +3722,7 @@
                   <true/>
                  </withParam>
                  <withParam name='Q{}instances' flags='t' as='map(xs:string, element())'>
-                  <varRef line='3097' name='Q{}instances' slot='7'/>
+                  <varRef line='3101' name='Q{}instances' slot='7'/>
                  </withParam>
                 </applyT>
                </resultDoc>
@@ -3730,9 +3740,9 @@
    </sequence>
   </template>
  </co>
- <co id='55' binds='23 22 43 43'>
-  <template name='Q{}refreshOutputs-JS' flags='os' line='2972' module='saxon-xforms.xsl' slots='8'>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2979' var='Q{}output-keys' as='item()?' slot='0' eval='8'>
+ <co id='56' binds='23 22 44 44'>
+  <template name='Q{}refreshOutputs-JS' flags='os' line='2976' module='saxon-xforms.xsl' slots='8'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2983' var='Q{}output-keys' as='item()?' slot='0' eval='8'>
     <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
      <check card='1' diag='0|0||ixsl:call'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -3740,9 +3750,9 @@
      <str val='getOutputKeys'/>
      <array size='0'/>
     </ifCall>
-    <forEach line='2981'>
+    <forEach line='2985'>
      <varRef name='Q{}output-keys' slot='0'/>
-     <let line='2982' var='Q{}this-key' as='xs:string' slot='1' eval='16'>
+     <let line='2986' var='Q{}this-key' as='xs:string' slot='1' eval='16'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|this-key'>
        <check card='1' diag='3|0|XTTE0570|this-key'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|this-key'>
@@ -3752,7 +3762,7 @@
         </cvUntyped>
        </check>
       </treat>
-      <let line='2983' var='Q{}this-output' as='map(*)' slot='2' eval='16'>
+      <let line='2987' var='Q{}this-output' as='map(*)' slot='2' eval='16'>
        <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|this-output'>
         <check card='1' diag='3|0|XTTE0570|this-output'>
          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
@@ -3766,7 +3776,7 @@
          </ifCall>
         </check>
        </treat>
-       <sequence line='2985'>
+       <sequence line='2989'>
         <message>
          <sequence role='select'>
           <valueOf>
@@ -3780,14 +3790,14 @@
          <str role='terminate' val='no'/>
          <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
         </message>
-        <let line='3002' var='Q{}xpath-mod' as='xs:string' slot='3' eval='16'>
+        <let line='3006' var='Q{}xpath-mod' as='xs:string' slot='3' eval='16'>
          <ufCall name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='0' eval='16'>
-          <choose line='2990'>
+          <choose line='2994'>
            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
             <varRef name='Q{}this-output' slot='2'/>
             <str val='@value'/>
            </ifCall>
-           <treat line='2991' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|xpath'>
+           <treat line='2995' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|xpath'>
             <check card='1' diag='3|0|XTTE0570|xpath'>
              <cvUntyped to='xs:string' diag='3|0|XTTE0570|xpath'>
               <data>
@@ -3799,11 +3809,11 @@
              </cvUntyped>
             </check>
            </treat>
-           <ifCall line='2993' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+           <ifCall line='2997' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
             <varRef name='Q{}this-output' slot='2'/>
             <str val='@ref'/>
            </ifCall>
-           <treat line='2994' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|xpath'>
+           <treat line='2998' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|xpath'>
             <check card='1' diag='3|0|XTTE0570|xpath'>
              <cvUntyped to='xs:string' diag='3|0|XTTE0570|xpath'>
               <data>
@@ -3819,7 +3829,7 @@
            <str val=''/>
           </choose>
          </ufCall>
-         <sequence line='3004'>
+         <sequence line='3008'>
           <message>
            <sequence role='select'>
             <valueOf>
@@ -3833,21 +3843,21 @@
            <str role='terminate' val='no'/>
            <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
           </message>
-          <let line='3020' var='Q{}contexti' as='element()?' slot='4' eval='7'>
-           <ufCall line='3021' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='16'>
-            <check line='3008' card='1' diag='3|0|XTTE0570|this-instance-id'>
+          <let line='3024' var='Q{}contexti' as='element()?' slot='4' eval='7'>
+           <ufCall line='3025' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='16'>
+            <check line='3012' card='1' diag='3|0|XTTE0570|this-instance-id'>
              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
               <choose>
                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
                 <varRef name='Q{}this-output' slot='2'/>
                 <str val='@ref'/>
                </ifCall>
-               <ufCall line='3010' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='2' eval='16'>
+               <ufCall line='3014' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='2' eval='16'>
                 <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:getInstanceMap'>
                  <check card='1' diag='0|0||xforms:getInstanceMap'>
                   <cvUntyped to='xs:string'>
                    <data>
-                    <ifCall line='3009' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                    <ifCall line='3013' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
                      <varRef name='Q{}this-output' slot='2'/>
                      <str val='@ref'/>
                     </ifCall>
@@ -3857,7 +3867,7 @@
                 </treat>
                </ufCall>
                <true/>
-               <ufCall line='3013' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='3' eval='0'>
+               <ufCall line='3017' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='3' eval='0'>
                 <str val='saxon-forms-default'/>
                </ufCall>
               </choose>
@@ -3865,7 +3875,7 @@
              </ifCall>
             </check>
            </ufCall>
-           <let line='3028' var='Q{}namespace-context-item' as='element()' slot='5' eval='16'>
+           <let line='3032' var='Q{}namespace-context-item' as='element()' slot='5' eval='16'>
             <choose>
              <fn name='exists'>
               <varRef name='Q{}contexti' slot='4'/>
@@ -3886,8 +3896,8 @@
               </check>
              </treat>
             </choose>
-            <let line='3030' var='Q{}value' as='xs:string?' slot='6' eval='7'>
-             <treat line='3031' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|value'>
+            <let line='3034' var='Q{}value' as='xs:string?' slot='6' eval='7'>
+             <treat line='3035' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|value'>
               <check card='?' diag='3|0|XTTE0570|value'>
                <cvUntyped to='xs:string' diag='3|0|XTTE0570|value'>
                 <data>
@@ -3903,7 +3913,7 @@
                </cvUntyped>
               </check>
              </treat>
-             <let line='3034' var='Q{}associated-form-control' as='element()?' slot='7' eval='7'>
+             <let line='3038' var='Q{}associated-form-control' as='element()?' slot='7' eval='7'>
               <check card='?' diag='3|0|XTTE0570|associated-form-control'>
                <filter flags='b'>
                 <slash simple='1'>
@@ -3918,16 +3928,16 @@
                 </vc>
                </filter>
               </check>
-              <choose line='3037'>
+              <choose line='3041'>
                <fn name='exists'>
                 <varRef name='Q{}associated-form-control' slot='7'/>
                </fn>
-               <resultDoc line='3038' global='#&#xD;&#xA;#Sat Mar 14 13:02:55 GMT 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Sat Mar 14 13:02:55 GMT 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
+               <resultDoc line='3042' global='#&#xD;&#xA;#Tue Mar 24 21:48:26 GMT 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Tue Mar 24 21:48:26 GMT 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
                 <fn role='href' name='concat'>
                  <str val='#'/>
                  <varRef name='Q{}this-key' slot='1'/>
                 </fn>
-                <valueOf role='content' line='3039'>
+                <valueOf role='content' line='3043'>
                  <varRef name='Q{}value' slot='6'/>
                 </valueOf>
                </resultDoc>
@@ -3945,9 +3955,9 @@
    </let>
   </template>
  </co>
- <co id='51' binds='66'>
-  <template name='Q{}xforms-focus' flags='os' line='3773' module='saxon-xforms.xsl' slots='5'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3774'>
+ <co id='52' binds='67'>
+  <template name='Q{}xforms-focus' flags='os' line='3779' module='saxon-xforms.xsl' slots='5'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3780'>
     <param name='Q{}control' slot='0' flags='i' as='xs:string'>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|control'>
       <check card='1' diag='8|0|XTTE0590|control'>
@@ -3959,10 +3969,10 @@
       </check>
      </treat>
     </param>
-    <let line='3775' var='Q{}xforms-control' as='element()' slot='1' eval='16'>
+    <let line='3781' var='Q{}xforms-control' as='element()' slot='1' eval='16'>
      <check card='1' diag='3|0|XTTE0570|xforms-control'>
       <filter flags='b'>
-       <gVarRef name='Q{http://saxon.sf.net/generated-variable}gg334130099' bSlot='0'/>
+       <gVarRef name='Q{http://saxon.sf.net/generated-variable}gg928129983' bSlot='0'/>
        <vc op='eq' onEmpty='0' comp='CCC'>
         <cast as='xs:string' emptiable='1'>
          <attVal name='Q{}id' chk='0'/>
@@ -3971,19 +3981,19 @@
        </vc>
       </filter>
      </check>
-     <choose line='3780'>
+     <choose line='3786'>
       <fn name='exists'>
        <slash simple='1'>
         <varRef name='Q{}xforms-control' slot='1'/>
         <axis name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
        </slash>
       </fn>
-      <let line='3784' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='2' eval='13'>
+      <let line='3790' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='2' eval='13'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
        </check>
-       <let line='3781' var='Q{}context-indexes' as='xs:double*' slot='3' eval='8'>
-        <convert line='3782' from='xs:anyAtomicType' to='xs:double' flags='p' diag='3|0|XTTE0570|context-indexes'>
+       <let line='3787' var='Q{}context-indexes' as='xs:double*' slot='3' eval='8'>
+        <convert line='3788' from='xs:anyAtomicType' to='xs:double' flags='p' diag='3|0|XTTE0570|context-indexes'>
          <cvUntyped to='xs:double' diag='3|0|XTTE0570|context-indexes'>
           <data>
            <forEach>
@@ -3994,7 +4004,7 @@
                <axis name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
               </fn>
              </slash>
-             <sortKey line='3783' comp='DESC|NC11'>
+             <sortKey line='3789' comp='DESC|NC11'>
               <fn role='select' name='position'/>
               <str role='order' val='descending'/>
               <str role='dataType' val='number'/>
@@ -4004,7 +4014,7 @@
               <str role='collation' val='http://www.w3.org/2005/xpath-functions/collation/codepoint'/>
              </sortKey>
             </sort>
-            <ifCall line='3784' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+            <ifCall line='3790' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
              <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='2'/>
              <str val='getRepeatIndex'/>
              <arrayBlock>
@@ -4017,12 +4027,12 @@
           </data>
          </cvUntyped>
         </convert>
-        <let line='3788' var='Q{}control-index' as='xs:string' slot='4' eval='8'>
+        <let line='3794' var='Q{}control-index' as='xs:string' slot='4' eval='8'>
          <fn name='string-join'>
           <varRef name='Q{}context-indexes' slot='3'/>
           <str val='.'/>
          </fn>
-         <sequence line='3789'>
+         <sequence line='3795'>
           <message>
            <sequence role='select'>
             <valueOf>
@@ -4040,7 +4050,7 @@
            <str role='terminate' val='no'/>
            <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
           </message>
-          <ifCall line='3790' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+          <ifCall line='3796' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
            <check card='1' diag='0|0||ixsl:call'>
             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
            </check>
@@ -4058,7 +4068,7 @@
        </let>
       </let>
       <true/>
-      <ifCall line='3793' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+      <ifCall line='3799' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
        </check>
@@ -4072,10 +4082,10 @@
    </sequence>
   </template>
  </co>
- <co id='41' binds='54'>
-  <function name='Q{http://www.w3.org/2002/xforms}checkRelevantFields' line='606' module='saxon-xforms.xsl' eval='8' flags='pU' as='item()*' slots='13'>
+ <co id='42' binds='55'>
+  <function name='Q{http://www.w3.org/2002/xforms}checkRelevantFields' line='610' module='saxon-xforms.xsl' eval='8' flags='pU' as='item()*' slots='13'>
    <arg name='Q{}refElement' as='xs:string'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='609' var='Q{}pendingUpdatesi' as='map(xs:string, xs:string)?' slot='1' eval='7'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='613' var='Q{}pendingUpdatesi' as='map(xs:string, xs:string)?' slot='1' eval='7'>
     <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|pendingUpdatesi'>
      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
       <check card='1' diag='0|0||ixsl:call'>
@@ -4085,7 +4095,7 @@
       <array size='0'/>
      </ifCall>
     </treat>
-    <let line='612' var='Q{}updatesi' as='map(xs:string, xs:string)?' slot='2' eval='7'>
+    <let line='616' var='Q{}updatesi' as='map(xs:string, xs:string)?' slot='2' eval='7'>
      <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|updatesi'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
@@ -4095,7 +4105,7 @@
        <array size='0'/>
       </ifCall>
      </treat>
-     <let line='615' var='Q{}relevantMap' as='map(xs:string, xs:string)' slot='3' eval='16'>
+     <let line='619' var='Q{}relevantMap' as='map(xs:string, xs:string)' slot='3' eval='16'>
       <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|relevantMap'>
        <check card='1' diag='3|0|XTTE0570|relevantMap'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
@@ -4107,16 +4117,16 @@
         </ifCall>
        </check>
       </treat>
-      <let line='616' var='Q{}mapKeys' as='xs:anyAtomicType*' slot='4' eval='4'>
+      <let line='620' var='Q{}mapKeys' as='xs:anyAtomicType*' slot='4' eval='4'>
        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
         <varRef name='Q{}relevantMap' slot='3'/>
        </ifCall>
-       <sequence line='646'>
+       <sequence line='650'>
         <forEach>
-         <sequence line='619'>
+         <sequence line='623'>
           <forEach>
            <varRef name='Q{}mapKeys' slot='4'/>
-           <choose line='620'>
+           <choose line='624'>
             <fn name='matches'>
              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
               <varRef name='Q{}relevantMap' slot='3'/>
@@ -4125,10 +4135,10 @@
              <varRef name='Q{}refElement' slot='0'/>
              <str val=''/>
             </fn>
-            <dot line='621' type='xs:anyAtomicType'/>
+            <dot line='625' type='xs:anyAtomicType'/>
            </choose>
           </forEach>
-          <forEach line='610'>
+          <forEach line='614'>
            <choose>
             <fn name='exists'>
              <varRef name='Q{}pendingUpdatesi' slot='1'/>
@@ -4139,7 +4149,7 @@
              </check>
             </ifCall>
            </choose>
-           <let line='627' var='Q{}keyi' as='xs:string?' slot='5' eval='7'>
+           <let line='631' var='Q{}keyi' as='xs:string?' slot='5' eval='7'>
             <lastOf>
              <fn name='tokenize'>
               <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||fn:tokenize'>
@@ -4151,13 +4161,13 @@
               <str val=''/>
              </fn>
             </lastOf>
-            <let line='629' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='6' eval='13'>
+            <let line='633' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='6' eval='13'>
              <check card='1' diag='0|1||fn:matches'>
               <varRef name='Q{}keyi' slot='5'/>
              </check>
-             <forEach line='628'>
+             <forEach line='632'>
               <varRef name='Q{}mapKeys' slot='4'/>
-              <choose line='629'>
+              <choose line='633'>
                <fn name='matches'>
                 <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
                  <varRef name='Q{}relevantMap' slot='3'/>
@@ -4166,13 +4176,13 @@
                 <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='6'/>
                 <str val=''/>
                </fn>
-               <dot line='630' type='xs:anyAtomicType'/>
+               <dot line='634' type='xs:anyAtomicType'/>
               </choose>
              </forEach>
             </let>
            </let>
           </forEach>
-          <forEach line='613'>
+          <forEach line='617'>
            <choose>
             <fn name='exists'>
              <varRef name='Q{}updatesi' slot='2'/>
@@ -4183,7 +4193,7 @@
              </check>
             </ifCall>
            </choose>
-           <let line='636' var='Q{}keyi' as='xs:string?' slot='7' eval='7'>
+           <let line='640' var='Q{}keyi' as='xs:string?' slot='7' eval='7'>
             <lastOf>
              <fn name='tokenize'>
               <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||fn:tokenize'>
@@ -4195,13 +4205,13 @@
               <str val=''/>
              </fn>
             </lastOf>
-            <let line='638' var='Q{http://saxon.sf.net/generated-variable}v1' as='xs:string' slot='8' eval='13'>
+            <let line='642' var='Q{http://saxon.sf.net/generated-variable}v1' as='xs:string' slot='8' eval='13'>
              <check card='1' diag='0|1||fn:matches'>
               <varRef name='Q{}keyi' slot='7'/>
              </check>
-             <forEach line='637'>
+             <forEach line='641'>
               <varRef name='Q{}mapKeys' slot='4'/>
-              <choose line='638'>
+              <choose line='642'>
                <fn name='matches'>
                 <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
                  <varRef name='Q{}relevantMap' slot='3'/>
@@ -4210,16 +4220,16 @@
                 <varRef name='Q{http://saxon.sf.net/generated-variable}v1' slot='8'/>
                 <str val=''/>
                </fn>
-               <dot line='639' type='xs:anyAtomicType'/>
+               <dot line='643' type='xs:anyAtomicType'/>
               </choose>
              </forEach>
             </let>
            </let>
           </forEach>
          </sequence>
-         <let line='647' var='Q{}keyi' as='xs:anyAtomicType' slot='9' eval='16'>
+         <let line='651' var='Q{}keyi' as='xs:anyAtomicType' slot='9' eval='16'>
           <dot type='xs:anyAtomicType'/>
-          <let line='648' var='Q{}context' as='element()*' slot='10' eval='8'>
+          <let line='652' var='Q{}context' as='element()*' slot='10' eval='8'>
            <filter flags='b'>
             <slash simple='1'>
              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
@@ -4230,7 +4240,7 @@
              <varRef name='Q{}keyi' slot='9'/>
             </gc>
            </filter>
-           <let line='649' var='Q{}updatedInstanceXML4' as='element()?' slot='11' eval='7'>
+           <let line='653' var='Q{}updatedInstanceXML4' as='element()?' slot='11' eval='7'>
             <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='0' eval='16'>
              <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:getInstance-JS'>
               <cvUntyped to='xs:string'>
@@ -4238,8 +4248,8 @@
               </cvUntyped>
              </treat>
             </ufCall>
-            <let line='651' var='Q{}relevantCheck' as='xs:boolean' slot='12' eval='16'>
-             <treat line='652' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantCheck'>
+            <let line='655' var='Q{}relevantCheck' as='xs:boolean' slot='12' eval='16'>
+             <treat line='656' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantCheck'>
               <check card='1' diag='3|0|XTTE0570|relevantCheck'>
                <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|relevantCheck'>
                 <data>
@@ -4264,9 +4274,9 @@
                </cvUntyped>
               </check>
              </treat>
-             <choose line='655'>
+             <choose line='659'>
               <varRef name='Q{}relevantCheck' slot='12'/>
-              <ifCall line='658' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+              <ifCall line='662' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
                <str val='style.display'/>
                <str val='inline'/>
                <check card='1' diag='0|2||ixsl:set-property'>
@@ -4286,7 +4296,7 @@
                </check>
               </ifCall>
               <true/>
-              <ifCall line='661' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+              <ifCall line='665' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
                <str val='style.display'/>
                <str val='none'/>
                <check card='1' diag='0|2||ixsl:set-property'>
@@ -4311,14 +4321,14 @@
           </let>
          </let>
         </forEach>
-        <ifCall line='666' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='670' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
          <str val='clearPendingUpdates'/>
          <array size='0'/>
         </ifCall>
-        <ifCall line='667' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='671' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -4332,14 +4342,14 @@
    </let>
   </function>
  </co>
- <co id='67' binds=''>
+ <co id='68' binds=''>
   <globalParam name='Q{}xform-html-id' type='xs:string' line='73' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
    <str val='xForm'/>
   </globalParam>
  </co>
- <co id='68' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}random' line='108' module='xforms-function-library.xsl' eval='16' flags='pU' as='xs:double' slots='0'>
-   <check role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='109' card='1' diag='3|0|XTTE0570|randomNumber'>
+ <co id='69' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}random' line='109' module='xforms-function-library.xsl' eval='16' flags='pU' as='xs:double' slots='0'>
+   <check role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='110' card='1' diag='3|0|XTTE0570|randomNumber'>
     <convert from='xs:anyAtomicType' to='xs:double' flags='p' diag='3|0|XTTE0570|randomNumber'>
      <cvUntyped to='xs:double' diag='3|0|XTTE0570|randomNumber'>
       <data>
@@ -4356,14 +4366,14 @@
    </check>
   </function>
  </co>
- <co id='69' vis='PRIVATE' binds='70 71' base='2' dpack='1'/>
- <co id='27' binds='21 22 23 23 39 55 62 72'>
-  <template name='Q{}xforms-recalculate' flags='os' line='3627' module='saxon-xforms.xsl' slots='11'>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3680' var='Q{http://saxon.sf.net/generated-variable}v1' as='item()' slot='0' eval='13'>
+ <co id='70' vis='PRIVATE' binds='71 72' base='2' dpack='1'/>
+ <co id='27' binds='21 22 23 23 40 56 63 73'>
+  <template name='Q{}xforms-recalculate' flags='os' line='3631' module='saxon-xforms.xsl' slots='11'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3684' var='Q{http://saxon.sf.net/generated-variable}v1' as='item()' slot='0' eval='13'>
     <check card='1' diag='0|0||ixsl:call'>
      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
     </check>
-    <sequence line='3628'>
+    <sequence line='3632'>
      <message>
       <valueOf role='select'>
        <str val='[xforms-recalculate] START'/>
@@ -4371,7 +4381,7 @@
       <str role='terminate' val='no'/>
       <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
      </message>
-     <let line='3629' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
+     <let line='3633' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -4379,7 +4389,7 @@
        <str val='getInstanceKeys'/>
        <array size='0'/>
       </ifCall>
-      <let line='3630' var='Q{}calculationMap' as='map(xs:string, xs:string)' slot='2' eval='16'>
+      <let line='3634' var='Q{}calculationMap' as='map(xs:string, xs:string)' slot='2' eval='16'>
        <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|calculationMap'>
         <check card='1' diag='3|0|XTTE0570|calculationMap'>
          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
@@ -4391,8 +4401,8 @@
          </ifCall>
         </check>
        </treat>
-       <let line='3632' var='Q{}instances-with-calculations' as='map(xs:string, map(*)*)' slot='3' eval='16'>
-        <treat line='3634' as='map(xs:string, map(*)*)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isMap(item)};function c() {return true;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances-with-calculations'>
+       <let line='3636' var='Q{}instances-with-calculations' as='map(xs:string, map(*)*)' slot='3' eval='16'>
+        <treat line='3638' as='map(xs:string, map(*)*)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isMap(item)};function c() {return true;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances-with-calculations'>
          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
           <forEachGroup algorithm='by'>
            <ifCall role='select' name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
@@ -4406,13 +4416,13 @@
             </treat>
            </ufCall>
            <str role='collation' val='http://www.w3.org/2005/xpath-functions/collation/codepoint'/>
-           <ifCall role='content' line='3635' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall role='content' line='3639' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <check card='1' diag='0|0||map:entry'>
              <currentGroupingKey/>
             </check>
-            <forEach line='3636'>
+            <forEach line='3640'>
              <currentGroup/>
-             <ifCall line='3638' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+             <ifCall line='3642' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
               <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                <dot type='xs:anyAtomicType'/>
                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
@@ -4438,12 +4448,12 @@
           </map>
          </ifCall>
         </treat>
-        <sequence line='3646'>
+        <sequence line='3650'>
          <forEach>
           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
            <varRef name='Q{}instances-with-calculations' slot='3'/>
           </ifCall>
-          <let line='3647' var='Q{}instanceXML' as='element()' slot='4' eval='16'>
+          <let line='3651' var='Q{}instanceXML' as='element()' slot='4' eval='16'>
            <check card='1' diag='3|0|XTTE0570|instanceXML'>
             <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='16'>
              <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:instance'>
@@ -4453,26 +4463,26 @@
              </treat>
             </ufCall>
            </check>
-           <let line='3649' var='Q{}calculations' as='map(xs:string, xs:string)*' slot='5' eval='4'>
+           <let line='3653' var='Q{}calculations' as='map(xs:string, xs:string)*' slot='5' eval='4'>
             <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|calculations'>
              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
               <varRef name='Q{}instances-with-calculations' slot='3'/>
               <dot type='xs:anyAtomicType'/>
              </ifCall>
             </treat>
-            <let line='3663' var='Q{http://saxon.sf.net/generated-variable}v0' as='map(xs:string, xs:string)' slot='6' eval='13'>
+            <let line='3667' var='Q{http://saxon.sf.net/generated-variable}v0' as='map(xs:string, xs:string)' slot='6' eval='13'>
              <check card='1' diag='0|0||map:get'>
               <varRef name='Q{}calculations' slot='5'/>
              </check>
-             <let line='3652' var='Q{}calculated-nodes' as='node()*' slot='7' eval='8'>
-              <treat line='3653' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|calculated-nodes'>
+             <let line='3656' var='Q{}calculated-nodes' as='node()*' slot='7' eval='8'>
+              <treat line='3657' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|calculated-nodes'>
                <forEach>
                 <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
                  <check card='1' diag='0|0||map:keys'>
                   <varRef name='Q{}calculations' slot='5'/>
                  </check>
                 </ifCall>
-                <evaluate line='3654' dxns=''>
+                <evaluate line='3658' dxns=''>
                  <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
                   <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:impose'>
                    <cvUntyped to='xs:string'>
@@ -4488,15 +4498,15 @@
                 </evaluate>
                </forEach>
               </treat>
-              <let line='3659' var='Q{}calculated-values' as='xs:string*' slot='8' eval='8'>
-               <forEach line='3660'>
+              <let line='3663' var='Q{}calculated-values' as='xs:string*' slot='8' eval='8'>
+               <forEach line='3664'>
                 <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
                  <check card='1' diag='0|0||map:keys'>
                   <varRef name='Q{}calculations' slot='5'/>
                  </check>
                 </ifCall>
-                <let line='3662' var='Q{}value' as='xs:string?' slot='9' eval='7'>
-                 <treat line='3663' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|value'>
+                <let line='3666' var='Q{}value' as='xs:string?' slot='9' eval='7'>
+                 <treat line='3667' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|value'>
                   <check card='?' diag='3|0|XTTE0570|value'>
                    <cvUntyped to='xs:string' diag='3|0|XTTE0570|value'>
                     <data>
@@ -4519,7 +4529,7 @@
                    </cvUntyped>
                   </check>
                  </treat>
-                 <first line='3669'>
+                 <first line='3673'>
                   <sequence>
                    <varRef name='Q{}value' slot='9'/>
                    <str val=''/>
@@ -4527,21 +4537,21 @@
                  </first>
                 </let>
                </forEach>
-               <let line='3673' var='Q{}updatedInstanceXML' as='element()' slot='10' eval='16'>
-                <treat line='3674' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+               <let line='3677' var='Q{}updatedInstanceXML' as='element()' slot='10' eval='16'>
+                <treat line='3678' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
                  <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
                   <applyT mode='Q{}recalculate' bSlot='4'>
                    <varRef role='select' name='Q{}instanceXML' slot='4'/>
                    <withParam name='Q{}updated-nodes' flags='t' as='node()*'>
-                    <varRef line='3675' name='Q{}calculated-nodes' slot='7'/>
+                    <varRef line='3679' name='Q{}calculated-nodes' slot='7'/>
                    </withParam>
                    <withParam name='Q{}updated-values' flags='t' as='xs:string*'>
-                    <varRef line='3676' name='Q{}calculated-values' slot='8'/>
+                    <varRef line='3680' name='Q{}calculated-values' slot='8'/>
                    </withParam>
                   </applyT>
                  </check>
                 </treat>
-                <ifCall line='3680' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                <ifCall line='3684' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                  <varRef name='Q{http://saxon.sf.net/generated-variable}v1' slot='0'/>
                  <str val='setInstance'/>
                  <arrayBlock>
@@ -4556,9 +4566,9 @@
            </let>
           </let>
          </forEach>
-         <callT line='3684' name='Q{}refreshOutputs-JS' bSlot='5'/>
-         <callT line='3685' name='Q{}refreshRepeats-JS' bSlot='6'/>
-         <callT line='3686' name='Q{}refreshElementsUsingIndexFunction-JS' bSlot='7' flags='t'/>
+         <callT line='3688' name='Q{}refreshOutputs-JS' bSlot='5'/>
+         <callT line='3689' name='Q{}refreshRepeats-JS' bSlot='6'/>
+         <callT line='3690' name='Q{}refreshElementsUsingIndexFunction-JS' bSlot='7' flags='t'/>
         </sequence>
        </let>
       </let>
@@ -4567,7 +4577,7 @@
    </let>
   </template>
  </co>
- <co id='64' binds='73 73 73'>
+ <co id='65' binds='74 74 74'>
   <globalVariable name='Q{}xforms-doc' type='document-node()?' line='77' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='function test(item) {return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);};if (test(val)) {return val;} else {throw SaxonJS.XError(&#39;Conversion failed&#39;, &#39;XTTE0590&#39;);}' jsCardCheck='function c(n) {return n&lt;=1;};'>
    <choose ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='77'>
     <and op='and'>
@@ -4581,27 +4591,39 @@
     <fn name='doc'>
      <gVarRef name='Q{}xforms-file' bSlot='2'/>
     </fn>
+    <vc op='eq' onEmpty='0' comp='CCC'>
+     <fn name='namespace-uri'>
+      <check card='?' diag='0|0||fn:namespace-uri'>
+       <slash simple='1'>
+        <root/>
+        <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+       </slash>
+      </check>
+     </fn>
+     <str val='http://www.w3.org/2002/xforms'/>
+    </vc>
+    <root/>
    </choose>
   </globalVariable>
  </co>
- <co id='73' binds=''>
+ <co id='74' binds=''>
   <globalParam name='Q{}xforms-file' type='xs:string?' line='75' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n&lt;=1;};'>
    <empty/>
   </globalParam>
  </co>
- <co id='74' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}addNamespaceDeclarations' line='2540' module='saxon-xforms.xsl' eval='16' flags='pU' as='element()' slots='1'>
+ <co id='75' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}addNamespaceDeclarations' line='2544' module='saxon-xforms.xsl' eval='16' flags='pU' as='element()' slots='1'>
    <arg name='Q{}this' as='element()'/>
-   <compElem role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2542'>
+   <compElem role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2546'>
     <fn role='name' name='name'>
      <varRef name='Q{}this' slot='0'/>
     </fn>
-    <sequence role='content' line='2543'>
+    <sequence role='content' line='2547'>
      <namespace flags='l'>
       <str role='name' val='xforms'/>
       <str role='select' val='http://www.w3.org/2002/xforms'/>
      </namespace>
-     <forEach line='2544'>
+     <forEach line='2548'>
       <filter flags='b'>
        <filter flags='b'>
         <slash simple='1'>
@@ -4640,21 +4662,21 @@
         </gc>
        </fn>
       </filter>
-      <namespace line='2547' flags='l'>
-       <fn role='name' line='2546' name='substring-before'>
+      <namespace line='2551' flags='l'>
+       <fn role='name' line='2550' name='substring-before'>
         <fn name='name'>
          <dot type='element()'/>
         </fn>
         <str val=':'/>
        </fn>
        <convert role='select' from='xs:anyURI' to='xs:string'>
-        <fn line='2545' name='namespace-uri'>
+        <fn line='2549' name='namespace-uri'>
          <dot type='element()'/>
         </fn>
        </convert>
       </namespace>
      </forEach>
-     <copyOf line='2549' flags='vc'>
+     <copyOf line='2553' flags='vc'>
       <sequence>
        <slash simple='1'>
         <varRef name='Q{}this' slot='0'/>
@@ -4670,9 +4692,9 @@
    </compElem>
   </function>
  </co>
- <co id='31' binds='22 21 23 35 39 75 23 76 40 44'>
-  <template name='Q{}xforms-submit' flags='os' line='3806' module='saxon-xforms.xsl' slots='21'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3807'>
+ <co id='31' binds='22 21 23 35 40 76 23 77 41 45'>
+  <template name='Q{}xforms-submit' flags='os' line='3812' module='saxon-xforms.xsl' slots='21'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3813'>
     <param name='Q{}submission' slot='0' flags='i' as='xs:string'>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|submission'>
       <check card='1' diag='8|0|XTTE0590|submission'>
@@ -4684,7 +4706,7 @@
       </check>
      </treat>
     </param>
-    <let line='3809' var='Q{}submission-map' as='map(*)' slot='1' eval='16'>
+    <let line='3815' var='Q{}submission-map' as='map(*)' slot='1' eval='16'>
      <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|submission-map'>
       <check card='1' diag='3|0|XTTE0570|submission-map'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
@@ -4698,7 +4720,7 @@
        </ifCall>
       </check>
      </treat>
-     <let line='3810' var='Q{}actions' as='map(*)?' slot='2' eval='7'>
+     <let line='3816' var='Q{}actions' as='map(*)?' slot='2' eval='7'>
       <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
         <check card='1' diag='0|0||ixsl:call'>
@@ -4710,7 +4732,7 @@
         </arrayBlock>
        </ifCall>
       </treat>
-      <let line='3818' var='Q{}refi' as='xs:string?' slot='3' eval='7'>
+      <let line='3824' var='Q{}refi' as='xs:string?' slot='3' eval='7'>
        <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
         <check card='?' diag='3|0|XTTE0570|refi'>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
@@ -4723,13 +4745,13 @@
          </cvUntyped>
         </check>
        </treat>
-       <let line='3820' var='Q{}instance-id' as='xs:string' slot='4' eval='16'>
-        <choose line='3822'>
+       <let line='3826' var='Q{}instance-id' as='xs:string' slot='4' eval='16'>
+        <choose line='3828'>
          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
           <varRef name='Q{}submission-map' slot='1'/>
           <str val='@instance'/>
          </ifCall>
-         <treat line='3823' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|instance-id'>
+         <treat line='3829' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|instance-id'>
           <check card='1' diag='3|0|XTTE0570|instance-id'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|instance-id'>
             <data>
@@ -4744,19 +4766,19 @@
          <true/>
          <str val='saxon-forms-default'/>
         </choose>
-        <let line='3835' var='Q{}instanceXML' as='element()?' slot='5' eval='7'>
+        <let line='3841' var='Q{}instanceXML' as='element()?' slot='5' eval='7'>
          <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='0' eval='6'>
           <varRef name='Q{}instance-id' slot='4'/>
          </ufCall>
-         <choose line='3838'>
+         <choose line='3844'>
           <fn name='exists'>
            <varRef name='Q{}instanceXML' slot='5'/>
           </fn>
-          <let line='3844' var='Q{http://saxon.sf.net/generated-variable}v0' as='element()' slot='6' eval='13'>
+          <let line='3850' var='Q{http://saxon.sf.net/generated-variable}v0' as='element()' slot='6' eval='13'>
            <check card='1' diag='4|0|XTTE3170|xsl:evaluate/namespace-context'>
             <varRef name='Q{}instanceXML' slot='5'/>
            </check>
-           <let line='3839' var='Q{}data-fields' as='element()*' slot='7' eval='8'>
+           <let line='3845' var='Q{}data-fields' as='element()*' slot='7' eval='8'>
             <filter flags='b'>
              <filter flags='b'>
               <filter flags='b'>
@@ -4793,11 +4815,11 @@
               <varRef name='Q{}instance-id' slot='4'/>
              </vc>
             </filter>
-            <let line='3842' var='Q{}calculated-nodes' as='node()*' slot='8' eval='8'>
-             <treat line='3843' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|calculated-nodes'>
+            <let line='3848' var='Q{}calculated-nodes' as='node()*' slot='8' eval='8'>
+             <treat line='3849' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|calculated-nodes'>
               <forEach>
                <varRef name='Q{}data-fields' slot='7'/>
-               <evaluate line='3844' dxns=''>
+               <evaluate line='3850' dxns=''>
                 <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
                  <fn name='string'>
                   <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
@@ -4811,11 +4833,11 @@
                </evaluate>
               </forEach>
              </treat>
-             <let line='3849' var='Q{}calculated-values' as='xs:string*' slot='9' eval='3'>
-              <forEach line='3850'>
+             <let line='3855' var='Q{}calculated-values' as='xs:string*' slot='9' eval='3'>
+              <forEach line='3856'>
                <varRef name='Q{}data-fields' slot='7'/>
-               <let line='3852' var='Q{}value' as='xs:string' slot='10' eval='8'>
-                <cvUntyped line='3854' to='xs:string' diag='3|0|XTTE0570|value'>
+               <let line='3858' var='Q{}value' as='xs:string' slot='10' eval='8'>
+                <cvUntyped line='3860' to='xs:string' diag='3|0|XTTE0570|value'>
                  <cast as='xs:untypedAtomic' emptiable='0'>
                   <fn name='string-join'>
                    <convert from='xs:anyAtomicType' to='xs:string'>
@@ -4831,7 +4853,7 @@
                   </fn>
                  </cast>
                 </cvUntyped>
-                <first line='3861'>
+                <first line='3867'>
                  <sequence>
                   <varRef name='Q{}value' slot='10'/>
                   <str val=''/>
@@ -4839,21 +4861,21 @@
                 </first>
                </let>
               </forEach>
-              <let line='3865' var='Q{}updatedInstanceXML' as='element()' slot='11' eval='16'>
-               <treat line='3866' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+              <let line='3871' var='Q{}updatedInstanceXML' as='element()' slot='11' eval='16'>
+               <treat line='3872' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
                 <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
                  <applyT mode='Q{}recalculate' bSlot='4'>
                   <varRef role='select' name='Q{}instanceXML' slot='5'/>
                   <withParam name='Q{}updated-nodes' flags='t' as='node()*'>
-                   <varRef line='3867' name='Q{}calculated-nodes' slot='8'/>
+                   <varRef line='3873' name='Q{}calculated-nodes' slot='8'/>
                   </withParam>
                   <withParam name='Q{}updated-values' flags='t' as='xs:string*'>
-                   <varRef line='3868' name='Q{}calculated-values' slot='9'/>
+                   <varRef line='3874' name='Q{}calculated-values' slot='9'/>
                   </withParam>
                  </applyT>
                 </check>
                </treat>
-               <let line='3873' var='Q{}required-fieldsi' as='element()*' slot='12' eval='8'>
+               <let line='3879' var='Q{}required-fieldsi' as='element()*' slot='12' eval='8'>
                 <filter flags='b'>
                  <slash simple='1'>
                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
@@ -4863,18 +4885,18 @@
                   <axis name='attribute' nodeTest='attribute(Q{}data-required)' jsTest='return item.name===&#39;data-required&#39;'/>
                  </fn>
                 </filter>
-                <let line='3875' var='Q{}required-fields-check' as='element()*' slot='13' eval='3'>
+                <let line='3881' var='Q{}required-fields-check' as='element()*' slot='13' eval='3'>
                  <ufCall name='Q{http://www.w3.org/2002/xforms}check-required-fields' tailCall='false' bSlot='5' eval='6'>
                   <varRef name='Q{}updatedInstanceXML' slot='11'/>
                  </ufCall>
-                 <choose line='3881'>
+                 <choose line='3887'>
                   <fn name='empty'>
                    <varRef name='Q{}required-fields-check' slot='13'/>
                   </fn>
-                  <let line='3882' var='Q{}requestBody' as='node()' slot='14' eval='16'>
-                   <choose line='3884'>
+                  <let line='3888' var='Q{}requestBody' as='node()' slot='14' eval='16'>
+                   <choose line='3890'>
                     <varRef name='Q{}refi' slot='3'/>
-                    <treat line='3885' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|requestBody'>
+                    <treat line='3891' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|requestBody'>
                      <check card='1' diag='3|0|XTTE0570|requestBody'>
                       <evaluate dxns=''>
                        <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='6' eval='16'>
@@ -4893,12 +4915,12 @@
                      </check>
                     </treat>
                     <true/>
-                    <check line='3888' card='1' diag='3|0|XTTE0570|requestBody'>
+                    <check line='3894' card='1' diag='3|0|XTTE0570|requestBody'>
                      <varRef name='Q{}instanceXML' slot='5'/>
                     </check>
                    </choose>
-                   <let line='3893' var='Q{}requestBodyDoc' as='document-node()?' slot='15' eval='7'>
-                    <choose line='3894'>
+                   <let line='3899' var='Q{}requestBodyDoc' as='document-node()?' slot='15' eval='7'>
+                    <choose line='3900'>
                      <fn name='exists'>
                       <filter flags='b'>
                        <varRef name='Q{}requestBody' slot='14'/>
@@ -4907,11 +4929,11 @@
                        </fn>
                       </filter>
                      </fn>
-                     <doc line='3895'>
-                      <varRef line='3896' name='Q{}requestBody' slot='14'/>
+                     <doc line='3901'>
+                      <varRef line='3902' name='Q{}requestBody' slot='14'/>
                      </doc>
                     </choose>
-                    <let line='3901' var='Q{}method' as='xs:string' slot='16' eval='16'>
+                    <let line='3907' var='Q{}method' as='xs:string' slot='16' eval='16'>
                      <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|method'>
                       <check card='1' diag='3|0|XTTE0570|method'>
                        <cvUntyped to='xs:string' diag='3|0|XTTE0570|method'>
@@ -4924,7 +4946,7 @@
                        </cvUntyped>
                       </check>
                      </treat>
-                     <let line='3903' var='Q{}serialization' as='xs:string?' slot='17' eval='7'>
+                     <let line='3909' var='Q{}serialization' as='xs:string?' slot='17' eval='7'>
                       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|serialization'>
                        <check card='?' diag='3|0|XTTE0570|serialization'>
                         <cvUntyped to='xs:string' diag='3|0|XTTE0570|serialization'>
@@ -4937,8 +4959,8 @@
                         </cvUntyped>
                        </check>
                       </treat>
-                      <let line='3905' var='Q{}query-parameters' as='xs:string?' slot='18' eval='7'>
-                       <choose line='3906'>
+                      <let line='3911' var='Q{}query-parameters' as='xs:string?' slot='18' eval='7'>
+                       <choose line='3912'>
                         <and op='and'>
                          <fn name='exists'>
                           <varRef name='Q{}serialization' slot='17'/>
@@ -4948,17 +4970,17 @@
                           <str val='application/x-www-form-urlencoded'/>
                          </vc>
                         </and>
-                        <fn line='3924' name='string-join'>
-                         <choose line='3910'>
+                        <fn line='3930' name='string-join'>
+                         <choose line='3916'>
                           <fn name='exists'>
                            <varRef name='Q{}requestBodyDoc' slot='15'/>
                           </fn>
-                          <forEach line='3911'>
+                          <forEach line='3917'>
                            <slash simple='1'>
                             <varRef name='Q{}requestBody' slot='14'/>
                             <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
                            </slash>
-                           <fn line='3912' name='concat'>
+                           <fn line='3918' name='concat'>
                             <fn name='local-name'>
                              <dot type='element()'/>
                             </fn>
@@ -4972,7 +4994,7 @@
                          <str val='&amp;'/>
                         </fn>
                        </choose>
-                       <let line='3928' var='Q{}href-base' as='xs:string' slot='19' eval='16'>
+                       <let line='3934' var='Q{}href-base' as='xs:string' slot='19' eval='16'>
                         <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|href-base'>
                          <check card='1' diag='3|0|XTTE0570|href-base'>
                           <cvUntyped to='xs:string' diag='3|0|XTTE0570|href-base'>
@@ -4985,16 +5007,16 @@
                           </cvUntyped>
                          </check>
                         </treat>
-                        <sequence line='3972'>
+                        <sequence line='3978'>
                          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}schedule-action' type='item()*'>
                           <int val='0'/>
                           <empty/>
                           <callT name='Q{}HTTPsubmit' bSlot='7'>
                            <withParam name='Q{}instance-id' flags='c' as='xs:string'>
-                            <varRef line='3973' name='Q{}instance-id' slot='4'/>
+                            <varRef line='3979' name='Q{}instance-id' slot='4'/>
                            </withParam>
                            <withParam name='Q{}targetref' flags='c' as='xs:string?'>
-                            <treat line='3974' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|targetref'>
+                            <treat line='3980' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|targetref'>
                              <check card='?' diag='8|0|XTTE0590|targetref'>
                               <cvUntyped to='xs:string' diag='8|0|XTTE0590|targetref'>
                                <data>
@@ -5008,7 +5030,7 @@
                             </treat>
                            </withParam>
                            <withParam name='Q{}replace' flags='c' as='xs:string?'>
-                            <treat line='3975' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|replace'>
+                            <treat line='3981' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|replace'>
                              <check card='?' diag='8|0|XTTE0590|replace'>
                               <cvUntyped to='xs:string' diag='8|0|XTTE0590|replace'>
                                <data>
@@ -5022,7 +5044,7 @@
                             </treat>
                            </withParam>
                           </callT>
-                          <ifCall line='3949' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+                          <ifCall line='3955' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
                            <sequence>
                             <choose>
                              <vc op='ne' onEmpty='1' comp='CCC'>
@@ -5031,37 +5053,37 @@
                               </fn>
                               <str val='GET'/>
                              </vc>
-                             <choose line='3951'>
+                             <choose line='3957'>
                               <fn name='exists'>
                                <varRef name='Q{}requestBodyDoc' slot='15'/>
                               </fn>
-                              <ifCall line='3952' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                              <ifCall line='3958' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                                <str val='body'/>
                                <varRef name='Q{}requestBodyDoc' slot='15'/>
                               </ifCall>
                               <true/>
-                              <ifCall line='3955' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                              <ifCall line='3961' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                                <str val='body'/>
                                <varRef name='Q{}requestBody' slot='14'/>
                               </ifCall>
                              </choose>
                             </choose>
-                            <ifCall line='3960' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                            <ifCall line='3966' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                              <str val='method'/>
                              <varRef name='Q{}method' slot='16'/>
                             </ifCall>
-                            <ifCall line='3961' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                            <ifCall line='3967' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                              <str val='href'/>
-                             <choose line='3932'>
+                             <choose line='3938'>
                               <fn name='exists'>
                                <varRef name='Q{}query-parameters' slot='18'/>
                               </fn>
-                              <fn line='3933' name='concat'>
+                              <fn line='3939' name='concat'>
                                <varRef name='Q{}href-base' slot='19'/>
                                <str val='?'/>
                                <varRef name='Q{}query-parameters' slot='18'/>
                               </fn>
-                              <fn line='3935' name='exists'>
+                              <fn line='3941' name='exists'>
                                <filter flags='b'>
                                 <varRef name='Q{}requestBody' slot='14'/>
                                 <fn name='exists'>
@@ -5069,7 +5091,7 @@
                                 </fn>
                                </filter>
                               </fn>
-                              <fn line='3936' name='concat'>
+                              <fn line='3942' name='concat'>
                                <varRef name='Q{}href-base' slot='19'/>
                                <str val='/'/>
                                <data>
@@ -5077,12 +5099,12 @@
                                </data>
                               </fn>
                               <true/>
-                              <varRef line='3939' name='Q{}href-base' slot='19'/>
+                              <varRef line='3945' name='Q{}href-base' slot='19'/>
                              </choose>
                             </ifCall>
-                            <ifCall line='3962' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                            <ifCall line='3968' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                              <str val='media-type'/>
-                             <treat line='3944' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|mediatype'>
+                             <treat line='3950' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|mediatype'>
                               <check card='1' diag='3|0|XTTE0570|mediatype'>
                                <cvUntyped to='xs:string' diag='3|0|XTTE0570|mediatype'>
                                 <data>
@@ -5104,16 +5126,16 @@
                            </map>
                           </ifCall>
                          </ifCall>
-                         <forEach line='3979'>
+                         <forEach line='3985'>
                           <varRef name='Q{}actions' slot='2'/>
-                          <let line='3980' var='Q{}action-map' as='map(*)' slot='20' eval='16'>
+                          <let line='3986' var='Q{}action-map' as='map(*)' slot='20' eval='16'>
                            <dot type='map(*)'/>
-                           <choose line='3983'>
+                           <choose line='3989'>
                             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
                              <varRef name='Q{}action-map' slot='20'/>
                              <str val='@event'/>
                             </ifCall>
-                            <choose line='3984'>
+                            <choose line='3990'>
                              <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
                               <data>
                                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
@@ -5123,17 +5145,17 @@
                               </data>
                               <str val='xforms-submit-done'/>
                              </gc>
-                             <callT line='3985' name='Q{}applyActions' bSlot='8' flags='t'>
+                             <callT line='3991' name='Q{}applyActions' bSlot='8' flags='t'>
                               <withParam name='Q{}action-map' flags='t' as='item()'>
-                               <varRef line='3986' name='Q{}action-map' slot='20'/>
+                               <varRef line='3992' name='Q{}action-map' slot='20'/>
                               </withParam>
                               <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                               <check line='3987' card='1' diag='8|0|XTTE0590|nodeset'>
+                               <check line='3993' card='1' diag='8|0|XTTE0590|nodeset'>
                                 <varRef name='Q{}refi' slot='3'/>
                                </check>
                               </withParam>
                               <withParam name='Q{}instanceXML' flags='t' as='element()'>
-                               <check line='3988' card='1' diag='8|0|XTTE0590|instanceXML'>
+                               <check line='3994' card='1' diag='8|0|XTTE0590|instanceXML'>
                                 <varRef name='Q{}instanceXML' slot='5'/>
                                </check>
                               </withParam>
@@ -5150,23 +5172,23 @@
                    </let>
                   </let>
                   <true/>
-                  <ifCall line='4001' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                  <ifCall line='4007' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                    <check card='1' diag='0|0||ixsl:call'>
                     <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                    </check>
                    <str val='alert'/>
                    <arrayBlock>
                     <fn name='serialize'>
-                     <doc line='3996' flags='t' validation='preserve'>
+                     <doc line='4002' flags='t' validation='preserve'>
                       <forEach>
                        <varRef name='Q{}required-fields-check' slot='13'/>
-                       <valueOf line='3998' flags='l'>
+                       <valueOf line='4004' flags='l'>
                         <fn name='concat'>
                          <str val='Value error see: '/>
                          <fn name='serialize'>
-                          <slash line='3997' simple='1'>
+                          <slash line='4003' simple='1'>
                            <dot type='element()'/>
-                           <axis line='3998' name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
+                           <axis line='4004' name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
                           </slash>
                          </fn>
                          <str val='&#xA;'/>
@@ -5186,9 +5208,9 @@
            </let>
           </let>
           <true/>
-          <callT line='4007' name='Q{}logToPage' bSlot='9' flags='t'>
+          <callT line='4013' name='Q{}logToPage' bSlot='9' flags='t'>
            <withParam name='Q{}message' flags='c' as='xs:string'>
-            <fn line='4008' name='concat'>
+            <fn line='4014' name='concat'>
              <str val='Unable to locate XForms instance relating to submission '/>
              <fn name='serialize'>
               <varRef name='Q{}submission-map' slot='1'/>
@@ -5208,9 +5230,9 @@
    </sequence>
   </template>
  </co>
- <co id='57' binds='54 77 73'>
-  <template name='Q{}xforms-rebuild' flags='os' line='3602' module='saxon-xforms.xsl' slots='2'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3603'>
+ <co id='58' binds='55 78'>
+  <template name='Q{}xforms-rebuild' flags='os' line='3606' module='saxon-xforms.xsl' slots='2'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3607'>
     <message>
      <valueOf role='select'>
       <str val='[xforms-rebuild] START'/>
@@ -5218,8 +5240,8 @@
      <str role='terminate' val='no'/>
      <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
     </message>
-    <let line='3604' var='Q{}instanceDocs' as='map(xs:anyAtomicType, element()?)' slot='0' eval='8'>
-     <let line='3605' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
+    <let line='3608' var='Q{}instanceDocs' as='map(xs:anyAtomicType, element()?)' slot='0' eval='8'>
+     <let line='3609' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -5227,15 +5249,15 @@
        <str val='getInstanceKeys'/>
        <array size='0'/>
       </ifCall>
-      <ifCall line='3607' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+      <ifCall line='3611' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
        <forEach>
         <varRef name='Q{}instance-keys' slot='1'/>
-        <ifCall line='3609' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+        <ifCall line='3613' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
          <atomSing diag='0|0||map:entry'>
           <dot/>
          </atomSing>
          <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='0' eval='16'>
-          <fn line='3608' name='concat'>
+          <fn line='3612' name='concat'>
            <str val='instance(&#39;'/>
            <atomSing card='?' diag='0|1||fn:concat'>
             <dot/>
@@ -5253,41 +5275,38 @@
        </map>
       </ifCall>
      </let>
-     <callT line='3614' name='Q{}xformsjs-main' bSlot='1' flags='t'>
-      <withParam name='Q{}xforms-file' flags='c' as='xs:string?'>
-       <gVarRef line='3615' name='Q{}xforms-file' bSlot='2'/>
-      </withParam>
+     <callT line='3618' name='Q{}xformsjs-main' bSlot='1' flags='t'>
       <withParam name='Q{}instance-docs' flags='c' as='map(*)'>
-       <varRef line='3616' name='Q{}instanceDocs' slot='0'/>
+       <varRef line='3620' name='Q{}instanceDocs' slot='0'/>
       </withParam>
      </callT>
     </let>
    </sequence>
   </template>
  </co>
- <co id='53' binds=''>
+ <co id='54' binds=''>
   <mode name='Q{}set-field' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.25' seq='37' rank='0' minImp='0' slots='1' flags='s' line='2472' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='37' rank='0' minImp='0' slots='1' flags='s' line='2476' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:textarea' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;textarea&#39;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2473'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2477'>
      <param name='Q{}value' slot='0' flags='t'>
       <str role='select' val=''/>
       <supplied role='conversion' slot='0'/>
      </param>
-     <ifCall line='2477' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+     <ifCall line='2481' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
       <dot type='*:textarea'/>
       <str val='value'/>
      </ifCall>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='-0.25' seq='36' rank='0' minImp='0' slots='1' flags='s' line='2458' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='36' rank='0' minImp='0' slots='1' flags='s' line='2462' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:select' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;select&#39;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2459'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2463'>
      <param name='Q{}value' slot='0' flags='t'>
       <str role='select' val=''/>
       <supplied role='conversion' slot='0'/>
      </param>
-     <forEach line='2461'>
+     <forEach line='2465'>
       <filter flags='b'>
        <axis name='child' nodeTest='element(Q{}option)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;option&#39;;'/>
        <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
@@ -5297,7 +5316,7 @@
         <attVal name='Q{}value' chk='0'/>
        </gc>
       </filter>
-      <ifCall line='2462' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+      <ifCall line='2466' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
        <str val='selected'/>
        <true/>
        <dot type='element(Q{}option)'/>
@@ -5305,14 +5324,14 @@
      </forEach>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='-0.25' seq='35' rank='0' minImp='0' slots='1' flags='s' line='2437' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='35' rank='0' minImp='0' slots='1' flags='s' line='2441' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:input' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;input&#39;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2438'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2442'>
      <param name='Q{}value' slot='0' flags='t'>
       <str role='select' val=''/>
       <supplied role='conversion' slot='0'/>
      </param>
-     <choose line='2442'>
+     <choose line='2446'>
       <and op='and'>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}type)' jsTest='return item.name===&#39;type&#39;'/>
@@ -5324,7 +5343,7 @@
         <str val='checkbox'/>
        </vc>
       </and>
-      <ifCall line='2443' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+      <ifCall line='2447' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
        <str val='checked'/>
        <choose>
         <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
@@ -5342,7 +5361,7 @@
        <dot type='*:input'/>
       </ifCall>
       <true/>
-      <ifCall line='2446' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+      <ifCall line='2450' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
        <str val='value'/>
        <check card='?' diag='0|1||ixsl:set-property'>
         <varRef name='Q{}value' slot='0'/>
@@ -5354,9 +5373,9 @@
    </templateRule>
   </mode>
  </co>
- <co id='72' binds='63'>
-  <template name='Q{}refreshElementsUsingIndexFunction-JS' flags='os' line='3115' module='saxon-xforms.xsl' slots='6'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3116'>
+ <co id='73' binds='64'>
+  <template name='Q{}refreshElementsUsingIndexFunction-JS' flags='os' line='3119' module='saxon-xforms.xsl' slots='6'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3120'>
     <message>
      <valueOf role='select'>
       <str val='[refreshElementsUsingIndexFunction-JS] START'/>
@@ -5364,7 +5383,7 @@
      <str role='terminate' val='no'/>
      <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
     </message>
-    <let line='3117' var='Q{}ElementsUsingIndexFunction-keys' as='item()?' slot='0' eval='8'>
+    <let line='3121' var='Q{}ElementsUsingIndexFunction-keys' as='item()?' slot='0' eval='8'>
      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
       <check card='1' diag='0|0||ixsl:call'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -5372,7 +5391,7 @@
       <str val='getElementsUsingIndexFunctionKeys'/>
       <array size='0'/>
      </ifCall>
-     <let line='3119' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
+     <let line='3123' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -5380,12 +5399,12 @@
        <str val='getInstanceKeys'/>
        <array size='0'/>
       </ifCall>
-      <let line='3120' var='Q{}instances' as='map(xs:string, element())' slot='2' eval='16'>
-       <treat line='3122' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances'>
+      <let line='3124' var='Q{}instances' as='map(xs:string, element())' slot='2' eval='16'>
+       <treat line='3126' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances'>
         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
          <forEach>
           <varRef name='Q{}instance-keys' slot='1'/>
-          <ifCall line='3123' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <ifCall line='3127' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
            <atomSing diag='0|0||map:entry'>
             <dot/>
            </atomSing>
@@ -5408,9 +5427,9 @@
          </map>
         </ifCall>
        </treat>
-       <forEach line='3129'>
+       <forEach line='3133'>
         <varRef name='Q{}ElementsUsingIndexFunction-keys' slot='0'/>
-        <let line='3130' var='Q{}this-key' as='xs:string' slot='3' eval='16'>
+        <let line='3134' var='Q{}this-key' as='xs:string' slot='3' eval='16'>
          <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|this-key'>
           <check card='1' diag='3|0|XTTE0570|this-key'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|this-key'>
@@ -5420,7 +5439,7 @@
            </cvUntyped>
           </check>
          </treat>
-         <sequence line='3132'>
+         <sequence line='3136'>
           <message>
            <sequence role='select'>
             <valueOf>
@@ -5434,7 +5453,7 @@
            <str role='terminate' val='no'/>
            <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
           </message>
-          <let line='3134' var='Q{}this-element' as='element()' slot='4' eval='16'>
+          <let line='3138' var='Q{}this-element' as='element()' slot='4' eval='16'>
            <treat as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|this-element'>
             <check card='1' diag='3|0|XTTE0570|this-element'>
              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
@@ -5448,8 +5467,8 @@
              </ifCall>
             </check>
            </treat>
-           <let line='3135' var='Q{}this-element-refi' as='xs:string?' slot='5' eval='7'>
-            <choose line='3137'>
+           <let line='3139' var='Q{}this-element-refi' as='xs:string?' slot='5' eval='7'>
+            <choose line='3141'>
              <fn name='exists'>
               <slash simple='1'>
                <varRef name='Q{}this-element' slot='4'/>
@@ -5464,13 +5483,13 @@
                </slash>
               </data>
              </cvUntyped>
-             <fn line='3138' name='exists'>
+             <fn line='3142' name='exists'>
               <slash simple='1'>
                <varRef name='Q{}this-element' slot='4'/>
                <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
               </slash>
              </fn>
-             <cvUntyped line='3138' to='xs:string' diag='3|0|XTTE0570|this-element-refi'>
+             <cvUntyped line='3142' to='xs:string' diag='3|0|XTTE0570|this-element-refi'>
               <data>
                <slash simple='1'>
                 <varRef name='Q{}this-element' slot='4'/>
@@ -5479,12 +5498,12 @@
               </data>
              </cvUntyped>
             </choose>
-            <resultDoc line='3142' global='#&#xD;&#xA;#Sat Mar 14 13:02:55 GMT 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Sat Mar 14 13:02:55 GMT 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
+            <resultDoc line='3146' global='#&#xD;&#xA;#Tue Mar 24 21:48:26 GMT 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Tue Mar 24 21:48:26 GMT 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
              <fn role='href' name='concat'>
               <str val='#'/>
               <varRef name='Q{}this-key' slot='3'/>
              </fn>
-             <applyT role='content' line='3143' bSlot='0'>
+             <applyT role='content' line='3147' bSlot='0'>
               <slash role='select' simple='1'>
                <varRef name='Q{}this-element' slot='4'/>
                <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
@@ -5493,10 +5512,10 @@
                <true/>
               </withParam>
               <withParam name='Q{}instances' flags='t' as='map(xs:string, element())'>
-               <varRef line='3144' name='Q{}instances' slot='2'/>
+               <varRef line='3148' name='Q{}instances' slot='2'/>
               </withParam>
               <withParam name='Q{}nodeset' flags='t' as='xs:string?'>
-               <choose line='3145'>
+               <choose line='3149'>
                 <fn name='exists'>
                  <varRef name='Q{}this-element-refi' slot='5'/>
                 </fn>
@@ -5518,7 +5537,7 @@
    </sequence>
   </template>
  </co>
- <co id='78' binds=''>
+ <co id='79' binds=''>
   <globalVariable name='Q{}xforms-actions' type='xs:string+' line='101' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n&gt;=1;};'>
    <literal count='15'>
     <str val='setvalue'/>
@@ -5539,16 +5558,16 @@
    </literal>
   </globalVariable>
  </co>
- <co id='79' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}foo' line='90' module='xforms-function-library.xsl' eval='16' flags='pU' as='xs:boolean' slots='1'>
+ <co id='80' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}foo' line='91' module='xforms-function-library.xsl' eval='16' flags='pU' as='xs:boolean' slots='1'>
    <arg name='Q{}num' as='xs:integer'/>
-   <compareToInt role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='93' op='lt' val='5'>
+   <compareToInt role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='94' op='lt' val='5'>
     <varRef name='Q{}num' slot='0'/>
    </compareToInt>
   </function>
  </co>
- <co id='80' vis='PRIVATE' binds='70 81' base='13' dpack='1'/>
- <co id='82' binds='83 83'>
+ <co id='81' vis='PRIVATE' binds='71 82' base='13' dpack='1'/>
+ <co id='83' binds='84 84'>
   <globalVariable name='Q{}LOGLEVEL_INT' type='xs:integer' line='67' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.integer.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
    <choose ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='67'>
     <castable as='xs:integer' emptiable='0'>
@@ -5562,90 +5581,96 @@
    </choose>
   </globalVariable>
  </co>
- <co id='84' binds=''>
+ <co id='85' binds=''>
   <globalParam name='Q{}xforms-cache-id' type='xs:string' line='70' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
    <str val='xforms-cache'/>
   </globalParam>
  </co>
- <co id='23' binds='85'>
+ <co id='67' binds='65'>
+  <globalVariable name='Q{http://saxon.sf.net/generated-variable}gg928129983' type='element()*' line='3781' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='function test(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};if (test(val)) {return val;} else {throw SaxonJS.XError(&#39;Conversion failed&#39;, &#39;XTTE0590&#39;);}' jsCardCheck='function c() {return true;};'>
+   <slash ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3781' simple='1'>
+    <gVarRef name='Q{}xforms-doc' bSlot='0'/>
+    <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+   </slash>
+  </globalVariable>
+ </co>
+ <co id='23' binds=''>
   <function name='Q{http://www.w3.org/2002/xforms}impose' line='22' module='xforms-function-library.xsl' eval='8' flags='pU' as='xs:string' slots='3'>
    <arg name='Q{}input' as='xs:string'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='36' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:anyAtomicType*' slot='1' eval='4'>
-    <data>
-     <gVarRef name='Q{}xform-functions' bSlot='0'/>
-    </data>
-    <let line='53' var='Q{}parts2' as='xs:string*' slot='2' eval='8'>
-     <analyzeString line='58'>
-      <fn role='select' line='33' name='string-join'>
-       <analyzeString>
-        <varRef role='select' name='Q{}input' slot='0'/>
-        <str role='regex' val='\i\c*\('/>
-        <str role='flags' val=''/>
-        <choose role='matching' line='36'>
-         <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
-          <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='1'/>
-          <fn name='substring-before'>
-           <dot type='xs:string'/>
-           <str val='('/>
-          </fn>
-         </gc>
-         <fn line='37' name='concat'>
-          <str val='xforms:'/>
-          <dot type='xs:string'/>
-         </fn>
-         <true/>
-         <dot line='41' type='xs:string'/>
-        </choose>
-        <dot role='nonMatching' line='46' type='xs:string'/>
-       </analyzeString>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='24' var='Q{}parts' as='xs:string*' slot='1' eval='4'>
+    <analyzeString line='33'>
+     <varRef role='select' name='Q{}input' slot='0'/>
+     <str role='regex' val='\i\c*\('/>
+     <str role='flags' val=''/>
+     <choose role='matching' line='36'>
+      <gc op='=' card='N:1' comp='CCC'>
+       <literal count='6'>
+        <str val='instance'/>
+        <str val='index'/>
+        <str val='avg'/>
+        <str val='foo'/>
+        <str val='current-date'/>
+        <str val='random'/>
+       </literal>
+       <fn name='substring-before'>
+        <dot type='xs:string'/>
+        <str val='('/>
+       </fn>
+      </gc>
+      <fn line='37' name='concat'>
+       <str val='xforms:'/>
+       <dot type='xs:string'/>
+      </fn>
+      <true/>
+      <dot line='41' type='xs:string'/>
+     </choose>
+     <dot role='nonMatching' line='46' type='xs:string'/>
+    </analyzeString>
+    <let line='54' var='Q{}parts2' as='xs:string*' slot='2' eval='8'>
+     <analyzeString line='59'>
+      <fn role='select' line='51' name='string-join'>
+       <varRef name='Q{}parts' slot='1'/>
       </fn>
       <str role='regex' val='(^\s*|[^\i\c\]])/\i\c*(/)'/>
       <str role='flags' val=''/>
-      <sequence role='matching' line='60'>
+      <sequence role='matching' line='61'>
        <fn name='regex-group'>
         <int val='1'/>
        </fn>
-       <fn line='61' name='regex-group'>
+       <fn line='62' name='regex-group'>
         <int val='2'/>
        </fn>
       </sequence>
-      <dot role='nonMatching' line='64' type='xs:string'/>
+      <dot role='nonMatching' line='65' type='xs:string'/>
      </analyzeString>
-     <fn line='69' name='string-join'>
-      <varRef name='Q{}parts2' slot='2'/>
+     <fn line='70' name='string-join'>
+      <varRef name='Q{}parts' slot='1'/>
      </fn>
     </let>
    </let>
   </function>
  </co>
- <co id='85' binds=''>
-  <globalVariable name='Q{}xform-functions' type='item()+' line='20' module='xforms-function-library.xsl' visibility='PRIVATE' jsAcceptor='return val;' jsCardCheck='function c(n) {return n&gt;=1;};'>
-   <sequence ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='20'>
-    <literal count='5'>
-     <str val='instance'/>
-     <str val='index'/>
-     <str val='avg'/>
-     <str val='foo'/>
-     <str val='current-date'/>
-    </literal>
-    <slash simple='1'>
-     <treat as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='14|3|XPTY0020|'>
-      <dot flags='a'/>
-     </treat>
-     <axis name='child' nodeTest='element(Q{}random)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;random&#39;;'/>
-    </slash>
-   </sequence>
+ <co id='86' binds=''>
+  <globalVariable name='Q{}xform-functions' type='xs:string+' line='20' module='xforms-function-library.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n&gt;=1;};'>
+   <literal count='6'>
+    <str val='instance'/>
+    <str val='index'/>
+    <str val='avg'/>
+    <str val='foo'/>
+    <str val='current-date'/>
+    <str val='random'/>
+   </literal>
   </globalVariable>
  </co>
- <co id='83' binds=''>
+ <co id='84' binds=''>
   <globalParam name='Q{}LOGLEVEL' type='xs:string' line='66' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
    <str val='40'/>
   </globalParam>
  </co>
- <co id='75' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}check-required-fields' line='910' module='saxon-xforms.xsl' eval='8' flags='pU' as='item()*' slots='3'>
+ <co id='76' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}check-required-fields' line='914' module='saxon-xforms.xsl' eval='8' flags='pU' as='item()*' slots='3'>
    <arg name='Q{}instanceXML' as='element()'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='913' var='Q{}required-fieldsi' as='element()*' slot='1' eval='8'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='917' var='Q{}required-fieldsi' as='element()*' slot='1' eval='8'>
     <filter flags='b'>
      <slash simple='1'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
@@ -5655,10 +5680,10 @@
       <axis name='attribute' nodeTest='attribute(Q{}data-required)' jsTest='return item.name===&#39;data-required&#39;'/>
      </fn>
     </filter>
-    <forEach line='915'>
+    <forEach line='919'>
      <varRef name='Q{}required-fieldsi' slot='1'/>
-     <let line='917' var='Q{}resulti' as='document-node()' slot='2' eval='16'>
-      <doc line='920' validation='preserve'>
+     <let line='921' var='Q{}resulti' as='document-node()' slot='2' eval='16'>
+      <doc line='924' validation='preserve'>
        <evaluate dxns=''>
         <fn role='xpath' name='concat'>
          <str val='boolean(normalize-space('/>
@@ -5676,7 +5701,7 @@
         <map role='wp' size='0'/>
        </evaluate>
       </doc>
-      <choose line='926'>
+      <choose line='930'>
        <vc op='eq' onEmpty='0' comp='CCC'>
         <cast as='xs:string' emptiable='0'>
          <data>
@@ -5692,10 +5717,10 @@
    </let>
   </function>
  </co>
- <co id='48' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}index' line='97' module='xforms-function-library.xsl' eval='16' flags='pU' as='xs:integer' slots='2'>
+ <co id='49' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}index' line='98' module='xforms-function-library.xsl' eval='16' flags='pU' as='xs:integer' slots='2'>
    <arg name='Q{}repeatID' as='xs:string'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='101' var='Q{}repeat-index' as='xs:double?' slot='1' eval='7'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='102' var='Q{}repeat-index' as='xs:double?' slot='1' eval='7'>
     <check card='?' diag='3|0|XTTE0570|repeat-index'>
      <convert from='xs:anyAtomicType' to='xs:double' flags='p' diag='3|0|XTTE0570|repeat-index'>
       <cvUntyped to='xs:double' diag='3|0|XTTE0570|repeat-index'>
@@ -5713,7 +5738,7 @@
       </cvUntyped>
      </convert>
     </check>
-    <choose line='104'>
+    <choose line='105'>
      <fn name='exists'>
       <varRef name='Q{}repeat-index' slot='1'/>
      </fn>
@@ -5728,26 +5753,18 @@
    </let>
   </function>
  </co>
- <co id='66' binds='64'>
-  <globalVariable name='Q{http://saxon.sf.net/generated-variable}gg334130099' type='element()*' line='3775' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='function test(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};if (test(val)) {return val;} else {throw SaxonJS.XError(&#39;Conversion failed&#39;, &#39;XTTE0590&#39;);}' jsCardCheck='function c() {return true;};'>
-   <slash ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3775' simple='1'>
-    <gVarRef name='Q{}xforms-doc' bSlot='0'/>
-    <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-   </slash>
-  </globalVariable>
- </co>
  <co id='29' binds='29'>
   <mode name='Q{}delete-node' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='22' rank='0' minImp='0' slots='2' flags='s' line='1935' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='22' rank='0' minImp='0' slots='2' flags='s' line='1939' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1936'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1940'>
      <param name='Q{}delete-node' slot='0' flags='t' as='node()*'>
       <empty role='select'/>
       <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|delete-node'>
        <supplied slot='0'/>
       </treat>
      </param>
-     <choose line='1939'>
+     <choose line='1943'>
       <some var='Q{}n' slot='1'>
        <varRef name='Q{}delete-node' slot='0'/>
        <is op='is'>
@@ -5757,12 +5774,12 @@
       </some>
       <empty/>
       <true/>
-      <copy line='1944' flags='cin'>
+      <copy line='1948' flags='cin'>
        <sequence role='content'>
         <copyOf flags='vc'>
          <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
         </copyOf>
-        <applyT line='1945' mode='Q{}delete-node' bSlot='0'>
+        <applyT line='1949' mode='Q{}delete-node' bSlot='0'>
          <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
         </applyT>
        </sequence>
@@ -5774,16 +5791,16 @@
  </co>
  <co id='35' binds=''>
   <mode name='Q{}get-field' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.25' seq='34' rank='0' minImp='0' slots='0' flags='s' line='2424' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='34' rank='0' minImp='0' slots='0' flags='s' line='2428' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:textarea' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;textarea&#39;'/>
-    <ifCall role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2427' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+    <ifCall role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2431' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
      <dot type='*:textarea'/>
      <str val='value'/>
     </ifCall>
    </templateRule>
-   <templateRule prec='0' prio='-0.25' seq='33' rank='0' minImp='0' slots='0' flags='s' line='2414' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='33' rank='0' minImp='0' slots='0' flags='s' line='2418' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:select' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;select&#39;'/>
-    <ifCall role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2416' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+    <ifCall role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2420' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
      <check card='?' diag='0|0||ixsl:get'>
       <filter flags='b'>
        <axis name='child' nodeTest='element(Q{}option)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;option&#39;;'/>
@@ -5801,9 +5818,9 @@
      <str val='value'/>
     </ifCall>
    </templateRule>
-   <templateRule prec='0' prio='-0.25' seq='32' rank='0' minImp='0' slots='0' flags='s' line='2395' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='32' rank='0' minImp='0' slots='0' flags='s' line='2399' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:input' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;input&#39;'/>
-    <choose role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2399'>
+    <choose role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2403'>
      <and op='and'>
       <fn name='exists'>
        <axis name='attribute' nodeTest='attribute(Q{}type)' jsTest='return item.name===&#39;type&#39;'/>
@@ -5815,7 +5832,7 @@
        <str val='checkbox'/>
       </vc>
      </and>
-     <choose line='2400'>
+     <choose line='2404'>
       <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
        <data>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
@@ -5830,7 +5847,7 @@
       <str val=''/>
      </choose>
      <true/>
-     <ifCall line='2403' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+     <ifCall line='2407' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
       <dot type='*:input'/>
       <str val='value'/>
      </ifCall>
@@ -5838,23 +5855,20 @@
    </templateRule>
   </mode>
  </co>
- <co id='63' binds='77 67 86 63 63 87 88 42 89 63 63 63 87 88 42 23 89 63 87 88 42 89 87 88 89 63 87 88 42 23 23 63 87 88 42 63 63 63 63'>
+ <co id='64' binds='78 68 87 64 88 89 43 90 64 64 88 89 43 64 64 64 64 64 88 89 43 23 90 64 88 89 43 90 88 89 90 64 88 89 43 23 23 64 64'>
   <mode onNo='TC' flags='dW' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='7' rank='0' minImp='0' slots='0' flags='s' line='1070' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='7' rank='0' minImp='0' slots='0' flags='s' line='1074' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='document-node()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);'/>
-    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1071' name='Q{}xformsjs-main' bSlot='0' flags='t'>
-     <withParam name='Q{}xforms-doc' flags='c' as='document-node()'>
-      <dot line='1072' type='document-node()'/>
-     </withParam>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1075' name='Q{}xformsjs-main' bSlot='0' flags='t'>
      <withParam name='Q{}xFormsId' flags='c' as='xs:string'>
-      <gVarRef line='1073' name='Q{}xform-html-id' bSlot='1'/>
+      <gVarRef line='1077' name='Q{}xform-html-id' bSlot='1'/>
      </withParam>
     </callT>
    </templateRule>
-   <templateRule prec='0' prio='0.5' seq='25' part='1' rank='2' minImp='0' slots='1' flags='s' line='2052' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.5' seq='25' part='1' rank='2' minImp='0' slots='1' flags='s' line='2056' module='saxon-xforms.xsl'>
     <p.withPredicate role='match'>
      <p.nodeTest test='Q{http://www.w3.org/2002/xforms}*' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.uri===&#39;http://www.w3.org/2002/xforms&#39;'/>
-     <gc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2052' op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+     <gc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2056' op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
       <literal count='15'>
        <str val='setvalue'/>
        <str val='insert'/>
@@ -5877,101 +5891,28 @@
       </fn>
      </gc>
     </p.withPredicate>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2060' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2061' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2064' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2065' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
       <check card='1' diag='3|0|XTTE0570|action-map'>
        <callT name='Q{}setAction' bSlot='2'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2062' type='element()'/>
+         <dot line='2066' type='element()'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <varRef line='2075' name='Q{}action-map' slot='0'/>
+     <varRef line='2079' name='Q{}action-map' slot='0'/>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='20' rank='1' minImp='0' slots='2' flags='s' line='1861' module='saxon-xforms.xsl'>
-    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}submit)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;submit&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1862'>
-     <param name='Q{}submissions' slot='0' flags='t' as='map(xs:string, map(*))'>
-      <map role='select' size='0'/>
-      <treat role='conversion' as='map(xs:string, map(*))' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isMap(item)};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|submissions'>
-       <check card='1' diag='8|0|XTTE0590|submissions'>
-        <supplied slot='0'/>
-       </check>
-      </treat>
-     </param>
-     <let line='1868' var='Q{}innerbody' as='document-node()' slot='1' eval='16'>
-      <doc line='1869' validation='preserve'>
-       <applyT bSlot='3'>
-        <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
-       </applyT>
-      </doc>
-      <choose line='1873'>
-       <vc op='eq' onEmpty='0' comp='CCC'>
-        <cast as='xs:string' emptiable='1'>
-         <attVal name='Q{}appearance' chk='0'/>
-        </cast>
-        <str val='minimal'/>
-       </vc>
-       <elem line='1874' name='a' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
-        <copyOf line='1875' flags='vc'>
-         <varRef name='Q{}innerbody' slot='1'/>
-        </copyOf>
-       </elem>
-       <true/>
-       <elem line='1879' name='button' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
-        <sequence>
-         <att name='type' flags='l'>
-          <str val='button'/>
-         </att>
-         <copyOf line='1880' flags='vc'>
-          <filter flags='b'>
-           <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
-           <vc op='ne' onEmpty='0' comp='CCC'>
-            <fn name='local-name'>
-             <dot type='attribute()'/>
-            </fn>
-            <str val='submission'/>
-           </vc>
-          </filter>
-         </copyOf>
-         <choose line='1881'>
-          <and op='and'>
-           <fn name='exists'>
-            <axis name='attribute' nodeTest='attribute(Q{}submission)' jsTest='return item.name===&#39;submission&#39;'/>
-           </fn>
-           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
-            <varRef name='Q{}submissions' slot='0'/>
-            <atomSing diag='0|1||map:contains'>
-             <axis name='attribute' nodeTest='attribute(Q{}submission)' jsTest='return item.name===&#39;submission&#39;'/>
-            </atomSing>
-           </ifCall>
-          </and>
-          <att line='1883' name='data-submit' flags='l'>
-           <convert from='xs:untypedAtomic' to='xs:string'>
-            <attVal name='Q{}submission' chk='0'/>
-           </convert>
-          </att>
-         </choose>
-         <copyOf line='1885' flags='vc'>
-          <varRef name='Q{}innerbody' slot='1'/>
-         </copyOf>
-        </sequence>
-       </elem>
-      </choose>
-     </let>
-    </sequence>
-   </templateRule>
-   <templateRule prec='0' prio='0.0' seq='8' part='1' rank='1' minImp='0' slots='0' flags='s' line='1087' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='8' part='1' rank='1' minImp='0' slots='0' flags='s' line='1091' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{}html)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;html&#39;;'/>
-    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1088' name='html' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
-     <sequence line='1089'>
+    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1092' name='html' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+     <sequence line='1093'>
       <copyOf flags='vc'>
        <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
       </copyOf>
-      <elem line='1090' name='head' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
-       <sequence line='1091'>
+      <elem line='1094' name='head' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
+       <sequence line='1095'>
         <copyOf flags='vc'>
          <union op='|'>
           <slash simple='2'>
@@ -5984,7 +5925,7 @@
           </slash>
          </union>
         </copyOf>
-        <elem line='1092' name='meta' nsuri='' flags='l'>
+        <elem line='1096' name='meta' nsuri='' flags='l'>
          <sequence>
           <att name='http-equiv' flags='l'>
            <str val='Content-Type'/>
@@ -5994,7 +5935,7 @@
           </att>
          </sequence>
         </elem>
-        <forEach line='1094'>
+        <forEach line='1098'>
          <union op='|'>
           <filter flags='b'>
            <slash simple='2'>
@@ -6021,19 +5962,19 @@
            </vc>
           </filter>
          </union>
-         <elem line='1095' name='meta' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
-          <copyOf line='1096' flags='vc'>
+         <elem line='1099' name='meta' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
+          <copyOf line='1100' flags='vc'>
            <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
           </copyOf>
          </elem>
         </forEach>
-        <copyOf line='1101' flags='vc'>
+        <copyOf line='1105' flags='vc'>
          <axis name='child' nodeTest='element(Q{}script)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;script&#39;;'/>
         </copyOf>
        </sequence>
       </elem>
-      <elem line='1103' name='body' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
-       <applyT line='1104' bSlot='4'>
+      <elem line='1107' name='body' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
+       <applyT line='1108' bSlot='3'>
         <slash role='select' simple='2'>
          <axis name='child' nodeTest='element(Q{}body)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;body&#39;;'/>
          <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
@@ -6043,9 +5984,9 @@
      </sequence>
     </elem>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='13' rank='1' minImp='0' slots='12' flags='s' line='1519' module='saxon-xforms.xsl'>
-    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}select1)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;select1&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1520'>
+   <templateRule prec='0' prio='0.0' seq='13' part='1' rank='1' minImp='0' slots='12' flags='s' line='1523' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}select)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;select&#39;;'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1524'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -6058,7 +5999,7 @@
        </check>
       </treat>
      </param>
-     <param line='1521' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1525' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -6070,7 +6011,7 @@
        </check>
       </treat>
      </param>
-     <let line='1525' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='1529' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -6086,7 +6027,7 @@
          <dot type='element()'/>
         </fn>
         <str val='-'/>
-        <choose line='1523'>
+        <choose line='1527'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -6096,13 +6037,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1527'>
+      <sequence line='1531'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element()' slot='3' eval='16'>
           <dot type='element()'/>
-          <fn line='2532' name='exists'>
-           <sequence line='2507'>
+          <fn line='2536' name='exists'>
+           <sequence line='2511'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -6114,7 +6055,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2510'>
+             <choose role='matching' line='2514'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -6126,7 +6067,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='2519'>
+            <analyzeString line='2523'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -6137,7 +6078,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2522'>
+             <choose role='matching' line='2526'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -6160,8 +6101,8 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='2532' name='exists'>
-             <sequence line='2507'>
+            <fn line='2536' name='exists'>
+             <sequence line='2511'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
@@ -6173,7 +6114,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2510'>
+               <choose role='matching' line='2514'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -6185,7 +6126,7 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
-              <analyzeString line='2519'>
+              <analyzeString line='2523'>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
@@ -6196,7 +6137,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2522'>
+               <choose role='matching' line='2526'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -6214,7 +6155,7 @@
           </filter>
          </fn>
         </and>
-        <ifCall line='1528' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1532' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -6225,60 +6166,60 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1535' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='1536' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='1539' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1540' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
-          <callT name='Q{}getBinding' bSlot='5'>
+          <callT name='Q{}getBinding' bSlot='4'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='1537' type='element()'/>
+            <dot line='1541' type='element()'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='1542' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='1543' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='1546' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1547' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
-             <callT name='Q{}getDataRef' bSlot='6'>
+             <callT name='Q{}getDataRef' bSlot='5'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='1544' type='element()'/>
+               <dot line='1548' type='element()'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='1545' name='Q{}bindingi' slot='5'/>
+               <varRef line='1549' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='1550' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
-          <treat line='1551' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+         <let line='1554' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
+          <treat line='1555' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
            <check card='?' diag='3|0|XTTE0570|instanceField'>
-            <callT name='Q{}getReferencedInstanceField' bSlot='7'>
+            <callT name='Q{}getReferencedInstanceField' bSlot='6'>
              <withParam name='Q{}refi' flags='c' as='xs:string'>
-              <varRef line='1552' name='Q{}refi' slot='6'/>
+              <varRef line='1556' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </check>
           </treat>
-          <let line='1557' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
-           <treat line='1558' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
-            <callT name='Q{}setActions' bSlot='8'>
+          <let line='1561' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
+           <treat line='1562' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+            <callT name='Q{}setActions' bSlot='7'>
              <withParam name='Q{}this' flags='c' as='element()'>
-              <dot line='1559' type='element()'/>
+              <dot line='1563' type='element()'/>
              </withParam>
              <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-              <varRef line='1560' name='Q{}refi' slot='6'/>
+              <varRef line='1564' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </treat>
-           <sequence line='1564'>
+           <sequence line='1568'>
             <choose>
              <fn name='exists'>
               <varRef name='Q{}actions' slot='8'/>
              </fn>
-             <ifCall line='1565' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+             <ifCall line='1569' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
               <check card='1' diag='0|0||ixsl:call'>
                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
               </check>
@@ -6289,27 +6230,27 @@
               </arrayBlock>
              </ifCall>
             </choose>
-            <elem line='1582' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+            <elem line='1586' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
              <sequence>
               <att name='class' flags='l'>
                <str val='xforms-select'/>
               </att>
-              <applyT line='1583' bSlot='9'>
+              <applyT line='1587' bSlot='8'>
                <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
               </applyT>
-              <elem line='1585' name='select' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
-               <sequence line='1586'>
+              <elem line='1589' name='select' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
+               <sequence line='1590'>
                 <let var='Q{}element' as='element()' slot='9' eval='16'>
                  <dot type='element()'/>
-                 <let line='2604' var='Q{}class' as='xs:string?' slot='10' eval='7'>
-                  <choose line='2605'>
+                 <let line='2608' var='Q{}class' as='xs:string?' slot='10' eval='7'>
+                  <choose line='2609'>
                    <fn name='exists'>
                     <slash simple='1'>
                      <varRef name='Q{}element' slot='9'/>
                      <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
                     </slash>
                    </fn>
-                   <cvUntyped line='2606' to='xs:string' diag='3|0|XTTE0570|class'>
+                   <cvUntyped line='2610' to='xs:string' diag='3|0|XTTE0570|class'>
                     <cast as='xs:untypedAtomic' emptiable='0'>
                      <fn name='string'>
                       <convert from='xs:untypedAtomic' to='xs:string'>
@@ -6324,15 +6265,15 @@
                     </cast>
                    </cvUntyped>
                   </choose>
-                  <let line='2609' var='Q{}class-mod' as='xs:string?' slot='11' eval='7'>
-                   <choose line='2611'>
+                  <let line='2613' var='Q{}class-mod' as='xs:string?' slot='11' eval='7'>
+                   <choose line='2615'>
                     <fn name='exists'>
                      <slash simple='1'>
                       <varRef name='Q{}element' slot='9'/>
                       <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
                      </slash>
                     </fn>
-                    <cvUntyped line='2612' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                    <cvUntyped line='2616' to='xs:string' diag='3|0|XTTE0570|class-mod'>
                      <cast as='xs:untypedAtomic' emptiable='0'>
                       <fn name='string-join'>
                        <sequence>
@@ -6344,13 +6285,13 @@
                      </cast>
                     </cvUntyped>
                     <true/>
-                    <varRef line='2615' name='Q{}class' slot='10'/>
+                    <varRef line='2619' name='Q{}class' slot='10'/>
                    </choose>
-                   <choose line='2619'>
+                   <choose line='2623'>
                     <fn name='exists'>
                      <varRef name='Q{}class-mod' slot='11'/>
                     </fn>
-                    <treat line='2620' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                    <treat line='2624' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
                      <att name='class' flags='l'>
                       <varRef name='Q{}class-mod' slot='11'/>
                      </att>
@@ -6359,7 +6300,7 @@
                   </let>
                  </let>
                 </let>
-                <copyOf line='1587' flags='vc'>
+                <copyOf line='1591' flags='vc'>
                  <except op='except'>
                   <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
                   <docOrder intra='1'>
@@ -6371,11 +6312,11 @@
                   </docOrder>
                  </except>
                 </copyOf>
-                <att line='1589' name='data-ref' flags='l'>
+                <att line='1593' name='data-ref' flags='l'>
                  <varRef name='Q{}refi' slot='6'/>
                 </att>
-                <att line='1590' name='data-element' flags='l'>
-                 <lastOf line='1580'>
+                <att line='1594' name='data-element' flags='l'>
+                 <lastOf line='1584'>
                   <fn name='tokenize'>
                    <varRef name='Q{}refi' slot='6'/>
                    <str val='/'/>
@@ -6383,7 +6324,7 @@
                   </fn>
                  </lastOf>
                 </att>
-                <choose line='1592'>
+                <choose line='1596'>
                  <and op='and'>
                   <fn name='exists'>
                    <varRef name='Q{}bindingi' slot='5'/>
@@ -6395,7 +6336,7 @@
                    </slash>
                   </fn>
                  </and>
-                 <att line='1593' name='data-constraint' flags='l'>
+                 <att line='1597' name='data-constraint' flags='l'>
                   <convert from='xs:untypedAtomic' to='xs:string'>
                    <data>
                     <slash simple='1'>
@@ -6406,19 +6347,19 @@
                   </convert>
                  </att>
                 </choose>
-                <choose line='1596'>
+                <choose line='1600'>
                  <vc op='eq' onEmpty='0' comp='CCC'>
                   <fn name='local-name'>
                    <dot type='element()'/>
                   </fn>
                   <str val='select'/>
                  </vc>
-                 <sequence line='1597'>
+                 <sequence line='1601'>
                   <att name='multiple' flags='l'>
                    <str val='true'/>
                   </att>
-                  <att line='1598' name='size' flags='l'>
-                   <convert line='1599' from='xs:integer' to='xs:string'>
+                  <att line='1602' name='size' flags='l'>
+                   <convert line='1603' from='xs:integer' to='xs:string'>
                     <fn name='count'>
                      <axis name='descendant' nodeTest='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
                     </fn>
@@ -6426,22 +6367,22 @@
                   </att>
                  </sequence>
                 </choose>
-                <choose line='1602'>
+                <choose line='1606'>
                  <fn name='exists'>
                   <varRef name='Q{}actions' slot='8'/>
                  </fn>
-                 <att line='1603' name='data-action' flags='l'>
+                 <att line='1607' name='data-action' flags='l'>
                   <varRef name='Q{}myid' slot='2'/>
                  </att>
                 </choose>
-                <applyT line='1606' bSlot='10'>
+                <applyT line='1610' bSlot='9'>
                  <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
                  <withParam name='Q{}selectedValue' as='xs:string'>
-                  <choose line='1571'>
+                  <choose line='1575'>
                    <fn name='exists'>
                     <varRef name='Q{}instanceField' slot='7'/>
                    </fn>
-                   <cvUntyped line='1572' to='xs:string' diag='3|0|XTTE0570|selectedValue'>
+                   <cvUntyped line='1576' to='xs:string' diag='3|0|XTTE0570|selectedValue'>
                     <cast as='xs:untypedAtomic' emptiable='0'>
                      <fn name='string'>
                       <convert from='xs:anyAtomicType' to='xs:string'>
@@ -6470,61 +6411,24 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='16' rank='1' minImp='0' slots='0' flags='s' line='1644' module='saxon-xforms.xsl'>
-    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
-    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1645' name='label' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
-     <sequence line='1646'>
-      <copyOf flags='vc'>
-       <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
-      </copyOf>
-      <choose line='1648'>
-       <fn name='exists'>
-        <axis name='child' nodeTest='( element() | text() | comment() | processing-instruction() )' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);'/>
-       </fn>
-       <applyT line='1649' bSlot='11'>
-        <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
-       </applyT>
-       <true/>
-       <valueOf flags='l'>
-        <str val=' '/>
-       </valueOf>
-      </choose>
-     </sequence>
-    </elem>
-   </templateRule>
-   <templateRule prec='0' prio='0.0' seq='25' part='5' rank='1' minImp='0' slots='1' flags='s' line='2052' module='saxon-xforms.xsl'>
-    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}unload)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;unload&#39;;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2060' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2061' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+   <templateRule prec='0' prio='0.0' seq='25' rank='1' minImp='0' slots='1' flags='s' line='2056' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}action)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;action&#39;;'/>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2064' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2065' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
       <check card='1' diag='3|0|XTTE0570|action-map'>
        <callT name='Q{}setAction' bSlot='2'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2062' type='element()'/>
+         <dot line='2066' type='element()'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <varRef line='2075' name='Q{}action-map' slot='0'/>
+     <varRef line='2079' name='Q{}action-map' slot='0'/>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='25' part='2' rank='1' minImp='0' slots='1' flags='s' line='2052' module='saxon-xforms.xsl'>
-    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}show)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;show&#39;;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2060' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2061' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
-      <check card='1' diag='3|0|XTTE0570|action-map'>
-       <callT name='Q{}setAction' bSlot='2'>
-        <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2062' type='element()'/>
-        </withParam>
-       </callT>
-      </check>
-     </treat>
-     <varRef line='2075' name='Q{}action-map' slot='0'/>
-    </let>
-   </templateRule>
-   <templateRule prec='0' prio='0.0' seq='10' rank='1' minImp='0' slots='17' flags='s' line='1237' module='saxon-xforms.xsl'>
-    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1238'>
+   <templateRule prec='0' prio='0.0' seq='19' rank='1' minImp='0' slots='15' flags='s' line='1732' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1733'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -6537,7 +6441,7 @@
        </check>
       </treat>
      </param>
-     <param line='1239' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1734' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -6549,7 +6453,1138 @@
        </check>
       </treat>
      </param>
-     <let line='1241' var='Q{}string-position' as='xs:string' slot='2' eval='16'>
+     <param line='1735' name='Q{}recalculate' slot='2' as='xs:boolean'>
+      <false role='select'/>
+      <treat role='conversion' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='8|0|XTTE0590|recalculate'>
+       <check card='1' diag='8|0|XTTE0590|recalculate'>
+        <cvUntyped to='xs:boolean' diag='8|0|XTTE0590|recalculate'>
+         <data>
+          <supplied slot='2'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <param line='1736' name='Q{}refreshRepeats' slot='3' as='xs:boolean'>
+      <false role='select'/>
+      <treat role='conversion' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='8|0|XTTE0590|refreshRepeats'>
+       <check card='1' diag='8|0|XTTE0590|refreshRepeats'>
+        <cvUntyped to='xs:boolean' diag='8|0|XTTE0590|refreshRepeats'>
+         <data>
+          <supplied slot='3'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <let line='1740' var='Q{}myid' as='xs:string' slot='4' eval='16'>
+      <choose>
+       <fn name='exists'>
+        <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+       </fn>
+       <check card='1' diag='3|0|XTTE0570|myid'>
+        <cvUntyped to='xs:string' diag='3|0|XTTE0570|myid'>
+         <attVal name='Q{}id' chk='0'/>
+        </cvUntyped>
+       </check>
+       <true/>
+       <fn name='concat'>
+        <fn name='generate-id'>
+         <dot type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
+        </fn>
+        <str val='-'/>
+        <choose line='1738'>
+         <varRef name='Q{}context-position' slot='1'/>
+         <varRef name='Q{}context-position' slot='1'/>
+         <true/>
+         <fn name='string'>
+          <varRef name='Q{}position' slot='0'/>
+         </fn>
+        </choose>
+       </fn>
+      </choose>
+      <sequence line='1748'>
+       <choose>
+        <varRef name='Q{}recalculate' slot='2'/>
+        <empty/>
+        <true/>
+        <ifCall line='1767' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+         <check card='1' diag='0|0||ixsl:call'>
+          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+         </check>
+         <str val='setRepeatIndex'/>
+         <arrayBlock>
+          <varRef name='Q{}myid' slot='4'/>
+          <choose line='1754'>
+           <fn name='empty'>
+            <axis name='attribute' nodeTest='attribute(Q{}startindex)' jsTest='return item.name===&#39;startindex&#39;'/>
+           </fn>
+           <dbl val='1'/>
+           <castable line='1757' as='xs:double' emptiable='0'>
+            <axis name='attribute' nodeTest='attribute(Q{}startindex)' jsTest='return item.name===&#39;startindex&#39;'/>
+           </castable>
+           <cvUntyped line='1758' to='xs:double' diag='3|0|XTTE0570|this-index'>
+            <convert from='xs:double' to='xs:untypedAtomic'>
+             <fn name='number'>
+              <attVal name='Q{}startindex' chk='0'/>
+             </fn>
+            </convert>
+           </cvUntyped>
+           <true/>
+           <dbl val='1'/>
+          </choose>
+         </arrayBlock>
+        </ifCall>
+       </choose>
+       <let line='1774' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1775' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+         <check card='?' diag='3|0|XTTE0570|bindingi'>
+          <callT name='Q{}getBinding' bSlot='10'>
+           <withParam name='Q{}this' flags='c' as='element()'>
+            <dot line='1776' type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
+           </withParam>
+          </callT>
+         </check>
+        </treat>
+        <let line='1781' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1782' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+          <check card='1' diag='3|0|XTTE0570|refi'>
+           <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
+            <data>
+             <callT name='Q{}getDataRef' bSlot='11'>
+              <withParam name='Q{}this' flags='c' as='element()'>
+               <dot line='1783' type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
+              </withParam>
+              <withParam name='Q{}bindingi' flags='c' as='node()?'>
+               <varRef line='1784' name='Q{}bindingi' slot='5'/>
+              </withParam>
+             </callT>
+            </data>
+           </cvUntyped>
+          </check>
+         </treat>
+         <let line='1790' var='Q{}selectedRepeatVar' as='element()*' slot='7' eval='8'>
+          <treat line='1792' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|selectedRepeatVar'>
+           <callT name='Q{}getReferencedInstanceField' bSlot='12'>
+            <withParam name='Q{}refi' flags='c' as='xs:string'>
+             <varRef line='1793' name='Q{}refi' slot='6'/>
+            </withParam>
+           </callT>
+          </treat>
+          <let line='1808' var='Q{}repeat-items' as='element(Q{}div, Q{http://www.w3.org/2001/XMLSchema}untyped)*' slot='8' eval='3'>
+           <let line='1809' var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}repeat)' slot='9' eval='16'>
+            <dot type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
+            <let line='1814' var='Q{http://saxon.sf.net/generated-variable}v0' as='element()*' slot='10' eval='4'>
+             <slash simple='1'>
+              <varRef name='Q{}this' slot='9'/>
+              <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+             </slash>
+             <forEach line='1810'>
+              <varRef name='Q{}selectedRepeatVar' slot='7'/>
+              <let line='1811' var='Q{}string-position' as='xs:string' slot='11' eval='8'>
+               <fn name='string'>
+                <fn name='position'/>
+               </fn>
+               <elem line='1813' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+                <sequence>
+                 <att name='data-repeat-item' flags='l'>
+                  <str val='true'/>
+                 </att>
+                 <applyT line='1814' bSlot='13'>
+                  <varRef role='select' name='Q{http://saxon.sf.net/generated-variable}v0' slot='10'/>
+                  <withParam name='Q{}position' as='xs:integer'>
+                   <fn line='1816' name='position'/>
+                  </withParam>
+                  <withParam name='Q{}context-position' as='xs:string'>
+                   <choose line='1812'>
+                    <varRef name='Q{}context-position' slot='1'/>
+                    <fn name='concat'>
+                     <varRef name='Q{}context-position' slot='1'/>
+                     <str val='.'/>
+                     <varRef name='Q{}string-position' slot='11'/>
+                    </fn>
+                    <true/>
+                    <varRef name='Q{}string-position' slot='11'/>
+                   </choose>
+                  </withParam>
+                  <withParam name='Q{}nodeset' flags='t' as='xs:string'>
+                   <fn line='1815' name='concat'>
+                    <varRef name='Q{}refi' slot='6'/>
+                    <str val='['/>
+                    <fn name='position'/>
+                    <str val=']'/>
+                   </fn>
+                  </withParam>
+                 </applyT>
+                </sequence>
+               </elem>
+              </let>
+             </forEach>
+            </let>
+           </let>
+           <sequence line='1825'>
+            <choose>
+             <varRef name='Q{}refreshRepeats' slot='3'/>
+             <varRef line='1826' name='Q{}repeat-items' slot='8'/>
+             <true/>
+             <elem line='1829' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+              <sequence line='1830'>
+               <let var='Q{}element' as='element(Q{http://www.w3.org/2002/xforms}repeat)' slot='12' eval='16'>
+                <dot type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
+                <let line='2608' var='Q{}class' as='xs:string?' slot='13' eval='7'>
+                 <choose line='2609'>
+                  <fn name='exists'>
+                   <slash simple='1'>
+                    <varRef name='Q{}element' slot='12'/>
+                    <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
+                   </slash>
+                  </fn>
+                  <cvUntyped line='2610' to='xs:string' diag='3|0|XTTE0570|class'>
+                   <cast as='xs:untypedAtomic' emptiable='0'>
+                    <fn name='string'>
+                     <convert from='xs:untypedAtomic' to='xs:string'>
+                      <data>
+                       <slash simple='1'>
+                        <varRef name='Q{}element' slot='12'/>
+                        <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
+                       </slash>
+                      </data>
+                     </convert>
+                    </fn>
+                   </cast>
+                  </cvUntyped>
+                 </choose>
+                 <let line='2613' var='Q{}class-mod' as='xs:string?' slot='14' eval='7'>
+                  <choose line='2615'>
+                   <fn name='exists'>
+                    <slash simple='1'>
+                     <varRef name='Q{}element' slot='12'/>
+                     <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
+                    </slash>
+                   </fn>
+                   <cvUntyped line='2616' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                    <cast as='xs:untypedAtomic' emptiable='0'>
+                     <fn name='string-join'>
+                      <sequence>
+                       <varRef name='Q{}class' slot='13'/>
+                       <str val='incremental'/>
+                      </sequence>
+                      <str val=' '/>
+                     </fn>
+                    </cast>
+                   </cvUntyped>
+                   <true/>
+                   <varRef line='2619' name='Q{}class' slot='13'/>
+                  </choose>
+                  <choose line='2623'>
+                   <fn name='exists'>
+                    <varRef name='Q{}class-mod' slot='14'/>
+                   </fn>
+                   <treat line='2624' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                    <att name='class' flags='l'>
+                     <varRef name='Q{}class-mod' slot='14'/>
+                    </att>
+                   </treat>
+                  </choose>
+                 </let>
+                </let>
+               </let>
+               <att line='1832' name='data-repeatable-context' flags='l'>
+                <varRef name='Q{}refi' slot='6'/>
+               </att>
+               <att line='1833' name='data-count' flags='l'>
+                <convert from='xs:integer' to='xs:string'>
+                 <fn name='count'>
+                  <varRef name='Q{}selectedRepeatVar' slot='7'/>
+                 </fn>
+                </convert>
+               </att>
+               <att line='1834' name='id' flags='l'>
+                <varRef name='Q{}myid' slot='4'/>
+               </att>
+               <varRef line='1836' name='Q{}repeat-items' slot='8'/>
+              </sequence>
+             </elem>
+            </choose>
+            <choose line='1844'>
+             <and op='and'>
+              <fn name='not'>
+               <varRef name='Q{}recalculate' slot='2'/>
+              </fn>
+              <fn name='empty'>
+               <slash simple='1'>
+                <dot type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
+                <axis name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
+               </slash>
+              </fn>
+             </and>
+             <ifCall line='1848' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+              <check card='1' diag='0|0||ixsl:call'>
+               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+              </check>
+              <str val='addRepeat'/>
+              <arrayBlock>
+               <varRef name='Q{}myid' slot='4'/>
+               <varRef name='Q{}refi' slot='6'/>
+              </arrayBlock>
+             </ifCall>
+            </choose>
+            <ifCall line='1852' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+             <check card='1' diag='0|0||ixsl:call'>
+              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+             </check>
+             <str val='setRepeatSize'/>
+             <arrayBlock>
+              <varRef name='Q{}myid' slot='4'/>
+              <fn name='count'>
+               <varRef name='Q{}selectedRepeatVar' slot='7'/>
+              </fn>
+             </arrayBlock>
+            </ifCall>
+           </sequence>
+          </let>
+         </let>
+        </let>
+       </let>
+      </sequence>
+     </let>
+    </sequence>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='5' rank='1' minImp='0' slots='0' flags='s' line='1055' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
+    <applyT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1056' flags='t' bSlot='14'>
+     <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
+    </applyT>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='18' rank='1' minImp='0' slots='6' flags='s' line='1688' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}group)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;group&#39;;'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1689'>
+     <param name='Q{}position' slot='0' as='xs:integer'>
+      <int role='select' val='0'/>
+      <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
+       <check card='1' diag='8|0|XTTE0590|position'>
+        <cvUntyped to='xs:integer' diag='8|0|XTTE0590|position'>
+         <data>
+          <supplied slot='0'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <param line='1690' name='Q{}context-position' slot='1' as='xs:string'>
+      <str role='select' val=''/>
+      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
+       <check card='1' diag='8|0|XTTE0590|context-position'>
+        <cvUntyped to='xs:string' diag='8|0|XTTE0590|context-position'>
+         <data>
+          <supplied slot='1'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <let line='1694' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+      <choose>
+       <fn name='exists'>
+        <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+       </fn>
+       <check card='1' diag='3|0|XTTE0570|myid'>
+        <cvUntyped to='xs:string' diag='3|0|XTTE0570|myid'>
+         <attVal name='Q{}id' chk='0'/>
+        </cvUntyped>
+       </check>
+       <true/>
+       <fn name='concat'>
+        <fn name='generate-id'>
+         <dot type='element(Q{http://www.w3.org/2002/xforms}group)'/>
+        </fn>
+        <str val='-'/>
+        <choose line='1692'>
+         <varRef name='Q{}context-position' slot='1'/>
+         <varRef name='Q{}context-position' slot='1'/>
+         <true/>
+         <fn name='string'>
+          <varRef name='Q{}position' slot='0'/>
+         </fn>
+        </choose>
+       </fn>
+      </choose>
+      <sequence line='1696'>
+       <choose>
+        <and op='and'>
+         <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}group)' slot='3' eval='16'>
+          <dot type='element(Q{http://www.w3.org/2002/xforms}group)'/>
+          <fn line='2536' name='exists'>
+           <sequence line='2511'>
+            <analyzeString>
+             <cvUntyped role='select' to='xs:string'>
+              <data>
+               <slash simple='1'>
+                <varRef name='Q{}this' slot='3'/>
+                <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+               </slash>
+              </data>
+             </cvUntyped>
+             <str role='regex' val='\i\c*\('/>
+             <str role='flags' val=''/>
+             <choose role='matching' line='2514'>
+              <vc op='eq' onEmpty='0' comp='CCC'>
+               <fn name='substring-before'>
+                <dot type='xs:string'/>
+                <str val='('/>
+               </fn>
+               <str val='index'/>
+              </vc>
+              <str val='i'/>
+             </choose>
+             <empty role='nonMatching'/>
+            </analyzeString>
+            <analyzeString line='2523'>
+             <cvUntyped role='select' to='xs:string'>
+              <data>
+               <slash simple='1'>
+                <varRef name='Q{}this' slot='3'/>
+                <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+               </slash>
+              </data>
+             </cvUntyped>
+             <str role='regex' val='\i\c*\('/>
+             <str role='flags' val=''/>
+             <choose role='matching' line='2526'>
+              <vc op='eq' onEmpty='0' comp='CCC'>
+               <fn name='substring-before'>
+                <dot type='xs:string'/>
+                <str val='('/>
+               </fn>
+               <str val='index'/>
+              </vc>
+              <str val='i'/>
+             </choose>
+             <empty role='nonMatching'/>
+            </analyzeString>
+           </sequence>
+          </fn>
+         </let>
+         <fn name='empty'>
+          <filter flags='b'>
+           <slash simple='1'>
+            <dot type='element(Q{http://www.w3.org/2002/xforms}group)'/>
+            <axis name='ancestor' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+           </slash>
+           <let var='Q{}this' as='element()' slot='4' eval='16'>
+            <dot type='element()'/>
+            <fn line='2536' name='exists'>
+             <sequence line='2511'>
+              <analyzeString>
+               <cvUntyped role='select' to='xs:string'>
+                <data>
+                 <slash simple='1'>
+                  <varRef name='Q{}this' slot='4'/>
+                  <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+                 </slash>
+                </data>
+               </cvUntyped>
+               <str role='regex' val='\i\c*\('/>
+               <str role='flags' val=''/>
+               <choose role='matching' line='2514'>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <fn name='substring-before'>
+                  <dot type='xs:string'/>
+                  <str val='('/>
+                 </fn>
+                 <str val='index'/>
+                </vc>
+                <str val='i'/>
+               </choose>
+               <empty role='nonMatching'/>
+              </analyzeString>
+              <analyzeString line='2523'>
+               <cvUntyped role='select' to='xs:string'>
+                <data>
+                 <slash simple='1'>
+                  <varRef name='Q{}this' slot='4'/>
+                  <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+                 </slash>
+                </data>
+               </cvUntyped>
+               <str role='regex' val='\i\c*\('/>
+               <str role='flags' val=''/>
+               <choose role='matching' line='2526'>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <fn name='substring-before'>
+                  <dot type='xs:string'/>
+                  <str val='('/>
+                 </fn>
+                 <str val='index'/>
+                </vc>
+                <str val='i'/>
+               </choose>
+               <empty role='nonMatching'/>
+              </analyzeString>
+             </sequence>
+            </fn>
+           </let>
+          </filter>
+         </fn>
+        </and>
+        <ifCall line='1697' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+         <check card='1' diag='0|0||ixsl:call'>
+          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+         </check>
+         <str val='setElementUsingIndexFunction'/>
+         <arrayBlock>
+          <varRef name='Q{}myid' slot='2'/>
+          <dot type='element(Q{http://www.w3.org/2002/xforms}group)'/>
+         </arrayBlock>
+        </ifCall>
+       </choose>
+       <let line='1700' var='Q{}refi' as='xs:string?' slot='5' eval='7'>
+        <choose line='1702'>
+         <fn name='exists'>
+          <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+         </fn>
+         <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
+          <attVal name='Q{}nodeset' chk='0'/>
+         </cvUntyped>
+         <fn line='1703' name='exists'>
+          <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+         </fn>
+         <cvUntyped line='1703' to='xs:string' diag='3|0|XTTE0570|refi'>
+          <attVal name='Q{}ref' chk='0'/>
+         </cvUntyped>
+        </choose>
+        <elem line='1709' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+         <sequence line='1710'>
+          <att name='id' flags='l'>
+           <varRef name='Q{}myid' slot='2'/>
+          </att>
+          <choose line='1711'>
+           <fn name='exists'>
+            <varRef name='Q{}refi' slot='5'/>
+           </fn>
+           <att line='1712' name='data-group-ref' flags='l'>
+            <varRef name='Q{}refi' slot='5'/>
+           </att>
+          </choose>
+          <applyT line='1714' bSlot='15'>
+           <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+           <withParam name='Q{}nodeset' flags='t' as='xs:string?'>
+            <choose line='1715'>
+             <fn name='exists'>
+              <varRef name='Q{}refi' slot='5'/>
+             </fn>
+             <varRef name='Q{}refi' slot='5'/>
+             <true/>
+             <str val=''/>
+            </choose>
+           </withParam>
+          </applyT>
+         </sequence>
+        </elem>
+       </let>
+      </sequence>
+     </let>
+    </sequence>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='25' part='3' rank='1' minImp='0' slots='1' flags='s' line='2056' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}hide)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;hide&#39;;'/>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2064' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2065' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+      <check card='1' diag='3|0|XTTE0570|action-map'>
+       <callT name='Q{}setAction' bSlot='2'>
+        <withParam name='Q{}this' flags='c' as='element()'>
+         <dot line='2066' type='element()'/>
+        </withParam>
+       </callT>
+      </check>
+     </treat>
+     <varRef line='2079' name='Q{}action-map' slot='0'/>
+    </let>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='12' rank='1' minImp='0' slots='0' flags='s' line='1512' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}hint)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;hint&#39;;'/>
+    <empty role='action'/>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='20' rank='1' minImp='0' slots='2' flags='s' line='1865' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}submit)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;submit&#39;;'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1866'>
+     <param name='Q{}submissions' slot='0' flags='t' as='map(xs:string, map(*))'>
+      <map role='select' size='0'/>
+      <treat role='conversion' as='map(xs:string, map(*))' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isMap(item)};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|submissions'>
+       <check card='1' diag='8|0|XTTE0590|submissions'>
+        <supplied slot='0'/>
+       </check>
+      </treat>
+     </param>
+     <let line='1872' var='Q{}innerbody' as='document-node()' slot='1' eval='16'>
+      <doc line='1873' validation='preserve'>
+       <applyT bSlot='16'>
+        <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
+       </applyT>
+      </doc>
+      <choose line='1877'>
+       <vc op='eq' onEmpty='0' comp='CCC'>
+        <cast as='xs:string' emptiable='1'>
+         <attVal name='Q{}appearance' chk='0'/>
+        </cast>
+        <str val='minimal'/>
+       </vc>
+       <elem line='1878' name='a' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+        <copyOf line='1879' flags='vc'>
+         <varRef name='Q{}innerbody' slot='1'/>
+        </copyOf>
+       </elem>
+       <true/>
+       <elem line='1883' name='button' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+        <sequence>
+         <att name='type' flags='l'>
+          <str val='button'/>
+         </att>
+         <copyOf line='1884' flags='vc'>
+          <filter flags='b'>
+           <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+           <vc op='ne' onEmpty='0' comp='CCC'>
+            <fn name='local-name'>
+             <dot type='attribute()'/>
+            </fn>
+            <str val='submission'/>
+           </vc>
+          </filter>
+         </copyOf>
+         <choose line='1885'>
+          <and op='and'>
+           <fn name='exists'>
+            <axis name='attribute' nodeTest='attribute(Q{}submission)' jsTest='return item.name===&#39;submission&#39;'/>
+           </fn>
+           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+            <varRef name='Q{}submissions' slot='0'/>
+            <atomSing diag='0|1||map:contains'>
+             <axis name='attribute' nodeTest='attribute(Q{}submission)' jsTest='return item.name===&#39;submission&#39;'/>
+            </atomSing>
+           </ifCall>
+          </and>
+          <att line='1887' name='data-submit' flags='l'>
+           <convert from='xs:untypedAtomic' to='xs:string'>
+            <attVal name='Q{}submission' chk='0'/>
+           </convert>
+          </att>
+         </choose>
+         <copyOf line='1889' flags='vc'>
+          <varRef name='Q{}innerbody' slot='1'/>
+         </copyOf>
+        </sequence>
+       </elem>
+      </choose>
+     </let>
+    </sequence>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='13' rank='1' minImp='0' slots='12' flags='s' line='1523' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}select1)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;select1&#39;;'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1524'>
+     <param name='Q{}position' slot='0' as='xs:integer'>
+      <int role='select' val='0'/>
+      <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
+       <check card='1' diag='8|0|XTTE0590|position'>
+        <cvUntyped to='xs:integer' diag='8|0|XTTE0590|position'>
+         <data>
+          <supplied slot='0'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <param line='1525' name='Q{}context-position' slot='1' as='xs:string'>
+      <str role='select' val=''/>
+      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
+       <check card='1' diag='8|0|XTTE0590|context-position'>
+        <cvUntyped to='xs:string' diag='8|0|XTTE0590|context-position'>
+         <data>
+          <supplied slot='1'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <let line='1529' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+      <choose>
+       <fn name='exists'>
+        <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+       </fn>
+       <check card='1' diag='3|0|XTTE0570|myid'>
+        <cvUntyped to='xs:string' diag='3|0|XTTE0570|myid'>
+         <attVal name='Q{}id' chk='0'/>
+        </cvUntyped>
+       </check>
+       <true/>
+       <fn name='concat'>
+        <fn name='generate-id'>
+         <dot type='element()'/>
+        </fn>
+        <str val='-'/>
+        <choose line='1527'>
+         <varRef name='Q{}context-position' slot='1'/>
+         <varRef name='Q{}context-position' slot='1'/>
+         <true/>
+         <fn name='string'>
+          <varRef name='Q{}position' slot='0'/>
+         </fn>
+        </choose>
+       </fn>
+      </choose>
+      <sequence line='1531'>
+       <choose>
+        <and op='and'>
+         <let var='Q{}this' as='element()' slot='3' eval='16'>
+          <dot type='element()'/>
+          <fn line='2536' name='exists'>
+           <sequence line='2511'>
+            <analyzeString>
+             <cvUntyped role='select' to='xs:string'>
+              <data>
+               <slash simple='1'>
+                <varRef name='Q{}this' slot='3'/>
+                <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+               </slash>
+              </data>
+             </cvUntyped>
+             <str role='regex' val='\i\c*\('/>
+             <str role='flags' val=''/>
+             <choose role='matching' line='2514'>
+              <vc op='eq' onEmpty='0' comp='CCC'>
+               <fn name='substring-before'>
+                <dot type='xs:string'/>
+                <str val='('/>
+               </fn>
+               <str val='index'/>
+              </vc>
+              <str val='i'/>
+             </choose>
+             <empty role='nonMatching'/>
+            </analyzeString>
+            <analyzeString line='2523'>
+             <cvUntyped role='select' to='xs:string'>
+              <data>
+               <slash simple='1'>
+                <varRef name='Q{}this' slot='3'/>
+                <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+               </slash>
+              </data>
+             </cvUntyped>
+             <str role='regex' val='\i\c*\('/>
+             <str role='flags' val=''/>
+             <choose role='matching' line='2526'>
+              <vc op='eq' onEmpty='0' comp='CCC'>
+               <fn name='substring-before'>
+                <dot type='xs:string'/>
+                <str val='('/>
+               </fn>
+               <str val='index'/>
+              </vc>
+              <str val='i'/>
+             </choose>
+             <empty role='nonMatching'/>
+            </analyzeString>
+           </sequence>
+          </fn>
+         </let>
+         <fn name='empty'>
+          <filter flags='b'>
+           <slash simple='1'>
+            <dot type='element()'/>
+            <axis name='ancestor' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+           </slash>
+           <let var='Q{}this' as='element()' slot='4' eval='16'>
+            <dot type='element()'/>
+            <fn line='2536' name='exists'>
+             <sequence line='2511'>
+              <analyzeString>
+               <cvUntyped role='select' to='xs:string'>
+                <data>
+                 <slash simple='1'>
+                  <varRef name='Q{}this' slot='4'/>
+                  <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+                 </slash>
+                </data>
+               </cvUntyped>
+               <str role='regex' val='\i\c*\('/>
+               <str role='flags' val=''/>
+               <choose role='matching' line='2514'>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <fn name='substring-before'>
+                  <dot type='xs:string'/>
+                  <str val='('/>
+                 </fn>
+                 <str val='index'/>
+                </vc>
+                <str val='i'/>
+               </choose>
+               <empty role='nonMatching'/>
+              </analyzeString>
+              <analyzeString line='2523'>
+               <cvUntyped role='select' to='xs:string'>
+                <data>
+                 <slash simple='1'>
+                  <varRef name='Q{}this' slot='4'/>
+                  <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+                 </slash>
+                </data>
+               </cvUntyped>
+               <str role='regex' val='\i\c*\('/>
+               <str role='flags' val=''/>
+               <choose role='matching' line='2526'>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <fn name='substring-before'>
+                  <dot type='xs:string'/>
+                  <str val='('/>
+                 </fn>
+                 <str val='index'/>
+                </vc>
+                <str val='i'/>
+               </choose>
+               <empty role='nonMatching'/>
+              </analyzeString>
+             </sequence>
+            </fn>
+           </let>
+          </filter>
+         </fn>
+        </and>
+        <ifCall line='1532' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+         <check card='1' diag='0|0||ixsl:call'>
+          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+         </check>
+         <str val='setElementUsingIndexFunction'/>
+         <arrayBlock>
+          <varRef name='Q{}myid' slot='2'/>
+          <dot type='element()'/>
+         </arrayBlock>
+        </ifCall>
+       </choose>
+       <let line='1539' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1540' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+         <check card='?' diag='3|0|XTTE0570|bindingi'>
+          <callT name='Q{}getBinding' bSlot='4'>
+           <withParam name='Q{}this' flags='c' as='element()'>
+            <dot line='1541' type='element()'/>
+           </withParam>
+          </callT>
+         </check>
+        </treat>
+        <let line='1546' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1547' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+          <check card='1' diag='3|0|XTTE0570|refi'>
+           <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
+            <data>
+             <callT name='Q{}getDataRef' bSlot='5'>
+              <withParam name='Q{}this' flags='c' as='element()'>
+               <dot line='1548' type='element()'/>
+              </withParam>
+              <withParam name='Q{}bindingi' flags='c' as='node()?'>
+               <varRef line='1549' name='Q{}bindingi' slot='5'/>
+              </withParam>
+             </callT>
+            </data>
+           </cvUntyped>
+          </check>
+         </treat>
+         <let line='1554' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
+          <treat line='1555' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+           <check card='?' diag='3|0|XTTE0570|instanceField'>
+            <callT name='Q{}getReferencedInstanceField' bSlot='6'>
+             <withParam name='Q{}refi' flags='c' as='xs:string'>
+              <varRef line='1556' name='Q{}refi' slot='6'/>
+             </withParam>
+            </callT>
+           </check>
+          </treat>
+          <let line='1561' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
+           <treat line='1562' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+            <callT name='Q{}setActions' bSlot='7'>
+             <withParam name='Q{}this' flags='c' as='element()'>
+              <dot line='1563' type='element()'/>
+             </withParam>
+             <withParam name='Q{}nodeset' flags='t' as='xs:string'>
+              <varRef line='1564' name='Q{}refi' slot='6'/>
+             </withParam>
+            </callT>
+           </treat>
+           <sequence line='1568'>
+            <choose>
+             <fn name='exists'>
+              <varRef name='Q{}actions' slot='8'/>
+             </fn>
+             <ifCall line='1569' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+              <check card='1' diag='0|0||ixsl:call'>
+               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+              </check>
+              <str val='addAction'/>
+              <arrayBlock>
+               <varRef name='Q{}myid' slot='2'/>
+               <varRef name='Q{}actions' slot='8'/>
+              </arrayBlock>
+             </ifCall>
+            </choose>
+            <elem line='1586' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+             <sequence>
+              <att name='class' flags='l'>
+               <str val='xforms-select'/>
+              </att>
+              <applyT line='1587' bSlot='8'>
+               <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
+              </applyT>
+              <elem line='1589' name='select' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
+               <sequence line='1590'>
+                <let var='Q{}element' as='element()' slot='9' eval='16'>
+                 <dot type='element()'/>
+                 <let line='2608' var='Q{}class' as='xs:string?' slot='10' eval='7'>
+                  <choose line='2609'>
+                   <fn name='exists'>
+                    <slash simple='1'>
+                     <varRef name='Q{}element' slot='9'/>
+                     <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
+                    </slash>
+                   </fn>
+                   <cvUntyped line='2610' to='xs:string' diag='3|0|XTTE0570|class'>
+                    <cast as='xs:untypedAtomic' emptiable='0'>
+                     <fn name='string'>
+                      <convert from='xs:untypedAtomic' to='xs:string'>
+                       <data>
+                        <slash simple='1'>
+                         <varRef name='Q{}element' slot='9'/>
+                         <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
+                        </slash>
+                       </data>
+                      </convert>
+                     </fn>
+                    </cast>
+                   </cvUntyped>
+                  </choose>
+                  <let line='2613' var='Q{}class-mod' as='xs:string?' slot='11' eval='7'>
+                   <choose line='2615'>
+                    <fn name='exists'>
+                     <slash simple='1'>
+                      <varRef name='Q{}element' slot='9'/>
+                      <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
+                     </slash>
+                    </fn>
+                    <cvUntyped line='2616' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                     <cast as='xs:untypedAtomic' emptiable='0'>
+                      <fn name='string-join'>
+                       <sequence>
+                        <varRef name='Q{}class' slot='10'/>
+                        <str val='incremental'/>
+                       </sequence>
+                       <str val=' '/>
+                      </fn>
+                     </cast>
+                    </cvUntyped>
+                    <true/>
+                    <varRef line='2619' name='Q{}class' slot='10'/>
+                   </choose>
+                   <choose line='2623'>
+                    <fn name='exists'>
+                     <varRef name='Q{}class-mod' slot='11'/>
+                    </fn>
+                    <treat line='2624' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                     <att name='class' flags='l'>
+                      <varRef name='Q{}class-mod' slot='11'/>
+                     </att>
+                    </treat>
+                   </choose>
+                  </let>
+                 </let>
+                </let>
+                <copyOf line='1591' flags='vc'>
+                 <except op='except'>
+                  <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+                  <docOrder intra='1'>
+                   <sequence>
+                    <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
+                    <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
+                    <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
+                   </sequence>
+                  </docOrder>
+                 </except>
+                </copyOf>
+                <att line='1593' name='data-ref' flags='l'>
+                 <varRef name='Q{}refi' slot='6'/>
+                </att>
+                <att line='1594' name='data-element' flags='l'>
+                 <lastOf line='1584'>
+                  <fn name='tokenize'>
+                   <varRef name='Q{}refi' slot='6'/>
+                   <str val='/'/>
+                   <str val=''/>
+                  </fn>
+                 </lastOf>
+                </att>
+                <choose line='1596'>
+                 <and op='and'>
+                  <fn name='exists'>
+                   <varRef name='Q{}bindingi' slot='5'/>
+                  </fn>
+                  <fn name='exists'>
+                   <slash simple='1'>
+                    <varRef name='Q{}bindingi' slot='5'/>
+                    <axis name='attribute' nodeTest='attribute(Q{}constraint)' jsTest='return item.name===&#39;constraint&#39;'/>
+                   </slash>
+                  </fn>
+                 </and>
+                 <att line='1597' name='data-constraint' flags='l'>
+                  <convert from='xs:untypedAtomic' to='xs:string'>
+                   <data>
+                    <slash simple='1'>
+                     <varRef name='Q{}bindingi' slot='5'/>
+                     <axis name='attribute' nodeTest='attribute(Q{}constraint)' jsTest='return item.name===&#39;constraint&#39;'/>
+                    </slash>
+                   </data>
+                  </convert>
+                 </att>
+                </choose>
+                <choose line='1600'>
+                 <vc op='eq' onEmpty='0' comp='CCC'>
+                  <fn name='local-name'>
+                   <dot type='element()'/>
+                  </fn>
+                  <str val='select'/>
+                 </vc>
+                 <sequence line='1601'>
+                  <att name='multiple' flags='l'>
+                   <str val='true'/>
+                  </att>
+                  <att line='1602' name='size' flags='l'>
+                   <convert line='1603' from='xs:integer' to='xs:string'>
+                    <fn name='count'>
+                     <axis name='descendant' nodeTest='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
+                    </fn>
+                   </convert>
+                  </att>
+                 </sequence>
+                </choose>
+                <choose line='1606'>
+                 <fn name='exists'>
+                  <varRef name='Q{}actions' slot='8'/>
+                 </fn>
+                 <att line='1607' name='data-action' flags='l'>
+                  <varRef name='Q{}myid' slot='2'/>
+                 </att>
+                </choose>
+                <applyT line='1610' bSlot='9'>
+                 <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
+                 <withParam name='Q{}selectedValue' as='xs:string'>
+                  <choose line='1575'>
+                   <fn name='exists'>
+                    <varRef name='Q{}instanceField' slot='7'/>
+                   </fn>
+                   <cvUntyped line='1576' to='xs:string' diag='3|0|XTTE0570|selectedValue'>
+                    <cast as='xs:untypedAtomic' emptiable='0'>
+                     <fn name='string'>
+                      <convert from='xs:anyAtomicType' to='xs:string'>
+                       <data>
+                        <varRef name='Q{}instanceField' slot='7'/>
+                       </data>
+                      </convert>
+                     </fn>
+                    </cast>
+                   </cvUntyped>
+                   <true/>
+                   <str val=''/>
+                  </choose>
+                 </withParam>
+                </applyT>
+               </sequence>
+              </elem>
+             </sequence>
+            </elem>
+           </sequence>
+          </let>
+         </let>
+        </let>
+       </let>
+      </sequence>
+     </let>
+    </sequence>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='16' rank='1' minImp='0' slots='0' flags='s' line='1648' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
+    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1649' name='label' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+     <sequence line='1650'>
+      <copyOf flags='vc'>
+       <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
+      </copyOf>
+      <choose line='1652'>
+       <fn name='exists'>
+        <axis name='child' nodeTest='( element() | text() | comment() | processing-instruction() )' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);'/>
+       </fn>
+       <applyT line='1653' bSlot='17'>
+        <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
+       </applyT>
+       <true/>
+       <valueOf flags='l'>
+        <str val=' '/>
+       </valueOf>
+      </choose>
+     </sequence>
+    </elem>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='25' part='5' rank='1' minImp='0' slots='1' flags='s' line='2056' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}unload)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;unload&#39;;'/>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2064' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2065' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+      <check card='1' diag='3|0|XTTE0570|action-map'>
+       <callT name='Q{}setAction' bSlot='2'>
+        <withParam name='Q{}this' flags='c' as='element()'>
+         <dot line='2066' type='element()'/>
+        </withParam>
+       </callT>
+      </check>
+     </treat>
+     <varRef line='2079' name='Q{}action-map' slot='0'/>
+    </let>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='25' part='2' rank='1' minImp='0' slots='1' flags='s' line='2056' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}show)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;show&#39;;'/>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2064' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2065' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+      <check card='1' diag='3|0|XTTE0570|action-map'>
+       <callT name='Q{}setAction' bSlot='2'>
+        <withParam name='Q{}this' flags='c' as='element()'>
+         <dot line='2066' type='element()'/>
+        </withParam>
+       </callT>
+      </check>
+     </treat>
+     <varRef line='2079' name='Q{}action-map' slot='0'/>
+    </let>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='10' rank='1' minImp='0' slots='17' flags='s' line='1241' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1242'>
+     <param name='Q{}position' slot='0' as='xs:integer'>
+      <int role='select' val='0'/>
+      <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
+       <check card='1' diag='8|0|XTTE0590|position'>
+        <cvUntyped to='xs:integer' diag='8|0|XTTE0590|position'>
+         <data>
+          <supplied slot='0'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <param line='1243' name='Q{}context-position' slot='1' as='xs:string'>
+      <str role='select' val=''/>
+      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
+       <check card='1' diag='8|0|XTTE0590|context-position'>
+        <cvUntyped to='xs:string' diag='8|0|XTTE0590|context-position'>
+         <data>
+          <supplied slot='1'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </treat>
+     </param>
+     <let line='1245' var='Q{}string-position' as='xs:string' slot='2' eval='16'>
       <choose>
        <varRef name='Q{}context-position' slot='1'/>
        <varRef name='Q{}context-position' slot='1'/>
@@ -6558,7 +7593,7 @@
         <varRef name='Q{}position' slot='0'/>
        </fn>
       </choose>
-      <let line='1243' var='Q{}myid' as='xs:string' slot='3' eval='16'>
+      <let line='1247' var='Q{}myid' as='xs:string' slot='3' eval='16'>
        <choose>
         <fn name='exists'>
          <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -6577,13 +7612,13 @@
          <varRef name='Q{}string-position' slot='2'/>
         </fn>
        </choose>
-       <sequence line='1245'>
+       <sequence line='1249'>
         <choose>
          <and op='and'>
           <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}input)' slot='4' eval='16'>
            <dot type='element(Q{http://www.w3.org/2002/xforms}input)'/>
-           <fn line='2532' name='exists'>
-            <sequence line='2507'>
+           <fn line='2536' name='exists'>
+            <sequence line='2511'>
              <analyzeString>
               <cvUntyped role='select' to='xs:string'>
                <data>
@@ -6595,7 +7630,7 @@
               </cvUntyped>
               <str role='regex' val='\i\c*\('/>
               <str role='flags' val=''/>
-              <choose role='matching' line='2510'>
+              <choose role='matching' line='2514'>
                <vc op='eq' onEmpty='0' comp='CCC'>
                 <fn name='substring-before'>
                  <dot type='xs:string'/>
@@ -6607,7 +7642,7 @@
               </choose>
               <empty role='nonMatching'/>
              </analyzeString>
-             <analyzeString line='2519'>
+             <analyzeString line='2523'>
               <cvUntyped role='select' to='xs:string'>
                <data>
                 <slash simple='1'>
@@ -6618,7 +7653,7 @@
               </cvUntyped>
               <str role='regex' val='\i\c*\('/>
               <str role='flags' val=''/>
-              <choose role='matching' line='2522'>
+              <choose role='matching' line='2526'>
                <vc op='eq' onEmpty='0' comp='CCC'>
                 <fn name='substring-before'>
                  <dot type='xs:string'/>
@@ -6641,8 +7676,8 @@
             </slash>
             <let var='Q{}this' as='element()' slot='5' eval='16'>
              <dot type='element()'/>
-             <fn line='2532' name='exists'>
-              <sequence line='2507'>
+             <fn line='2536' name='exists'>
+              <sequence line='2511'>
                <analyzeString>
                 <cvUntyped role='select' to='xs:string'>
                  <data>
@@ -6654,7 +7689,7 @@
                 </cvUntyped>
                 <str role='regex' val='\i\c*\('/>
                 <str role='flags' val=''/>
-                <choose role='matching' line='2510'>
+                <choose role='matching' line='2514'>
                  <vc op='eq' onEmpty='0' comp='CCC'>
                   <fn name='substring-before'>
                    <dot type='xs:string'/>
@@ -6666,7 +7701,7 @@
                 </choose>
                 <empty role='nonMatching'/>
                </analyzeString>
-               <analyzeString line='2519'>
+               <analyzeString line='2523'>
                 <cvUntyped role='select' to='xs:string'>
                  <data>
                   <slash simple='1'>
@@ -6677,7 +7712,7 @@
                 </cvUntyped>
                 <str role='regex' val='\i\c*\('/>
                 <str role='flags' val=''/>
-                <choose role='matching' line='2522'>
+                <choose role='matching' line='2526'>
                  <vc op='eq' onEmpty='0' comp='CCC'>
                   <fn name='substring-before'>
                    <dot type='xs:string'/>
@@ -6695,7 +7730,7 @@
            </filter>
           </fn>
          </and>
-         <ifCall line='1246' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+         <ifCall line='1250' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
           <check card='1' diag='0|0||ixsl:call'>
            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
           </check>
@@ -6706,45 +7741,45 @@
           </arrayBlock>
          </ifCall>
         </choose>
-        <let line='1254' var='Q{}bindingi' as='node()?' slot='6' eval='7'>
-         <treat line='1255' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+        <let line='1258' var='Q{}bindingi' as='node()?' slot='6' eval='7'>
+         <treat line='1259' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
           <check card='?' diag='3|0|XTTE0570|bindingi'>
-           <callT name='Q{}getBinding' bSlot='12'>
+           <callT name='Q{}getBinding' bSlot='18'>
             <withParam name='Q{}this' flags='c' as='element()'>
-             <dot line='1256' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
+             <dot line='1260' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
             </withParam>
            </callT>
           </check>
          </treat>
-         <let line='1264' var='Q{}refi' as='xs:string' slot='7' eval='16'>
-          <treat line='1265' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+         <let line='1268' var='Q{}refi' as='xs:string' slot='7' eval='16'>
+          <treat line='1269' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
            <check card='1' diag='3|0|XTTE0570|refi'>
             <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
              <data>
-              <callT name='Q{}getDataRef' bSlot='13'>
+              <callT name='Q{}getDataRef' bSlot='19'>
                <withParam name='Q{}this' flags='c' as='element()'>
-                <dot line='1266' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
+                <dot line='1270' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
                </withParam>
                <withParam name='Q{}bindingi' flags='c' as='node()?'>
-                <varRef line='1267' name='Q{}bindingi' slot='6'/>
+                <varRef line='1271' name='Q{}bindingi' slot='6'/>
                </withParam>
               </callT>
              </data>
             </cvUntyped>
            </check>
           </treat>
-          <let line='1274' var='Q{}instanceField' as='node()?' slot='8' eval='7'>
-           <treat line='1275' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+          <let line='1278' var='Q{}instanceField' as='node()?' slot='8' eval='7'>
+           <treat line='1279' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
             <check card='?' diag='3|0|XTTE0570|instanceField'>
-             <callT name='Q{}getReferencedInstanceField' bSlot='14'>
+             <callT name='Q{}getReferencedInstanceField' bSlot='20'>
               <withParam name='Q{}refi' flags='c' as='xs:string'>
-               <varRef line='1276' name='Q{}refi' slot='7'/>
+               <varRef line='1280' name='Q{}refi' slot='7'/>
               </withParam>
              </callT>
             </check>
            </treat>
-           <let line='1290' var='Q{}relevantVar' as='xs:boolean' slot='9' eval='16'>
-            <choose line='1292'>
+           <let line='1294' var='Q{}relevantVar' as='xs:boolean' slot='9' eval='16'>
+            <choose line='1296'>
              <and op='and'>
               <and op='and'>
                <fn name='exists'>
@@ -6761,12 +7796,12 @@
                <varRef name='Q{}instanceField' slot='8'/>
               </fn>
              </and>
-             <treat line='1293' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantVar'>
+             <treat line='1297' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantVar'>
               <check card='1' diag='3|0|XTTE0570|relevantVar'>
                <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|relevantVar'>
                 <data>
                  <evaluate dxns=''>
-                  <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='15' eval='16'>
+                  <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='21' eval='16'>
                    <check card='1' diag='0|0||xforms:impose'>
                     <cvUntyped to='xs:string'>
                      <data>
@@ -6779,7 +7814,7 @@
                    </check>
                   </ufCall>
                   <varRef role='cxt' name='Q{}instanceField' slot='8'/>
-                  <choose role='nsCxt' line='1285'>
+                  <choose role='nsCxt' line='1289'>
                    <fn name='exists'>
                     <varRef name='Q{}instanceField' slot='8'/>
                    </fn>
@@ -6796,16 +7831,16 @@
                       <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
                      </slash>
                     </check>
-                    <compElem line='2542'>
+                    <compElem line='2546'>
                      <fn role='name' name='name'>
                       <varRef name='Q{}this' slot='10'/>
                      </fn>
-                     <sequence role='content' line='2543'>
+                     <sequence role='content' line='2547'>
                       <namespace flags='l'>
                        <str role='name' val='xforms'/>
                        <str role='select' val='http://www.w3.org/2002/xforms'/>
                       </namespace>
-                      <forEach line='2544'>
+                      <forEach line='2548'>
                        <filter flags='b'>
                         <filter flags='b'>
                          <slash simple='1'>
@@ -6844,21 +7879,21 @@
                          </gc>
                         </fn>
                        </filter>
-                       <namespace line='2547' flags='l'>
-                        <fn role='name' line='2546' name='substring-before'>
+                       <namespace line='2551' flags='l'>
+                        <fn role='name' line='2550' name='substring-before'>
                          <fn name='name'>
                           <dot type='element()'/>
                          </fn>
                          <str val=':'/>
                         </fn>
                         <convert role='select' from='xs:anyURI' to='xs:string'>
-                         <fn line='2545' name='namespace-uri'>
+                         <fn line='2549' name='namespace-uri'>
                           <dot type='element()'/>
                          </fn>
                         </convert>
                        </namespace>
                       </forEach>
-                      <copyOf line='2549' flags='vc'>
+                      <copyOf line='2553' flags='vc'>
                        <sequence>
                         <slash simple='1'>
                          <varRef name='Q{}this' slot='10'/>
@@ -6885,23 +7920,23 @@
              <true/>
              <true/>
             </choose>
-            <let line='1303' var='Q{}actions' as='map(*)*' slot='11' eval='8'>
-             <treat line='1304' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
-              <callT name='Q{}setActions' bSlot='16'>
+            <let line='1307' var='Q{}actions' as='map(*)*' slot='11' eval='8'>
+             <treat line='1308' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+              <callT name='Q{}setActions' bSlot='22'>
                <withParam name='Q{}this' flags='c' as='element()'>
-                <dot line='1305' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
+                <dot line='1309' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
                </withParam>
                <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                <varRef line='1306' name='Q{}refi' slot='7'/>
+                <varRef line='1310' name='Q{}refi' slot='7'/>
                </withParam>
               </callT>
              </treat>
-             <sequence line='1311'>
+             <sequence line='1315'>
               <choose>
                <fn name='exists'>
                 <varRef name='Q{}actions' slot='11'/>
                </fn>
-               <ifCall line='1312' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+               <ifCall line='1316' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                 <check card='1' diag='0|0||ixsl:call'>
                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                 </check>
@@ -6912,12 +7947,12 @@
                 </arrayBlock>
                </ifCall>
               </choose>
-              <elem line='1317' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+              <elem line='1321' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
                <sequence>
                 <att name='class' flags='l'>
                  <str val='xforms-input'/>
                 </att>
-                <att line='1318' name='style' flags='l'>
+                <att line='1322' name='style' flags='l'>
                  <choose>
                   <varRef name='Q{}relevantVar' slot='9'/>
                   <str val='display:block'/>
@@ -6925,27 +7960,27 @@
                   <str val='display:none'/>
                  </choose>
                 </att>
-                <applyT line='1320' bSlot='17'>
+                <applyT line='1324' bSlot='23'>
                  <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
                 </applyT>
-                <let line='1322' var='Q{}hints' as='text()*' slot='12' eval='4'>
+                <let line='1326' var='Q{}hints' as='text()*' slot='12' eval='4'>
                  <slash simple='2'>
                   <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}hint)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;hint&#39;;'/>
                   <axis name='child' nodeTest='text()' jsTest='return item.nodeType===3;'/>
                  </slash>
-                 <elem line='1326' name='input' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
-                  <sequence line='1327'>
+                 <elem line='1330' name='input' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
+                  <sequence line='1331'>
                    <let var='Q{}element' as='element(Q{http://www.w3.org/2002/xforms}input)' slot='13' eval='16'>
                     <dot type='element(Q{http://www.w3.org/2002/xforms}input)'/>
-                    <let line='2604' var='Q{}class' as='xs:string?' slot='14' eval='7'>
-                     <choose line='2605'>
+                    <let line='2608' var='Q{}class' as='xs:string?' slot='14' eval='7'>
+                     <choose line='2609'>
                       <fn name='exists'>
                        <slash simple='1'>
                         <varRef name='Q{}element' slot='13'/>
                         <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
                        </slash>
                       </fn>
-                      <cvUntyped line='2606' to='xs:string' diag='3|0|XTTE0570|class'>
+                      <cvUntyped line='2610' to='xs:string' diag='3|0|XTTE0570|class'>
                        <cast as='xs:untypedAtomic' emptiable='0'>
                         <fn name='string'>
                          <convert from='xs:untypedAtomic' to='xs:string'>
@@ -6960,15 +7995,15 @@
                        </cast>
                       </cvUntyped>
                      </choose>
-                     <let line='2609' var='Q{}class-mod' as='xs:string?' slot='15' eval='7'>
-                      <choose line='2611'>
+                     <let line='2613' var='Q{}class-mod' as='xs:string?' slot='15' eval='7'>
+                      <choose line='2615'>
                        <fn name='exists'>
                         <slash simple='1'>
                          <varRef name='Q{}element' slot='13'/>
                          <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
                         </slash>
                        </fn>
-                       <cvUntyped line='2612' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                       <cvUntyped line='2616' to='xs:string' diag='3|0|XTTE0570|class-mod'>
                         <cast as='xs:untypedAtomic' emptiable='0'>
                          <fn name='string-join'>
                           <sequence>
@@ -6980,13 +8015,13 @@
                         </cast>
                        </cvUntyped>
                        <true/>
-                       <varRef line='2615' name='Q{}class' slot='14'/>
+                       <varRef line='2619' name='Q{}class' slot='14'/>
                       </choose>
-                      <choose line='2619'>
+                      <choose line='2623'>
                        <fn name='exists'>
                         <varRef name='Q{}class-mod' slot='15'/>
                        </fn>
-                       <treat line='2620' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                       <treat line='2624' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
                         <att name='class' flags='l'>
                          <varRef name='Q{}class-mod' slot='15'/>
                         </att>
@@ -6995,14 +8030,14 @@
                      </let>
                     </let>
                    </let>
-                   <att line='1328' name='id' flags='l'>
+                   <att line='1332' name='id' flags='l'>
                     <varRef name='Q{}myid' slot='3'/>
                    </att>
-                   <att line='1330' name='data-ref' flags='l'>
+                   <att line='1334' name='data-ref' flags='l'>
                     <varRef name='Q{}refi' slot='7'/>
                    </att>
-                   <att line='1331' name='data-element' flags='l'>
-                    <lastOf line='1324'>
+                   <att line='1335' name='data-element' flags='l'>
+                    <lastOf line='1328'>
                      <fn name='tokenize'>
                       <varRef name='Q{}refi' slot='7'/>
                       <str val='/'/>
@@ -7010,7 +8045,7 @@
                      </fn>
                     </lastOf>
                    </att>
-                   <choose line='1333'>
+                   <choose line='1337'>
                     <and op='and'>
                      <fn name='exists'>
                       <varRef name='Q{}bindingi' slot='6'/>
@@ -7022,7 +8057,7 @@
                       </slash>
                      </fn>
                     </and>
-                    <att line='1334' name='data-required' flags='l'>
+                    <att line='1338' name='data-required' flags='l'>
                      <convert from='xs:untypedAtomic' to='xs:string'>
                       <data>
                        <slash simple='1'>
@@ -7033,7 +8068,7 @@
                      </convert>
                     </att>
                    </choose>
-                   <choose line='1336'>
+                   <choose line='1340'>
                     <and op='and'>
                      <fn name='exists'>
                       <varRef name='Q{}bindingi' slot='6'/>
@@ -7045,7 +8080,7 @@
                       </slash>
                      </fn>
                     </and>
-                    <att line='1337' name='data-constraint' flags='l'>
+                    <att line='1341' name='data-constraint' flags='l'>
                      <convert from='xs:untypedAtomic' to='xs:string'>
                       <data>
                        <slash simple='1'>
@@ -7056,15 +8091,15 @@
                      </convert>
                     </att>
                    </choose>
-                   <choose line='1339'>
+                   <choose line='1343'>
                     <fn name='exists'>
                      <varRef name='Q{}actions' slot='11'/>
                     </fn>
-                    <att line='1340' name='data-action' flags='l'>
+                    <att line='1344' name='data-action' flags='l'>
                      <varRef name='Q{}myid' slot='3'/>
                     </att>
                    </choose>
-                   <choose line='1343'>
+                   <choose line='1347'>
                     <and op='and'>
                      <fn name='exists'>
                       <varRef name='Q{}bindingi' slot='6'/>
@@ -7076,7 +8111,7 @@
                       </slash>
                      </fn>
                     </and>
-                    <att line='1344' name='data-relevant' flags='l'>
+                    <att line='1348' name='data-relevant' flags='l'>
                      <convert from='xs:untypedAtomic' to='xs:string'>
                       <data>
                        <slash simple='1'>
@@ -7087,12 +8122,12 @@
                      </convert>
                     </att>
                    </choose>
-                   <let line='1347' var='Q{}input-value' as='xs:string' slot='16' eval='16'>
-                    <choose line='1349'>
+                   <let line='1351' var='Q{}input-value' as='xs:string' slot='16' eval='16'>
+                    <choose line='1353'>
                      <fn name='exists'>
                       <varRef name='Q{}instanceField' slot='8'/>
                      </fn>
-                     <cvUntyped line='1350' to='xs:string' diag='3|0|XTTE0570|input-value'>
+                     <cvUntyped line='1354' to='xs:string' diag='3|0|XTTE0570|input-value'>
                       <cast as='xs:untypedAtomic' emptiable='0'>
                        <fn name='string'>
                         <convert from='xs:anyAtomicType' to='xs:string'>
@@ -7106,7 +8141,7 @@
                      <true/>
                      <str val=''/>
                     </choose>
-                    <sequence line='1364'>
+                    <sequence line='1368'>
                      <choose>
                       <choose>
                        <fn name='exists'>
@@ -7126,18 +8161,18 @@
                        <true/>
                        <false/>
                       </choose>
-                      <sequence line='1365'>
+                      <sequence line='1369'>
                        <att name='data-type' flags='l'>
                         <str val='date'/>
                        </att>
-                       <att line='1367' name='type' flags='l'>
+                       <att line='1371' name='type' flags='l'>
                         <str val='date'/>
                        </att>
-                       <att line='1369' name='value' flags='l'>
+                       <att line='1373' name='value' flags='l'>
                         <varRef name='Q{}input-value' slot='16'/>
                        </att>
                       </sequence>
-                      <choose line='1376'>
+                      <choose line='1380'>
                        <fn name='exists'>
                         <varRef name='Q{}bindingi' slot='6'/>
                        </fn>
@@ -7155,18 +8190,18 @@
                        <true/>
                        <false/>
                       </choose>
-                      <sequence line='1377'>
+                      <sequence line='1381'>
                        <att name='data-type' flags='l'>
                         <str val='time'/>
                        </att>
-                       <att line='1379' name='type' flags='l'>
+                       <att line='1383' name='type' flags='l'>
                         <str val='time'/>
                        </att>
-                       <att line='1382' name='value' flags='l'>
+                       <att line='1386' name='value' flags='l'>
                         <varRef name='Q{}input-value' slot='16'/>
                        </att>
                       </sequence>
-                      <choose line='1389'>
+                      <choose line='1393'>
                        <fn name='exists'>
                         <varRef name='Q{}bindingi' slot='6'/>
                        </fn>
@@ -7184,48 +8219,48 @@
                        <true/>
                        <false/>
                       </choose>
-                      <sequence line='1390'>
+                      <sequence line='1394'>
                        <att name='data-type' flags='l'>
                         <str val='checkbox'/>
                        </att>
-                       <att line='1392' name='type' flags='l'>
+                       <att line='1396' name='type' flags='l'>
                         <str val='checkbox'/>
                        </att>
-                       <choose line='1397'>
+                       <choose line='1401'>
                         <fn name='exists'>
                          <varRef name='Q{}instanceField' slot='8'/>
                         </fn>
-                        <choose line='1398'>
+                        <choose line='1402'>
                          <and op='and'>
                           <varRef name='Q{}input-value' slot='16'/>
                           <cast as='xs:boolean' emptiable='0'>
                            <varRef name='Q{}input-value' slot='16'/>
                           </cast>
                          </and>
-                         <att line='1399' name='checked' flags='l'>
+                         <att line='1403' name='checked' flags='l'>
                           <varRef name='Q{}input-value' slot='16'/>
                          </att>
                         </choose>
                        </choose>
                       </sequence>
                       <true/>
-                      <sequence line='1405'>
+                      <sequence line='1409'>
                        <choose>
                         <varRef name='Q{}relevantVar' slot='9'/>
-                        <att line='1406' name='type' flags='l'>
+                        <att line='1410' name='type' flags='l'>
                          <str val='text'/>
                         </att>
                        </choose>
-                       <att line='1408' name='value' flags='l'>
+                       <att line='1412' name='value' flags='l'>
                         <varRef name='Q{}input-value' slot='16'/>
                        </att>
                       </sequence>
                      </choose>
-                     <choose line='1412'>
+                     <choose line='1416'>
                       <fn name='exists'>
                        <varRef name='Q{}hints' slot='12'/>
                       </fn>
-                      <att line='1413' name='title' flags='l'>
+                      <att line='1417' name='title' flags='l'>
                        <fn name='string-join'>
                         <convert from='xs:untypedAtomic' to='xs:string'>
                          <data>
@@ -7238,11 +8273,11 @@
                        </fn>
                       </att>
                      </choose>
-                     <choose line='1415'>
+                     <choose line='1419'>
                       <fn name='exists'>
                        <axis name='attribute' nodeTest='attribute(Q{}size)' jsTest='return item.name===&#39;size&#39;'/>
                       </fn>
-                      <att line='1416' name='size' flags='l'>
+                      <att line='1420' name='size' flags='l'>
                        <convert from='xs:untypedAtomic' to='xs:string'>
                         <attVal name='Q{}size' chk='0'/>
                        </convert>
@@ -7266,19 +8301,19 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='6' rank='1' minImp='0' slots='0' flags='s' line='1061' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='6' rank='1' minImp='0' slots='0' flags='s' line='1065' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
     <empty role='action'/>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='8' rank='1' minImp='0' slots='0' flags='s' line='1087' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='8' rank='1' minImp='0' slots='0' flags='s' line='1091' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/1999/xhtml}html)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/1999/xhtml&#39;&amp;&amp;q.local===&#39;html&#39;;'/>
-    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1088' name='html' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
-     <sequence line='1089'>
+    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1092' name='html' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+     <sequence line='1093'>
       <copyOf flags='vc'>
        <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
       </copyOf>
-      <elem line='1090' name='head' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
-       <sequence line='1091'>
+      <elem line='1094' name='head' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
+       <sequence line='1095'>
         <copyOf flags='vc'>
          <union op='|'>
           <slash simple='2'>
@@ -7291,7 +8326,7 @@
           </slash>
          </union>
         </copyOf>
-        <elem line='1092' name='meta' nsuri='' flags='l'>
+        <elem line='1096' name='meta' nsuri='' flags='l'>
          <sequence>
           <att name='http-equiv' flags='l'>
            <str val='Content-Type'/>
@@ -7301,7 +8336,7 @@
           </att>
          </sequence>
         </elem>
-        <forEach line='1094'>
+        <forEach line='1098'>
          <union op='|'>
           <filter flags='b'>
            <slash simple='2'>
@@ -7328,19 +8363,19 @@
            </vc>
           </filter>
          </union>
-         <elem line='1095' name='meta' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
-          <copyOf line='1096' flags='vc'>
+         <elem line='1099' name='meta' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
+          <copyOf line='1100' flags='vc'>
            <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
           </copyOf>
          </elem>
         </forEach>
-        <copyOf line='1101' flags='vc'>
+        <copyOf line='1105' flags='vc'>
          <axis name='child' nodeTest='element(Q{}script)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;script&#39;;'/>
         </copyOf>
        </sequence>
       </elem>
-      <elem line='1103' name='body' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
-       <applyT line='1104' bSlot='4'>
+      <elem line='1107' name='body' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
+       <applyT line='1108' bSlot='3'>
         <slash role='select' simple='2'>
          <axis name='child' nodeTest='element(Q{}body)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;body&#39;;'/>
          <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
@@ -7350,9 +8385,9 @@
      </sequence>
     </elem>
    </templateRule>
-   <templateRule prec='0' prio='2.0' seq='11' rank='3' minImp='0' slots='10' flags='s' line='1434' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='2.0' seq='11' rank='3' minImp='0' slots='10' flags='s' line='1438' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}textarea)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;textarea&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1435'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1439'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -7365,7 +8400,7 @@
        </check>
       </treat>
      </param>
-     <param line='1436' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1440' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -7377,7 +8412,7 @@
        </check>
       </treat>
      </param>
-     <let line='1440' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='1444' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -7393,7 +8428,7 @@
          <dot type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
         </fn>
         <str val='-'/>
-        <choose line='1438'>
+        <choose line='1442'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -7403,13 +8438,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1442'>
+      <sequence line='1446'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}textarea)' slot='3' eval='16'>
           <dot type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
-          <fn line='2532' name='exists'>
-           <sequence line='2507'>
+          <fn line='2536' name='exists'>
+           <sequence line='2511'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -7421,7 +8456,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2510'>
+             <choose role='matching' line='2514'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -7433,7 +8468,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='2519'>
+            <analyzeString line='2523'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -7444,7 +8479,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2522'>
+             <choose role='matching' line='2526'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -7467,8 +8502,8 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='2532' name='exists'>
-             <sequence line='2507'>
+            <fn line='2536' name='exists'>
+             <sequence line='2511'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
@@ -7480,7 +8515,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2510'>
+               <choose role='matching' line='2514'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -7492,7 +8527,7 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
-              <analyzeString line='2519'>
+              <analyzeString line='2523'>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
@@ -7503,7 +8538,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2522'>
+               <choose role='matching' line='2526'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -7521,7 +8556,7 @@
           </filter>
          </fn>
         </and>
-        <ifCall line='1443' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1447' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -7532,60 +8567,60 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1447' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='1448' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='1451' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1452' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
-          <callT name='Q{}getBinding' bSlot='18'>
+          <callT name='Q{}getBinding' bSlot='24'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='1449' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
+            <dot line='1453' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='1454' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='1455' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='1458' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1459' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
-             <callT name='Q{}getDataRef' bSlot='19'>
+             <callT name='Q{}getDataRef' bSlot='25'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='1456' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
+               <dot line='1460' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='1457' name='Q{}bindingi' slot='5'/>
+               <varRef line='1461' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='1462' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
-          <treat line='1463' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+         <let line='1466' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
+          <treat line='1467' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
            <check card='?' diag='3|0|XTTE0570|instanceField'>
-            <callT name='Q{}getReferencedInstanceField' bSlot='20'>
+            <callT name='Q{}getReferencedInstanceField' bSlot='26'>
              <withParam name='Q{}refi' flags='c' as='xs:string'>
-              <varRef line='1464' name='Q{}refi' slot='6'/>
+              <varRef line='1468' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </check>
           </treat>
-          <let line='1469' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
-           <treat line='1470' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
-            <callT name='Q{}setActions' bSlot='21'>
+          <let line='1473' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
+           <treat line='1474' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+            <callT name='Q{}setActions' bSlot='27'>
              <withParam name='Q{}this' flags='c' as='element()'>
-              <dot line='1471' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
+              <dot line='1475' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
              </withParam>
              <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-              <varRef line='1472' name='Q{}refi' slot='6'/>
+              <varRef line='1476' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </treat>
-           <sequence line='1476'>
+           <sequence line='1480'>
             <choose>
              <fn name='exists'>
               <varRef name='Q{}actions' slot='8'/>
              </fn>
-             <ifCall line='1477' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+             <ifCall line='1481' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
               <check card='1' diag='0|0||ixsl:call'>
                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
               </check>
@@ -7596,13 +8631,13 @@
               </arrayBlock>
              </ifCall>
             </choose>
-            <let line='1482' var='Q{}hints' as='text()*' slot='9' eval='4'>
+            <let line='1486' var='Q{}hints' as='text()*' slot='9' eval='4'>
              <slash simple='2'>
               <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}hint)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;hint&#39;;'/>
               <axis name='child' nodeTest='text()' jsTest='return item.nodeType===3;'/>
              </slash>
-             <elem line='1484' name='textarea' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
-              <sequence line='1485'>
+             <elem line='1488' name='textarea' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+              <sequence line='1489'>
                <copyOf flags='vc'>
                 <filter flags='b'>
                  <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
@@ -7614,8 +8649,8 @@
                  </vc>
                 </filter>
                </copyOf>
-               <att line='1486' name='data-element' flags='l'>
-                <lastOf line='1480'>
+               <att line='1490' name='data-element' flags='l'>
+                <lastOf line='1484'>
                  <fn name='tokenize'>
                   <varRef name='Q{}refi' slot='6'/>
                   <str val='/'/>
@@ -7623,14 +8658,14 @@
                  </fn>
                 </lastOf>
                </att>
-               <att line='1487' name='data-ref' flags='l'>
+               <att line='1491' name='data-ref' flags='l'>
                 <varRef name='Q{}refi' slot='6'/>
                </att>
-               <choose line='1489'>
+               <choose line='1493'>
                 <fn name='exists'>
                  <varRef name='Q{}instanceField' slot='7'/>
                 </fn>
-                <valueOf line='1490' flags='l'>
+                <valueOf line='1494' flags='l'>
                  <convert from='xs:anyAtomicType' to='xs:string'>
                   <data>
                    <varRef name='Q{}instanceField' slot='7'/>
@@ -7638,7 +8673,7 @@
                  </convert>
                 </valueOf>
                 <true/>
-                <sequence line='1492'>
+                <sequence line='1496'>
                  <valueOf flags='Sl'>
                   <str val=''/>
                  </valueOf>
@@ -7647,11 +8682,11 @@
                  </valueOf>
                 </sequence>
                </choose>
-               <choose line='1495'>
+               <choose line='1499'>
                 <fn name='exists'>
                  <varRef name='Q{}hints' slot='9'/>
                 </fn>
-                <att line='1496' name='title' flags='l'>
+                <att line='1500' name='title' flags='l'>
                  <fn name='string-join'>
                   <convert from='xs:untypedAtomic' to='xs:string'>
                    <data>
@@ -7676,9 +8711,9 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='24' rank='1' minImp='0' slots='9' flags='s' line='1971' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='24' rank='1' minImp='0' slots='9' flags='s' line='1975' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}trigger)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;trigger&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1972'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1976'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -7691,7 +8726,7 @@
        </check>
       </treat>
      </param>
-     <param line='1973' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1977' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -7703,7 +8738,7 @@
        </check>
       </treat>
      </param>
-     <let line='1977' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='1981' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -7719,7 +8754,7 @@
          <dot type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
         </fn>
         <str val='-'/>
-        <choose line='1975'>
+        <choose line='1979'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -7729,13 +8764,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1979'>
+      <sequence line='1983'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}trigger)' slot='3' eval='16'>
           <dot type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
-          <fn line='2532' name='exists'>
-           <sequence line='2507'>
+          <fn line='2536' name='exists'>
+           <sequence line='2511'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -7747,7 +8782,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2510'>
+             <choose role='matching' line='2514'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -7759,7 +8794,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='2519'>
+            <analyzeString line='2523'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -7770,7 +8805,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2522'>
+             <choose role='matching' line='2526'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -7793,8 +8828,8 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='2532' name='exists'>
-             <sequence line='2507'>
+            <fn line='2536' name='exists'>
+             <sequence line='2511'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
@@ -7806,7 +8841,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2510'>
+               <choose role='matching' line='2514'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -7818,7 +8853,7 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
-              <analyzeString line='2519'>
+              <analyzeString line='2523'>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
@@ -7829,7 +8864,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2522'>
+               <choose role='matching' line='2526'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -7847,7 +8882,7 @@
           </filter>
          </fn>
         </and>
-        <ifCall line='1980' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1984' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -7858,50 +8893,50 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1984' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='1985' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='1988' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1989' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
-          <callT name='Q{}getBinding' bSlot='22'>
+          <callT name='Q{}getBinding' bSlot='28'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='1986' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
+            <dot line='1990' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='1991' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='1992' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='1995' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1996' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
-             <callT name='Q{}getDataRef' bSlot='23'>
+             <callT name='Q{}getDataRef' bSlot='29'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='1993' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
+               <dot line='1997' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='1994' name='Q{}bindingi' slot='5'/>
+               <varRef line='1998' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='2001' var='Q{}actions' as='map(*)*' slot='7' eval='8'>
-          <treat line='2002' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
-           <callT name='Q{}setActions' bSlot='24'>
+         <let line='2005' var='Q{}actions' as='map(*)*' slot='7' eval='8'>
+          <treat line='2006' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+           <callT name='Q{}setActions' bSlot='30'>
             <withParam name='Q{}this' flags='c' as='element()'>
-             <dot line='2003' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
+             <dot line='2007' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
             </withParam>
             <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-             <varRef line='2004' name='Q{}refi' slot='6'/>
+             <varRef line='2008' name='Q{}refi' slot='6'/>
             </withParam>
            </callT>
           </treat>
-          <sequence line='2008'>
+          <sequence line='2012'>
            <choose>
             <fn name='exists'>
              <varRef name='Q{}actions' slot='7'/>
             </fn>
-            <ifCall line='2009' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+            <ifCall line='2013' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
              <check card='1' diag='0|0||ixsl:call'>
               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
              </check>
@@ -7912,28 +8947,28 @@
              </arrayBlock>
             </ifCall>
            </choose>
-           <let line='2012' var='Q{}innerbody' as='document-node()' slot='8' eval='16'>
-            <doc line='2014' validation='preserve'>
+           <let line='2016' var='Q{}innerbody' as='document-node()' slot='8' eval='16'>
+            <doc line='2018' validation='preserve'>
              <choose>
               <fn name='exists'>
                <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
               </fn>
-              <applyT line='2015' bSlot='25'>
+              <applyT line='2019' bSlot='31'>
                <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
               </applyT>
               <true/>
-              <valueOf line='2017' flags='l'>
+              <valueOf line='2021' flags='l'>
                <str val=' '/>
               </valueOf>
              </choose>
             </doc>
-            <elem line='2021' name='span' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+            <elem line='2025' name='span' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
              <sequence>
               <att name='style' flags='l'>
                <str val='display:&#39;inline&#39;'/>
               </att>
-              <compElem line='2032' flags='l'>
-               <choose role='name' line='2024'>
+              <compElem line='2036' flags='l'>
+               <choose role='name' line='2028'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <cast as='xs:string' emptiable='1'>
                   <attVal name='Q{}appearance' chk='0'/>
@@ -7944,7 +8979,7 @@
                 <true/>
                 <str val='button'/>
                </choose>
-               <sequence role='content' line='2033'>
+               <sequence role='content' line='2037'>
                 <choose>
                  <vc op='eq' onEmpty='0' comp='CCC'>
                   <cast as='xs:string' emptiable='1'>
@@ -7952,17 +8987,17 @@
                   </cast>
                   <str val='minimal'/>
                  </vc>
-                 <att line='2034' name='type' flags='l'>
+                 <att line='2038' name='type' flags='l'>
                   <str val='button'/>
                  </att>
                 </choose>
-                <att line='2037' name='data-ref' flags='l'>
+                <att line='2041' name='data-ref' flags='l'>
                  <varRef name='Q{}refi' slot='6'/>
                 </att>
-                <att line='2038' name='data-action' flags='l'>
+                <att line='2042' name='data-action' flags='l'>
                  <varRef name='Q{}myid' slot='2'/>
                 </att>
-                <copyOf line='2039' flags='vc'>
+                <copyOf line='2043' flags='vc'>
                  <varRef name='Q{}innerbody' slot='8'/>
                 </copyOf>
                </sequence>
@@ -7978,9 +9013,9 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='9' rank='1' minImp='0' slots='15' flags='s' line='1119' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='9' rank='1' minImp='0' slots='15' flags='s' line='1123' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}output)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;output&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1120'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1124'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -7993,7 +9028,7 @@
        </check>
       </treat>
      </param>
-     <param line='1121' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1125' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -8005,7 +9040,7 @@
        </check>
       </treat>
      </param>
-     <let line='1125' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='1129' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -8021,7 +9056,7 @@
          <dot type='element(Q{http://www.w3.org/2002/xforms}output)'/>
         </fn>
         <str val='-'/>
-        <choose line='1123'>
+        <choose line='1127'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -8031,13 +9066,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1127'>
+      <sequence line='1131'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}output)' slot='3' eval='16'>
           <dot type='element(Q{http://www.w3.org/2002/xforms}output)'/>
-          <fn line='2532' name='exists'>
-           <sequence line='2507'>
+          <fn line='2536' name='exists'>
+           <sequence line='2511'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -8049,7 +9084,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2510'>
+             <choose role='matching' line='2514'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -8061,7 +9096,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='2519'>
+            <analyzeString line='2523'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -8072,7 +9107,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2522'>
+             <choose role='matching' line='2526'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -8095,8 +9130,8 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='2532' name='exists'>
-             <sequence line='2507'>
+            <fn line='2536' name='exists'>
+             <sequence line='2511'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
@@ -8108,7 +9143,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2510'>
+               <choose role='matching' line='2514'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -8120,7 +9155,7 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
-              <analyzeString line='2519'>
+              <analyzeString line='2523'>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
@@ -8131,7 +9166,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2522'>
+               <choose role='matching' line='2526'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -8149,7 +9184,7 @@
           </filter>
          </fn>
         </and>
-        <ifCall line='1128' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1132' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -8160,44 +9195,44 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1133' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='1134' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='1137' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1138' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
-          <callT name='Q{}getBinding' bSlot='26'>
+          <callT name='Q{}getBinding' bSlot='32'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='1135' type='element(Q{http://www.w3.org/2002/xforms}output)'/>
+            <dot line='1139' type='element(Q{http://www.w3.org/2002/xforms}output)'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='1140' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='1141' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='1144' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1145' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
-             <callT name='Q{}getDataRef' bSlot='27'>
+             <callT name='Q{}getDataRef' bSlot='33'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='1142' type='element(Q{http://www.w3.org/2002/xforms}output)'/>
+               <dot line='1146' type='element(Q{http://www.w3.org/2002/xforms}output)'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='1143' name='Q{}bindingi' slot='5'/>
+               <varRef line='1147' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='1148' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
-          <treat line='1149' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+         <let line='1152' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
+          <treat line='1153' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
            <check card='?' diag='3|0|XTTE0570|instanceField'>
-            <callT name='Q{}getReferencedInstanceField' bSlot='28'>
+            <callT name='Q{}getReferencedInstanceField' bSlot='34'>
              <withParam name='Q{}refi' flags='c' as='xs:string'>
-              <varRef line='1150' name='Q{}refi' slot='6'/>
+              <varRef line='1154' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </check>
           </treat>
-          <let line='1161' var='Q{}namespace-context-item' as='element()' slot='8' eval='16'>
+          <let line='1165' var='Q{}namespace-context-item' as='element()' slot='8' eval='16'>
            <choose>
             <fn name='exists'>
              <varRef name='Q{}instanceField' slot='7'/>
@@ -8232,16 +9267,16 @@
                <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
               </slash>
              </check>
-             <compElem line='2542'>
+             <compElem line='2546'>
               <fn role='name' name='name'>
                <varRef name='Q{}this' slot='9'/>
               </fn>
-              <sequence role='content' line='2543'>
+              <sequence role='content' line='2547'>
                <namespace flags='l'>
                 <str role='name' val='xforms'/>
                 <str role='select' val='http://www.w3.org/2002/xforms'/>
                </namespace>
-               <forEach line='2544'>
+               <forEach line='2548'>
                 <filter flags='b'>
                  <filter flags='b'>
                   <slash simple='1'>
@@ -8280,21 +9315,21 @@
                   </gc>
                  </fn>
                 </filter>
-                <namespace line='2547' flags='l'>
-                 <fn role='name' line='2546' name='substring-before'>
+                <namespace line='2551' flags='l'>
+                 <fn role='name' line='2550' name='substring-before'>
                   <fn name='name'>
                    <dot type='element()'/>
                   </fn>
                   <str val=':'/>
                  </fn>
                  <convert role='select' from='xs:anyURI' to='xs:string'>
-                  <fn line='2545' name='namespace-uri'>
+                  <fn line='2549' name='namespace-uri'>
                    <dot type='element()'/>
                   </fn>
                  </convert>
                 </namespace>
                </forEach>
-               <copyOf line='2549' flags='vc'>
+               <copyOf line='2553' flags='vc'>
                 <sequence>
                  <slash simple='1'>
                   <varRef name='Q{}this' slot='9'/>
@@ -8310,13 +9345,13 @@
              </compElem>
             </let>
            </choose>
-           <let line='1163' var='Q{}valueExecuted' as='xs:string' slot='10' eval='16'>
-            <choose line='1165'>
+           <let line='1167' var='Q{}valueExecuted' as='xs:string' slot='10' eval='16'>
+            <choose line='1169'>
              <fn name='exists'>
               <axis name='attribute' nodeTest='attribute(Q{}value)' jsTest='return item.name===&#39;value&#39;'/>
              </fn>
-             <evaluate line='1166' as='xs:string' dxns=''>
-              <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='29' eval='16'>
+             <evaluate line='1170' as='xs:string' dxns=''>
+              <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='35' eval='16'>
                <check card='1' diag='0|0||xforms:impose'>
                 <cvUntyped to='xs:string'>
                  <attVal name='Q{}value' chk='0'/>
@@ -8330,7 +9365,7 @@
               <map role='wp' size='0'/>
              </evaluate>
              <true/>
-             <cvUntyped line='1169' to='xs:string' diag='3|0|XTTE0570|valueExecuted'>
+             <cvUntyped line='1173' to='xs:string' diag='3|0|XTTE0570|valueExecuted'>
               <cast as='xs:untypedAtomic' emptiable='0'>
                <fn name='string'>
                 <convert from='xs:anyAtomicType' to='xs:string'>
@@ -8342,8 +9377,8 @@
               </cast>
              </cvUntyped>
             </choose>
-            <let line='1175' var='Q{}relevantVar' as='xs:boolean' slot='11' eval='16'>
-             <choose line='1177'>
+            <let line='1179' var='Q{}relevantVar' as='xs:boolean' slot='11' eval='16'>
+             <choose line='1181'>
               <and op='and'>
                <and op='and'>
                 <fn name='exists'>
@@ -8360,12 +9395,12 @@
                 <varRef name='Q{}instanceField' slot='7'/>
                </fn>
               </and>
-              <treat line='1178' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantVar'>
+              <treat line='1182' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantVar'>
                <check card='1' diag='3|0|XTTE0570|relevantVar'>
                 <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|relevantVar'>
                  <data>
                   <evaluate dxns=''>
-                   <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='30' eval='16'>
+                   <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='36' eval='16'>
                     <check card='1' diag='0|0||xforms:impose'>
                      <cvUntyped to='xs:string'>
                       <data>
@@ -8390,20 +9425,20 @@
               <true/>
               <true/>
              </choose>
-             <sequence line='1189'>
+             <sequence line='1193'>
               <elem name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
-               <sequence line='1190'>
+               <sequence line='1194'>
                 <let var='Q{}element' as='element(Q{http://www.w3.org/2002/xforms}output)' slot='12' eval='16'>
                  <dot type='element(Q{http://www.w3.org/2002/xforms}output)'/>
-                 <let line='2604' var='Q{}class' as='xs:string?' slot='13' eval='7'>
-                  <choose line='2605'>
+                 <let line='2608' var='Q{}class' as='xs:string?' slot='13' eval='7'>
+                  <choose line='2609'>
                    <fn name='exists'>
                     <slash simple='1'>
                      <varRef name='Q{}element' slot='12'/>
                      <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
                     </slash>
                    </fn>
-                   <cvUntyped line='2606' to='xs:string' diag='3|0|XTTE0570|class'>
+                   <cvUntyped line='2610' to='xs:string' diag='3|0|XTTE0570|class'>
                     <cast as='xs:untypedAtomic' emptiable='0'>
                      <fn name='string'>
                       <convert from='xs:untypedAtomic' to='xs:string'>
@@ -8418,15 +9453,15 @@
                     </cast>
                    </cvUntyped>
                   </choose>
-                  <let line='2609' var='Q{}class-mod' as='xs:string?' slot='14' eval='7'>
-                   <choose line='2611'>
+                  <let line='2613' var='Q{}class-mod' as='xs:string?' slot='14' eval='7'>
+                   <choose line='2615'>
                     <fn name='exists'>
                      <slash simple='1'>
                       <varRef name='Q{}element' slot='12'/>
                       <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
                      </slash>
                     </fn>
-                    <cvUntyped line='2612' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                    <cvUntyped line='2616' to='xs:string' diag='3|0|XTTE0570|class-mod'>
                      <cast as='xs:untypedAtomic' emptiable='0'>
                       <fn name='string-join'>
                        <sequence>
@@ -8438,13 +9473,13 @@
                      </cast>
                     </cvUntyped>
                     <true/>
-                    <varRef line='2615' name='Q{}class' slot='13'/>
+                    <varRef line='2619' name='Q{}class' slot='13'/>
                    </choose>
-                   <choose line='2619'>
+                   <choose line='2623'>
                     <fn name='exists'>
                      <varRef name='Q{}class-mod' slot='14'/>
                     </fn>
-                    <treat line='2620' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                    <treat line='2624' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
                      <att name='class' flags='l'>
                       <varRef name='Q{}class-mod' slot='14'/>
                      </att>
@@ -8453,15 +9488,15 @@
                   </let>
                  </let>
                 </let>
-                <applyT line='1192' bSlot='31'>
+                <applyT line='1196' bSlot='37'>
                  <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
                 </applyT>
-                <elem line='1194' name='span' nsuri='' flags='l'>
-                 <sequence line='1195'>
+                <elem line='1198' name='span' nsuri='' flags='l'>
+                 <sequence line='1199'>
                   <att name='id' flags='l'>
                    <varRef name='Q{}myid' slot='2'/>
                   </att>
-                  <att line='1196' name='style' flags='l'>
+                  <att line='1200' name='style' flags='l'>
                    <choose>
                     <varRef name='Q{}relevantVar' slot='11'/>
                     <str val='display:inline'/>
@@ -8469,42 +9504,42 @@
                     <str val='display:none'/>
                    </choose>
                   </att>
-                  <att line='1197' name='data-ref' flags='l'>
+                  <att line='1201' name='data-ref' flags='l'>
                    <varRef name='Q{}refi' slot='6'/>
                   </att>
-                  <varRef line='1199' name='Q{}valueExecuted' slot='10'/>
+                  <varRef line='1203' name='Q{}valueExecuted' slot='10'/>
                  </sequence>
                 </elem>
                </sequence>
               </elem>
-              <choose line='1204'>
+              <choose line='1208'>
                <fn name='empty'>
                 <slash simple='1'>
                  <dot type='element(Q{http://www.w3.org/2002/xforms}output)'/>
                  <axis name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
                 </slash>
                </fn>
-               <ifCall line='1223' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+               <ifCall line='1227' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                 <check card='1' diag='0|0||ixsl:call'>
                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                 </check>
                 <str val='addOutput'/>
                 <arrayBlock>
                  <varRef name='Q{}myid' slot='2'/>
-                 <ifCall line='1207' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+                 <ifCall line='1211' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
                   <sequence>
                    <choose>
                     <varRef name='Q{}refi' slot='6'/>
-                    <ifCall line='1208' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                    <ifCall line='1212' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                      <str val='@ref'/>
                      <varRef name='Q{}refi' slot='6'/>
                     </ifCall>
                    </choose>
-                   <choose line='1211'>
+                   <choose line='1215'>
                     <fn name='exists'>
                      <axis name='attribute' nodeTest='attribute(Q{}value)' jsTest='return item.name===&#39;value&#39;'/>
                     </fn>
-                    <ifCall line='1212' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                    <ifCall line='1216' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                      <str val='@value'/>
                      <cast as='xs:string' emptiable='1'>
                       <attVal name='Q{}value' chk='0'/>
@@ -8533,9 +9568,9 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='17' rank='1' minImp='0' slots='1' flags='s' line='1663' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='17' rank='1' minImp='0' slots='1' flags='s' line='1667' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1664'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1668'>
      <param name='Q{}selectedValue' slot='0' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|selectedValue'>
@@ -8548,7 +9583,7 @@
        </check>
       </treat>
      </param>
-     <elem line='1666' name='option' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+     <elem line='1670' name='option' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
       <sequence>
        <att name='value' flags='l'>
         <fn name='string-join'>
@@ -8560,7 +9595,7 @@
          <str val=' '/>
         </fn>
        </att>
-       <choose line='1667'>
+       <choose line='1671'>
         <vc op='eq' onEmpty='0' comp='CCC'>
          <varRef name='Q{}selectedValue' slot='0'/>
          <cast as='xs:string' emptiable='1'>
@@ -8572,11 +9607,11 @@
           </atomSing>
          </cast>
         </vc>
-        <att line='1668' name='selected' flags='l'>
+        <att line='1672' name='selected' flags='l'>
          <varRef name='Q{}selectedValue' slot='0'/>
         </att>
        </choose>
-       <valueOf line='1671' flags='l'>
+       <valueOf line='1675' flags='l'>
         <fn name='string-join'>
          <convert from='xs:untypedAtomic' to='xs:string'>
           <data>
@@ -8590,1045 +9625,24 @@
      </elem>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='25' part='4' rank='1' minImp='0' slots='1' flags='s' line='2052' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='25' part='4' rank='1' minImp='0' slots='1' flags='s' line='2056' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}script)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;script&#39;;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2060' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2061' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2064' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2065' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
       <check card='1' diag='3|0|XTTE0570|action-map'>
        <callT name='Q{}setAction' bSlot='2'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2062' type='element()'/>
+         <dot line='2066' type='element()'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <varRef line='2075' name='Q{}action-map' slot='0'/>
+     <varRef line='2079' name='Q{}action-map' slot='0'/>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='13' part='1' rank='1' minImp='0' slots='12' flags='s' line='1519' module='saxon-xforms.xsl'>
-    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}select)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;select&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1520'>
-     <param name='Q{}position' slot='0' as='xs:integer'>
-      <int role='select' val='0'/>
-      <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
-       <check card='1' diag='8|0|XTTE0590|position'>
-        <cvUntyped to='xs:integer' diag='8|0|XTTE0590|position'>
-         <data>
-          <supplied slot='0'/>
-         </data>
-        </cvUntyped>
-       </check>
-      </treat>
-     </param>
-     <param line='1521' name='Q{}context-position' slot='1' as='xs:string'>
-      <str role='select' val=''/>
-      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
-       <check card='1' diag='8|0|XTTE0590|context-position'>
-        <cvUntyped to='xs:string' diag='8|0|XTTE0590|context-position'>
-         <data>
-          <supplied slot='1'/>
-         </data>
-        </cvUntyped>
-       </check>
-      </treat>
-     </param>
-     <let line='1525' var='Q{}myid' as='xs:string' slot='2' eval='16'>
-      <choose>
-       <fn name='exists'>
-        <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
-       </fn>
-       <check card='1' diag='3|0|XTTE0570|myid'>
-        <cvUntyped to='xs:string' diag='3|0|XTTE0570|myid'>
-         <attVal name='Q{}id' chk='0'/>
-        </cvUntyped>
-       </check>
-       <true/>
-       <fn name='concat'>
-        <fn name='generate-id'>
-         <dot type='element()'/>
-        </fn>
-        <str val='-'/>
-        <choose line='1523'>
-         <varRef name='Q{}context-position' slot='1'/>
-         <varRef name='Q{}context-position' slot='1'/>
-         <true/>
-         <fn name='string'>
-          <varRef name='Q{}position' slot='0'/>
-         </fn>
-        </choose>
-       </fn>
-      </choose>
-      <sequence line='1527'>
-       <choose>
-        <and op='and'>
-         <let var='Q{}this' as='element()' slot='3' eval='16'>
-          <dot type='element()'/>
-          <fn line='2532' name='exists'>
-           <sequence line='2507'>
-            <analyzeString>
-             <cvUntyped role='select' to='xs:string'>
-              <data>
-               <slash simple='1'>
-                <varRef name='Q{}this' slot='3'/>
-                <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
-               </slash>
-              </data>
-             </cvUntyped>
-             <str role='regex' val='\i\c*\('/>
-             <str role='flags' val=''/>
-             <choose role='matching' line='2510'>
-              <vc op='eq' onEmpty='0' comp='CCC'>
-               <fn name='substring-before'>
-                <dot type='xs:string'/>
-                <str val='('/>
-               </fn>
-               <str val='index'/>
-              </vc>
-              <str val='i'/>
-             </choose>
-             <empty role='nonMatching'/>
-            </analyzeString>
-            <analyzeString line='2519'>
-             <cvUntyped role='select' to='xs:string'>
-              <data>
-               <slash simple='1'>
-                <varRef name='Q{}this' slot='3'/>
-                <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
-               </slash>
-              </data>
-             </cvUntyped>
-             <str role='regex' val='\i\c*\('/>
-             <str role='flags' val=''/>
-             <choose role='matching' line='2522'>
-              <vc op='eq' onEmpty='0' comp='CCC'>
-               <fn name='substring-before'>
-                <dot type='xs:string'/>
-                <str val='('/>
-               </fn>
-               <str val='index'/>
-              </vc>
-              <str val='i'/>
-             </choose>
-             <empty role='nonMatching'/>
-            </analyzeString>
-           </sequence>
-          </fn>
-         </let>
-         <fn name='empty'>
-          <filter flags='b'>
-           <slash simple='1'>
-            <dot type='element()'/>
-            <axis name='ancestor' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-           </slash>
-           <let var='Q{}this' as='element()' slot='4' eval='16'>
-            <dot type='element()'/>
-            <fn line='2532' name='exists'>
-             <sequence line='2507'>
-              <analyzeString>
-               <cvUntyped role='select' to='xs:string'>
-                <data>
-                 <slash simple='1'>
-                  <varRef name='Q{}this' slot='4'/>
-                  <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
-                 </slash>
-                </data>
-               </cvUntyped>
-               <str role='regex' val='\i\c*\('/>
-               <str role='flags' val=''/>
-               <choose role='matching' line='2510'>
-                <vc op='eq' onEmpty='0' comp='CCC'>
-                 <fn name='substring-before'>
-                  <dot type='xs:string'/>
-                  <str val='('/>
-                 </fn>
-                 <str val='index'/>
-                </vc>
-                <str val='i'/>
-               </choose>
-               <empty role='nonMatching'/>
-              </analyzeString>
-              <analyzeString line='2519'>
-               <cvUntyped role='select' to='xs:string'>
-                <data>
-                 <slash simple='1'>
-                  <varRef name='Q{}this' slot='4'/>
-                  <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
-                 </slash>
-                </data>
-               </cvUntyped>
-               <str role='regex' val='\i\c*\('/>
-               <str role='flags' val=''/>
-               <choose role='matching' line='2522'>
-                <vc op='eq' onEmpty='0' comp='CCC'>
-                 <fn name='substring-before'>
-                  <dot type='xs:string'/>
-                  <str val='('/>
-                 </fn>
-                 <str val='index'/>
-                </vc>
-                <str val='i'/>
-               </choose>
-               <empty role='nonMatching'/>
-              </analyzeString>
-             </sequence>
-            </fn>
-           </let>
-          </filter>
-         </fn>
-        </and>
-        <ifCall line='1528' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-         <check card='1' diag='0|0||ixsl:call'>
-          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-         </check>
-         <str val='setElementUsingIndexFunction'/>
-         <arrayBlock>
-          <varRef name='Q{}myid' slot='2'/>
-          <dot type='element()'/>
-         </arrayBlock>
-        </ifCall>
-       </choose>
-       <let line='1535' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='1536' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
-         <check card='?' diag='3|0|XTTE0570|bindingi'>
-          <callT name='Q{}getBinding' bSlot='5'>
-           <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='1537' type='element()'/>
-           </withParam>
-          </callT>
-         </check>
-        </treat>
-        <let line='1542' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='1543' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
-          <check card='1' diag='3|0|XTTE0570|refi'>
-           <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
-            <data>
-             <callT name='Q{}getDataRef' bSlot='6'>
-              <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='1544' type='element()'/>
-              </withParam>
-              <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='1545' name='Q{}bindingi' slot='5'/>
-              </withParam>
-             </callT>
-            </data>
-           </cvUntyped>
-          </check>
-         </treat>
-         <let line='1550' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
-          <treat line='1551' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
-           <check card='?' diag='3|0|XTTE0570|instanceField'>
-            <callT name='Q{}getReferencedInstanceField' bSlot='7'>
-             <withParam name='Q{}refi' flags='c' as='xs:string'>
-              <varRef line='1552' name='Q{}refi' slot='6'/>
-             </withParam>
-            </callT>
-           </check>
-          </treat>
-          <let line='1557' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
-           <treat line='1558' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
-            <callT name='Q{}setActions' bSlot='8'>
-             <withParam name='Q{}this' flags='c' as='element()'>
-              <dot line='1559' type='element()'/>
-             </withParam>
-             <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-              <varRef line='1560' name='Q{}refi' slot='6'/>
-             </withParam>
-            </callT>
-           </treat>
-           <sequence line='1564'>
-            <choose>
-             <fn name='exists'>
-              <varRef name='Q{}actions' slot='8'/>
-             </fn>
-             <ifCall line='1565' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-              <check card='1' diag='0|0||ixsl:call'>
-               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-              </check>
-              <str val='addAction'/>
-              <arrayBlock>
-               <varRef name='Q{}myid' slot='2'/>
-               <varRef name='Q{}actions' slot='8'/>
-              </arrayBlock>
-             </ifCall>
-            </choose>
-            <elem line='1582' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
-             <sequence>
-              <att name='class' flags='l'>
-               <str val='xforms-select'/>
-              </att>
-              <applyT line='1583' bSlot='9'>
-               <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
-              </applyT>
-              <elem line='1585' name='select' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
-               <sequence line='1586'>
-                <let var='Q{}element' as='element()' slot='9' eval='16'>
-                 <dot type='element()'/>
-                 <let line='2604' var='Q{}class' as='xs:string?' slot='10' eval='7'>
-                  <choose line='2605'>
-                   <fn name='exists'>
-                    <slash simple='1'>
-                     <varRef name='Q{}element' slot='9'/>
-                     <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
-                    </slash>
-                   </fn>
-                   <cvUntyped line='2606' to='xs:string' diag='3|0|XTTE0570|class'>
-                    <cast as='xs:untypedAtomic' emptiable='0'>
-                     <fn name='string'>
-                      <convert from='xs:untypedAtomic' to='xs:string'>
-                       <data>
-                        <slash simple='1'>
-                         <varRef name='Q{}element' slot='9'/>
-                         <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
-                        </slash>
-                       </data>
-                      </convert>
-                     </fn>
-                    </cast>
-                   </cvUntyped>
-                  </choose>
-                  <let line='2609' var='Q{}class-mod' as='xs:string?' slot='11' eval='7'>
-                   <choose line='2611'>
-                    <fn name='exists'>
-                     <slash simple='1'>
-                      <varRef name='Q{}element' slot='9'/>
-                      <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
-                     </slash>
-                    </fn>
-                    <cvUntyped line='2612' to='xs:string' diag='3|0|XTTE0570|class-mod'>
-                     <cast as='xs:untypedAtomic' emptiable='0'>
-                      <fn name='string-join'>
-                       <sequence>
-                        <varRef name='Q{}class' slot='10'/>
-                        <str val='incremental'/>
-                       </sequence>
-                       <str val=' '/>
-                      </fn>
-                     </cast>
-                    </cvUntyped>
-                    <true/>
-                    <varRef line='2615' name='Q{}class' slot='10'/>
-                   </choose>
-                   <choose line='2619'>
-                    <fn name='exists'>
-                     <varRef name='Q{}class-mod' slot='11'/>
-                    </fn>
-                    <treat line='2620' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
-                     <att name='class' flags='l'>
-                      <varRef name='Q{}class-mod' slot='11'/>
-                     </att>
-                    </treat>
-                   </choose>
-                  </let>
-                 </let>
-                </let>
-                <copyOf line='1587' flags='vc'>
-                 <except op='except'>
-                  <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
-                  <docOrder intra='1'>
-                   <sequence>
-                    <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
-                    <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
-                    <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
-                   </sequence>
-                  </docOrder>
-                 </except>
-                </copyOf>
-                <att line='1589' name='data-ref' flags='l'>
-                 <varRef name='Q{}refi' slot='6'/>
-                </att>
-                <att line='1590' name='data-element' flags='l'>
-                 <lastOf line='1580'>
-                  <fn name='tokenize'>
-                   <varRef name='Q{}refi' slot='6'/>
-                   <str val='/'/>
-                   <str val=''/>
-                  </fn>
-                 </lastOf>
-                </att>
-                <choose line='1592'>
-                 <and op='and'>
-                  <fn name='exists'>
-                   <varRef name='Q{}bindingi' slot='5'/>
-                  </fn>
-                  <fn name='exists'>
-                   <slash simple='1'>
-                    <varRef name='Q{}bindingi' slot='5'/>
-                    <axis name='attribute' nodeTest='attribute(Q{}constraint)' jsTest='return item.name===&#39;constraint&#39;'/>
-                   </slash>
-                  </fn>
-                 </and>
-                 <att line='1593' name='data-constraint' flags='l'>
-                  <convert from='xs:untypedAtomic' to='xs:string'>
-                   <data>
-                    <slash simple='1'>
-                     <varRef name='Q{}bindingi' slot='5'/>
-                     <axis name='attribute' nodeTest='attribute(Q{}constraint)' jsTest='return item.name===&#39;constraint&#39;'/>
-                    </slash>
-                   </data>
-                  </convert>
-                 </att>
-                </choose>
-                <choose line='1596'>
-                 <vc op='eq' onEmpty='0' comp='CCC'>
-                  <fn name='local-name'>
-                   <dot type='element()'/>
-                  </fn>
-                  <str val='select'/>
-                 </vc>
-                 <sequence line='1597'>
-                  <att name='multiple' flags='l'>
-                   <str val='true'/>
-                  </att>
-                  <att line='1598' name='size' flags='l'>
-                   <convert line='1599' from='xs:integer' to='xs:string'>
-                    <fn name='count'>
-                     <axis name='descendant' nodeTest='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
-                    </fn>
-                   </convert>
-                  </att>
-                 </sequence>
-                </choose>
-                <choose line='1602'>
-                 <fn name='exists'>
-                  <varRef name='Q{}actions' slot='8'/>
-                 </fn>
-                 <att line='1603' name='data-action' flags='l'>
-                  <varRef name='Q{}myid' slot='2'/>
-                 </att>
-                </choose>
-                <applyT line='1606' bSlot='10'>
-                 <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
-                 <withParam name='Q{}selectedValue' as='xs:string'>
-                  <choose line='1571'>
-                   <fn name='exists'>
-                    <varRef name='Q{}instanceField' slot='7'/>
-                   </fn>
-                   <cvUntyped line='1572' to='xs:string' diag='3|0|XTTE0570|selectedValue'>
-                    <cast as='xs:untypedAtomic' emptiable='0'>
-                     <fn name='string'>
-                      <convert from='xs:anyAtomicType' to='xs:string'>
-                       <data>
-                        <varRef name='Q{}instanceField' slot='7'/>
-                       </data>
-                      </convert>
-                     </fn>
-                    </cast>
-                   </cvUntyped>
-                   <true/>
-                   <str val=''/>
-                  </choose>
-                 </withParam>
-                </applyT>
-               </sequence>
-              </elem>
-             </sequence>
-            </elem>
-           </sequence>
-          </let>
-         </let>
-        </let>
-       </let>
-      </sequence>
-     </let>
-    </sequence>
-   </templateRule>
-   <templateRule prec='0' prio='0.0' seq='25' rank='1' minImp='0' slots='1' flags='s' line='2052' module='saxon-xforms.xsl'>
-    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}action)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;action&#39;;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2060' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2061' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
-      <check card='1' diag='3|0|XTTE0570|action-map'>
-       <callT name='Q{}setAction' bSlot='2'>
-        <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2062' type='element()'/>
-        </withParam>
-       </callT>
-      </check>
-     </treat>
-     <varRef line='2075' name='Q{}action-map' slot='0'/>
-    </let>
-   </templateRule>
-   <templateRule prec='0' prio='0.0' seq='19' rank='1' minImp='0' slots='15' flags='s' line='1728' module='saxon-xforms.xsl'>
-    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1729'>
-     <param name='Q{}position' slot='0' as='xs:integer'>
-      <int role='select' val='0'/>
-      <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
-       <check card='1' diag='8|0|XTTE0590|position'>
-        <cvUntyped to='xs:integer' diag='8|0|XTTE0590|position'>
-         <data>
-          <supplied slot='0'/>
-         </data>
-        </cvUntyped>
-       </check>
-      </treat>
-     </param>
-     <param line='1730' name='Q{}context-position' slot='1' as='xs:string'>
-      <str role='select' val=''/>
-      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
-       <check card='1' diag='8|0|XTTE0590|context-position'>
-        <cvUntyped to='xs:string' diag='8|0|XTTE0590|context-position'>
-         <data>
-          <supplied slot='1'/>
-         </data>
-        </cvUntyped>
-       </check>
-      </treat>
-     </param>
-     <param line='1731' name='Q{}recalculate' slot='2' as='xs:boolean'>
-      <false role='select'/>
-      <treat role='conversion' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='8|0|XTTE0590|recalculate'>
-       <check card='1' diag='8|0|XTTE0590|recalculate'>
-        <cvUntyped to='xs:boolean' diag='8|0|XTTE0590|recalculate'>
-         <data>
-          <supplied slot='2'/>
-         </data>
-        </cvUntyped>
-       </check>
-      </treat>
-     </param>
-     <param line='1732' name='Q{}refreshRepeats' slot='3' as='xs:boolean'>
-      <false role='select'/>
-      <treat role='conversion' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='8|0|XTTE0590|refreshRepeats'>
-       <check card='1' diag='8|0|XTTE0590|refreshRepeats'>
-        <cvUntyped to='xs:boolean' diag='8|0|XTTE0590|refreshRepeats'>
-         <data>
-          <supplied slot='3'/>
-         </data>
-        </cvUntyped>
-       </check>
-      </treat>
-     </param>
-     <let line='1736' var='Q{}myid' as='xs:string' slot='4' eval='16'>
-      <choose>
-       <fn name='exists'>
-        <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
-       </fn>
-       <check card='1' diag='3|0|XTTE0570|myid'>
-        <cvUntyped to='xs:string' diag='3|0|XTTE0570|myid'>
-         <attVal name='Q{}id' chk='0'/>
-        </cvUntyped>
-       </check>
-       <true/>
-       <fn name='concat'>
-        <fn name='generate-id'>
-         <dot type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
-        </fn>
-        <str val='-'/>
-        <choose line='1734'>
-         <varRef name='Q{}context-position' slot='1'/>
-         <varRef name='Q{}context-position' slot='1'/>
-         <true/>
-         <fn name='string'>
-          <varRef name='Q{}position' slot='0'/>
-         </fn>
-        </choose>
-       </fn>
-      </choose>
-      <sequence line='1744'>
-       <choose>
-        <varRef name='Q{}recalculate' slot='2'/>
-        <empty/>
-        <true/>
-        <ifCall line='1763' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-         <check card='1' diag='0|0||ixsl:call'>
-          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-         </check>
-         <str val='setRepeatIndex'/>
-         <arrayBlock>
-          <varRef name='Q{}myid' slot='4'/>
-          <choose line='1750'>
-           <fn name='empty'>
-            <axis name='attribute' nodeTest='attribute(Q{}startindex)' jsTest='return item.name===&#39;startindex&#39;'/>
-           </fn>
-           <dbl val='1'/>
-           <castable line='1753' as='xs:double' emptiable='0'>
-            <axis name='attribute' nodeTest='attribute(Q{}startindex)' jsTest='return item.name===&#39;startindex&#39;'/>
-           </castable>
-           <cvUntyped line='1754' to='xs:double' diag='3|0|XTTE0570|this-index'>
-            <convert from='xs:double' to='xs:untypedAtomic'>
-             <fn name='number'>
-              <attVal name='Q{}startindex' chk='0'/>
-             </fn>
-            </convert>
-           </cvUntyped>
-           <true/>
-           <dbl val='1'/>
-          </choose>
-         </arrayBlock>
-        </ifCall>
-       </choose>
-       <let line='1770' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='1771' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
-         <check card='?' diag='3|0|XTTE0570|bindingi'>
-          <callT name='Q{}getBinding' bSlot='32'>
-           <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='1772' type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
-           </withParam>
-          </callT>
-         </check>
-        </treat>
-        <let line='1777' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='1778' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
-          <check card='1' diag='3|0|XTTE0570|refi'>
-           <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
-            <data>
-             <callT name='Q{}getDataRef' bSlot='33'>
-              <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='1779' type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
-              </withParam>
-              <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='1780' name='Q{}bindingi' slot='5'/>
-              </withParam>
-             </callT>
-            </data>
-           </cvUntyped>
-          </check>
-         </treat>
-         <let line='1786' var='Q{}selectedRepeatVar' as='element()*' slot='7' eval='8'>
-          <treat line='1788' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|selectedRepeatVar'>
-           <callT name='Q{}getReferencedInstanceField' bSlot='34'>
-            <withParam name='Q{}refi' flags='c' as='xs:string'>
-             <varRef line='1789' name='Q{}refi' slot='6'/>
-            </withParam>
-           </callT>
-          </treat>
-          <let line='1804' var='Q{}repeat-items' as='element(Q{}div, Q{http://www.w3.org/2001/XMLSchema}untyped)*' slot='8' eval='3'>
-           <let line='1805' var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}repeat)' slot='9' eval='16'>
-            <dot type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
-            <let line='1810' var='Q{http://saxon.sf.net/generated-variable}v0' as='element()*' slot='10' eval='4'>
-             <slash simple='1'>
-              <varRef name='Q{}this' slot='9'/>
-              <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-             </slash>
-             <forEach line='1806'>
-              <varRef name='Q{}selectedRepeatVar' slot='7'/>
-              <let line='1807' var='Q{}string-position' as='xs:string' slot='11' eval='8'>
-               <fn name='string'>
-                <fn name='position'/>
-               </fn>
-               <elem line='1809' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
-                <sequence>
-                 <att name='data-repeat-item' flags='l'>
-                  <str val='true'/>
-                 </att>
-                 <applyT line='1810' bSlot='35'>
-                  <varRef role='select' name='Q{http://saxon.sf.net/generated-variable}v0' slot='10'/>
-                  <withParam name='Q{}position' as='xs:integer'>
-                   <fn line='1812' name='position'/>
-                  </withParam>
-                  <withParam name='Q{}context-position' as='xs:string'>
-                   <choose line='1808'>
-                    <varRef name='Q{}context-position' slot='1'/>
-                    <fn name='concat'>
-                     <varRef name='Q{}context-position' slot='1'/>
-                     <str val='.'/>
-                     <varRef name='Q{}string-position' slot='11'/>
-                    </fn>
-                    <true/>
-                    <varRef name='Q{}string-position' slot='11'/>
-                   </choose>
-                  </withParam>
-                  <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                   <fn line='1811' name='concat'>
-                    <varRef name='Q{}refi' slot='6'/>
-                    <str val='['/>
-                    <fn name='position'/>
-                    <str val=']'/>
-                   </fn>
-                  </withParam>
-                 </applyT>
-                </sequence>
-               </elem>
-              </let>
-             </forEach>
-            </let>
-           </let>
-           <sequence line='1821'>
-            <choose>
-             <varRef name='Q{}refreshRepeats' slot='3'/>
-             <varRef line='1822' name='Q{}repeat-items' slot='8'/>
-             <true/>
-             <elem line='1825' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
-              <sequence line='1826'>
-               <let var='Q{}element' as='element(Q{http://www.w3.org/2002/xforms}repeat)' slot='12' eval='16'>
-                <dot type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
-                <let line='2604' var='Q{}class' as='xs:string?' slot='13' eval='7'>
-                 <choose line='2605'>
-                  <fn name='exists'>
-                   <slash simple='1'>
-                    <varRef name='Q{}element' slot='12'/>
-                    <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
-                   </slash>
-                  </fn>
-                  <cvUntyped line='2606' to='xs:string' diag='3|0|XTTE0570|class'>
-                   <cast as='xs:untypedAtomic' emptiable='0'>
-                    <fn name='string'>
-                     <convert from='xs:untypedAtomic' to='xs:string'>
-                      <data>
-                       <slash simple='1'>
-                        <varRef name='Q{}element' slot='12'/>
-                        <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
-                       </slash>
-                      </data>
-                     </convert>
-                    </fn>
-                   </cast>
-                  </cvUntyped>
-                 </choose>
-                 <let line='2609' var='Q{}class-mod' as='xs:string?' slot='14' eval='7'>
-                  <choose line='2611'>
-                   <fn name='exists'>
-                    <slash simple='1'>
-                     <varRef name='Q{}element' slot='12'/>
-                     <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
-                    </slash>
-                   </fn>
-                   <cvUntyped line='2612' to='xs:string' diag='3|0|XTTE0570|class-mod'>
-                    <cast as='xs:untypedAtomic' emptiable='0'>
-                     <fn name='string-join'>
-                      <sequence>
-                       <varRef name='Q{}class' slot='13'/>
-                       <str val='incremental'/>
-                      </sequence>
-                      <str val=' '/>
-                     </fn>
-                    </cast>
-                   </cvUntyped>
-                   <true/>
-                   <varRef line='2615' name='Q{}class' slot='13'/>
-                  </choose>
-                  <choose line='2619'>
-                   <fn name='exists'>
-                    <varRef name='Q{}class-mod' slot='14'/>
-                   </fn>
-                   <treat line='2620' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
-                    <att name='class' flags='l'>
-                     <varRef name='Q{}class-mod' slot='14'/>
-                    </att>
-                   </treat>
-                  </choose>
-                 </let>
-                </let>
-               </let>
-               <att line='1828' name='data-repeatable-context' flags='l'>
-                <varRef name='Q{}refi' slot='6'/>
-               </att>
-               <att line='1829' name='data-count' flags='l'>
-                <convert from='xs:integer' to='xs:string'>
-                 <fn name='count'>
-                  <varRef name='Q{}selectedRepeatVar' slot='7'/>
-                 </fn>
-                </convert>
-               </att>
-               <att line='1830' name='id' flags='l'>
-                <varRef name='Q{}myid' slot='4'/>
-               </att>
-               <varRef line='1832' name='Q{}repeat-items' slot='8'/>
-              </sequence>
-             </elem>
-            </choose>
-            <choose line='1840'>
-             <and op='and'>
-              <fn name='not'>
-               <varRef name='Q{}recalculate' slot='2'/>
-              </fn>
-              <fn name='empty'>
-               <slash simple='1'>
-                <dot type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
-                <axis name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
-               </slash>
-              </fn>
-             </and>
-             <ifCall line='1844' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-              <check card='1' diag='0|0||ixsl:call'>
-               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-              </check>
-              <str val='addRepeat'/>
-              <arrayBlock>
-               <varRef name='Q{}myid' slot='4'/>
-               <varRef name='Q{}refi' slot='6'/>
-              </arrayBlock>
-             </ifCall>
-            </choose>
-            <ifCall line='1848' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-             <check card='1' diag='0|0||ixsl:call'>
-              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-             </check>
-             <str val='setRepeatSize'/>
-             <arrayBlock>
-              <varRef name='Q{}myid' slot='4'/>
-              <fn name='count'>
-               <varRef name='Q{}selectedRepeatVar' slot='7'/>
-              </fn>
-             </arrayBlock>
-            </ifCall>
-           </sequence>
-          </let>
-         </let>
-        </let>
-       </let>
-      </sequence>
-     </let>
-    </sequence>
-   </templateRule>
-   <templateRule prec='0' prio='0.0' seq='5' rank='1' minImp='0' slots='0' flags='s' line='1051' module='saxon-xforms.xsl'>
-    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
-    <applyT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1052' flags='t' bSlot='36'>
-     <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
-    </applyT>
-   </templateRule>
-   <templateRule prec='0' prio='0.0' seq='18' rank='1' minImp='0' slots='6' flags='s' line='1684' module='saxon-xforms.xsl'>
-    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}group)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;group&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1685'>
-     <param name='Q{}position' slot='0' as='xs:integer'>
-      <int role='select' val='0'/>
-      <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
-       <check card='1' diag='8|0|XTTE0590|position'>
-        <cvUntyped to='xs:integer' diag='8|0|XTTE0590|position'>
-         <data>
-          <supplied slot='0'/>
-         </data>
-        </cvUntyped>
-       </check>
-      </treat>
-     </param>
-     <param line='1686' name='Q{}context-position' slot='1' as='xs:string'>
-      <str role='select' val=''/>
-      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
-       <check card='1' diag='8|0|XTTE0590|context-position'>
-        <cvUntyped to='xs:string' diag='8|0|XTTE0590|context-position'>
-         <data>
-          <supplied slot='1'/>
-         </data>
-        </cvUntyped>
-       </check>
-      </treat>
-     </param>
-     <let line='1690' var='Q{}myid' as='xs:string' slot='2' eval='16'>
-      <choose>
-       <fn name='exists'>
-        <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
-       </fn>
-       <check card='1' diag='3|0|XTTE0570|myid'>
-        <cvUntyped to='xs:string' diag='3|0|XTTE0570|myid'>
-         <attVal name='Q{}id' chk='0'/>
-        </cvUntyped>
-       </check>
-       <true/>
-       <fn name='concat'>
-        <fn name='generate-id'>
-         <dot type='element(Q{http://www.w3.org/2002/xforms}group)'/>
-        </fn>
-        <str val='-'/>
-        <choose line='1688'>
-         <varRef name='Q{}context-position' slot='1'/>
-         <varRef name='Q{}context-position' slot='1'/>
-         <true/>
-         <fn name='string'>
-          <varRef name='Q{}position' slot='0'/>
-         </fn>
-        </choose>
-       </fn>
-      </choose>
-      <sequence line='1692'>
-       <choose>
-        <and op='and'>
-         <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}group)' slot='3' eval='16'>
-          <dot type='element(Q{http://www.w3.org/2002/xforms}group)'/>
-          <fn line='2532' name='exists'>
-           <sequence line='2507'>
-            <analyzeString>
-             <cvUntyped role='select' to='xs:string'>
-              <data>
-               <slash simple='1'>
-                <varRef name='Q{}this' slot='3'/>
-                <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
-               </slash>
-              </data>
-             </cvUntyped>
-             <str role='regex' val='\i\c*\('/>
-             <str role='flags' val=''/>
-             <choose role='matching' line='2510'>
-              <vc op='eq' onEmpty='0' comp='CCC'>
-               <fn name='substring-before'>
-                <dot type='xs:string'/>
-                <str val='('/>
-               </fn>
-               <str val='index'/>
-              </vc>
-              <str val='i'/>
-             </choose>
-             <empty role='nonMatching'/>
-            </analyzeString>
-            <analyzeString line='2519'>
-             <cvUntyped role='select' to='xs:string'>
-              <data>
-               <slash simple='1'>
-                <varRef name='Q{}this' slot='3'/>
-                <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
-               </slash>
-              </data>
-             </cvUntyped>
-             <str role='regex' val='\i\c*\('/>
-             <str role='flags' val=''/>
-             <choose role='matching' line='2522'>
-              <vc op='eq' onEmpty='0' comp='CCC'>
-               <fn name='substring-before'>
-                <dot type='xs:string'/>
-                <str val='('/>
-               </fn>
-               <str val='index'/>
-              </vc>
-              <str val='i'/>
-             </choose>
-             <empty role='nonMatching'/>
-            </analyzeString>
-           </sequence>
-          </fn>
-         </let>
-         <fn name='empty'>
-          <filter flags='b'>
-           <slash simple='1'>
-            <dot type='element(Q{http://www.w3.org/2002/xforms}group)'/>
-            <axis name='ancestor' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-           </slash>
-           <let var='Q{}this' as='element()' slot='4' eval='16'>
-            <dot type='element()'/>
-            <fn line='2532' name='exists'>
-             <sequence line='2507'>
-              <analyzeString>
-               <cvUntyped role='select' to='xs:string'>
-                <data>
-                 <slash simple='1'>
-                  <varRef name='Q{}this' slot='4'/>
-                  <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
-                 </slash>
-                </data>
-               </cvUntyped>
-               <str role='regex' val='\i\c*\('/>
-               <str role='flags' val=''/>
-               <choose role='matching' line='2510'>
-                <vc op='eq' onEmpty='0' comp='CCC'>
-                 <fn name='substring-before'>
-                  <dot type='xs:string'/>
-                  <str val='('/>
-                 </fn>
-                 <str val='index'/>
-                </vc>
-                <str val='i'/>
-               </choose>
-               <empty role='nonMatching'/>
-              </analyzeString>
-              <analyzeString line='2519'>
-               <cvUntyped role='select' to='xs:string'>
-                <data>
-                 <slash simple='1'>
-                  <varRef name='Q{}this' slot='4'/>
-                  <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
-                 </slash>
-                </data>
-               </cvUntyped>
-               <str role='regex' val='\i\c*\('/>
-               <str role='flags' val=''/>
-               <choose role='matching' line='2522'>
-                <vc op='eq' onEmpty='0' comp='CCC'>
-                 <fn name='substring-before'>
-                  <dot type='xs:string'/>
-                  <str val='('/>
-                 </fn>
-                 <str val='index'/>
-                </vc>
-                <str val='i'/>
-               </choose>
-               <empty role='nonMatching'/>
-              </analyzeString>
-             </sequence>
-            </fn>
-           </let>
-          </filter>
-         </fn>
-        </and>
-        <ifCall line='1693' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-         <check card='1' diag='0|0||ixsl:call'>
-          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-         </check>
-         <str val='setElementUsingIndexFunction'/>
-         <arrayBlock>
-          <varRef name='Q{}myid' slot='2'/>
-          <dot type='element(Q{http://www.w3.org/2002/xforms}group)'/>
-         </arrayBlock>
-        </ifCall>
-       </choose>
-       <let line='1696' var='Q{}refi' as='xs:string?' slot='5' eval='7'>
-        <choose line='1698'>
-         <fn name='exists'>
-          <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
-         </fn>
-         <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
-          <attVal name='Q{}nodeset' chk='0'/>
-         </cvUntyped>
-         <fn line='1699' name='exists'>
-          <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
-         </fn>
-         <cvUntyped line='1699' to='xs:string' diag='3|0|XTTE0570|refi'>
-          <attVal name='Q{}ref' chk='0'/>
-         </cvUntyped>
-        </choose>
-        <elem line='1705' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
-         <sequence line='1706'>
-          <att name='id' flags='l'>
-           <varRef name='Q{}myid' slot='2'/>
-          </att>
-          <choose line='1707'>
-           <fn name='exists'>
-            <varRef name='Q{}refi' slot='5'/>
-           </fn>
-           <att line='1708' name='data-group-ref' flags='l'>
-            <varRef name='Q{}refi' slot='5'/>
-           </att>
-          </choose>
-          <applyT line='1710' bSlot='37'>
-           <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-           <withParam name='Q{}nodeset' flags='t' as='xs:string?'>
-            <choose line='1711'>
-             <fn name='exists'>
-              <varRef name='Q{}refi' slot='5'/>
-             </fn>
-             <varRef name='Q{}refi' slot='5'/>
-             <true/>
-             <str val=''/>
-            </choose>
-           </withParam>
-          </applyT>
-         </sequence>
-        </elem>
-       </let>
-      </sequence>
-     </let>
-    </sequence>
-   </templateRule>
-   <templateRule prec='0' prio='0.0' seq='25' part='3' rank='1' minImp='0' slots='1' flags='s' line='2052' module='saxon-xforms.xsl'>
-    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}hide)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;hide&#39;;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2060' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2061' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
-      <check card='1' diag='3|0|XTTE0570|action-map'>
-       <callT name='Q{}setAction' bSlot='2'>
-        <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2062' type='element()'/>
-        </withParam>
-       </callT>
-      </check>
-     </treat>
-     <varRef line='2075' name='Q{}action-map' slot='0'/>
-    </let>
-   </templateRule>
-   <templateRule prec='0' prio='0.0' seq='12' rank='1' minImp='0' slots='0' flags='s' line='1508' module='saxon-xforms.xsl'>
-    <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}hint)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;hint&#39;;'/>
-    <empty role='action'/>
-   </templateRule>
-   <templateRule prec='0' prio='-0.5' seq='14' part='1' rank='0' minImp='0' slots='0' flags='s' line='1623' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='14' part='1' rank='0' minImp='0' slots='0' flags='s' line='1627' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
-    <copy role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1625' flags='cin'>
+    <copy role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1629' flags='cin'>
      <applyT role='content' bSlot='38'>
       <sequence role='select'>
        <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
@@ -9637,16 +9651,16 @@
      </applyT>
     </copy>
    </templateRule>
-   <templateRule prec='0' prio='0.5' seq='15' rank='2' minImp='0' slots='0' flags='s' line='1634' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.5' seq='15' rank='2' minImp='0' slots='0' flags='s' line='1638' module='saxon-xforms.xsl'>
     <p.withPredicate role='match'>
      <p.nodeTest test='text()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===3;'/>
-     <axis ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1634' name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
+     <axis ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1638' name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
     </p.withPredicate>
     <empty role='action'/>
    </templateRule>
-   <templateRule prec='0' prio='-0.5' seq='14' rank='0' minImp='0' slots='0' flags='s' line='1623' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='14' rank='0' minImp='0' slots='0' flags='s' line='1627' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='( element() | text() | comment() | processing-instruction() )' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);'/>
-    <copy role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1625' flags='cin'>
+    <copy role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1629' flags='cin'>
      <applyT role='content' bSlot='38'>
       <sequence role='select'>
        <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
@@ -9657,9 +9671,9 @@
    </templateRule>
   </mode>
  </co>
- <co id='88' binds='87'>
-  <template name='Q{}getDataRef' flags='os' line='2839' module='saxon-xforms.xsl' slots='16'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2840'>
+ <co id='89' binds='88'>
+  <template name='Q{}getDataRef' flags='os' line='2843' module='saxon-xforms.xsl' slots='16'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2844'>
     <param name='Q{}this' slot='0' flags='r' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
       <check card='1' diag='8|0|XTTE0590|this'>
@@ -9667,7 +9681,7 @@
       </check>
      </treat>
     </param>
-    <param line='2841' name='Q{}nodeset' slot='1' flags='t' as='xs:string'>
+    <param line='2845' name='Q{}nodeset' slot='1' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -9679,7 +9693,7 @@
       </check>
      </treat>
     </param>
-    <param line='2842' name='Q{}bindingi' slot='2' as='node()?'>
+    <param line='2846' name='Q{}bindingi' slot='2' as='node()?'>
      <empty role='select'/>
      <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|bindingi'>
       <check card='?' diag='8|0|XTTE0590|bindingi'>
@@ -9687,7 +9701,7 @@
       </check>
      </treat>
     </param>
-    <let line='2850' var='Q{}this-ref' as='xs:string?' slot='3' eval='7'>
+    <let line='2854' var='Q{}this-ref' as='xs:string?' slot='3' eval='7'>
      <choose>
       <fn name='exists'>
        <slash simple='1'>
@@ -9722,12 +9736,12 @@
        </cast>
       </fn>
      </choose>
-     <let line='2857' var='Q{}this-binding-ref' as='xs:string?' slot='4' eval='7'>
-      <choose line='2859'>
+     <let line='2861' var='Q{}this-binding-ref' as='xs:string?' slot='4' eval='7'>
+      <choose line='2863'>
        <fn name='exists'>
         <varRef name='Q{}bindingi' slot='2'/>
        </fn>
-       <cvUntyped line='2870' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
+       <cvUntyped line='2874' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
         <cast as='xs:untypedAtomic' emptiable='0'>
          <choose>
           <fn name='exists'>
@@ -9761,23 +9775,23 @@
         </cast>
        </cvUntyped>
        <true/>
-       <let line='2874' var='Q{}this-binding' as='node()?' slot='5' eval='7'>
-        <treat line='2875' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|this-binding'>
+       <let line='2878' var='Q{}this-binding' as='node()?' slot='5' eval='7'>
+        <treat line='2879' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|this-binding'>
          <check card='?' diag='3|0|XTTE0570|this-binding'>
           <callT name='Q{}getBinding' bSlot='0'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <treat line='2876' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+            <treat line='2880' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
              <dot flags='a'/>
             </treat>
            </withParam>
           </callT>
          </check>
         </treat>
-        <choose line='2879'>
+        <choose line='2883'>
          <fn name='exists'>
           <varRef name='Q{}this-binding' slot='5'/>
          </fn>
-         <cvUntyped line='2886' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
+         <cvUntyped line='2890' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
           <cast as='xs:untypedAtomic' emptiable='0'>
            <choose>
             <fn name='exists'>
@@ -9813,30 +9827,30 @@
         </choose>
        </let>
       </choose>
-      <choose line='2896'>
+      <choose line='2900'>
        <fn name='exists'>
         <varRef name='Q{}bindingi' slot='2'/>
        </fn>
-       <let line='2898' var='Q{}relative' as='xs:string' slot='6' eval='16'>
+       <let line='2902' var='Q{}relative' as='xs:string' slot='6' eval='16'>
         <check card='1' diag='0|1||xforms:resolveXPathStrings'>
          <varRef name='Q{}this-binding-ref' slot='4'/>
         </check>
-        <choose line='811'>
+        <choose line='815'>
          <fn name='starts-with'>
           <varRef name='Q{}relative' slot='6'/>
           <str val='/'/>
          </fn>
-         <varRef line='812' name='Q{}relative' slot='6'/>
-         <fn line='814' name='starts-with'>
+         <varRef line='816' name='Q{}relative' slot='6'/>
+         <fn line='818' name='starts-with'>
           <varRef name='Q{}relative' slot='6'/>
           <str val='instance('/>
          </fn>
-         <varRef line='815' name='Q{}relative' slot='6'/>
+         <varRef line='819' name='Q{}relative' slot='6'/>
          <true/>
-         <varRef line='818' name='Q{}relative' slot='6'/>
+         <varRef line='822' name='Q{}relative' slot='6'/>
         </choose>
        </let>
-       <and line='2900' op='and'>
+       <and line='2904' op='and'>
         <fn name='exists'>
          <varRef name='Q{}this-ref' slot='3'/>
         </fn>
@@ -9844,7 +9858,7 @@
          <varRef name='Q{}nodeset' slot='1'/>
         </fn>
        </and>
-       <let line='2855' var='Q{}base' as='xs:string' slot='7' eval='16'>
+       <let line='2859' var='Q{}base' as='xs:string' slot='7' eval='16'>
         <choose>
          <fn name='exists'>
           <slash simple='1'>
@@ -9865,26 +9879,26 @@
          <true/>
          <str val='.'/>
         </choose>
-        <let line='2901' var='Q{}relative' as='xs:string' slot='8' eval='16'>
+        <let line='2905' var='Q{}relative' as='xs:string' slot='8' eval='16'>
          <check card='1' diag='0|1||xforms:resolveXPathStrings'>
           <varRef name='Q{}this-ref' slot='3'/>
          </check>
-         <choose line='811'>
+         <choose line='815'>
           <fn name='starts-with'>
            <varRef name='Q{}relative' slot='8'/>
            <str val='/'/>
           </fn>
-          <varRef line='812' name='Q{}relative' slot='8'/>
-          <fn line='814' name='starts-with'>
+          <varRef line='816' name='Q{}relative' slot='8'/>
+          <fn line='818' name='starts-with'>
            <varRef name='Q{}relative' slot='8'/>
            <str val='instance('/>
           </fn>
-          <varRef line='815' name='Q{}relative' slot='8'/>
-          <fn line='817' name='not'>
+          <varRef line='819' name='Q{}relative' slot='8'/>
+          <fn line='821' name='not'>
            <varRef name='Q{}base' slot='7'/>
           </fn>
-          <varRef line='818' name='Q{}relative' slot='8'/>
-          <or line='820' op='or'>
+          <varRef line='822' name='Q{}relative' slot='8'/>
+          <or line='824' op='or'>
            <fn name='not'>
             <varRef name='Q{}relative' slot='8'/>
            </fn>
@@ -9893,9 +9907,9 @@
             <str val='.'/>
            </vc>
           </or>
-          <varRef line='821' name='Q{}base' slot='7'/>
+          <varRef line='825' name='Q{}base' slot='7'/>
           <true/>
-          <let line='825' var='Q{}parentCallCount' as='xs:integer' slot='9' eval='16'>
+          <let line='829' var='Q{}parentCallCount' as='xs:integer' slot='9' eval='16'>
            <choose>
             <fn name='contains'>
              <varRef name='Q{}relative' slot='8'/>
@@ -9922,7 +9936,7 @@
             <true/>
             <int val='0'/>
            </choose>
-           <let line='828' var='Q{}slashes' as='xs:integer*' slot='10' eval='4'>
+           <let line='832' var='Q{}slashes' as='xs:integer*' slot='10' eval='4'>
             <choose>
              <fn name='contains'>
               <varRef name='Q{}base' slot='7'/>
@@ -9937,15 +9951,15 @@
              <true/>
              <int val='0'/>
             </choose>
-            <choose line='860'>
+            <choose line='864'>
              <compareToInt op='gt' val='0'>
               <varRef name='Q{}parentCallCount' slot='9'/>
              </compareToInt>
-             <fn line='864' name='concat'>
+             <fn line='868' name='concat'>
               <fn name='substring'>
                <varRef name='Q{}base' slot='7'/>
                <int val='1'/>
-               <choose line='839'>
+               <choose line='843'>
                 <and op='and'>
                  <vc op='ge' onEmpty='0' comp='CAVC'>
                   <fn name='count'>
@@ -9957,7 +9971,7 @@
                   <varRef name='Q{}parentCallCount' slot='9'/>
                  </compareToInt>
                 </and>
-                <let line='840' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='11' eval='13'>
+                <let line='844' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='11' eval='13'>
                  <arith op='-' calc='i-i'>
                   <varRef name='Q{}parentCallCount' slot='9'/>
                   <int val='1'/>
@@ -9973,7 +9987,7 @@
                  </check>
                 </let>
                 <true/>
-                <check line='843' card='1' diag='3|0|XTTE0570|parentSlash'>
+                <check line='847' card='1' diag='3|0|XTTE0570|parentSlash'>
                  <lastOf>
                   <varRef name='Q{}slashes' slot='10'/>
                  </lastOf>
@@ -9988,7 +10002,7 @@
               </fn>
              </fn>
              <true/>
-             <fn line='867' name='concat'>
+             <fn line='871' name='concat'>
               <varRef name='Q{}base' slot='7'/>
               <str val='/'/>
               <varRef name='Q{}relative' slot='8'/>
@@ -9999,29 +10013,29 @@
          </choose>
         </let>
        </let>
-       <fn line='2903' name='exists'>
+       <fn line='2907' name='exists'>
         <varRef name='Q{}this-ref' slot='3'/>
        </fn>
-       <let line='2905' var='Q{}relative' as='xs:string' slot='12' eval='16'>
+       <let line='2909' var='Q{}relative' as='xs:string' slot='12' eval='16'>
         <check card='1' diag='0|1||xforms:resolveXPathStrings'>
          <varRef name='Q{}this-ref' slot='3'/>
         </check>
-        <choose line='811'>
+        <choose line='815'>
          <fn name='starts-with'>
           <varRef name='Q{}relative' slot='12'/>
           <str val='/'/>
          </fn>
-         <varRef line='812' name='Q{}relative' slot='12'/>
-         <fn line='814' name='starts-with'>
+         <varRef line='816' name='Q{}relative' slot='12'/>
+         <fn line='818' name='starts-with'>
           <varRef name='Q{}relative' slot='12'/>
           <str val='instance('/>
          </fn>
-         <varRef line='815' name='Q{}relative' slot='12'/>
-         <fn line='2905' name='not'>
+         <varRef line='819' name='Q{}relative' slot='12'/>
+         <fn line='2909' name='not'>
           <varRef name='Q{}nodeset' slot='1'/>
          </fn>
-         <varRef line='818' name='Q{}relative' slot='12'/>
-         <or line='820' op='or'>
+         <varRef line='822' name='Q{}relative' slot='12'/>
+         <or line='824' op='or'>
           <fn name='not'>
            <varRef name='Q{}relative' slot='12'/>
           </fn>
@@ -10030,9 +10044,9 @@
            <str val='.'/>
           </vc>
          </or>
-         <varRef line='2905' name='Q{}nodeset' slot='1'/>
+         <varRef line='2909' name='Q{}nodeset' slot='1'/>
          <true/>
-         <let line='825' var='Q{}parentCallCount' as='xs:integer' slot='13' eval='16'>
+         <let line='829' var='Q{}parentCallCount' as='xs:integer' slot='13' eval='16'>
           <choose>
            <fn name='contains'>
             <varRef name='Q{}relative' slot='12'/>
@@ -10059,30 +10073,30 @@
            <true/>
            <int val='0'/>
           </choose>
-          <let line='828' var='Q{}slashes' as='xs:integer*' slot='14' eval='4'>
+          <let line='832' var='Q{}slashes' as='xs:integer*' slot='14' eval='4'>
            <choose>
-            <fn line='2905' name='contains'>
+            <fn line='2909' name='contains'>
              <varRef name='Q{}nodeset' slot='1'/>
              <str val='/'/>
             </fn>
             <fn name='index-of'>
              <fn name='string-to-codepoints'>
-              <varRef line='2905' name='Q{}nodeset' slot='1'/>
+              <varRef line='2909' name='Q{}nodeset' slot='1'/>
              </fn>
              <int val='47'/>
             </fn>
             <true/>
             <int val='0'/>
            </choose>
-           <choose line='860'>
+           <choose line='864'>
             <compareToInt op='gt' val='0'>
              <varRef name='Q{}parentCallCount' slot='13'/>
             </compareToInt>
-            <fn line='864' name='concat'>
+            <fn line='868' name='concat'>
              <fn name='substring'>
-              <varRef line='2905' name='Q{}nodeset' slot='1'/>
+              <varRef line='2909' name='Q{}nodeset' slot='1'/>
               <int val='1'/>
-              <choose line='839'>
+              <choose line='843'>
                <and op='and'>
                 <vc op='ge' onEmpty='0' comp='CAVC'>
                  <fn name='count'>
@@ -10094,7 +10108,7 @@
                  <varRef name='Q{}parentCallCount' slot='13'/>
                 </compareToInt>
                </and>
-               <let line='840' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='15' eval='13'>
+               <let line='844' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='15' eval='13'>
                 <arith op='-' calc='i-i'>
                  <varRef name='Q{}parentCallCount' slot='13'/>
                  <int val='1'/>
@@ -10110,7 +10124,7 @@
                 </check>
                </let>
                <true/>
-               <check line='843' card='1' diag='3|0|XTTE0570|parentSlash'>
+               <check line='847' card='1' diag='3|0|XTTE0570|parentSlash'>
                 <lastOf>
                  <varRef name='Q{}slashes' slot='14'/>
                 </lastOf>
@@ -10125,18 +10139,18 @@
              </fn>
             </fn>
             <true/>
-            <fn line='2905' name='concat'>
+            <fn line='2909' name='concat'>
              <varRef name='Q{}nodeset' slot='1'/>
              <str val='/'/>
-             <varRef line='867' name='Q{}relative' slot='12'/>
+             <varRef line='871' name='Q{}relative' slot='12'/>
             </fn>
            </choose>
           </let>
          </let>
         </choose>
        </let>
-       <varRef line='2907' name='Q{}nodeset' slot='1'/>
-       <choose line='2910'>
+       <varRef line='2911' name='Q{}nodeset' slot='1'/>
+       <choose line='2914'>
         <fn name='starts-with'>
          <varRef name='Q{}nodeset' slot='1'/>
          <str val='/'/>
@@ -10151,7 +10165,7 @@
         <varRef name='Q{}nodeset' slot='1'/>
        </choose>
        <true/>
-       <cvUntyped line='2914' to='xs:string' diag='3|0|XTTE0570|data-ref'>
+       <cvUntyped line='2918' to='xs:string' diag='3|0|XTTE0570|data-ref'>
         <cast as='xs:untypedAtomic' emptiable='0'>
          <varRef name='Q{}nodeset' slot='1'/>
         </cast>
@@ -10162,18 +10176,18 @@
    </sequence>
   </template>
  </co>
- <co id='25' binds='43'>
-  <function name='Q{http://www.w3.org/2002/xforms}setInstance-JS' line='2775' module='saxon-xforms.xsl' eval='7' flags='pU' as='empty-sequence()' slots='2'>
+ <co id='25' binds='44'>
+  <function name='Q{http://www.w3.org/2002/xforms}setInstance-JS' line='2779' module='saxon-xforms.xsl' eval='7' flags='pU' as='empty-sequence()' slots='2'>
    <arg name='Q{}ref' as='xs:string'/>
    <arg name='Q{}updatedInstance' as='element()'/>
-   <check role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2783' card='°' diag='5|0|XTTE0780|xforms:setInstance-JS#2'>
+   <check role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2787' card='°' diag='5|0|XTTE0780|xforms:setInstance-JS#2'>
     <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
      <check card='1' diag='0|0||ixsl:call'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
      </check>
      <str val='setInstance'/>
      <arrayBlock>
-      <check line='2781' card='1' diag='3|0|XTTE0570|this-instance-id'>
+      <check line='2785' card='1' diag='3|0|XTTE0570|this-instance-id'>
        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
         <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='0' eval='6'>
          <varRef name='Q{}ref' slot='0'/>
@@ -10187,15 +10201,15 @@
    </check>
   </function>
  </co>
- <co id='54' binds='22 43'>
-  <function name='Q{http://www.w3.org/2002/xforms}getInstance-JS' line='2748' module='saxon-xforms.xsl' eval='7' flags='pU' as='element()?' slots='1'>
+ <co id='55' binds='22 44'>
+  <function name='Q{http://www.w3.org/2002/xforms}getInstance-JS' line='2752' module='saxon-xforms.xsl' eval='7' flags='pU' as='element()?' slots='1'>
    <arg name='Q{}ref' as='xs:string'/>
-   <tailCallLoop role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2752'>
+   <tailCallLoop role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2756'>
     <choose>
      <fn name='not'>
       <varRef name='Q{}ref' slot='0'/>
      </fn>
-     <treat line='2753' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='5|0|XTTE0780|xforms:getInstance-JS#1'>
+     <treat line='2757' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='5|0|XTTE0780|xforms:getInstance-JS#1'>
       <message>
        <valueOf role='select'>
         <str val='[xforms:getInstance-JS] Empty ref supplied, no instance will be returned'/>
@@ -10205,8 +10219,8 @@
       </message>
      </treat>
      <true/>
-     <ufCall line='2758' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='foreign' bSlot='0' eval='16'>
-      <check line='2756' card='1' diag='3|0|XTTE0570|this-instance-id'>
+     <ufCall line='2762' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='foreign' bSlot='0' eval='16'>
+      <check line='2760' card='1' diag='3|0|XTTE0570|this-instance-id'>
        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
         <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='1' eval='6'>
          <varRef name='Q{}ref' slot='0'/>
@@ -10219,54 +10233,54 @@
    </tailCallLoop>
   </function>
  </co>
- <co id='43' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}getInstanceMap' line='2645' module='saxon-xforms.xsl' eval='8' flags='pU' as='map(xs:string, xs:string)' slots='3'>
+ <co id='44' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}getInstanceMap' line='2649' module='saxon-xforms.xsl' eval='8' flags='pU' as='map(xs:string, xs:string)' slots='3'>
    <arg name='Q{}nodeset' as='xs:string'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2666' var='Q{http://saxon.sf.net/generated-variable}v0' as='map(xs:string, xs:string)+' slot='1' eval='4'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2670' var='Q{http://saxon.sf.net/generated-variable}v0' as='map(xs:string, xs:string)+' slot='1' eval='4'>
     <sequence>
      <map size='1'>
       <str val='instance-id'/>
       <str val='saxon-forms-default'/>
      </map>
-     <ifCall line='2667' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+     <ifCall line='2671' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
       <str val='xpath'/>
       <fn name='normalize-space'>
        <varRef name='Q{}nodeset' slot='0'/>
       </fn>
      </ifCall>
     </sequence>
-    <ifCall line='2650' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+    <ifCall line='2654' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
      <analyzeString>
       <fn role='select' name='normalize-space'>
        <varRef name='Q{}nodeset' slot='0'/>
       </fn>
       <str role='regex' val='^instance\s*\(\s*&#39;([^&#39;]+)&#39;\s*\)\s*(/\s*(.*)|)$'/>
       <str role='flags' val=''/>
-      <let role='matching' line='2652' var='Q{}xpath' as='xs:string' slot='2' eval='16'>
-       <choose line='2654'>
+      <let role='matching' line='2656' var='Q{}xpath' as='xs:string' slot='2' eval='16'>
+       <choose line='2658'>
         <fn name='regex-group'>
          <int val='2'/>
         </fn>
-        <fn line='2655' name='regex-group'>
+        <fn line='2659' name='regex-group'>
          <int val='3'/>
         </fn>
         <true/>
         <str val='.'/>
        </choose>
-       <sequence line='2662'>
+       <sequence line='2666'>
         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
          <str val='instance-id'/>
          <fn name='regex-group'>
           <int val='1'/>
          </fn>
         </ifCall>
-        <ifCall line='2663' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+        <ifCall line='2667' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
          <str val='xpath'/>
          <varRef name='Q{}xpath' slot='2'/>
         </ifCall>
        </sequence>
       </let>
-      <varRef role='nonMatching' line='2666' name='Q{http://saxon.sf.net/generated-variable}v0' slot='1'/>
+      <varRef role='nonMatching' line='2670' name='Q{http://saxon.sf.net/generated-variable}v0' slot='1'/>
      </analyzeString>
      <map size='2'>
       <str val='duplicates'/>
@@ -10278,14 +10292,14 @@
    </let>
   </function>
  </co>
- <co id='21' binds='43'>
-  <function name='Q{http://www.w3.org/2002/xforms}getInstanceId' line='2632' module='saxon-xforms.xsl' eval='8' flags='pU' as='xs:string' slots='1'>
+ <co id='21' binds='44'>
+  <function name='Q{http://www.w3.org/2002/xforms}getInstanceId' line='2636' module='saxon-xforms.xsl' eval='8' flags='pU' as='xs:string' slots='1'>
    <arg name='Q{}nodeset' as='xs:string'/>
-   <cvUntyped role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2635' to='xs:string' diag='5|0|XTTE0780|xforms:getInstanceId#1'>
+   <cvUntyped role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2639' to='xs:string' diag='5|0|XTTE0780|xforms:getInstanceId#1'>
     <cast as='xs:untypedAtomic' emptiable='0'>
      <fn name='string'>
       <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-       <ufCall line='2634' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='0' eval='6'>
+       <ufCall line='2638' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='0' eval='6'>
         <varRef name='Q{}nodeset' slot='0'/>
        </ufCall>
        <str val='instance-id'/>
@@ -10295,20 +10309,20 @@
    </cvUntyped>
   </function>
  </co>
- <co id='90' binds=''>
+ <co id='91' binds=''>
   <globalVariable name='Q{}debugMode' type='xs:boolean' line='79' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.boolean.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
    <true/>
   </globalVariable>
  </co>
- <co id='91' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}getWhileStatement' line='782' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
+ <co id='92' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}getWhileStatement' line='786' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
    <arg name='Q{}map' as='map(*)'/>
-   <choose role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='785'>
+   <choose role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='789'>
     <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
      <varRef name='Q{}map' slot='0'/>
      <str val='@while'/>
     </ifCall>
-    <treat line='786' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
+    <treat line='790' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
      <check card='?' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
       <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
        <data>
@@ -10321,7 +10335,7 @@
      </check>
     </treat>
     <true/>
-    <treat line='789' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
+    <treat line='793' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
      <check card='?' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
       <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
        <data>
@@ -10342,9 +10356,9 @@
    </choose>
   </function>
  </co>
- <co id='92' binds='21 22 23 35 39 40'>
-  <template name='Q{}DOMActivate' flags='os' line='4024' module='saxon-xforms.xsl' slots='9'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4025'>
+ <co id='93' binds='21 22 23 35 40 41'>
+  <template name='Q{}DOMActivate' flags='os' line='4030' module='saxon-xforms.xsl' slots='9'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4031'>
     <param name='Q{}form-control' slot='0' flags='i' as='node()'>
      <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|form-control'>
       <check card='1' diag='8|0|XTTE0590|form-control'>
@@ -10352,7 +10366,7 @@
       </check>
      </treat>
     </param>
-    <let line='4027' var='Q{}actions' as='map(*)?' slot='1' eval='7'>
+    <let line='4033' var='Q{}actions' as='map(*)?' slot='1' eval='7'>
      <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
@@ -10369,12 +10383,12 @@
        </arrayBlock>
       </ifCall>
      </treat>
-     <let line='4029' var='Q{}refi' as='attribute(Q{}data-ref)?' slot='2' eval='8'>
+     <let line='4035' var='Q{}refi' as='attribute(Q{}data-ref)?' slot='2' eval='8'>
       <slash simple='1'>
        <varRef name='Q{}form-control' slot='0'/>
        <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
       </slash>
-      <let line='4031' var='Q{}instance-id' as='xs:string' slot='3' eval='16'>
+      <let line='4037' var='Q{}instance-id' as='xs:string' slot='3' eval='16'>
        <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='16'>
         <check card='1' diag='0|0||xforms:getInstanceId'>
          <cvUntyped to='xs:string'>
@@ -10384,12 +10398,12 @@
          </cvUntyped>
         </check>
        </ufCall>
-       <let line='4044' var='Q{}instanceXML' as='element()?' slot='4' eval='7'>
+       <let line='4050' var='Q{}instanceXML' as='element()?' slot='4' eval='7'>
         <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='6'>
          <varRef name='Q{}instance-id' slot='3'/>
         </ufCall>
-        <let line='4046' var='Q{}updatedInstanceXML' as='element()?' slot='5' eval='7'>
-         <choose line='4048'>
+        <let line='4052' var='Q{}updatedInstanceXML' as='element()?' slot='5' eval='7'>
+         <choose line='4054'>
           <and op='and'>
            <fn name='exists'>
             <varRef name='Q{}refi' slot='2'/>
@@ -10398,8 +10412,8 @@
             <varRef name='Q{}instanceXML' slot='4'/>
            </fn>
           </and>
-          <let line='4049' var='Q{}updatedNode' as='node()' slot='6' eval='16'>
-           <treat line='4050' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|updatedNode'>
+          <let line='4055' var='Q{}updatedNode' as='node()' slot='6' eval='16'>
+           <treat line='4056' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|updatedNode'>
             <check card='1' diag='3|0|XTTE0570|updatedNode'>
              <evaluate dxns=''>
               <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
@@ -10421,8 +10435,8 @@
              </evaluate>
             </check>
            </treat>
-           <let line='4052' var='Q{}new-value' as='xs:string' slot='7' eval='16'>
-            <treat line='4053' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-value'>
+           <let line='4058' var='Q{}new-value' as='xs:string' slot='7' eval='16'>
+            <treat line='4059' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-value'>
              <check card='1' diag='3|0|XTTE0570|new-value'>
               <cvUntyped to='xs:string' diag='3|0|XTTE0570|new-value'>
                <data>
@@ -10433,18 +10447,18 @@
               </cvUntyped>
              </check>
             </treat>
-            <treat line='4055' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+            <treat line='4061' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
              <check card='?' diag='3|0|XTTE0570|updatedInstanceXML'>
               <applyT mode='Q{}recalculate' bSlot='4'>
                <varRef role='select' name='Q{}instanceXML' slot='4'/>
                <withParam name='Q{}instance-id' as='xs:string'>
-                <varRef line='4056' name='Q{}instance-id' slot='3'/>
+                <varRef line='4062' name='Q{}instance-id' slot='3'/>
                </withParam>
                <withParam name='Q{}updated-nodes' flags='t' as='node()'>
-                <varRef line='4057' name='Q{}updatedNode' slot='6'/>
+                <varRef line='4063' name='Q{}updatedNode' slot='6'/>
                </withParam>
                <withParam name='Q{}updated-values' flags='t' as='xs:string'>
-                <varRef line='4058' name='Q{}new-value' slot='7'/>
+                <varRef line='4064' name='Q{}new-value' slot='7'/>
                </withParam>
               </applyT>
              </check>
@@ -10452,18 +10466,18 @@
            </let>
           </let>
           <true/>
-          <varRef line='4062' name='Q{}instanceXML' slot='4'/>
+          <varRef line='4068' name='Q{}instanceXML' slot='4'/>
          </choose>
-         <forEach line='4069'>
+         <forEach line='4075'>
           <varRef name='Q{}actions' slot='1'/>
-          <let line='4070' var='Q{}action-map' as='map(*)' slot='8' eval='16'>
+          <let line='4076' var='Q{}action-map' as='map(*)' slot='8' eval='16'>
            <dot type='map(*)'/>
-           <choose line='4073'>
+           <choose line='4079'>
             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
              <varRef name='Q{}action-map' slot='8'/>
              <str val='@event'/>
             </ifCall>
-            <choose line='4074'>
+            <choose line='4080'>
              <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
               <data>
                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
@@ -10473,12 +10487,12 @@
               </data>
               <str val='DOMActivate'/>
              </gc>
-             <callT line='4075' name='Q{}applyActions' bSlot='5' flags='t'>
+             <callT line='4081' name='Q{}applyActions' bSlot='5' flags='t'>
               <withParam name='Q{}action-map' flags='t' as='item()'>
-               <varRef line='4076' name='Q{}action-map' slot='8'/>
+               <varRef line='4082' name='Q{}action-map' slot='8'/>
               </withParam>
               <withParam name='Q{}instanceXML' flags='t' as='element()?'>
-               <varRef line='4077' name='Q{}updatedInstanceXML' slot='5'/>
+               <varRef line='4083' name='Q{}updatedInstanceXML' slot='5'/>
               </withParam>
              </callT>
             </choose>
@@ -10493,10 +10507,10 @@
    </sequence>
   </template>
  </co>
- <co id='93' vis='PRIVATE' binds='70 94' base='18' dpack='1'/>
- <co id='89' binds='63'>
-  <template name='Q{}setActions' flags='os' line='3160' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3161'>
+ <co id='39' vis='PRIVATE' binds='71 94' base='18' dpack='1'/>
+ <co id='90' binds='64'>
+  <template name='Q{}setActions' flags='os' line='3164' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3165'>
     <param name='Q{}this' slot='0' flags='i' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
       <check card='1' diag='8|0|XTTE0590|this'>
@@ -10504,7 +10518,7 @@
       </check>
      </treat>
     </param>
-    <applyT line='3163' flags='t' bSlot='0'>
+    <applyT line='3167' flags='t' bSlot='0'>
      <union role='select' op='|'>
       <union op='|'>
        <union op='|'>
@@ -10568,8 +10582,8 @@
   </template>
  </co>
  <co id='95' binds=''>
-  <template name='Q{}serverError' flags='os' line='1040' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1041'>
+  <template name='Q{}serverError' flags='os' line='1044' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1045'>
     <param name='Q{}responseMap' slot='0' flags='i' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|responseMap'>
       <check card='1' diag='8|0|XTTE0590|responseMap'>
@@ -10577,7 +10591,7 @@
       </check>
      </treat>
     </param>
-    <message line='1042'>
+    <message line='1046'>
      <sequence role='select'>
       <valueOf>
        <str val='Server side error HTTP response - '/>
@@ -10606,9 +10620,9 @@
    </sequence>
   </template>
  </co>
- <co id='86' binds='87 88 63'>
-  <template name='Q{}setAction' flags='os' line='3340' module='saxon-xforms.xsl' slots='20'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3341'>
+ <co id='87' binds='88 89 64'>
+  <template name='Q{}setAction' flags='os' line='3344' module='saxon-xforms.xsl' slots='20'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3345'>
     <param name='Q{}this' slot='0' flags='i' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
       <check card='1' diag='8|0|XTTE0590|this'>
@@ -10616,42 +10630,42 @@
       </check>
      </treat>
     </param>
-    <param line='3342' name='Q{}nodeset' slot='1' flags='t'>
+    <param line='3346' name='Q{}nodeset' slot='1' flags='t'>
      <str role='select' val=''/>
      <supplied role='conversion' slot='1'/>
     </param>
-    <let line='3345' var='Q{}bindingi' as='node()?' slot='2' eval='7'>
-     <treat line='3346' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+    <let line='3349' var='Q{}bindingi' as='node()?' slot='2' eval='7'>
+     <treat line='3350' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
       <check card='?' diag='3|0|XTTE0570|bindingi'>
        <callT name='Q{}getBinding' bSlot='0'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <treat line='3347' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+         <treat line='3351' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
           <dot flags='a'/>
          </treat>
         </withParam>
        </callT>
       </check>
      </treat>
-     <let line='3352' var='Q{}refi' as='xs:string' slot='3' eval='16'>
-      <treat line='3353' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+     <let line='3356' var='Q{}refi' as='xs:string' slot='3' eval='16'>
+      <treat line='3357' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
        <check card='1' diag='3|0|XTTE0570|refi'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
          <data>
           <callT name='Q{}getDataRef' bSlot='1'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <treat line='3354' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+            <treat line='3358' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
              <dot flags='a'/>
             </treat>
            </withParam>
            <withParam name='Q{}bindingi' flags='c' as='node()?'>
-            <varRef line='3355' name='Q{}bindingi' slot='2'/>
+            <varRef line='3359' name='Q{}bindingi' slot='2'/>
            </withParam>
           </callT>
          </data>
         </cvUntyped>
        </check>
       </treat>
-      <ifCall line='3363' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+      <ifCall line='3367' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
        <sequence>
         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
          <str val='name'/>
@@ -10661,14 +10675,14 @@
           </treat>
          </fn>
         </ifCall>
-        <choose line='3365'>
+        <choose line='3369'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}value)' jsTest='return item.name===&#39;value&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3366' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3370' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@value'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10678,7 +10692,7 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3368'>
+        <choose line='3372'>
          <and op='and'>
           <fn name='empty'>
            <slash simple='1'>
@@ -10695,25 +10709,25 @@
            </slash>
           </fn>
          </and>
-         <ifCall line='3369' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3373' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='value'/>
           <fn name='string'>
            <dot flags='a'/>
           </fn>
          </ifCall>
         </choose>
-        <ifCall line='3372' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+        <ifCall line='3376' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
          <str val='@ref'/>
          <varRef name='Q{}refi' slot='3'/>
         </ifCall>
-        <choose line='3378'>
+        <choose line='3382'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}position)' jsTest='return item.name===&#39;position&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3379' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3383' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@position'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10723,14 +10737,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3381'>
+        <choose line='3385'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}at)' jsTest='return item.name===&#39;at&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3382' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3386' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@at'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10740,14 +10754,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3386'>
+        <choose line='3390'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}if)' jsTest='return item.name===&#39;if&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3387' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3391' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@if'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10757,14 +10771,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3391'>
+        <choose line='3395'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}while)' jsTest='return item.name===&#39;while&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3392' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3396' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@while'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10774,14 +10788,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3395'>
+        <choose line='3399'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='@*:event' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===2&amp;&amp;q.local===&#39;event&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3396' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3400' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@event'/>
           <fn name='string'>
            <check card='?' diag='0|0||fn:string'>
@@ -10793,14 +10807,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3398'>
+        <choose line='3402'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}submission)' jsTest='return item.name===&#39;submission&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3399' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3403' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@submission'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10810,14 +10824,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3402'>
+        <choose line='3406'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}model)' jsTest='return item.name===&#39;model&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3403' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3407' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@model'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10827,14 +10841,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3406'>
+        <choose line='3410'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}control)' jsTest='return item.name===&#39;control&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3407' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3411' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@control'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10844,14 +10858,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3410'>
+        <choose line='3414'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}repeat)' jsTest='return item.name===&#39;repeat&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3411' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3415' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@repeat'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10861,14 +10875,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3414'>
+        <choose line='3418'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}index)' jsTest='return item.name===&#39;index&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3415' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3419' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@index'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10878,14 +10892,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3418'>
+        <choose line='3422'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}level)' jsTest='return item.name===&#39;level&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3419' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3423' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@level'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10895,16 +10909,16 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3422'>
+        <choose line='3426'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}origin)' jsTest='return item.name===&#39;origin&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3430' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3434' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@origin'/>
-          <let line='3426' var='Q{}base' as='xs:string' slot='4' eval='16'>
+          <let line='3430' var='Q{}base' as='xs:string' slot='4' eval='16'>
            <choose>
             <fn name='exists'>
              <slash simple='1'>
@@ -10933,22 +10947,22 @@
                 </data>
                </cvUntyped>
               </check>
-              <choose line='811'>
+              <choose line='815'>
                <fn name='starts-with'>
                 <varRef name='Q{}relative' slot='6'/>
                 <str val='/'/>
                </fn>
-               <varRef line='812' name='Q{}relative' slot='6'/>
-               <fn line='814' name='starts-with'>
+               <varRef line='816' name='Q{}relative' slot='6'/>
+               <fn line='818' name='starts-with'>
                 <varRef name='Q{}relative' slot='6'/>
                 <str val='instance('/>
                </fn>
-               <varRef line='815' name='Q{}relative' slot='6'/>
-               <fn line='817' name='not'>
+               <varRef line='819' name='Q{}relative' slot='6'/>
+               <fn line='821' name='not'>
                 <varRef name='Q{}base' slot='5'/>
                </fn>
-               <varRef line='818' name='Q{}relative' slot='6'/>
-               <or line='820' op='or'>
+               <varRef line='822' name='Q{}relative' slot='6'/>
+               <or line='824' op='or'>
                 <fn name='not'>
                  <varRef name='Q{}relative' slot='6'/>
                 </fn>
@@ -10957,9 +10971,9 @@
                  <str val='.'/>
                 </vc>
                </or>
-               <varRef line='821' name='Q{}base' slot='5'/>
+               <varRef line='825' name='Q{}base' slot='5'/>
                <true/>
-               <let line='825' var='Q{}parentCallCount' as='xs:integer' slot='7' eval='16'>
+               <let line='829' var='Q{}parentCallCount' as='xs:integer' slot='7' eval='16'>
                 <choose>
                  <fn name='contains'>
                   <varRef name='Q{}relative' slot='6'/>
@@ -10986,7 +11000,7 @@
                  <true/>
                  <int val='0'/>
                 </choose>
-                <let line='828' var='Q{}slashes' as='xs:integer*' slot='8' eval='4'>
+                <let line='832' var='Q{}slashes' as='xs:integer*' slot='8' eval='4'>
                  <choose>
                   <fn name='contains'>
                    <varRef name='Q{}base' slot='5'/>
@@ -11001,15 +11015,15 @@
                   <true/>
                   <int val='0'/>
                  </choose>
-                 <choose line='860'>
+                 <choose line='864'>
                   <compareToInt op='gt' val='0'>
                    <varRef name='Q{}parentCallCount' slot='7'/>
                   </compareToInt>
-                  <fn line='864' name='concat'>
+                  <fn line='868' name='concat'>
                    <fn name='substring'>
                     <varRef name='Q{}base' slot='5'/>
                     <int val='1'/>
-                    <choose line='839'>
+                    <choose line='843'>
                      <and op='and'>
                       <vc op='ge' onEmpty='0' comp='CAVC'>
                        <fn name='count'>
@@ -11021,7 +11035,7 @@
                        <varRef name='Q{}parentCallCount' slot='7'/>
                       </compareToInt>
                      </and>
-                     <let line='840' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='9' eval='16'>
+                     <let line='844' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='9' eval='16'>
                       <arith op='-' calc='i-i'>
                        <varRef name='Q{}parentCallCount' slot='7'/>
                        <int val='1'/>
@@ -11037,7 +11051,7 @@
                       </check>
                      </let>
                      <true/>
-                     <check line='843' card='1' diag='3|0|XTTE0570|parentSlash'>
+                     <check line='847' card='1' diag='3|0|XTTE0570|parentSlash'>
                       <lastOf>
                        <varRef name='Q{}slashes' slot='8'/>
                       </lastOf>
@@ -11052,7 +11066,7 @@
                    </fn>
                   </fn>
                   <true/>
-                  <fn line='867' name='concat'>
+                  <fn line='871' name='concat'>
                    <varRef name='Q{}base' slot='5'/>
                    <str val='/'/>
                    <varRef name='Q{}relative' slot='6'/>
@@ -11074,7 +11088,7 @@
              </check>
             </treat>
            </choose>
-           <let line='3428' var='Q{}relative' as='xs:string' slot='10' eval='16'>
+           <let line='3432' var='Q{}relative' as='xs:string' slot='10' eval='16'>
             <check card='1' diag='0|1||xforms:resolveXPathStrings'>
              <cvUntyped to='xs:string'>
               <data>
@@ -11085,22 +11099,22 @@
               </data>
              </cvUntyped>
             </check>
-            <choose line='811'>
+            <choose line='815'>
              <fn name='starts-with'>
               <varRef name='Q{}relative' slot='10'/>
               <str val='/'/>
              </fn>
-             <varRef line='812' name='Q{}relative' slot='10'/>
-             <fn line='814' name='starts-with'>
+             <varRef line='816' name='Q{}relative' slot='10'/>
+             <fn line='818' name='starts-with'>
               <varRef name='Q{}relative' slot='10'/>
               <str val='instance('/>
              </fn>
-             <varRef line='815' name='Q{}relative' slot='10'/>
-             <fn line='817' name='not'>
+             <varRef line='819' name='Q{}relative' slot='10'/>
+             <fn line='821' name='not'>
               <varRef name='Q{}base' slot='4'/>
              </fn>
-             <varRef line='818' name='Q{}relative' slot='10'/>
-             <or line='820' op='or'>
+             <varRef line='822' name='Q{}relative' slot='10'/>
+             <or line='824' op='or'>
               <fn name='not'>
                <varRef name='Q{}relative' slot='10'/>
               </fn>
@@ -11109,9 +11123,9 @@
                <str val='.'/>
               </vc>
              </or>
-             <varRef line='821' name='Q{}base' slot='4'/>
+             <varRef line='825' name='Q{}base' slot='4'/>
              <true/>
-             <let line='825' var='Q{}parentCallCount' as='xs:integer' slot='11' eval='16'>
+             <let line='829' var='Q{}parentCallCount' as='xs:integer' slot='11' eval='16'>
               <choose>
                <fn name='contains'>
                 <varRef name='Q{}relative' slot='10'/>
@@ -11138,7 +11152,7 @@
                <true/>
                <int val='0'/>
               </choose>
-              <let line='828' var='Q{}slashes' as='xs:integer*' slot='12' eval='4'>
+              <let line='832' var='Q{}slashes' as='xs:integer*' slot='12' eval='4'>
                <choose>
                 <fn name='contains'>
                  <varRef name='Q{}base' slot='4'/>
@@ -11153,15 +11167,15 @@
                 <true/>
                 <int val='0'/>
                </choose>
-               <choose line='860'>
+               <choose line='864'>
                 <compareToInt op='gt' val='0'>
                  <varRef name='Q{}parentCallCount' slot='11'/>
                 </compareToInt>
-                <fn line='864' name='concat'>
+                <fn line='868' name='concat'>
                  <fn name='substring'>
                   <varRef name='Q{}base' slot='4'/>
                   <int val='1'/>
-                  <choose line='839'>
+                  <choose line='843'>
                    <and op='and'>
                     <vc op='ge' onEmpty='0' comp='CAVC'>
                      <fn name='count'>
@@ -11173,7 +11187,7 @@
                      <varRef name='Q{}parentCallCount' slot='11'/>
                     </compareToInt>
                    </and>
-                   <let line='840' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='13' eval='13'>
+                   <let line='844' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='13' eval='13'>
                     <arith op='-' calc='i-i'>
                      <varRef name='Q{}parentCallCount' slot='11'/>
                      <int val='1'/>
@@ -11189,7 +11203,7 @@
                     </check>
                    </let>
                    <true/>
-                   <check line='843' card='1' diag='3|0|XTTE0570|parentSlash'>
+                   <check line='847' card='1' diag='3|0|XTTE0570|parentSlash'>
                     <lastOf>
                      <varRef name='Q{}slashes' slot='12'/>
                     </lastOf>
@@ -11204,7 +11218,7 @@
                  </fn>
                 </fn>
                 <true/>
-                <fn line='867' name='concat'>
+                <fn line='871' name='concat'>
                  <varRef name='Q{}base' slot='4'/>
                  <str val='/'/>
                  <varRef name='Q{}relative' slot='10'/>
@@ -11217,14 +11231,14 @@
           </let>
          </ifCall>
         </choose>
-        <choose line='3433'>
+        <choose line='3437'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}context)' jsTest='return item.name===&#39;context&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3434' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3438' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@context'/>
           <let var='Q{}base' as='xs:string' slot='14' eval='16'>
            <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:resolveXPathStrings'>
@@ -11247,22 +11261,22 @@
               </data>
              </cvUntyped>
             </check>
-            <choose line='811'>
+            <choose line='815'>
              <fn name='starts-with'>
               <varRef name='Q{}relative' slot='15'/>
               <str val='/'/>
              </fn>
-             <varRef line='812' name='Q{}relative' slot='15'/>
-             <fn line='814' name='starts-with'>
+             <varRef line='816' name='Q{}relative' slot='15'/>
+             <fn line='818' name='starts-with'>
               <varRef name='Q{}relative' slot='15'/>
               <str val='instance('/>
              </fn>
-             <varRef line='815' name='Q{}relative' slot='15'/>
-             <fn line='817' name='not'>
+             <varRef line='819' name='Q{}relative' slot='15'/>
+             <fn line='821' name='not'>
               <varRef name='Q{}base' slot='14'/>
              </fn>
-             <varRef line='818' name='Q{}relative' slot='15'/>
-             <or line='820' op='or'>
+             <varRef line='822' name='Q{}relative' slot='15'/>
+             <or line='824' op='or'>
               <fn name='not'>
                <varRef name='Q{}relative' slot='15'/>
               </fn>
@@ -11271,9 +11285,9 @@
                <str val='.'/>
               </vc>
              </or>
-             <varRef line='821' name='Q{}base' slot='14'/>
+             <varRef line='825' name='Q{}base' slot='14'/>
              <true/>
-             <let line='825' var='Q{}parentCallCount' as='xs:integer' slot='16' eval='16'>
+             <let line='829' var='Q{}parentCallCount' as='xs:integer' slot='16' eval='16'>
               <choose>
                <fn name='contains'>
                 <varRef name='Q{}relative' slot='15'/>
@@ -11300,7 +11314,7 @@
                <true/>
                <int val='0'/>
               </choose>
-              <let line='828' var='Q{}slashes' as='xs:integer*' slot='17' eval='4'>
+              <let line='832' var='Q{}slashes' as='xs:integer*' slot='17' eval='4'>
                <choose>
                 <fn name='contains'>
                  <varRef name='Q{}base' slot='14'/>
@@ -11315,15 +11329,15 @@
                 <true/>
                 <int val='0'/>
                </choose>
-               <choose line='860'>
+               <choose line='864'>
                 <compareToInt op='gt' val='0'>
                  <varRef name='Q{}parentCallCount' slot='16'/>
                 </compareToInt>
-                <fn line='864' name='concat'>
+                <fn line='868' name='concat'>
                  <fn name='substring'>
                   <varRef name='Q{}base' slot='14'/>
                   <int val='1'/>
-                  <choose line='839'>
+                  <choose line='843'>
                    <and op='and'>
                     <vc op='ge' onEmpty='0' comp='CAVC'>
                      <fn name='count'>
@@ -11335,7 +11349,7 @@
                      <varRef name='Q{}parentCallCount' slot='16'/>
                     </compareToInt>
                    </and>
-                   <let line='840' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='18' eval='13'>
+                   <let line='844' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='18' eval='13'>
                     <arith op='-' calc='i-i'>
                      <varRef name='Q{}parentCallCount' slot='16'/>
                      <int val='1'/>
@@ -11351,7 +11365,7 @@
                     </check>
                    </let>
                    <true/>
-                   <check line='843' card='1' diag='3|0|XTTE0570|parentSlash'>
+                   <check line='847' card='1' diag='3|0|XTTE0570|parentSlash'>
                     <lastOf>
                      <varRef name='Q{}slashes' slot='17'/>
                     </lastOf>
@@ -11366,7 +11380,7 @@
                  </fn>
                 </fn>
                 <true/>
-                <fn line='867' name='concat'>
+                <fn line='871' name='concat'>
                  <varRef name='Q{}base' slot='14'/>
                  <str val='/'/>
                  <varRef name='Q{}relative' slot='15'/>
@@ -11379,28 +11393,28 @@
           </let>
          </ifCall>
         </choose>
-        <choose line='3438'>
+        <choose line='3442'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
           </slash>
          </fn>
-         <ifCall line='3439' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3443' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='nested-actions'/>
-          <let line='3440' var='Q{}array' as='map(*)*' slot='19' eval='3'>
-           <treat line='3441' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|array'>
+          <let line='3444' var='Q{}array' as='map(*)*' slot='19' eval='3'>
+           <treat line='3445' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|array'>
             <forEach>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
              </slash>
-             <applyT line='3442' bSlot='2'>
+             <applyT line='3446' bSlot='2'>
               <dot role='select' type='element()'/>
              </applyT>
             </forEach>
            </treat>
-           <ifCall line='3445' name='Q{http://www.w3.org/2005/xpath-functions/array}_from-sequence' type='array(*)'>
+           <ifCall line='3449' name='Q{http://www.w3.org/2005/xpath-functions/array}_from-sequence' type='array(*)'>
             <varRef name='Q{}array' slot='19'/>
            </ifCall>
           </let>
@@ -11420,9 +11434,9 @@
   </template>
  </co>
  <co id='96' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}check-constraints-on-fields' line='932' module='saxon-xforms.xsl' eval='8' flags='pU' as='item()*' slots='4'>
+  <function name='Q{http://www.w3.org/2002/xforms}check-constraints-on-fields' line='936' module='saxon-xforms.xsl' eval='8' flags='pU' as='item()*' slots='4'>
    <arg name='Q{}updatedInstanceXML' as='document-node()'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='935' var='Q{}constraint-fieldsi' as='element()*' slot='1' eval='8'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='939' var='Q{}constraint-fieldsi' as='element()*' slot='1' eval='8'>
     <filter flags='b'>
      <slash simple='1'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
@@ -11432,10 +11446,10 @@
       <axis name='attribute' nodeTest='attribute(Q{}data-constraint)' jsTest='return item.name===&#39;data-constraint&#39;'/>
      </fn>
     </filter>
-    <forEach line='939'>
+    <forEach line='943'>
      <varRef name='Q{}constraint-fieldsi' slot='1'/>
-     <let line='940' var='Q{}contexti' as='node()' slot='2' eval='16'>
-      <treat line='941' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|contexti'>
+     <let line='944' var='Q{}contexti' as='node()' slot='2' eval='16'>
+      <treat line='945' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|contexti'>
        <check card='1' diag='3|0|XTTE0570|contexti'>
         <evaluate dxns=''>
          <check role='xpath' card='1' diag='4|0||xsl:evaluate/xpath'>
@@ -11451,8 +11465,8 @@
         </evaluate>
        </check>
       </treat>
-      <let line='944' var='Q{}resulti' as='xs:boolean' slot='3' eval='16'>
-       <treat line='947' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|resulti'>
+      <let line='948' var='Q{}resulti' as='xs:boolean' slot='3' eval='16'>
+       <treat line='951' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|resulti'>
         <check card='1' diag='3|0|XTTE0570|resulti'>
          <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|resulti'>
           <data>
@@ -11472,7 +11486,7 @@
          </cvUntyped>
         </check>
        </treat>
-       <choose line='955'>
+       <choose line='959'>
         <fn name='not'>
          <varRef name='Q{}resulti' slot='3'/>
         </fn>
@@ -11484,78 +11498,58 @@
    </let>
   </function>
  </co>
- <co id='97' binds='82'>
+ <co id='97' binds='83'>
   <globalVariable name='Q{http://saxon.sf.net/ns/packages}LOGLEVEL' type='xs:integer' line='62' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.integer.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
    <gVarRef ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='62' name='Q{}LOGLEVEL_INT' bSlot='0'/>
   </globalVariable>
  </co>
  <co id='98' binds='38 38'>
   <mode name='Q{http://saxonica.com/ns/interactiveXSLT}onchange' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='0.0' seq='1' rank='0' minImp='0' slots='0' flags='s' line='685' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='1' rank='0' minImp='0' slots='0' flags='s' line='689' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
-    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='686' name='Q{}xforms-value-changed' bSlot='0' flags='t'>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='690' name='Q{}xforms-value-changed' bSlot='0' flags='t'>
      <withParam name='Q{}form-control' flags='c' as='node()'>
-      <dot line='687' type='element(Q{}input)'/>
+      <dot line='691' type='element(Q{}input)'/>
      </withParam>
     </callT>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='2' rank='0' minImp='0' slots='0' flags='s' line='695' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='2' rank='0' minImp='0' slots='0' flags='s' line='699' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{}select)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;select&#39;;'/>
-    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='696' name='Q{}xforms-value-changed' bSlot='1' flags='t'>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='700' name='Q{}xforms-value-changed' bSlot='1' flags='t'>
      <withParam name='Q{}form-control' flags='c' as='node()'>
-      <dot line='697' type='element(Q{}select)'/>
+      <dot line='701' type='element(Q{}select)'/>
      </withParam>
     </callT>
    </templateRule>
   </mode>
  </co>
  <co id='99' vis='PRIVATE' binds='' base='1' dpack='1'/>
- <co id='77' binds='67 93 100 84 84 101 63'>
-  <template name='Q{}xformsjs-main' flags='os' line='116' module='saxon-xforms.xsl' slots='22'>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='583' var='Q{http://saxon.sf.net/generated-variable}v1' as='item()' slot='4' eval='13'>
+ <co id='78' binds='68 39 65 100 65 65 101 65 65 65 65 85 65 85 65 65 102 64 65'>
+  <template name='Q{}xformsjs-main' flags='os' line='116' module='saxon-xforms.xsl' slots='19'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='587' var='Q{http://saxon.sf.net/generated-variable}v1' as='item()' slot='2' eval='13'>
     <check card='1' diag='0|0||ixsl:call'>
      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
     </check>
-    <let line='554' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='5' eval='13'>
+    <let line='558' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='3' eval='13'>
      <check card='1' diag='0|0||ixsl:call'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
      </check>
-     <sequence line='117'>
-      <param name='Q{}xforms-doc' slot='0' as='document-node()?'>
+     <sequence line='119'>
+      <param name='Q{}instance-docs' slot='0' as='map(*)?'>
        <empty role='select'/>
-       <treat role='conversion' as='document-node()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);' diag='8|0|XTTE0590|xforms-doc'>
-        <check card='?' diag='8|0|XTTE0590|xforms-doc'>
+       <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|instance-docs'>
+        <check card='?' diag='8|0|XTTE0590|instance-docs'>
          <supplied slot='0'/>
         </check>
        </treat>
       </param>
-      <param line='118' name='Q{}xforms-file' slot='1' as='xs:string?'>
-       <empty role='select'/>
-       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|xforms-file'>
-        <check card='?' diag='8|0|XTTE0590|xforms-file'>
-         <cvUntyped to='xs:string' diag='8|0|XTTE0590|xforms-file'>
-          <data>
-           <supplied slot='1'/>
-          </data>
-         </cvUntyped>
-        </check>
-       </treat>
-      </param>
-      <param line='119' name='Q{}instance-docs' slot='2' as='map(*)?'>
-       <empty role='select'/>
-       <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|instance-docs'>
-        <check card='?' diag='8|0|XTTE0590|instance-docs'>
-         <supplied slot='2'/>
-        </check>
-       </treat>
-      </param>
-      <param line='121' name='Q{}xFormsId' slot='3' as='xs:string'>
+      <param line='121' name='Q{}xFormsId' slot='1' as='xs:string'>
        <gVarRef role='select' name='Q{}xform-html-id' bSlot='0'/>
        <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|xFormsId'>
         <check card='1' diag='8|0|XTTE0590|xFormsId'>
          <cvUntyped to='xs:string' diag='8|0|XTTE0590|xFormsId'>
           <data>
-           <supplied slot='3'/>
+           <supplied slot='1'/>
           </data>
          </cvUntyped>
         </check>
@@ -11571,167 +11565,344 @@
       <ufCall line='124' name='Q{http://saxon.sf.net/ns/packages}logInfo' tailCall='false' bSlot='1' eval='0'>
        <str val='[xformsjs-main] START'/>
       </ufCall>
-      <let line='126' var='Q{}xforms-doci' as='document-node()?' slot='6' eval='7'>
-       <choose>
-        <fn name='empty'>
-         <varRef name='Q{}xforms-doc' slot='0'/>
-        </fn>
-        <fn name='doc'>
-         <varRef name='Q{}xforms-file' slot='1'/>
-        </fn>
-        <true/>
-        <varRef name='Q{}xforms-doc' slot='0'/>
-       </choose>
-       <let line='128' var='Q{}xform' as='element(Q{http://www.w3.org/2002/xforms}xform, Q{http://www.w3.org/2001/XMLSchema}untyped)' slot='7' eval='16'>
-        <treat as='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;' diag='3|0|XTTE0570|xform'>
-         <let var='Q{}this' as='element()' slot='8' eval='16'>
-          <check card='1' diag='0|0||xforms:addNamespaceDeclarations'>
-           <slash simple='1'>
-            <varRef name='Q{}xforms-doci' slot='6'/>
-            <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-           </slash>
-          </check>
-          <compElem line='2542'>
-           <fn role='name' name='name'>
-            <varRef name='Q{}this' slot='8'/>
-           </fn>
-           <sequence role='content' line='2543'>
-            <namespace flags='l'>
-             <str role='name' val='xforms'/>
-             <str role='select' val='http://www.w3.org/2002/xforms'/>
-            </namespace>
-            <forEach line='2544'>
+      <choose line='128'>
+       <fn name='empty'>
+        <gVarRef name='Q{}xforms-doc' bSlot='2'/>
+       </fn>
+       <ufCall line='129' name='Q{http://saxon.sf.net/ns/packages}logFatal' tailCall='false' bSlot='3' eval='0'>
+        <str val='[xformsjs-main] Unable to load XForm!'/>
+       </ufCall>
+      </choose>
+      <let line='132' var='Q{}xform' as='element(Q{http://www.w3.org/2002/xforms}xform, Q{http://www.w3.org/2001/XMLSchema}untyped)' slot='4' eval='16'>
+       <treat as='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;' diag='3|0|XTTE0570|xform'>
+        <let var='Q{}this' as='element()' slot='5' eval='16'>
+         <check card='1' diag='0|0||xforms:addNamespaceDeclarations'>
+          <slash simple='1'>
+           <gVarRef name='Q{}xforms-doc' bSlot='4'/>
+           <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+          </slash>
+         </check>
+         <compElem line='2546'>
+          <fn role='name' name='name'>
+           <varRef name='Q{}this' slot='5'/>
+          </fn>
+          <sequence role='content' line='2547'>
+           <namespace flags='l'>
+            <str role='name' val='xforms'/>
+            <str role='select' val='http://www.w3.org/2002/xforms'/>
+           </namespace>
+           <forEach line='2548'>
+            <filter flags='b'>
              <filter flags='b'>
-              <filter flags='b'>
-               <slash simple='1'>
-                <varRef name='Q{}this' slot='8'/>
-                <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-               </slash>
-               <fn name='boolean'>
-                <fn name='namespace-uri'>
-                 <dot type='element()'/>
-                </fn>
+              <slash simple='1'>
+               <varRef name='Q{}this' slot='5'/>
+               <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+              </slash>
+              <fn name='boolean'>
+               <fn name='namespace-uri'>
+                <dot type='element()'/>
                </fn>
-              </filter>
-              <fn name='not'>
-               <gc op='=' card='N:1' comp='CCC'>
-                <sequence>
-                 <slash>
-                  <fn name='reverse'>
-                   <axis name='ancestor' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-                  </fn>
-                  <fn name='namespace-uri'>
-                   <dot type='element()'/>
-                  </fn>
-                 </slash>
-                 <slash>
-                  <fn name='reverse'>
-                   <axis name='preceding' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-                  </fn>
-                  <fn name='namespace-uri'>
-                   <dot type='element()'/>
-                  </fn>
-                 </slash>
-                </sequence>
-                <fn name='namespace-uri'>
-                 <dot type='element()'/>
-                </fn>
-               </gc>
               </fn>
              </filter>
-             <namespace line='2547' flags='l'>
-              <fn role='name' line='2546' name='substring-before'>
-               <fn name='name'>
-                <dot type='element()'/>
-               </fn>
-               <str val=':'/>
-              </fn>
-              <convert role='select' from='xs:anyURI' to='xs:string'>
-               <fn line='2545' name='namespace-uri'>
-                <dot type='element()'/>
-               </fn>
-              </convert>
-             </namespace>
-            </forEach>
-            <copyOf line='2549' flags='vc'>
-             <sequence>
-              <slash simple='1'>
-               <varRef name='Q{}this' slot='8'/>
-               <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
-              </slash>
-              <slash simple='1'>
-               <varRef name='Q{}this' slot='8'/>
-               <axis name='child' nodeTest='( element() | text() | comment() | processing-instruction() )' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);'/>
-              </slash>
-             </sequence>
-            </copyOf>
-           </sequence>
-          </compElem>
-         </let>
-        </treat>
-        <let line='131' var='Q{}xforms-instances' as='map(xs:string, element())' slot='9' eval='16'>
-         <choose line='133'>
-          <fn name='empty'>
-           <varRef name='Q{}instance-docs' slot='2'/>
-          </fn>
-          <let line='134' var='Q{}instances' as='element(Q{http://www.w3.org/2002/xforms}instance)*' slot='10' eval='4'>
-           <slash simple='2'>
-            <slash simple='2'>
-             <slash simple='1'>
-              <varRef name='Q{}xforms-doci' slot='6'/>
-              <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
-             </slash>
-             <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
-            </slash>
-            <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}instance)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;instance&#39;;'/>
-           </slash>
-           <check line='135' card='1' diag='3|0|XTTE0570|xforms-instances'>
-            <sequence>
-             <choose>
-              <fn name='exists'>
-               <tail start='2'>
-                <filter flags='b'>
-                 <varRef name='Q{}instances' slot='10'/>
-                 <fn name='empty'>
-                  <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+             <fn name='not'>
+              <gc op='=' card='N:1' comp='CCC'>
+               <sequence>
+                <slash>
+                 <fn name='reverse'>
+                  <axis name='ancestor' nodeTest='element()' jsTest='return item.nodeType===1;'/>
                  </fn>
-                </filter>
-               </tail>
+                 <fn name='namespace-uri'>
+                  <dot type='element()'/>
+                 </fn>
+                </slash>
+                <slash>
+                 <fn name='reverse'>
+                  <axis name='preceding' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+                 </fn>
+                 <fn name='namespace-uri'>
+                  <dot type='element()'/>
+                 </fn>
+                </slash>
+               </sequence>
+               <fn name='namespace-uri'>
+                <dot type='element()'/>
+               </fn>
+              </gc>
+             </fn>
+            </filter>
+            <namespace line='2551' flags='l'>
+             <fn role='name' line='2550' name='substring-before'>
+              <fn name='name'>
+               <dot type='element()'/>
               </fn>
-              <treat line='137' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|xforms-instances'>
-               <message>
-                <str role='select' val='[xformsjs-main] FATAL ERROR: The XForm contains more than one instance with no ID. At most one instance may have no ID.'/>
-                <str role='terminate' val='yes'/>
-                <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-               </message>
-              </treat>
-             </choose>
-             <ifCall line='141' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+              <str val=':'/>
+             </fn>
+             <convert role='select' from='xs:anyURI' to='xs:string'>
+              <fn line='2549' name='namespace-uri'>
+               <dot type='element()'/>
+              </fn>
+             </convert>
+            </namespace>
+           </forEach>
+           <copyOf line='2553' flags='vc'>
+            <sequence>
+             <slash simple='1'>
+              <varRef name='Q{}this' slot='5'/>
+              <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+             </slash>
+             <slash simple='1'>
+              <varRef name='Q{}this' slot='5'/>
+              <axis name='child' nodeTest='( element() | text() | comment() | processing-instruction() )' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);'/>
+             </slash>
+            </sequence>
+           </copyOf>
+          </sequence>
+         </compElem>
+        </let>
+       </treat>
+       <let line='135' var='Q{}xforms-instances' as='map(xs:string, element())' slot='6' eval='16'>
+        <choose line='137'>
+         <fn name='empty'>
+          <varRef name='Q{}instance-docs' slot='0'/>
+         </fn>
+         <let line='138' var='Q{}instances' as='element(Q{http://www.w3.org/2002/xforms}instance)*' slot='7' eval='4'>
+          <slash simple='2'>
+           <slash simple='2'>
+            <slash simple='1'>
+             <gVarRef name='Q{}xforms-doc' bSlot='5'/>
+             <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
+            </slash>
+            <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
+           </slash>
+           <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}instance)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;instance&#39;;'/>
+          </slash>
+          <check line='139' card='1' diag='3|0|XTTE0570|xforms-instances'>
+           <sequence>
+            <choose>
+             <fn name='exists'>
+              <tail start='2'>
+               <filter flags='b'>
+                <varRef name='Q{}instances' slot='7'/>
+                <fn name='empty'>
+                 <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+                </fn>
+               </filter>
+              </tail>
+             </fn>
+             <treat line='141' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|xforms-instances'>
+              <message>
+               <str role='select' val='[xformsjs-main] FATAL ERROR: The XForm contains more than one instance with no ID. At most one instance may have no ID.'/>
+               <str role='terminate' val='yes'/>
+               <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+              </message>
+             </treat>
+            </choose>
+            <ifCall line='145' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+             <forEach>
+              <varRef name='Q{}instances' slot='7'/>
+              <let line='146' var='Q{}instance-with-explicit-namespaces' as='element()' slot='8' eval='16'>
+               <treat line='147' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-explicit-namespaces'>
+                <check card='1' diag='3|0|XTTE0570|instance-with-explicit-namespaces'>
+                 <applyT mode='Q{}namespace-fix' bSlot='6'>
+                  <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+                 </applyT>
+                </check>
+               </treat>
+               <ifCall line='156' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                <check card='1' diag='0|0||map:entry'>
+                 <cast as='xs:string' emptiable='1'>
+                  <choose>
+                   <fn name='exists'>
+                    <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+                   </fn>
+                   <attVal name='Q{}id' chk='0'/>
+                   <true/>
+                   <str val='saxon-forms-default'/>
+                  </choose>
+                 </cast>
+                </check>
+                <varRef name='Q{}instance-with-explicit-namespaces' slot='8'/>
+               </ifCall>
+              </let>
+             </forEach>
+             <map size='2'>
+              <str val='duplicates'/>
+              <str val='reject'/>
+              <str val='duplicates-error-code'/>
+              <str val='XTDE3365'/>
+             </map>
+            </ifCall>
+           </sequence>
+          </check>
+         </let>
+         <true/>
+         <treat line='161' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|xforms-instances'>
+          <check card='1' diag='3|0|XTTE0570|xforms-instances'>
+           <varRef name='Q{}instance-docs' slot='0'/>
+          </check>
+         </treat>
+        </choose>
+        <let line='168' var='Q{}default-instance' as='element()' slot='9' eval='16'>
+         <choose line='170'>
+          <fn name='empty'>
+           <varRef name='Q{}instance-docs' slot='0'/>
+          </fn>
+          <choose line='172'>
+           <fn name='exists'>
+            <filter flags='b'>
+             <slash simple='2'>
+              <slash simple='2'>
+               <slash simple='1'>
+                <gVarRef name='Q{}xforms-doc' bSlot='7'/>
+                <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
+               </slash>
+               <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
+              </slash>
+              <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}instance)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;instance&#39;;'/>
+             </slash>
+             <fn name='empty'>
+              <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+             </fn>
+            </filter>
+           </fn>
+           <check line='173' card='1' diag='3|0|XTTE0570|default-instance'>
+            <slash simple='2'>
+             <slash>
+              <slash simple='2'>
+               <slash simple='1'>
+                <gVarRef name='Q{}xforms-doc' bSlot='8'/>
+                <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
+               </slash>
+               <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
+              </slash>
+              <first>
+               <filter flags='b'>
+                <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}instance)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;instance&#39;;'/>
+                <fn name='empty'>
+                 <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+                </fn>
+               </filter>
+              </first>
+             </slash>
+             <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+            </slash>
+           </check>
+           <true/>
+           <check line='176' card='1' diag='3|0|XTTE0570|default-instance'>
+            <slash simple='2'>
+             <slash>
+              <slash simple='2'>
+               <slash simple='1'>
+                <gVarRef name='Q{}xforms-doc' bSlot='9'/>
+                <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
+               </slash>
+               <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
+              </slash>
+              <first>
+               <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}instance)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;instance&#39;;'/>
+              </first>
+             </slash>
+             <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+            </slash>
+           </check>
+          </choose>
+          <true/>
+          <treat line='182' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|default-instance'>
+           <check card='1' diag='3|0|XTTE0570|default-instance'>
+            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+             <check card='1' diag='0|0||ixsl:call'>
+              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+             </check>
+             <str val='getDefaultInstance'/>
+             <array size='0'/>
+            </ifCall>
+           </check>
+          </treat>
+         </choose>
+         <let line='188' var='Q{}bindings' as='map(xs:string, element(Q{http://www.w3.org/2002/xforms}bind))' slot='10' eval='8'>
+          <ifCall line='190' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+           <forEach>
+            <slash simple='2'>
+             <slash simple='2'>
+              <slash simple='1'>
+               <gVarRef name='Q{}xforms-doc' bSlot='10'/>
+               <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
+              </slash>
+              <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
+             </slash>
+             <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}bind)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;bind&#39;;'/>
+            </slash>
+            <ifCall line='198' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+             <check card='1' diag='0|0||map:entry'>
+              <cast as='xs:string' emptiable='1'>
+               <choose>
+                <fn name='exists'>
+                 <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+                </fn>
+                <attVal name='Q{}id' chk='0'/>
+                <true/>
+                <attVal name='Q{}nodeset' chk='0'/>
+               </choose>
+              </cast>
+             </check>
+             <dot type='element(Q{http://www.w3.org/2002/xforms}bind)'/>
+            </ifCall>
+           </forEach>
+           <map size='2'>
+            <str val='duplicates'/>
+            <str val='reject'/>
+            <str val='duplicates-error-code'/>
+            <str val='XTDE3365'/>
+           </map>
+          </ifCall>
+          <let line='212' var='Q{}bindingKeys' as='xs:anyAtomicType*' slot='11' eval='3'>
+           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
+            <varRef name='Q{}bindings' slot='10'/>
+           </ifCall>
+           <let line='214' var='Q{}RelevantBindings' as='map(xs:string, xs:string)' slot='12' eval='16'>
+            <treat line='216' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|RelevantBindings'>
+             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
               <forEach>
-               <varRef name='Q{}instances' slot='10'/>
-               <let line='142' var='Q{}instance-with-explicit-namespaces' as='element()' slot='11' eval='16'>
-                <treat line='143' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-explicit-namespaces'>
-                 <check card='1' diag='3|0|XTTE0570|instance-with-explicit-namespaces'>
-                  <applyT mode='Q{}namespace-fix' bSlot='2'>
-                   <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-                  </applyT>
-                 </check>
-                </treat>
-                <ifCall line='152' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
-                 <check card='1' diag='0|0||map:entry'>
-                  <cast as='xs:string' emptiable='1'>
-                   <choose>
-                    <fn name='exists'>
-                     <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
-                    </fn>
-                    <attVal name='Q{}id' chk='0'/>
-                    <true/>
-                    <str val='saxon-forms-default'/>
-                   </choose>
+               <varRef name='Q{}bindingKeys' slot='11'/>
+               <let line='217' var='Q{}bindingNode' as='element(Q{http://www.w3.org/2002/xforms}bind)' slot='13' eval='16'>
+                <check card='1' diag='3|0|XTTE0570|bindingNode'>
+                 <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                  <varRef name='Q{}bindings' slot='10'/>
+                  <cast as='xs:string' emptiable='0'>
+                   <dot type='xs:anyAtomicType'/>
                   </cast>
-                 </check>
-                 <varRef name='Q{}instance-with-explicit-namespaces' slot='11'/>
-                </ifCall>
+                 </ifCall>
+                </check>
+                <choose line='219'>
+                 <fn name='exists'>
+                  <filter flags='b'>
+                   <varRef name='Q{}bindingNode' slot='13'/>
+                   <fn name='exists'>
+                    <axis name='attribute' nodeTest='attribute(Q{}relevant)' jsTest='return item.name===&#39;relevant&#39;'/>
+                   </fn>
+                  </filter>
+                 </fn>
+                 <ifCall line='221' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                  <check line='220' card='1' diag='3|0|XTTE0570|keyi'>
+                   <cast as='xs:string' emptiable='1'>
+                    <data>
+                     <slash simple='1'>
+                      <varRef name='Q{}bindingNode' slot='13'/>
+                      <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
+                     </slash>
+                    </data>
+                   </cast>
+                  </check>
+                  <cast as='xs:string' emptiable='1'>
+                   <data>
+                    <slash simple='1'>
+                     <varRef name='Q{}bindingNode' slot='13'/>
+                     <axis name='attribute' nodeTest='attribute(Q{}relevant)' jsTest='return item.name===&#39;relevant&#39;'/>
+                    </slash>
+                   </data>
+                  </cast>
+                 </ifCall>
+                </choose>
                </let>
               </forEach>
               <map size='2'>
@@ -11741,162 +11912,36 @@
                <str val='XTDE3365'/>
               </map>
              </ifCall>
-            </sequence>
-           </check>
-          </let>
-          <true/>
-          <treat line='157' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|xforms-instances'>
-           <check card='1' diag='3|0|XTTE0570|xforms-instances'>
-            <varRef name='Q{}instance-docs' slot='2'/>
-           </check>
-          </treat>
-         </choose>
-         <let line='164' var='Q{}default-instance' as='element()' slot='12' eval='16'>
-          <choose line='166'>
-           <fn name='empty'>
-            <varRef name='Q{}instance-docs' slot='2'/>
-           </fn>
-           <choose line='168'>
-            <fn name='exists'>
-             <filter flags='b'>
-              <slash simple='2'>
-               <slash simple='2'>
-                <slash simple='1'>
-                 <varRef name='Q{}xforms-doci' slot='6'/>
-                 <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
-                </slash>
-                <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
-               </slash>
-               <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}instance)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;instance&#39;;'/>
-              </slash>
-              <fn name='empty'>
-               <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
-              </fn>
-             </filter>
-            </fn>
-            <check line='169' card='1' diag='3|0|XTTE0570|default-instance'>
-             <slash simple='2'>
-              <slash>
-               <slash simple='2'>
-                <slash simple='1'>
-                 <varRef name='Q{}xforms-doci' slot='6'/>
-                 <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
-                </slash>
-                <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
-               </slash>
-               <first>
-                <filter flags='b'>
-                 <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}instance)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;instance&#39;;'/>
-                 <fn name='empty'>
-                  <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
-                 </fn>
-                </filter>
-               </first>
-              </slash>
-              <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-             </slash>
-            </check>
-            <true/>
-            <check line='172' card='1' diag='3|0|XTTE0570|default-instance'>
-             <slash simple='2'>
-              <slash>
-               <slash simple='2'>
-                <slash simple='1'>
-                 <varRef name='Q{}xforms-doci' slot='6'/>
-                 <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
-                </slash>
-                <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
-               </slash>
-               <first>
-                <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}instance)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;instance&#39;;'/>
-               </first>
-              </slash>
-              <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-             </slash>
-            </check>
-           </choose>
-           <true/>
-           <treat line='178' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|default-instance'>
-            <check card='1' diag='3|0|XTTE0570|default-instance'>
-             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-              <check card='1' diag='0|0||ixsl:call'>
-               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-              </check>
-              <str val='getDefaultInstance'/>
-              <array size='0'/>
-             </ifCall>
-            </check>
-           </treat>
-          </choose>
-          <let line='184' var='Q{}bindings' as='map(xs:string, element(Q{http://www.w3.org/2002/xforms}bind))' slot='13' eval='8'>
-           <ifCall line='186' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
-            <forEach>
-             <slash simple='2'>
-              <slash simple='2'>
-               <slash simple='1'>
-                <varRef name='Q{}xforms-doci' slot='6'/>
-                <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
-               </slash>
-               <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
-              </slash>
-              <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}bind)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;bind&#39;;'/>
-             </slash>
-             <ifCall line='194' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
-              <check card='1' diag='0|0||map:entry'>
-               <cast as='xs:string' emptiable='1'>
-                <choose>
-                 <fn name='exists'>
-                  <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
-                 </fn>
-                 <attVal name='Q{}id' chk='0'/>
-                 <true/>
-                 <attVal name='Q{}nodeset' chk='0'/>
-                </choose>
-               </cast>
-              </check>
-              <dot type='element(Q{http://www.w3.org/2002/xforms}bind)'/>
-             </ifCall>
-            </forEach>
-            <map size='2'>
-             <str val='duplicates'/>
-             <str val='reject'/>
-             <str val='duplicates-error-code'/>
-             <str val='XTDE3365'/>
-            </map>
-           </ifCall>
-           <let line='208' var='Q{}bindingKeys' as='xs:anyAtomicType*' slot='14' eval='3'>
-            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
-             <varRef name='Q{}bindings' slot='13'/>
-            </ifCall>
-            <let line='210' var='Q{}RelevantBindings' as='map(xs:string, xs:string)' slot='15' eval='16'>
-             <treat line='212' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|RelevantBindings'>
+            </treat>
+            <let line='230' var='Q{}CalculationBindings' as='map(xs:string, xs:string)' slot='14' eval='16'>
+             <treat line='232' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|CalculationBindings'>
               <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
                <forEach>
-                <varRef name='Q{}bindingKeys' slot='14'/>
-                <let line='213' var='Q{}bindingNode' as='element(Q{http://www.w3.org/2002/xforms}bind)' slot='16' eval='16'>
+                <varRef name='Q{}bindingKeys' slot='11'/>
+                <let line='233' var='Q{}bindingNode' as='element(Q{http://www.w3.org/2002/xforms}bind)' slot='15' eval='16'>
                  <check card='1' diag='3|0|XTTE0570|bindingNode'>
                   <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                   <varRef name='Q{}bindings' slot='13'/>
+                   <varRef name='Q{}bindings' slot='10'/>
                    <cast as='xs:string' emptiable='0'>
                     <dot type='xs:anyAtomicType'/>
                    </cast>
                   </ifCall>
                  </check>
-                 <choose line='215'>
+                 <choose line='235'>
                   <fn name='exists'>
                    <filter flags='b'>
-                    <varRef name='Q{}bindingNode' slot='16'/>
+                    <varRef name='Q{}bindingNode' slot='15'/>
                     <fn name='exists'>
-                     <axis name='attribute' nodeTest='attribute(Q{}relevant)' jsTest='return item.name===&#39;relevant&#39;'/>
+                     <axis name='attribute' nodeTest='attribute(Q{}calculate)' jsTest='return item.name===&#39;calculate&#39;'/>
                     </fn>
                    </filter>
                   </fn>
-                  <ifCall line='217' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
-                   <check line='216' card='1' diag='3|0|XTTE0570|keyi'>
+                  <ifCall line='237' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                   <check line='236' card='1' diag='3|0|XTTE0570|keyi'>
                     <cast as='xs:string' emptiable='1'>
                      <data>
                       <slash simple='1'>
-                       <varRef name='Q{}bindingNode' slot='16'/>
+                       <varRef name='Q{}bindingNode' slot='15'/>
                        <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
                       </slash>
                      </data>
@@ -11905,8 +11950,8 @@
                    <cast as='xs:string' emptiable='1'>
                     <data>
                      <slash simple='1'>
-                      <varRef name='Q{}bindingNode' slot='16'/>
-                      <axis name='attribute' nodeTest='attribute(Q{}relevant)' jsTest='return item.name===&#39;relevant&#39;'/>
+                      <varRef name='Q{}bindingNode' slot='15'/>
+                      <axis name='attribute' nodeTest='attribute(Q{}calculate)' jsTest='return item.name===&#39;calculate&#39;'/>
                      </slash>
                     </data>
                    </cast>
@@ -11922,50 +11967,232 @@
                </map>
               </ifCall>
              </treat>
-             <let line='226' var='Q{}CalculationBindings' as='map(xs:string, xs:string)' slot='17' eval='16'>
-              <treat line='228' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|CalculationBindings'>
-               <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+             <sequence line='249'>
+              <choose>
+               <gc op='=' card='N:1' comp='CCC'>
+                <data>
+                 <slash simple='2'>
+                  <slash simple='1'>
+                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
+                   <axis name='descendant' nodeTest='element(Q{}script)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;script&#39;;'/>
+                  </slash>
+                  <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+                 </slash>
+                </data>
+                <gVarRef name='Q{}xforms-cache-id' bSlot='11'/>
+               </gc>
+               <sequence line='250'>
+                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <check card='1' diag='0|0||ixsl:call'>
+                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                 </check>
+                 <str val='setXFormsDoc'/>
+                 <arrayBlock>
+                  <gVarRef name='Q{}xforms-doc' bSlot='12'/>
+                 </arrayBlock>
+                </ifCall>
+                <ifCall line='251' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <check card='1' diag='0|0||ixsl:call'>
+                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                 </check>
+                 <str val='setXForm'/>
+                 <arrayBlock>
+                  <varRef name='Q{}xform' slot='4'/>
+                 </arrayBlock>
+                </ifCall>
+                <ifCall line='252' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <check card='1' diag='0|0||ixsl:call'>
+                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                 </check>
+                 <str val='setXFormsID'/>
+                 <arrayBlock>
+                  <varRef name='Q{}xFormsId' slot='1'/>
+                 </arrayBlock>
+                </ifCall>
+                <ifCall line='253' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <check card='1' diag='0|0||ixsl:call'>
+                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                 </check>
+                 <str val='setRelevantMap'/>
+                 <arrayBlock>
+                  <varRef name='Q{}RelevantBindings' slot='12'/>
+                 </arrayBlock>
+                </ifCall>
+                <ifCall line='254' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <check card='1' diag='0|0||ixsl:call'>
+                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                 </check>
+                 <str val='setCalculationMap'/>
+                 <arrayBlock>
+                  <varRef name='Q{}CalculationBindings' slot='14'/>
+                 </arrayBlock>
+                </ifCall>
+               </sequence>
+               <true/>
+               <sequence line='265'>
                 <forEach>
-                 <varRef name='Q{}bindingKeys' slot='14'/>
-                 <let line='229' var='Q{}bindingNode' as='element(Q{http://www.w3.org/2002/xforms}bind)' slot='18' eval='16'>
-                  <check card='1' diag='3|0|XTTE0570|bindingNode'>
-                   <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                    <varRef name='Q{}bindings' slot='13'/>
-                    <cast as='xs:string' emptiable='0'>
-                     <dot type='xs:anyAtomicType'/>
-                    </cast>
-                   </ifCall>
-                  </check>
-                  <choose line='231'>
+                 <slash simple='1'>
+                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
+                  <axis name='descendant' nodeTest='element(Q{}head)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;head&#39;;'/>
+                 </slash>
+                 <resultDoc line='274' global='#&#xD;&#xA;#Tue Mar 24 21:48:26 GMT 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Tue Mar 24 21:48:26 GMT 2020&#xD;&#xA;'>
+                  <str role='href' val='?.'/>
+                  <elem role='content' line='275' name='script' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+                   <sequence>
+                    <att name='type' flags='l'>
+                     <str val='text/javascript'/>
+                    </att>
+                    <att name='id' flags='l'>
+                     <gVarRef name='Q{}xforms-cache-id' bSlot='13'/>
+                    </att>
+                    <valueOf flags='l'>
+                     <str val='                &#xA;                            var XFormsDoc = null;&#xA;                            var XForm = null;&#xA;                            var defaultInstanceDoc = null;&#xA;                            &#xA;                            // MD 2018: OND&#39;s suggestion for multiple instances&#xA;                            var instanceDocs = {};&#xA;                            &#xA;                            var pendingUpdatesMap = null;&#xA;                            var updatesMap = null;&#xA;                            var XFormsID = &#39;'/>
+                    </valueOf>
+                    <valueOf line='285' flags='l'>
+                     <varRef name='Q{}xFormsId' slot='1'/>
+                    </valueOf>
+                    <valueOf flags='l'>
+                     <str val='&#39;;&#xA;                            var actions = {};&#xA;                            var submissions = {};&#xA;                            var outputs = {};&#xA;                            var repeats = {};&#xA;                            var relevantMap = {};&#xA;                            var calculationMap = {};&#xA;                            var repeatIndexMap = {};&#xA;                            var repeatSizeMap = {};&#xA;                            var elementsUsingIndexFunction = {};&#xA;                            &#xA;                            var getCurrentDate = function(){&#xA;                                var today = new Date();&#xA;                                var dd = today.getDate();&#xA;                                var mm = today.getMonth()+1; //January is 0!&#xA;                                var yyyy = today.getFullYear();&#xA;                            &#xA;                                if(dd &lt; 10) {&#xA;                                    dd = &#39;0&#39; + dd;&#xA;                                } &#xA;                            &#xA;                                if(mm &lt; 10) {&#xA;                                    mm = &#39;0&#39; + mm;&#xA;                                } &#xA;                            &#xA;                                today = yyyy + &#39;-&#39; + mm + &#39;-&#39; + dd;&#xA;                                return today;&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var setXFormsDoc = function(doc) {&#xA;                                XFormsDoc = doc;&#xA;                            }&#xA;                            &#xA;                            var getXFormsDoc = function() {&#xA;                                return XFormsDoc;&#xA;                            }&#xA;                            &#xA;                            var setXForm = function(element) {&#xA;                                XForm = element;&#xA;                            }&#xA;                            &#xA;                            var getXForm = function() {&#xA;                                return XForm;&#xA;                            }&#xA;                            &#xA;                            var setXFormsID = function(id) {&#xA;                                XFormsID = id;&#xA;                            }&#xA;                            &#xA;                            var getXFormsID = function() {&#xA;                                return XFormsID;&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var setInstance = function(name, value) {&#xA;                                instanceDocs[name] = value;&#xA;                            } &#xA;                            &#xA;                            var getInstance = function(name) {&#xA;                                return instanceDocs[name];&#xA;                            }&#xA;                            &#xA;                            &#xA;                            //[OND] Maybe we can just set the key-&gt; value without having to copy the entire instanceDocs object.&#xA;                            var updateInstance = function(instanceDocs, key, value){&#xA;                                instanceDocs[key] = value;&#xA;                                return instanceDocs;&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var setDefaultInstance = function(doc) {&#xA;                                defaultInstanceDoc = doc;&#xA;                            }&#xA;                            &#xA;                            var getDefaultInstance = function() {&#xA;                                return defaultInstanceDoc;&#xA;                            }&#xA;                            &#xA;                           &#xA;                            var getInstanceKeys = function() {&#xA;                                return Object.keys(instanceDocs);&#xA;                            }&#xA;                            &#xA;                            var getInstances = function() {&#xA;                                return instanceDocs;&#xA;                            }&#xA;                            &#xA;                            var setPendingUpdates = function(map1) {&#xA;                                pendingUpdatesMap = map1;&#xA;                            }&#xA;                            &#xA;                            var clearPendingUpdates = function() {&#xA;                                pendingUpdatesMap = null;&#xA;                            }&#xA;                            &#xA;                            var getPendingUpdates = function() {&#xA;                                return pendingUpdatesMap;&#xA;                            }&#xA;                            &#xA;                            var setUpdates = function(map1) {&#xA;                                updatesMap = map1;&#xA;                            }&#xA;                            &#xA;                            var clearUpdates = function() {&#xA;                                updatesMap = null;&#xA;                            }&#xA;                            &#xA;                            var getUpdates = function() {&#xA;                                return updatesMap;&#xA;                            }&#xA;                            &#xA;                            var addAction = function(name, value){&#xA;                                actions[name] = value;&#xA;                            }&#xA;&#xA;                            var getAction = function(name){&#xA;                                return actions[name];&#xA;                            }&#xA;                            &#xA;                            var updateAction = function(actioni, key, value){&#xA;                                actioni[key] = value;&#xA;                                return actioni;&#xA;                            }&#xA;                            &#xA;                            var addSubmission = function(name, value){&#xA;                                submissions[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getSubmission = function(name){&#xA;                                return submissions[name];&#xA;                            }     &#xA;                            &#xA;                            var addOutput = function(name, value){&#xA;                                outputs[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getOutput = function(name){&#xA;                                return outputs[name];&#xA;                            }&#xA;                            &#xA;                            var getOutputKeys = function() {&#xA;                                return Object.keys(outputs);&#xA;                            }&#xA;                            &#xA;                            // repeats is a map of HTML IDs to (parsed) xf:repeat/@nodeset values&#xA;                            var addRepeat = function(name, value){&#xA;                                repeats[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getRepeat = function(name){&#xA;                                return repeats[name];&#xA;                            }&#xA;                            &#xA;                            var getRepeatKeys = function() {&#xA;                                return Object.keys(repeats);&#xA;                            }&#xA;                            &#xA;                            var setRelevantMap = function(map1) {&#xA;                                relevantMap = map1;                            &#xA;                            }&#xA;                            &#xA;                            var getRelevantMap = function() {&#xA;                                return relevantMap;&#xA;                            }&#xA;                            &#xA;  &#xA;                            var setCalculationMap = function(map1) {&#xA;                                calculationMap = map1;                            &#xA;                            }&#xA;  &#xA;                            var getCalculationMap = function() {&#xA;                                return calculationMap;&#xA;                            }&#xA;  &#xA;                            &#xA;                            var setRepeatIndex = function(name, value) {&#xA;                                repeatIndexMap[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getRepeatIndex = function(name) {&#xA;                                if ( typeof(repeatIndexMap[name]) != &#39;undefined&#39; ) {&#xA;                                    return repeatIndexMap[name];&#xA;                                }&#xA;                                else {&#xA;                                    return 0;&#xA;                                }&#xA;                            } &#xA;                            &#xA;                            var setRepeatSize = function(name, value) {&#xA;                                repeatSizeMap[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getRepeatSize = function(name) {&#xA;                                if ( typeof(repeatSizeMap[name]) != &#39;undefined&#39; ) {&#xA;                                    return repeatSizeMap[name];&#xA;                                }&#xA;                                else {&#xA;                                    return 0;&#xA;                                }&#xA;                            } &#xA;                            &#xA;                            var setElementUsingIndexFunction = function(name, value) {&#xA;                                elementsUsingIndexFunction[name] = value;&#xA;                            } &#xA;                            &#xA;                            var getElementUsingIndexFunction = function(name) {&#xA;                                return elementsUsingIndexFunction[name];&#xA;                            }&#xA;                            &#xA;                            var getElementsUsingIndexFunctionKeys = function() {&#xA;                                return Object.keys(elementsUsingIndexFunction);&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var startTime = function(name) {&#xA;                                console.time(name);&#xA;                            }&#xA;                            &#xA;                            var endTime = function(name) {&#xA;                                console.timeEnd(name);&#xA;                            }&#xA;                            &#xA;                            var highlightClicked = function(id) {&#xA;                                var item = document.getElementById(id);&#xA;                                toggleClass(item);&#xA;                            }&#xA;                            &#xA;                            var toggleClass = function(element) {&#xA;                                if (element.className == &#39;selected&#39;) {&#xA;                                    element.classList.remove(&#39;selected&#39;);&#xA;                                }&#xA;                                else {&#xA;                                    var x = document.getElementsByClassName(&#39;selected&#39;);&#xA;                                    var i;&#xA;                                    for (i = 0; i &lt; x.length; i++) {&#xA;                                        x[i].classList.remove(&#39;selected&#39;);&#xA;                                    } &#xA;                                    element.classList.add(&#39;selected&#39;);&#xA;                                }&#xA;                            }&#xA;                            &#xA;                            var setFocus = function(id) {&#xA;                                var item = document.getElementById(id);&#xA;                                item.focus();&#xA;                                // alert(&#39;setFocus on &#39; + id);&#xA;                            }&#xA;                            &#xA;                        '/>
+                    </valueOf>
+                   </sequence>
+                  </elem>
+                 </resultDoc>
+                </forEach>
+                <ifCall line='537' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <check card='1' diag='0|0||ixsl:call'>
+                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                 </check>
+                 <str val='setXFormsDoc'/>
+                 <arrayBlock>
+                  <gVarRef name='Q{}xforms-doc' bSlot='14'/>
+                 </arrayBlock>
+                </ifCall>
+                <ifCall line='538' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <check card='1' diag='0|0||ixsl:call'>
+                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                 </check>
+                 <str val='setXForm'/>
+                 <arrayBlock>
+                  <varRef name='Q{}xform' slot='4'/>
+                 </arrayBlock>
+                </ifCall>
+                <ifCall line='539' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <check card='1' diag='0|0||ixsl:call'>
+                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                 </check>
+                 <str val='setDefaultInstance'/>
+                 <arrayBlock>
+                  <varRef name='Q{}default-instance' slot='9'/>
+                 </arrayBlock>
+                </ifCall>
+                <ifCall line='540' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <check card='1' diag='0|0||ixsl:call'>
+                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                 </check>
+                 <str val='setRelevantMap'/>
+                 <arrayBlock>
+                  <varRef name='Q{}RelevantBindings' slot='12'/>
+                 </arrayBlock>
+                </ifCall>
+                <ifCall line='541' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <check card='1' diag='0|0||ixsl:call'>
+                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                 </check>
+                 <str val='setCalculationMap'/>
+                 <arrayBlock>
+                  <varRef name='Q{}CalculationBindings' slot='14'/>
+                 </arrayBlock>
+                </ifCall>
+                <ifCall line='546' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <check card='1' diag='0|0||ixsl:call'>
+                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                 </check>
+                 <str val='setPendingUpdates'/>
+                 <arrayBlock>
+                  <treat line='543' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||pendingInstanceUpdates'>
+                   <map size='0'/>
+                  </treat>
+                 </arrayBlock>
+                </ifCall>
+                <ifCall line='547' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <check card='1' diag='0|0||ixsl:call'>
+                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                 </check>
+                 <str val='setUpdates'/>
+                 <arrayBlock>
+                  <treat line='544' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||instanceUpdates'>
+                   <map size='0'/>
+                  </treat>
+                 </arrayBlock>
+                </ifCall>
+               </sequence>
+              </choose>
+              <forEach line='556'>
+               <treat line='554' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|instanceKeys'>
+                <cvUntyped to='xs:string' diag='3|0|XTTE0570|instanceKeys'>
+                 <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
+                  <varRef name='Q{}xforms-instances' slot='6'/>
+                 </ifCall>
+                </cvUntyped>
+               </treat>
+               <ifCall line='558' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='3'/>
+                <str val='setInstance'/>
+                <arrayBlock>
+                 <dot type='xs:string'/>
+                 <check line='557' card='1' diag='3|0|XTTE0570|instance'>
+                  <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                   <varRef name='Q{}xforms-instances' slot='6'/>
+                   <dot type='xs:string'/>
+                  </ifCall>
+                 </check>
+                </arrayBlock>
+               </ifCall>
+              </forEach>
+              <let line='563' var='Q{}submissions' as='map(xs:string, map(*))' slot='16' eval='8'>
+               <ifCall line='565' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+                <forEach>
+                 <slash simple='2'>
+                  <slash simple='2'>
+                   <slash simple='1'>
+                    <gVarRef name='Q{}xforms-doc' bSlot='15'/>
+                    <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
+                   </slash>
+                   <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
+                  </slash>
+                  <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}submission)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;submission&#39;;'/>
+                 </slash>
+                 <let line='569' var='Q{}map-key' as='xs:string' slot='17' eval='16'>
+                  <choose>
                    <fn name='exists'>
-                    <filter flags='b'>
-                     <varRef name='Q{}bindingNode' slot='18'/>
-                     <fn name='exists'>
-                      <axis name='attribute' nodeTest='attribute(Q{}calculate)' jsTest='return item.name===&#39;calculate&#39;'/>
-                     </fn>
-                    </filter>
+                    <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
                    </fn>
-                   <ifCall line='233' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
-                    <check line='232' card='1' diag='3|0|XTTE0570|keyi'>
-                     <cast as='xs:string' emptiable='1'>
-                      <data>
-                       <slash simple='1'>
-                        <varRef name='Q{}bindingNode' slot='18'/>
-                        <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
-                       </slash>
-                      </data>
-                     </cast>
-                    </check>
+                   <check card='1' diag='3|0|XTTE0570|map-key'>
                     <cast as='xs:string' emptiable='1'>
-                     <data>
-                      <slash simple='1'>
-                       <varRef name='Q{}bindingNode' slot='18'/>
-                       <axis name='attribute' nodeTest='attribute(Q{}calculate)' jsTest='return item.name===&#39;calculate&#39;'/>
-                      </slash>
-                     </data>
+                     <attVal name='Q{}id' chk='0'/>
                     </cast>
-                   </ifCall>
+                   </check>
+                   <true/>
+                   <str val='saxon-forms-default-submission'/>
                   </choose>
+                  <let line='570' var='Q{}map-value' as='map(*)' slot='18' eval='16'>
+                   <treat line='571' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|map-value'>
+                    <check card='1' diag='3|0|XTTE0570|map-value'>
+                     <callT name='Q{}setSubmission' bSlot='16'>
+                      <withParam name='Q{}this' flags='c' as='element()'>
+                       <dot line='572' type='element(Q{http://www.w3.org/2002/xforms}submission)'/>
+                      </withParam>
+                      <withParam name='Q{}submission-id' flags='c' as='xs:string'>
+                       <varRef line='573' name='Q{}map-key' slot='17'/>
+                      </withParam>
+                     </callT>
+                    </check>
+                   </treat>
+                   <ifCall line='576' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                    <varRef name='Q{}map-key' slot='17'/>
+                    <varRef name='Q{}map-value' slot='18'/>
+                   </ifCall>
+                  </let>
                  </let>
                 </forEach>
                 <map size='2'>
@@ -11975,293 +12202,56 @@
                  <str val='XTDE3365'/>
                 </map>
                </ifCall>
-              </treat>
-              <sequence line='245'>
-               <choose>
-                <gc op='=' card='N:1' comp='CCC'>
-                 <data>
-                  <slash simple='2'>
-                   <slash simple='1'>
-                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
-                    <axis name='descendant' nodeTest='element(Q{}script)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;script&#39;;'/>
-                   </slash>
-                   <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
-                  </slash>
-                 </data>
-                 <gVarRef name='Q{}xforms-cache-id' bSlot='3'/>
-                </gc>
-                <sequence line='246'>
-                 <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                  <check card='1' diag='0|0||ixsl:call'>
-                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-                  </check>
-                  <str val='setXFormsDoc'/>
-                  <arrayBlock>
-                   <varRef name='Q{}xforms-doci' slot='6'/>
-                  </arrayBlock>
-                 </ifCall>
-                 <ifCall line='247' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                  <check card='1' diag='0|0||ixsl:call'>
-                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-                  </check>
-                  <str val='setXForm'/>
-                  <arrayBlock>
-                   <varRef name='Q{}xform' slot='7'/>
-                  </arrayBlock>
-                 </ifCall>
-                 <ifCall line='248' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                  <check card='1' diag='0|0||ixsl:call'>
-                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-                  </check>
-                  <str val='setXFormsID'/>
-                  <arrayBlock>
-                   <varRef name='Q{}xFormsId' slot='3'/>
-                  </arrayBlock>
-                 </ifCall>
-                 <ifCall line='249' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                  <check card='1' diag='0|0||ixsl:call'>
-                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-                  </check>
-                  <str val='setRelevantMap'/>
-                  <arrayBlock>
-                   <varRef name='Q{}RelevantBindings' slot='15'/>
-                  </arrayBlock>
-                 </ifCall>
-                 <ifCall line='250' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                  <check card='1' diag='0|0||ixsl:call'>
-                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-                  </check>
-                  <str val='setCalculationMap'/>
-                  <arrayBlock>
-                   <varRef name='Q{}CalculationBindings' slot='17'/>
-                  </arrayBlock>
-                 </ifCall>
-                </sequence>
-                <true/>
-                <sequence line='261'>
-                 <forEach>
-                  <slash simple='1'>
-                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
-                   <axis name='descendant' nodeTest='element(Q{}head)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;head&#39;;'/>
-                  </slash>
-                  <resultDoc line='270' global='#&#xD;&#xA;#Sat Mar 14 13:02:55 GMT 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Sat Mar 14 13:02:55 GMT 2020&#xD;&#xA;'>
-                   <str role='href' val='?.'/>
-                   <elem role='content' line='271' name='script' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
-                    <sequence>
-                     <att name='type' flags='l'>
-                      <str val='text/javascript'/>
-                     </att>
-                     <att name='id' flags='l'>
-                      <gVarRef name='Q{}xforms-cache-id' bSlot='4'/>
-                     </att>
-                     <valueOf flags='l'>
-                      <str val='                &#xA;                            var XFormsDoc = null;&#xA;                            var XForm = null;&#xA;                            var defaultInstanceDoc = null;&#xA;                            &#xA;                            // MD 2018: OND&#39;s suggestion for multiple instances&#xA;                            var instanceDocs = {};&#xA;                            &#xA;                            var pendingUpdatesMap = null;&#xA;                            var updatesMap = null;&#xA;                            var XFormsID = &#39;'/>
-                     </valueOf>
-                     <valueOf line='281' flags='l'>
-                      <varRef name='Q{}xFormsId' slot='3'/>
-                     </valueOf>
-                     <valueOf flags='l'>
-                      <str val='&#39;;&#xA;                            var actions = {};&#xA;                            var submissions = {};&#xA;                            var outputs = {};&#xA;                            var repeats = {};&#xA;                            var relevantMap = {};&#xA;                            var calculationMap = {};&#xA;                            var repeatIndexMap = {};&#xA;                            var repeatSizeMap = {};&#xA;                            var elementsUsingIndexFunction = {};&#xA;                            &#xA;                            var getCurrentDate = function(){&#xA;                                var today = new Date();&#xA;                                var dd = today.getDate();&#xA;                                var mm = today.getMonth()+1; //January is 0!&#xA;                                var yyyy = today.getFullYear();&#xA;                            &#xA;                                if(dd &lt; 10) {&#xA;                                    dd = &#39;0&#39; + dd;&#xA;                                } &#xA;                            &#xA;                                if(mm &lt; 10) {&#xA;                                    mm = &#39;0&#39; + mm;&#xA;                                } &#xA;                            &#xA;                                today = yyyy + &#39;-&#39; + mm + &#39;-&#39; + dd;&#xA;                                return today;&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var setXFormsDoc = function(doc) {&#xA;                                XFormsDoc = doc;&#xA;                            }&#xA;                            &#xA;                            var getXFormsDoc = function() {&#xA;                                return XFormsDoc;&#xA;                            }&#xA;                            &#xA;                            var setXForm = function(element) {&#xA;                                XForm = element;&#xA;                            }&#xA;                            &#xA;                            var getXForm = function() {&#xA;                                return XForm;&#xA;                            }&#xA;                            &#xA;                            var setXFormsID = function(id) {&#xA;                                XFormsID = id;&#xA;                            }&#xA;                            &#xA;                            var getXFormsID = function() {&#xA;                                return XFormsID;&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var setInstance = function(name, value) {&#xA;                                instanceDocs[name] = value;&#xA;                            } &#xA;                            &#xA;                            var getInstance = function(name) {&#xA;                                return instanceDocs[name];&#xA;                            }&#xA;                            &#xA;                            &#xA;                            //[OND] Maybe we can just set the key-&gt; value without having to copy the entire instanceDocs object.&#xA;                            var updateInstance = function(instanceDocs, key, value){&#xA;                                instanceDocs[key] = value;&#xA;                                return instanceDocs;&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var setDefaultInstance = function(doc) {&#xA;                                defaultInstanceDoc = doc;&#xA;                            }&#xA;                            &#xA;                            var getDefaultInstance = function() {&#xA;                                return defaultInstanceDoc;&#xA;                            }&#xA;                            &#xA;                           &#xA;                            var getInstanceKeys = function() {&#xA;                                return Object.keys(instanceDocs);&#xA;                            }&#xA;                            &#xA;                            var getInstances = function() {&#xA;                                return instanceDocs;&#xA;                            }&#xA;                            &#xA;                            var setPendingUpdates = function(map1) {&#xA;                                pendingUpdatesMap = map1;&#xA;                            }&#xA;                            &#xA;                            var clearPendingUpdates = function() {&#xA;                                pendingUpdatesMap = null;&#xA;                            }&#xA;                            &#xA;                            var getPendingUpdates = function() {&#xA;                                return pendingUpdatesMap;&#xA;                            }&#xA;                            &#xA;                            var setUpdates = function(map1) {&#xA;                                updatesMap = map1;&#xA;                            }&#xA;                            &#xA;                            var clearUpdates = function() {&#xA;                                updatesMap = null;&#xA;                            }&#xA;                            &#xA;                            var getUpdates = function() {&#xA;                                return updatesMap;&#xA;                            }&#xA;                            &#xA;                            var addAction = function(name, value){&#xA;                                actions[name] = value;&#xA;                            }&#xA;&#xA;                            var getAction = function(name){&#xA;                                return actions[name];&#xA;                            }&#xA;                            &#xA;                            var updateAction = function(actioni, key, value){&#xA;                                actioni[key] = value;&#xA;                                return actioni;&#xA;                            }&#xA;                            &#xA;                            var addSubmission = function(name, value){&#xA;                                submissions[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getSubmission = function(name){&#xA;                                return submissions[name];&#xA;                            }     &#xA;                            &#xA;                            var addOutput = function(name, value){&#xA;                                outputs[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getOutput = function(name){&#xA;                                return outputs[name];&#xA;                            }&#xA;                            &#xA;                            var getOutputKeys = function() {&#xA;                                return Object.keys(outputs);&#xA;                            }&#xA;                            &#xA;                            // repeats is a map of HTML IDs to (parsed) xf:repeat/@nodeset values&#xA;                            var addRepeat = function(name, value){&#xA;                                repeats[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getRepeat = function(name){&#xA;                                return repeats[name];&#xA;                            }&#xA;                            &#xA;                            var getRepeatKeys = function() {&#xA;                                return Object.keys(repeats);&#xA;                            }&#xA;                            &#xA;                            var setRelevantMap = function(map1) {&#xA;                                relevantMap = map1;                            &#xA;                            }&#xA;                            &#xA;                            var getRelevantMap = function() {&#xA;                                return relevantMap;&#xA;                            }&#xA;                            &#xA;  &#xA;                            var setCalculationMap = function(map1) {&#xA;                                calculationMap = map1;                            &#xA;                            }&#xA;  &#xA;                            var getCalculationMap = function() {&#xA;                                return calculationMap;&#xA;                            }&#xA;  &#xA;                            &#xA;                            var setRepeatIndex = function(name, value) {&#xA;                                repeatIndexMap[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getRepeatIndex = function(name) {&#xA;                                if ( typeof(repeatIndexMap[name]) != &#39;undefined&#39; ) {&#xA;                                    return repeatIndexMap[name];&#xA;                                }&#xA;                                else {&#xA;                                    return 0;&#xA;                                }&#xA;                            } &#xA;                            &#xA;                            var setRepeatSize = function(name, value) {&#xA;                                repeatSizeMap[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getRepeatSize = function(name) {&#xA;                                if ( typeof(repeatSizeMap[name]) != &#39;undefined&#39; ) {&#xA;                                    return repeatSizeMap[name];&#xA;                                }&#xA;                                else {&#xA;                                    return 0;&#xA;                                }&#xA;                            } &#xA;                            &#xA;                            var setElementUsingIndexFunction = function(name, value) {&#xA;                                elementsUsingIndexFunction[name] = value;&#xA;                            } &#xA;                            &#xA;                            var getElementUsingIndexFunction = function(name) {&#xA;                                return elementsUsingIndexFunction[name];&#xA;                            }&#xA;                            &#xA;                            var getElementsUsingIndexFunctionKeys = function() {&#xA;                                return Object.keys(elementsUsingIndexFunction);&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var startTime = function(name) {&#xA;                                console.time(name);&#xA;                            }&#xA;                            &#xA;                            var endTime = function(name) {&#xA;                                console.timeEnd(name);&#xA;                            }&#xA;                            &#xA;                            var highlightClicked = function(id) {&#xA;                                var item = document.getElementById(id);&#xA;                                toggleClass(item);&#xA;                            }&#xA;                            &#xA;                            var toggleClass = function(element) {&#xA;                                if (element.className == &#39;selected&#39;) {&#xA;                                    element.classList.remove(&#39;selected&#39;);&#xA;                                }&#xA;                                else {&#xA;                                    var x = document.getElementsByClassName(&#39;selected&#39;);&#xA;                                    var i;&#xA;                                    for (i = 0; i &lt; x.length; i++) {&#xA;                                        x[i].classList.remove(&#39;selected&#39;);&#xA;                                    } &#xA;                                    element.classList.add(&#39;selected&#39;);&#xA;                                }&#xA;                            }&#xA;                            &#xA;                            var setFocus = function(id) {&#xA;                                var item = document.getElementById(id);&#xA;                                item.focus();&#xA;                                // alert(&#39;setFocus on &#39; + id);&#xA;                            }&#xA;                            &#xA;                        '/>
-                     </valueOf>
-                    </sequence>
-                   </elem>
-                  </resultDoc>
-                 </forEach>
-                 <ifCall line='533' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                  <check card='1' diag='0|0||ixsl:call'>
-                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-                  </check>
-                  <str val='setXFormsDoc'/>
-                  <arrayBlock>
-                   <varRef name='Q{}xforms-doc' slot='0'/>
-                  </arrayBlock>
-                 </ifCall>
-                 <ifCall line='534' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                  <check card='1' diag='0|0||ixsl:call'>
-                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-                  </check>
-                  <str val='setXForm'/>
-                  <arrayBlock>
-                   <varRef name='Q{}xform' slot='7'/>
-                  </arrayBlock>
-                 </ifCall>
-                 <ifCall line='535' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                  <check card='1' diag='0|0||ixsl:call'>
-                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-                  </check>
-                  <str val='setDefaultInstance'/>
-                  <arrayBlock>
-                   <varRef name='Q{}default-instance' slot='12'/>
-                  </arrayBlock>
-                 </ifCall>
-                 <ifCall line='536' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                  <check card='1' diag='0|0||ixsl:call'>
-                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-                  </check>
-                  <str val='setRelevantMap'/>
-                  <arrayBlock>
-                   <varRef name='Q{}RelevantBindings' slot='15'/>
-                  </arrayBlock>
-                 </ifCall>
-                 <ifCall line='537' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                  <check card='1' diag='0|0||ixsl:call'>
-                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-                  </check>
-                  <str val='setCalculationMap'/>
-                  <arrayBlock>
-                   <varRef name='Q{}CalculationBindings' slot='17'/>
-                  </arrayBlock>
-                 </ifCall>
-                 <ifCall line='542' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                  <check card='1' diag='0|0||ixsl:call'>
-                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-                  </check>
-                  <str val='setPendingUpdates'/>
-                  <arrayBlock>
-                   <treat line='539' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||pendingInstanceUpdates'>
-                    <map size='0'/>
-                   </treat>
-                  </arrayBlock>
-                 </ifCall>
-                 <ifCall line='543' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                  <check card='1' diag='0|0||ixsl:call'>
-                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-                  </check>
-                  <str val='setUpdates'/>
-                  <arrayBlock>
-                   <treat line='540' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||instanceUpdates'>
-                    <map size='0'/>
-                   </treat>
-                  </arrayBlock>
-                 </ifCall>
-                </sequence>
-               </choose>
-               <forEach line='552'>
-                <treat line='550' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|instanceKeys'>
-                 <cvUntyped to='xs:string' diag='3|0|XTTE0570|instanceKeys'>
-                  <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
-                   <varRef name='Q{}xforms-instances' slot='9'/>
-                  </ifCall>
-                 </cvUntyped>
-                </treat>
-                <ifCall line='554' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                 <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='5'/>
-                 <str val='setInstance'/>
-                 <arrayBlock>
-                  <dot type='xs:string'/>
-                  <check line='553' card='1' diag='3|0|XTTE0570|instance'>
-                   <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                    <varRef name='Q{}xforms-instances' slot='9'/>
-                    <dot type='xs:string'/>
+               <sequence line='585'>
+                <forEach>
+                 <treat line='583' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|submissionKeys'>
+                  <cvUntyped to='xs:string' diag='3|0|XTTE0570|submissionKeys'>
+                   <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
+                    <varRef name='Q{}submissions' slot='16'/>
                    </ifCall>
-                  </check>
-                 </arrayBlock>
-                </ifCall>
-               </forEach>
-               <let line='559' var='Q{}submissions' as='map(xs:string, map(*))' slot='19' eval='8'>
-                <ifCall line='561' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
-                 <forEach>
-                  <slash simple='2'>
-                   <slash simple='2'>
-                    <slash simple='1'>
-                     <varRef name='Q{}xforms-doci' slot='6'/>
-                     <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
-                    </slash>
-                    <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
-                   </slash>
-                   <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}submission)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;submission&#39;;'/>
+                  </cvUntyped>
+                 </treat>
+                 <ifCall line='587' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                  <varRef name='Q{http://saxon.sf.net/generated-variable}v1' slot='2'/>
+                  <str val='addSubmission'/>
+                  <arrayBlock>
+                   <dot type='xs:string'/>
+                   <check line='586' card='1' diag='3|0|XTTE0570|submission'>
+                    <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                     <varRef name='Q{}submissions' slot='16'/>
+                     <dot type='xs:string'/>
+                    </ifCall>
+                   </check>
+                  </arrayBlock>
+                 </ifCall>
+                </forEach>
+                <resultDoc line='596' global='#&#xD;&#xA;#Tue Mar 24 21:48:26 GMT 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Tue Mar 24 21:48:26 GMT 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
+                 <fn role='href' name='concat'>
+                  <str val='#'/>
+                  <varRef name='Q{}xFormsId' slot='1'/>
+                 </fn>
+                 <applyT role='content' line='597' bSlot='17'>
+                  <slash role='select' simple='1'>
+                   <gVarRef name='Q{}xforms-doc' bSlot='18'/>
+                   <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
                   </slash>
-                  <let line='565' var='Q{}map-key' as='xs:string' slot='20' eval='16'>
-                   <choose>
-                    <fn name='exists'>
-                     <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
-                    </fn>
-                    <check card='1' diag='3|0|XTTE0570|map-key'>
-                     <cast as='xs:string' emptiable='1'>
-                      <attVal name='Q{}id' chk='0'/>
-                     </cast>
-                    </check>
-                    <true/>
-                    <str val='saxon-forms-default-submission'/>
-                   </choose>
-                   <let line='566' var='Q{}map-value' as='map(*)' slot='21' eval='16'>
-                    <treat line='567' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|map-value'>
-                     <check card='1' diag='3|0|XTTE0570|map-value'>
-                      <callT name='Q{}setSubmission' bSlot='5'>
-                       <withParam name='Q{}this' flags='c' as='element()'>
-                        <dot line='568' type='element(Q{http://www.w3.org/2002/xforms}submission)'/>
-                       </withParam>
-                       <withParam name='Q{}submission-id' flags='c' as='xs:string'>
-                        <varRef line='569' name='Q{}map-key' slot='20'/>
-                       </withParam>
-                      </callT>
-                     </check>
-                    </treat>
-                    <ifCall line='572' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
-                     <varRef name='Q{}map-key' slot='20'/>
-                     <varRef name='Q{}map-value' slot='21'/>
-                    </ifCall>
-                   </let>
-                  </let>
-                 </forEach>
-                 <map size='2'>
-                  <str val='duplicates'/>
-                  <str val='reject'/>
-                  <str val='duplicates-error-code'/>
-                  <str val='XTDE3365'/>
-                 </map>
-                </ifCall>
-                <sequence line='581'>
-                 <forEach>
-                  <treat line='579' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|submissionKeys'>
-                   <cvUntyped to='xs:string' diag='3|0|XTTE0570|submissionKeys'>
-                    <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
-                     <varRef name='Q{}submissions' slot='19'/>
-                    </ifCall>
-                   </cvUntyped>
-                  </treat>
-                  <ifCall line='583' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                   <varRef name='Q{http://saxon.sf.net/generated-variable}v1' slot='4'/>
-                   <str val='addSubmission'/>
-                   <arrayBlock>
-                    <dot type='xs:string'/>
-                    <check line='582' card='1' diag='3|0|XTTE0570|submission'>
-                     <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                      <varRef name='Q{}submissions' slot='19'/>
-                      <dot type='xs:string'/>
-                     </ifCall>
-                    </check>
-                   </arrayBlock>
-                  </ifCall>
-                 </forEach>
-                 <resultDoc line='592' global='#&#xD;&#xA;#Sat Mar 14 13:02:55 GMT 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Sat Mar 14 13:02:55 GMT 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
-                  <fn role='href' name='concat'>
-                   <str val='#'/>
-                   <varRef name='Q{}xFormsId' slot='3'/>
-                  </fn>
-                  <applyT role='content' line='593' bSlot='6'>
-                   <slash role='select' simple='1'>
-                    <varRef name='Q{}xforms-doci' slot='6'/>
-                    <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
-                   </slash>
-                   <withParam name='Q{}instances' flags='t' as='map(xs:string, element())'>
-                    <varRef line='594' name='Q{}xforms-instances' slot='9'/>
-                   </withParam>
-                   <withParam name='Q{}bindings' flags='t' as='map(xs:string, node())'>
-                    <varRef line='595' name='Q{}bindings' slot='13'/>
-                   </withParam>
-                   <withParam name='Q{}submissions' flags='t' as='map(xs:string, map(*))'>
-                    <varRef line='596' name='Q{}submissions' slot='19'/>
-                   </withParam>
-                   <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                    <str val=''/>
-                   </withParam>
-                  </applyT>
-                 </resultDoc>
-                </sequence>
-               </let>
-              </sequence>
-             </let>
+                  <withParam name='Q{}instances' flags='t' as='map(xs:string, element())'>
+                   <varRef line='598' name='Q{}xforms-instances' slot='6'/>
+                  </withParam>
+                  <withParam name='Q{}bindings' flags='t' as='map(xs:string, node())'>
+                   <varRef line='599' name='Q{}bindings' slot='10'/>
+                  </withParam>
+                  <withParam name='Q{}submissions' flags='t' as='map(xs:string, map(*))'>
+                   <varRef line='600' name='Q{}submissions' slot='16'/>
+                  </withParam>
+                  <withParam name='Q{}nodeset' flags='t' as='xs:string'>
+                   <str val=''/>
+                  </withParam>
+                 </applyT>
+                </resultDoc>
+               </sequence>
+              </let>
+             </sequence>
             </let>
            </let>
           </let>
@@ -12274,19 +12264,19 @@
    </let>
   </template>
  </co>
- <co id='71' vis='PRIVATE' binds='' base='4' dpack='1'/>
+ <co id='72' vis='PRIVATE' binds='' base='4' dpack='1'/>
  <co id='94' vis='PRIVATE' binds='' base='7' dpack='1'/>
- <co id='100' binds='100'>
+ <co id='101' binds='101'>
   <mode name='Q{}namespace-fix' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='31' rank='0' minImp='0' slots='1' flags='s' line='2377' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='31' rank='0' minImp='0' slots='1' flags='s' line='2381' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2378' var='Q{}current-namespace' as='xs:anyURI' slot='0' eval='8'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2382' var='Q{}current-namespace' as='xs:anyURI' slot='0' eval='8'>
      <fn name='namespace-uri'>
       <dot type='element()'/>
      </fn>
-     <compElem line='2380'>
+     <compElem line='2384'>
       <convert role='name' from='xs:QName' to='xs:string'>
-       <fn line='2379' name='QName'>
+       <fn line='2383' name='QName'>
         <convert from='xs:anyURI' to='xs:string'>
          <varRef name='Q{}current-namespace' slot='0'/>
         </convert>
@@ -12298,12 +12288,12 @@
       <convert role='namespace' from='xs:anyURI' to='xs:string'>
        <varRef name='Q{}current-namespace' slot='0'/>
       </convert>
-      <sequence role='content' line='2381'>
+      <sequence role='content' line='2385'>
        <namespace flags='l'>
         <str role='name' val='xforms'/>
         <str role='select' val='http://www.w3.org/2002/xforms'/>
        </namespace>
-       <applyT line='2383' mode='Q{}namespace-fix' bSlot='0'>
+       <applyT line='2387' mode='Q{}namespace-fix' bSlot='0'>
         <sequence role='select'>
          <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
          <axis name='child' nodeTest='( element() | text() | comment() | processing-instruction() )' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);'/>
@@ -12315,12 +12305,12 @@
    </templateRule>
   </mode>
  </co>
- <co id='81' vis='PRIVATE' binds='' base='9' dpack='1'/>
- <co id='102' vis='PRIVATE' binds='' base='10' dpack='1'/>
- <co id='103' vis='PRIVATE' binds='' base='11' dpack='1'/>
- <co id='76' binds='95 25 27'>
-  <template name='Q{}HTTPsubmit' cxt='map(*)' jsTest='return SaxonJS.U.isMap(item)' flags='s' line='985' module='saxon-xforms.xsl' slots='5'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='989'>
+ <co id='82' vis='PRIVATE' binds='' base='9' dpack='1'/>
+ <co id='103' vis='PRIVATE' binds='' base='10' dpack='1'/>
+ <co id='104' vis='PRIVATE' binds='' base='11' dpack='1'/>
+ <co id='77' binds='95 25 27'>
+  <template name='Q{}HTTPsubmit' cxt='map(*)' jsTest='return SaxonJS.U.isMap(item)' flags='s' line='989' module='saxon-xforms.xsl' slots='5'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='993'>
     <param name='Q{}instance-id' slot='0' as='xs:string'>
      <str role='select' val='saxon-forms-default'/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|instance-id'>
@@ -12333,7 +12323,7 @@
       </check>
      </treat>
     </param>
-    <param line='990' name='Q{}targetref' slot='1' as='xs:string?'>
+    <param line='994' name='Q{}targetref' slot='1' as='xs:string?'>
      <empty role='select'/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|targetref'>
       <check card='?' diag='8|0|XTTE0590|targetref'>
@@ -12345,7 +12335,7 @@
       </check>
      </treat>
     </param>
-    <param line='991' name='Q{}replace' slot='2' as='xs:string?'>
+    <param line='995' name='Q{}replace' slot='2' as='xs:string?'>
      <empty role='select'/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|replace'>
       <check card='?' diag='8|0|XTTE0590|replace'>
@@ -12357,29 +12347,29 @@
       </check>
      </treat>
     </param>
-    <let line='993' var='Q{}refi' as='xs:string' slot='3' eval='8'>
+    <let line='997' var='Q{}refi' as='xs:string' slot='3' eval='8'>
      <fn name='concat'>
       <str val='instance(&#39;'/>
       <varRef name='Q{}instance-id' slot='0'/>
       <str val='&#39;)/'/>
      </fn>
-     <let line='1001' var='Q{}response' as='item()?' slot='4' eval='7'>
+     <let line='1005' var='Q{}response' as='item()?' slot='4' eval='7'>
       <check card='?' diag='3|0|XTTE0570|response'>
        <lookup>
         <dot type='map(*)'/>
         <str val='body'/>
        </lookup>
       </check>
-      <choose line='1004'>
+      <choose line='1008'>
        <fn name='empty'>
         <varRef name='Q{}response' slot='4'/>
        </fn>
-       <callT line='1005' name='Q{}serverError' bSlot='0' flags='t'>
+       <callT line='1009' name='Q{}serverError' bSlot='0' flags='t'>
         <withParam name='Q{}responseMap' flags='c' as='map(*)'>
-         <dot line='1006' type='map(*)'/>
+         <dot line='1010' type='map(*)'/>
         </withParam>
        </callT>
-       <and line='1018' op='and'>
+       <and line='1022' op='and'>
         <vc op='eq' onEmpty='0' comp='CCC'>
          <varRef name='Q{}replace' slot='2'/>
          <str val='instance'/>
@@ -12396,7 +12386,7 @@
          </fn>
         </filter>
        </and>
-       <sequence line='1019'>
+       <sequence line='1023'>
         <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='1' eval='6 16'>
          <varRef name='Q{}refi' slot='3'/>
          <check card='1' diag='0|1||xforms:setInstance-JS'>
@@ -12408,7 +12398,7 @@
           </slash>
          </check>
         </ufCall>
-        <callT line='1021' name='Q{}xforms-recalculate' bSlot='2' flags='t'/>
+        <callT line='1025' name='Q{}xforms-recalculate' bSlot='2' flags='t'/>
        </sequence>
       </choose>
      </let>
@@ -12417,9 +12407,9 @@
   </template>
  </co>
  <co id='22' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}instance' line='126' module='xforms-function-library.xsl' eval='7' flags='pU' as='element()?' slots='1'>
+  <function name='Q{http://www.w3.org/2002/xforms}instance' line='127' module='xforms-function-library.xsl' eval='7' flags='pU' as='element()?' slots='1'>
    <arg name='Q{}instance-id' as='xs:string'/>
-   <treat role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='128' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='5|0|XTTE0780|xforms:instance#1'>
+   <treat role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='129' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='5|0|XTTE0780|xforms:instance#1'>
     <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
      <check card='1' diag='0|0||ixsl:call'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -12432,20 +12422,20 @@
    </treat>
   </function>
  </co>
- <co id='104' binds='72 92 31'>
+ <co id='105' binds='73 93 31'>
   <mode name='Q{http://saxonica.com/ns/interactiveXSLT}onclick' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='0.5' seq='3' rank='0' minImp='0' slots='1' flags='s' line='707' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.5' seq='3' rank='0' minImp='0' slots='1' flags='s' line='711' module='saxon-xforms.xsl'>
     <p.withUpper role='match' axis='ancestor' upFirst='false'>
      <p.withPredicate>
       <p.nodeTest test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-      <or ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='707' op='or'>
+      <or ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='711' op='or'>
        <axis name='self' nodeTest='element(Q{}span)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;span&#39;;'/>
        <axis name='self' nodeTest='element(Q{}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
       </or>
      </p.withPredicate>
      <p.withPredicate>
       <p.nodeTest test='element(Q{}div)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;div&#39;;'/>
-      <vc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='707' op='eq' onEmpty='0' comp='CCC'>
+      <vc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='711' op='eq' onEmpty='0' comp='CCC'>
        <cast as='xs:string' emptiable='1'>
         <data>
          <axis name='attribute' nodeTest='attribute(Q{}data-repeat-item)' jsTest='return item.name===&#39;data-repeat-item&#39;'/>
@@ -12455,11 +12445,11 @@
       </vc>
      </p.withPredicate>
     </p.withUpper>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='716' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='0' eval='13'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='720' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='0' eval='13'>
      <check card='1' diag='0|0||ixsl:call'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
      </check>
-     <sequence line='708'>
+     <sequence line='712'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -12471,7 +12461,7 @@
         </fn>
        </arrayBlock>
       </ifCall>
-      <forEach line='711'>
+      <forEach line='715'>
        <fn name='reverse'>
         <filter flags='b'>
          <axis name='ancestor' nodeTest='element(Q{}div)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;div&#39;;'/>
@@ -12483,11 +12473,11 @@
          </vc>
         </filter>
        </fn>
-       <ifCall line='716' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+       <ifCall line='720' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
         <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='0'/>
         <str val='setRepeatIndex'/>
         <arrayBlock>
-         <check line='712' card='1' diag='3|0|XTTE0570|repeat-id'>
+         <check line='716' card='1' diag='3|0|XTTE0570|repeat-id'>
           <cvUntyped to='xs:string' diag='3|0|XTTE0570|repeat-id'>
            <data>
             <slash simple='1'>
@@ -12504,7 +12494,7 @@
            </data>
           </cvUntyped>
          </check>
-         <arith line='713' op='+' calc='i+i'>
+         <arith line='717' op='+' calc='i+i'>
           <fn name='count'>
            <filter flags='b'>
             <axis name='preceding-sibling' nodeTest='element(Q{}div)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;div&#39;;'/>
@@ -12521,38 +12511,38 @@
         </arrayBlock>
        </ifCall>
       </forEach>
-      <choose line='719'>
+      <choose line='723'>
        <fn name='exists'>
         <axis name='self' nodeTest='element(Q{}span)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;span&#39;;'/>
        </fn>
-       <callT line='720' name='Q{}refreshElementsUsingIndexFunction-JS' bSlot='0' flags='t'/>
+       <callT line='724' name='Q{}refreshElementsUsingIndexFunction-JS' bSlot='0' flags='t'/>
       </choose>
      </sequence>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.5' seq='23' rank='0' minImp='0' slots='0' flags='s' line='1955' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.5' seq='23' rank='0' minImp='0' slots='0' flags='s' line='1959' module='saxon-xforms.xsl'>
     <p.withPredicate role='match'>
      <p.nodeTest test='element(Q{}button)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;button&#39;;'/>
-     <fn ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1955' name='exists'>
+     <fn ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1959' name='exists'>
       <axis name='attribute' nodeTest='attribute(Q{}data-action)' jsTest='return item.name===&#39;data-action&#39;'/>
      </fn>
     </p.withPredicate>
-    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1956' name='Q{}DOMActivate' bSlot='1' flags='t'>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1960' name='Q{}DOMActivate' bSlot='1' flags='t'>
      <withParam name='Q{}form-control' flags='c' as='node()'>
-      <dot line='1957' type='element(Q{}button)'/>
+      <dot line='1961' type='element(Q{}button)'/>
      </withParam>
     </callT>
    </templateRule>
-   <templateRule prec='0' prio='0.5' seq='4' rank='0' minImp='0' slots='0' flags='s' line='967' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.5' seq='4' rank='0' minImp='0' slots='0' flags='s' line='971' module='saxon-xforms.xsl'>
     <p.withPredicate role='match'>
      <p.nodeTest test='element(Q{}button)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;button&#39;;'/>
-     <fn ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='967' name='exists'>
+     <fn ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='971' name='exists'>
       <axis name='attribute' nodeTest='attribute(Q{}data-submit)' jsTest='return item.name===&#39;data-submit&#39;'/>
      </fn>
     </p.withPredicate>
-    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='969' name='Q{}xforms-submit' bSlot='2' flags='t'>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='973' name='Q{}xforms-submit' bSlot='2' flags='t'>
      <withParam name='Q{}submission' flags='c' as='xs:string'>
-      <fn line='970' name='string'>
+      <fn line='974' name='string'>
        <axis name='attribute' nodeTest='attribute(Q{}data-submit)' jsTest='return item.name===&#39;data-submit&#39;'/>
       </fn>
      </withParam>
@@ -12560,9 +12550,9 @@
    </templateRule>
   </mode>
  </co>
- <co id='101' binds='87 88 89'>
-  <template name='Q{}setSubmission' flags='os' line='3463' module='saxon-xforms.xsl' slots='5'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3464'>
+ <co id='102' binds='88 89 90'>
+  <template name='Q{}setSubmission' flags='os' line='3467' module='saxon-xforms.xsl' slots='5'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3468'>
     <param name='Q{}this' slot='0' flags='i' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
       <check card='1' diag='8|0|XTTE0590|this'>
@@ -12570,7 +12560,7 @@
       </check>
      </treat>
     </param>
-    <param line='3465' name='Q{}submission-id' slot='1' flags='i' as='xs:string'>
+    <param line='3469' name='Q{}submission-id' slot='1' flags='i' as='xs:string'>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|submission-id'>
       <check card='1' diag='8|0|XTTE0590|submission-id'>
        <cvUntyped to='xs:string' diag='8|0|XTTE0590|submission-id'>
@@ -12581,52 +12571,52 @@
       </check>
      </treat>
     </param>
-    <let line='3468' var='Q{}bindingi' as='node()?' slot='2' eval='7'>
-     <treat line='3469' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+    <let line='3472' var='Q{}bindingi' as='node()?' slot='2' eval='7'>
+     <treat line='3473' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
       <check card='?' diag='3|0|XTTE0570|bindingi'>
        <callT name='Q{}getBinding' bSlot='0'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <varRef line='3470' name='Q{}this' slot='0'/>
+         <varRef line='3474' name='Q{}this' slot='0'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <let line='3475' var='Q{}refi' as='xs:string' slot='3' eval='16'>
-      <treat line='3476' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+     <let line='3479' var='Q{}refi' as='xs:string' slot='3' eval='16'>
+      <treat line='3480' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
        <check card='1' diag='3|0|XTTE0570|refi'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
          <data>
           <callT name='Q{}getDataRef' bSlot='1'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <varRef line='3477' name='Q{}this' slot='0'/>
+            <varRef line='3481' name='Q{}this' slot='0'/>
            </withParam>
            <withParam name='Q{}bindingi' flags='c' as='node()?'>
-            <varRef line='3478' name='Q{}bindingi' slot='2'/>
+            <varRef line='3482' name='Q{}bindingi' slot='2'/>
            </withParam>
           </callT>
          </data>
         </cvUntyped>
        </check>
       </treat>
-      <let line='3483' var='Q{}actions' as='map(*)*' slot='4' eval='8'>
-       <treat line='3484' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+      <let line='3487' var='Q{}actions' as='map(*)*' slot='4' eval='8'>
+       <treat line='3488' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
         <callT name='Q{}setActions' bSlot='2'>
          <withParam name='Q{}this' flags='c' as='element()'>
-          <treat line='3485' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+          <treat line='3489' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
            <dot flags='a'/>
           </treat>
          </withParam>
          <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-          <varRef line='3486' name='Q{}refi' slot='3'/>
+          <varRef line='3490' name='Q{}refi' slot='3'/>
          </withParam>
         </callT>
        </treat>
-       <sequence line='3490'>
+       <sequence line='3494'>
         <choose>
          <fn name='exists'>
           <varRef name='Q{}actions' slot='4'/>
          </fn>
-         <ifCall line='3491' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+         <ifCall line='3495' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
           <check card='1' diag='0|0||ixsl:call'>
            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
           </check>
@@ -12637,20 +12627,20 @@
           </arrayBlock>
          </ifCall>
         </choose>
-        <ifCall line='3496' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+        <ifCall line='3500' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
          <sequence>
-          <ifCall line='3497' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <ifCall line='3501' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
            <str val='@ref'/>
            <varRef name='Q{}refi' slot='3'/>
           </ifCall>
-          <choose line='3500'>
+          <choose line='3504'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}resource)' jsTest='return item.name===&#39;resource&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3501' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='3505' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@resource'/>
             <cast as='xs:string' emptiable='1'>
              <data>
@@ -12662,14 +12652,14 @@
             </cast>
            </ifCall>
           </choose>
-          <choose line='3503'>
+          <choose line='3507'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}mode)' jsTest='return item.name===&#39;mode&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3504' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='3508' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@mode'/>
             <cast as='xs:string' emptiable='1'>
              <data>
@@ -12681,16 +12671,16 @@
             </cast>
            </ifCall>
           </choose>
-          <ifCall line='3507' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <ifCall line='3511' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
            <str val='@method'/>
-           <choose line='3509'>
+           <choose line='3513'>
             <fn name='exists'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='attribute' nodeTest='attribute(Q{}method)' jsTest='return item.name===&#39;method&#39;'/>
              </slash>
             </fn>
-            <fn line='3510' name='string'>
+            <fn line='3514' name='string'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='attribute' nodeTest='attribute(Q{}method)' jsTest='return item.name===&#39;method&#39;'/>
@@ -12700,14 +12690,14 @@
             <str val='POST'/>
            </choose>
           </ifCall>
-          <choose line='3519'>
+          <choose line='3523'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}validate)' jsTest='return item.name===&#39;validate&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3520' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='3524' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@validate'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12717,14 +12707,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='3522'>
+          <choose line='3526'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}relevant)' jsTest='return item.name===&#39;relevant&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3523' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='3527' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@relevant'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12734,14 +12724,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='3525'>
+          <choose line='3529'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}serialization)' jsTest='return item.name===&#39;serialization&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3526' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='3530' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@serialization'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12751,14 +12741,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='3528'>
+          <choose line='3532'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}version)' jsTest='return item.name===&#39;version&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3529' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='3533' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@version'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12768,14 +12758,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='3531'>
+          <choose line='3535'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}indent)' jsTest='return item.name===&#39;indent&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3532' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='3536' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@indent'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12785,16 +12775,16 @@
             </fn>
            </ifCall>
           </choose>
-          <ifCall line='3536' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <ifCall line='3540' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
            <str val='@mediatype'/>
-           <choose line='3538'>
+           <choose line='3542'>
             <fn name='exists'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='attribute' nodeTest='attribute(Q{}mediatype)' jsTest='return item.name===&#39;mediatype&#39;'/>
              </slash>
             </fn>
-            <fn line='3539' name='string'>
+            <fn line='3543' name='string'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='attribute' nodeTest='attribute(Q{}mediatype)' jsTest='return item.name===&#39;mediatype&#39;'/>
@@ -12804,14 +12794,14 @@
             <str val='text/plain'/>
            </choose>
           </ifCall>
-          <choose line='3549'>
+          <choose line='3553'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}encoding)' jsTest='return item.name===&#39;encoding&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3550' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='3554' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@encoding'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12821,14 +12811,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='3552'>
+          <choose line='3556'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}omit-xml-declaration)' jsTest='return item.name===&#39;omit-xml-declaration&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3553' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='3557' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@omit-xml-declaration'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12838,14 +12828,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='3555'>
+          <choose line='3559'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}standalone)' jsTest='return item.name===&#39;standalone&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3556' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='3560' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@standalone'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12855,14 +12845,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='3558'>
+          <choose line='3562'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}cdata-section-elements)' jsTest='return item.name===&#39;cdata-section-elements&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3559' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='3563' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@cdata-section-elements'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12872,16 +12862,16 @@
             </fn>
            </ifCall>
           </choose>
-          <ifCall line='3562' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <ifCall line='3566' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
            <str val='@replace'/>
-           <choose line='3564'>
+           <choose line='3568'>
             <fn name='exists'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='attribute' nodeTest='attribute(Q{}replace)' jsTest='return item.name===&#39;replace&#39;'/>
              </slash>
             </fn>
-            <fn line='3565' name='string'>
+            <fn line='3569' name='string'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='attribute' nodeTest='attribute(Q{}replace)' jsTest='return item.name===&#39;replace&#39;'/>
@@ -12891,14 +12881,14 @@
             <str val='all'/>
            </choose>
           </ifCall>
-          <choose line='3576'>
+          <choose line='3580'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}instance)' jsTest='return item.name===&#39;instance&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3577' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='3581' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@instance'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12908,14 +12898,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='3579'>
+          <choose line='3583'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}targetref)' jsTest='return item.name===&#39;targetref&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3580' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='3584' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@targetref'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12925,14 +12915,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='3582'>
+          <choose line='3586'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}separator)' jsTest='return item.name===&#39;separator&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3583' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='3587' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@separator'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12942,14 +12932,14 @@
             </fn>
            </ifCall>
           </choose>
-          <choose line='3585'>
+          <choose line='3589'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}includenamespaceprefixes)' jsTest='return item.name===&#39;includenamespaceprefixes&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3586' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='3590' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@includenamespaceprefixes'/>
             <fn name='string'>
              <slash simple='1'>
@@ -12974,18 +12964,18 @@
    </sequence>
   </template>
  </co>
- <co id='105' binds='38'>
+ <co id='106' binds='38'>
   <mode name='Q{http://saxonica.com/ns/interactiveXSLT}onkeyup' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='0.5' seq='0' rank='0' minImp='0' slots='0' flags='s' line='674' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.5' seq='0' rank='0' minImp='0' slots='0' flags='s' line='678' module='saxon-xforms.xsl'>
     <p.withPredicate role='match'>
      <p.nodeTest test='element(Q{}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
-     <gc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='674' op='=' card='N:1' comp='CCC'>
+     <gc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='678' op='=' card='N:1' comp='CCC'>
       <fn name='tokenize'>
        <cvUntyped to='xs:string' diag='3|0|XTTE0570|class'>
         <data>
          <slash simple='1'>
           <dot type='element(Q{}input)'/>
-          <axis line='2584' name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
+          <axis line='2588' name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
          </slash>
         </data>
        </cvUntyped>
@@ -12993,17 +12983,17 @@
       <str val='incremental'/>
      </gc>
     </p.withPredicate>
-    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='676' name='Q{}xforms-value-changed' bSlot='0' flags='t'>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='680' name='Q{}xforms-value-changed' bSlot='0' flags='t'>
      <withParam name='Q{}form-control' flags='c' as='node()'>
-      <dot line='677' type='element(Q{}input)'/>
+      <dot line='681' type='element(Q{}input)'/>
      </withParam>
     </callT>
    </templateRule>
   </mode>
  </co>
- <co id='87' binds=''>
-  <template name='Q{}getBinding' flags='os' line='2795' module='saxon-xforms.xsl' slots='4'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2796'>
+ <co id='88' binds=''>
+  <template name='Q{}getBinding' flags='os' line='2799' module='saxon-xforms.xsl' slots='4'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2800'>
     <param name='Q{}this' slot='0' flags='r' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
       <check card='1' diag='8|0|XTTE0590|this'>
@@ -13011,7 +13001,7 @@
       </check>
      </treat>
     </param>
-    <param line='2797' name='Q{}bindings' slot='1' flags='t' as='map(xs:string, node())'>
+    <param line='2801' name='Q{}bindings' slot='1' flags='t' as='map(xs:string, node())'>
      <map role='select' size='0'/>
      <treat role='conversion' as='map(xs:string, node())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|bindings'>
       <check card='1' diag='8|0|XTTE0590|bindings'>
@@ -13019,7 +13009,7 @@
       </check>
      </treat>
     </param>
-    <let line='2806' var='Q{}ref-binding' as='xs:string' slot='2' eval='16'>
+    <let line='2810' var='Q{}ref-binding' as='xs:string' slot='2' eval='16'>
      <choose>
       <fn name='exists'>
        <slash simple='1'>
@@ -13056,8 +13046,8 @@
       <true/>
       <str val=''/>
      </choose>
-     <let line='2808' var='Q{}binding' as='element()?' slot='3' eval='7'>
-      <choose line='2813'>
+     <let line='2812' var='Q{}binding' as='element()?' slot='3' eval='7'>
+      <choose line='2817'>
        <fn name='empty'>
         <varRef name='Q{}ref-binding' slot='2'/>
        </fn>
@@ -13070,12 +13060,12 @@
         </ifCall>
        </treat>
       </choose>
-      <sequence line='2816'>
+      <sequence line='2820'>
        <choose>
         <fn name='exists'>
          <varRef name='Q{}binding' slot='3'/>
         </fn>
-        <message line='2822'>
+        <message line='2826'>
          <sequence role='select'>
           <valueOf>
            <str val='[getBinding for '/>
@@ -13098,16 +13088,16 @@
          <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
         </message>
        </choose>
-       <varRef line='2826' name='Q{}binding' slot='3'/>
+       <varRef line='2830' name='Q{}binding' slot='3'/>
       </sequence>
      </let>
     </let>
    </sequence>
   </template>
  </co>
- <co id='44' binds='67'>
-  <template name='Q{}logToPage' flags='os' line='2558' module='saxon-xforms.xsl' slots='2'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2559'>
+ <co id='45' binds='68'>
+  <template name='Q{}logToPage' flags='os' line='2562' module='saxon-xforms.xsl' slots='2'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2563'>
     <param name='Q{}message' slot='0' flags='i' as='xs:string'>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|message'>
       <check card='1' diag='8|0|XTTE0590|message'>
@@ -13119,7 +13109,7 @@
       </check>
      </treat>
     </param>
-    <param line='2560' name='Q{}level' slot='1' as='xs:string'>
+    <param line='2564' name='Q{}level' slot='1' as='xs:string'>
      <str role='select' val='info'/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|level'>
       <check card='1' diag='8|0|XTTE0590|level'>
@@ -13131,12 +13121,12 @@
       </check>
      </treat>
     </param>
-    <resultDoc line='2562' global='#&#xD;&#xA;#Sat Mar 14 13:02:55 GMT 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Sat Mar 14 13:02:55 GMT 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}append-content&#xD;&#xA;'>
+    <resultDoc line='2566' global='#&#xD;&#xA;#Tue Mar 24 21:48:26 GMT 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Tue Mar 24 21:48:26 GMT 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}append-content&#xD;&#xA;'>
      <fn role='href' name='concat'>
       <str val='#'/>
       <gVarRef name='Q{}xform-html-id' bSlot='0'/>
      </fn>
-     <elem role='content' line='2563' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+     <elem role='content' line='2567' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
       <sequence>
        <att name='class' flags='l'>
         <fn name='concat'>
@@ -13144,17 +13134,17 @@
          <varRef name='Q{}level' slot='1'/>
         </fn>
        </att>
-       <elem line='2564' name='p' nsuri='' flags='l'>
-        <sequence line='2565'>
+       <elem line='2568' name='p' nsuri='' flags='l'>
+        <sequence line='2569'>
          <elem name='b' nsuri='' flags='l'>
-          <fn line='2566' name='concat'>
+          <fn line='2570' name='concat'>
            <fn name='upper-case'>
             <varRef name='Q{}level' slot='1'/>
            </fn>
            <str val=': '/>
           </fn>
          </elem>
-         <varRef line='2568' name='Q{}message' slot='0'/>
+         <varRef line='2572' name='Q{}message' slot='0'/>
         </sequence>
        </elem>
       </sequence>
@@ -13163,23 +13153,23 @@
    </sequence>
   </template>
  </co>
- <co id='106' binds=''>
+ <co id='107' binds=''>
   <globalVariable name='Q{}default-instance-id' type='xs:string' line='81' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
    <str val='saxon-forms-default'/>
   </globalVariable>
  </co>
- <co id='107' vis='PRIVATE' binds='70 108' base='16' dpack='1'/>
- <co id='109' binds=''>
+ <co id='108' vis='PRIVATE' binds='71 109' base='16' dpack='1'/>
+ <co id='110' binds=''>
   <globalVariable name='Q{}debugTiming' type='xs:boolean' line='80' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.boolean.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
    <false/>
   </globalVariable>
  </co>
- <co id='108' vis='PRIVATE' binds='' base='6' dpack='1'/>
- <co id='65' binds='87'>
-  <function name='Q{http://www.w3.org/2002/xforms}getDataRef' line='2681' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:string' slots='11'>
+ <co id='109' vis='PRIVATE' binds='' base='6' dpack='1'/>
+ <co id='66' binds='88'>
+  <function name='Q{http://www.w3.org/2002/xforms}getDataRef' line='2685' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:string' slots='11'>
    <arg name='Q{}this' as='element()'/>
    <arg name='Q{}nodeset' as='xs:string?'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2690' var='Q{}this-ref' as='xs:string?' slot='2' eval='7'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2694' var='Q{}this-ref' as='xs:string?' slot='2' eval='7'>
     <choose>
      <fn name='exists'>
       <slash simple='1'>
@@ -13214,27 +13204,27 @@
       </cast>
      </fn>
     </choose>
-    <let line='2693' var='Q{}this-binding' as='node()?' slot='3' eval='7'>
-     <treat line='2694' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|this-binding'>
+    <let line='2697' var='Q{}this-binding' as='node()?' slot='3' eval='7'>
+     <treat line='2698' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|this-binding'>
       <check card='?' diag='3|0|XTTE0570|this-binding'>
        <callT name='Q{}getBinding' bSlot='0'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <varRef line='2695' name='Q{}this' slot='0'/>
+         <varRef line='2699' name='Q{}this' slot='0'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <choose line='2720'>
+     <choose line='2724'>
       <fn name='exists'>
        <varRef name='Q{}this-binding' slot='3'/>
       </fn>
-      <let line='2701' var='Q{}relative' as='xs:string' slot='4' eval='16'>
+      <let line='2705' var='Q{}relative' as='xs:string' slot='4' eval='16'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
         <choose>
          <fn name='exists'>
           <varRef name='Q{}this-binding' slot='3'/>
          </fn>
-         <cvUntyped line='2712' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
+         <cvUntyped line='2716' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
           <cast as='xs:untypedAtomic' emptiable='0'>
            <choose>
             <fn name='exists'>
@@ -13269,25 +13259,25 @@
          </cvUntyped>
         </choose>
        </check>
-       <choose line='811'>
+       <choose line='815'>
         <fn name='starts-with'>
          <varRef name='Q{}relative' slot='4'/>
          <str val='/'/>
         </fn>
-        <varRef line='812' name='Q{}relative' slot='4'/>
-        <fn line='814' name='starts-with'>
+        <varRef line='816' name='Q{}relative' slot='4'/>
+        <fn line='818' name='starts-with'>
          <varRef name='Q{}relative' slot='4'/>
          <str val='instance('/>
         </fn>
-        <varRef line='815' name='Q{}relative' slot='4'/>
+        <varRef line='819' name='Q{}relative' slot='4'/>
         <true/>
-        <varRef line='818' name='Q{}relative' slot='4'/>
+        <varRef line='822' name='Q{}relative' slot='4'/>
        </choose>
       </let>
-      <fn line='2723' name='exists'>
+      <fn line='2727' name='exists'>
        <varRef name='Q{}this-ref' slot='2'/>
       </fn>
-      <let line='2724' var='Q{}base' as='xs:string' slot='5' eval='16'>
+      <let line='2728' var='Q{}base' as='xs:string' slot='5' eval='16'>
        <check card='1' diag='0|0||xforms:resolveXPathStrings'>
         <varRef name='Q{}nodeset' slot='1'/>
        </check>
@@ -13295,22 +13285,22 @@
         <check card='1' diag='0|1||xforms:resolveXPathStrings'>
          <varRef name='Q{}this-ref' slot='2'/>
         </check>
-        <choose line='811'>
+        <choose line='815'>
          <fn name='starts-with'>
           <varRef name='Q{}relative' slot='6'/>
           <str val='/'/>
          </fn>
-         <varRef line='812' name='Q{}relative' slot='6'/>
-         <fn line='814' name='starts-with'>
+         <varRef line='816' name='Q{}relative' slot='6'/>
+         <fn line='818' name='starts-with'>
           <varRef name='Q{}relative' slot='6'/>
           <str val='instance('/>
          </fn>
-         <varRef line='815' name='Q{}relative' slot='6'/>
-         <fn line='817' name='not'>
+         <varRef line='819' name='Q{}relative' slot='6'/>
+         <fn line='821' name='not'>
           <varRef name='Q{}base' slot='5'/>
          </fn>
-         <varRef line='818' name='Q{}relative' slot='6'/>
-         <or line='820' op='or'>
+         <varRef line='822' name='Q{}relative' slot='6'/>
+         <or line='824' op='or'>
           <fn name='not'>
            <varRef name='Q{}relative' slot='6'/>
           </fn>
@@ -13319,9 +13309,9 @@
            <str val='.'/>
           </vc>
          </or>
-         <varRef line='821' name='Q{}base' slot='5'/>
+         <varRef line='825' name='Q{}base' slot='5'/>
          <true/>
-         <let line='825' var='Q{}parentCallCount' as='xs:integer' slot='7' eval='16'>
+         <let line='829' var='Q{}parentCallCount' as='xs:integer' slot='7' eval='16'>
           <choose>
            <fn name='contains'>
             <varRef name='Q{}relative' slot='6'/>
@@ -13348,7 +13338,7 @@
            <true/>
            <int val='0'/>
           </choose>
-          <let line='828' var='Q{}slashes' as='xs:integer*' slot='8' eval='4'>
+          <let line='832' var='Q{}slashes' as='xs:integer*' slot='8' eval='4'>
            <choose>
             <fn name='contains'>
              <varRef name='Q{}base' slot='5'/>
@@ -13363,15 +13353,15 @@
             <true/>
             <int val='0'/>
            </choose>
-           <choose line='860'>
+           <choose line='864'>
             <compareToInt op='gt' val='0'>
              <varRef name='Q{}parentCallCount' slot='7'/>
             </compareToInt>
-            <fn line='864' name='concat'>
+            <fn line='868' name='concat'>
              <fn name='substring'>
               <varRef name='Q{}base' slot='5'/>
               <int val='1'/>
-              <choose line='839'>
+              <choose line='843'>
                <and op='and'>
                 <vc op='ge' onEmpty='0' comp='CAVC'>
                  <fn name='count'>
@@ -13383,7 +13373,7 @@
                  <varRef name='Q{}parentCallCount' slot='7'/>
                 </compareToInt>
                </and>
-               <let line='840' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='9' eval='16'>
+               <let line='844' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='9' eval='16'>
                 <arith op='-' calc='i-i'>
                  <varRef name='Q{}parentCallCount' slot='7'/>
                  <int val='1'/>
@@ -13399,7 +13389,7 @@
                 </check>
                </let>
                <true/>
-               <check line='843' card='1' diag='3|0|XTTE0570|parentSlash'>
+               <check line='847' card='1' diag='3|0|XTTE0570|parentSlash'>
                 <lastOf>
                  <varRef name='Q{}slashes' slot='8'/>
                 </lastOf>
@@ -13414,7 +13404,7 @@
              </fn>
             </fn>
             <true/>
-            <fn line='867' name='concat'>
+            <fn line='871' name='concat'>
              <varRef name='Q{}base' slot='5'/>
              <str val='/'/>
              <varRef name='Q{}relative' slot='6'/>
@@ -13425,24 +13415,24 @@
         </choose>
        </let>
       </let>
-      <varRef line='2726' name='Q{}nodeset' slot='1'/>
-      <let line='2727' var='Q{}relative' as='xs:string' slot='10' eval='16'>
+      <varRef line='2730' name='Q{}nodeset' slot='1'/>
+      <let line='2731' var='Q{}relative' as='xs:string' slot='10' eval='16'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
         <varRef name='Q{}nodeset' slot='1'/>
        </check>
-       <choose line='811'>
+       <choose line='815'>
         <fn name='starts-with'>
          <varRef name='Q{}relative' slot='10'/>
          <str val='/'/>
         </fn>
-        <varRef line='812' name='Q{}relative' slot='10'/>
-        <fn line='814' name='starts-with'>
+        <varRef line='816' name='Q{}relative' slot='10'/>
+        <fn line='818' name='starts-with'>
          <varRef name='Q{}relative' slot='10'/>
          <str val='instance('/>
         </fn>
-        <varRef line='815' name='Q{}relative' slot='10'/>
+        <varRef line='819' name='Q{}relative' slot='10'/>
         <true/>
-        <varRef line='818' name='Q{}relative' slot='10'/>
+        <varRef line='822' name='Q{}relative' slot='10'/>
        </choose>
       </let>
       <true/>
@@ -13452,18 +13442,18 @@
    </let>
   </function>
  </co>
- <co id='39' binds='39 39'>
+ <co id='40' binds='40 40'>
   <mode name='Q{}recalculate' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='28' rank='0' minImp='0' slots='5' flags='s' line='2285' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='28' rank='0' minImp='0' slots='5' flags='s' line='2289' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2286'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2290'>
      <param name='Q{}updated-nodes' slot='0' flags='t' as='node()*'>
       <empty role='select'/>
       <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|updated-nodes'>
        <supplied slot='0'/>
       </treat>
      </param>
-     <param line='2287' name='Q{}updated-values' slot='1' flags='t' as='xs:string*'>
+     <param line='2291' name='Q{}updated-values' slot='1' flags='t' as='xs:string*'>
       <empty role='select'/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|updated-values'>
        <cvUntyped to='xs:string' diag='8|0|XTTE0590|updated-values'>
@@ -13473,14 +13463,14 @@
        </cvUntyped>
       </treat>
      </param>
-     <copy line='2293' flags='cin'>
+     <copy line='2297' flags='cin'>
       <sequence role='content'>
        <applyT mode='Q{}recalculate' bSlot='0'>
         <axis role='select' name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
        </applyT>
-       <choose line='2296'>
+       <choose line='2300'>
         <fn name='exists'>
-         <let line='2289' var='Q{http://saxon.sf.net/generated-variable}current-1969428406' as='element()' slot='2' eval='16'>
+         <let line='2293' var='Q{http://saxon.sf.net/generated-variable}current-1667792384' as='element()' slot='2' eval='16'>
           <dot type='element()'/>
           <treat as='element()' jsTest='return item.nodeType===1;' diag='3|0|XTTE0570|updated-node'>
            <check card='?' diag='3|0|XTTE0570|updated-node'>
@@ -13488,15 +13478,15 @@
              <varRef name='Q{}updated-nodes' slot='0'/>
              <is op='is'>
               <dot type='node()'/>
-              <varRef name='Q{http://saxon.sf.net/generated-variable}current-1969428406' slot='2'/>
+              <varRef name='Q{http://saxon.sf.net/generated-variable}current-1667792384' slot='2'/>
              </is>
             </filter>
            </check>
           </treat>
          </let>
         </fn>
-        <let line='2297' var='Q{}updated-node-position' as='xs:integer' slot='3' eval='16'>
-         <let var='Q{http://saxon.sf.net/generated-variable}current-822657580' as='element()' slot='4' eval='16'>
+        <let line='2301' var='Q{}updated-node-position' as='xs:integer' slot='3' eval='16'>
+         <let var='Q{http://saxon.sf.net/generated-variable}current-1131486098' as='element()' slot='4' eval='16'>
           <dot type='element()'/>
           <check card='1' diag='3|0|XTTE0570|updated-node-position'>
            <slash>
@@ -13504,20 +13494,20 @@
              <varRef name='Q{}updated-nodes' slot='0'/>
              <is op='is'>
               <dot type='node()'/>
-              <varRef name='Q{http://saxon.sf.net/generated-variable}current-822657580' slot='4'/>
+              <varRef name='Q{http://saxon.sf.net/generated-variable}current-1131486098' slot='4'/>
              </is>
             </filter>
             <fn name='position'/>
            </slash>
           </check>
          </let>
-         <subscript line='2298'>
+         <subscript line='2302'>
           <varRef name='Q{}updated-values' slot='1'/>
           <varRef name='Q{}updated-node-position' slot='3'/>
          </subscript>
         </let>
         <true/>
-        <applyT line='2301' mode='Q{}recalculate' bSlot='1'>
+        <applyT line='2305' mode='Q{}recalculate' bSlot='1'>
          <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
         </applyT>
        </choose>
@@ -13525,16 +13515,16 @@
      </copy>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='-0.5' seq='29' rank='0' minImp='0' slots='5' flags='s' line='2314' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='29' rank='0' minImp='0' slots='5' flags='s' line='2318' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2315'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2319'>
      <param name='Q{}updated-nodes' slot='0' flags='t' as='node()*'>
       <empty role='select'/>
       <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|updated-nodes'>
        <supplied slot='0'/>
       </treat>
      </param>
-     <param line='2316' name='Q{}updated-values' slot='1' flags='t' as='xs:string*'>
+     <param line='2320' name='Q{}updated-values' slot='1' flags='t' as='xs:string*'>
       <empty role='select'/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|updated-values'>
        <cvUntyped to='xs:string' diag='8|0|XTTE0590|updated-values'>
@@ -13544,9 +13534,9 @@
        </cvUntyped>
       </treat>
      </param>
-     <choose line='2321'>
+     <choose line='2325'>
       <fn name='exists'>
-       <let line='2318' var='Q{http://saxon.sf.net/generated-variable}current-1969428407' as='attribute()' slot='2' eval='16'>
+       <let line='2322' var='Q{http://saxon.sf.net/generated-variable}current-1667792381' as='attribute()' slot='2' eval='16'>
         <dot type='attribute()'/>
         <treat as='attribute()' jsTest='return SaxonJS.U.isAttr(item)' diag='3|0|XTTE0570|updated-node'>
          <check card='?' diag='3|0|XTTE0570|updated-node'>
@@ -13554,15 +13544,15 @@
            <varRef name='Q{}updated-nodes' slot='0'/>
            <is op='is'>
             <dot type='node()'/>
-            <varRef name='Q{http://saxon.sf.net/generated-variable}current-1969428407' slot='2'/>
+            <varRef name='Q{http://saxon.sf.net/generated-variable}current-1667792381' slot='2'/>
            </is>
           </filter>
          </check>
         </treat>
        </let>
       </fn>
-      <let line='2322' var='Q{}updated-node-position' as='xs:integer' slot='3' eval='16'>
-       <let var='Q{http://saxon.sf.net/generated-variable}current-822657580' as='attribute()' slot='4' eval='16'>
+      <let line='2326' var='Q{}updated-node-position' as='xs:integer' slot='3' eval='16'>
+       <let var='Q{http://saxon.sf.net/generated-variable}current-1131486098' as='attribute()' slot='4' eval='16'>
         <dot type='attribute()'/>
         <check card='1' diag='3|0|XTTE0570|updated-node-position'>
          <slash>
@@ -13570,14 +13560,14 @@
            <varRef name='Q{}updated-nodes' slot='0'/>
            <is op='is'>
             <dot type='node()'/>
-            <varRef name='Q{http://saxon.sf.net/generated-variable}current-822657580' slot='4'/>
+            <varRef name='Q{http://saxon.sf.net/generated-variable}current-1131486098' slot='4'/>
            </is>
           </filter>
           <fn name='position'/>
          </slash>
         </check>
        </let>
-       <compAtt line='2323'>
+       <compAtt line='2327'>
         <fn role='name' name='name'>
          <dot type='attribute()'/>
         </fn>
@@ -13588,7 +13578,7 @@
        </compAtt>
       </let>
       <true/>
-      <copyOf line='2326' flags='vc'>
+      <copyOf line='2330' flags='vc'>
        <dot type='attribute()'/>
       </copyOf>
      </choose>
@@ -13596,14 +13586,14 @@
    </templateRule>
   </mode>
  </co>
- <co id='110' vis='PRIVATE' binds='70 102' base='17' dpack='1'/>
+ <co id='100' vis='PRIVATE' binds='71 103' base='17' dpack='1'/>
  <co id='111' vis='HIDDEN' binds='99' base='0' dpack='1'/>
- <co id='112' vis='HIDDEN' binds='97 99 97 108' base='5' dpack='1'/>
+ <co id='112' vis='HIDDEN' binds='97 99 97 109' base='5' dpack='1'/>
  <co id='113' vis='HIDDEN' binds='97 99 97 94' base='8' dpack='1'/>
- <co id='114' vis='HIDDEN' binds='97 99 97 102' base='12' dpack='1'/>
- <co id='70' vis='HIDDEN' binds='102 114 71 115 108 112 94 113 116' base='3' dpack='1'/>
- <co id='115' vis='HIDDEN' binds='97 99 97 71' base='14' dpack='1'/>
- <co id='116' vis='HIDDEN' binds='97 99 97 81' base='15' dpack='1'/>
+ <co id='114' vis='HIDDEN' binds='97 99 97 103' base='12' dpack='1'/>
+ <co id='71' vis='HIDDEN' binds='103 114 72 115 109 112 94 113 116' base='3' dpack='1'/>
+ <co id='115' vis='HIDDEN' binds='97 99 97 72' base='14' dpack='1'/>
+ <co id='116' vis='HIDDEN' binds='97 99 97 82' base='15' dpack='1'/>
  <co id='117' vis='HIDDEN' binds='' base='19' dpack='1'/>
  <overridden>
   <co id='111' vis='HIDDEN' binds='99' base='0' dpack='1'/>
@@ -13619,4 +13609,4 @@
  </output>
  <decimalFormat/>
 </package>
-<?Σ 68983749?>
+<?Σ 3114b074?>

--- a/src/xforms-function-library.xsl
+++ b/src/xforms-function-library.xsl
@@ -17,7 +17,7 @@
     exclude-result-prefixes="xs math xforms"
     extension-element-prefixes="ixsl" version="3.0">
     
-    <xsl:variable name="xform-functions" select="'instance', 'index', 'avg', 'foo', 'current-date', random"/>
+    <xsl:variable name="xform-functions" select="'instance', 'index', 'avg', 'foo', 'current-date', 'random'"/>
     
     <xsl:function name="xforms:impose" as="xs:string">
         <xsl:param name="input" as="xs:string" />
@@ -50,6 +50,7 @@
         
         <xsl:variable name="input2" as="xs:string" select="string-join($parts)"/>
         
+        <!-- unnecessary? MD 2020-03-24 -->
         <xsl:variable name="parts2" as="xs:string*">
             <!-- 
                 Strip out start of XPath from root of instance "document" 
@@ -66,7 +67,7 @@
             </xsl:analyze-string>
         </xsl:variable>
         
-        <xsl:sequence select="string-join($parts2)" />
+        <xsl:sequence select="string-join($parts)" />
     </xsl:function>
     
     <xsl:function name="xforms:resolve-index" as="xs:string">


### PR DESCRIPTION
Some samples used out of date paths to the current SEF.

I think I also accidentally deprecated the "initialTemplate" method of processing the XForm. I've fixed this and simplified the code that populates the $xforms-doc variable.

There was also a bug in the function library, which mangled XPaths to elements more than one level deep in the instance.