### PR TITLE
 Update to handling of deferred updates and relevant fields

### DIFF
--- a/demos/demo-input-select-output.html
+++ b/demos/demo-input-select-output.html
@@ -33,6 +33,7 @@
                <li>Output (XForms <a href="https://www.w3.org/TR/xforms11/#ui-output" class="xforms-spec-link">&lt;output&gt;</a>)</li>
                <li>Trigger (XForms <a href="https://www.w3.org/TR/xforms11/#ui-trigger" class="xforms-spec-link">&lt;trigger&gt;</a>)</li>
                <li>Message (WIP) (XForms <a href="https://www.w3.org/TR/xforms11/#action-message" class="xforms-spec-link">&lt;message&gt;</a>)</li>
+               <li>Relevant binding to display a sentence only when the pet name is set to 'Blanket'.</li>
            </ul>
        </div>
       

--- a/demos/xml/demo-input-select-output-xform.xml
+++ b/demos/xml/demo-input-select-output-xform.xml
@@ -29,7 +29,10 @@
             "/>
         <xf:bind nodeset="instance('hello')/demo:PetType" constraint="text() != 'pet'" />
         
+        <xf:bind nodeset="instance('hello')/demo:CatName" relevant="text() = 'Blanket'"/>
+        
         <xf:submission id="test" resource="none" instance="hello"/>
+        
         
     </xf:model>
     
@@ -82,6 +85,8 @@
     
     <xf:output value="concat('My ', instance('hello')/demo:PetType, ' has ', instance('hello')/demo:FedTodayStatement , ' been fed today.')" class="block demo-output"/>
     
+    <xf:output bind="instance('hello')/demo:CatName" value="'Display this sentence only when pet name is ''Blanket''.'" class="block demo-output"/>
+    
     <xf:trigger>
         <xf:label>Demo message</xf:label>
         <xf:action ev:event="DOMActivate">
@@ -89,9 +94,14 @@
         </xf:action>
     </xf:trigger>
     
-    <xf:submit ref="test">
+    <xf:submit submission="test">
         <xf:label>Submit</xf:label>
     </xf:submit>
+    
+    <xf:trigger id="setvalue-test">
+        <xf:label>Set pet name to 'Blanket'</xf:label>
+        <xf:setvalue ref="instance('hello')/demo:CatName" ev:event="DOMActivate">Blanket</xf:setvalue>
+    </xf:trigger>
     
 
     

--- a/sef/saxon-xforms.sef.xml
+++ b/sef/saxon-xforms.sef.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns='http://ns.saxonica.com/xslt/export' xmlns:fn='http://www.w3.org/2005/xpath-functions' xmlns:xs='http://www.w3.org/2001/XMLSchema' xmlns:vv='http://saxon.sf.net/generated-variable' xmlns:java-type='http://saxon.sf.net/java-type' when='2020-04-04T13:28:45.487+01:00' id='0' version='30' packageVersion='1' saxonVersion='9.9.1.5' target='JS' targetVersion='1' relocatable='true' implicit='true'>
- <co id='0' binds='1 2 1 2 3 3 3 4 5 6 3 7'>
-  <template name='Q{}action-insert' flags='os' line='4235' module='saxon-xforms.xsl' slots='21'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4236'>
+<package xmlns='http://ns.saxonica.com/xslt/export' xmlns:fn='http://www.w3.org/2005/xpath-functions' xmlns:xs='http://www.w3.org/2001/XMLSchema' xmlns:vv='http://saxon.sf.net/generated-variable' xmlns:java-type='http://saxon.sf.net/java-type' when='2020-04-05T16:19:18.336+01:00' id='0' version='30' packageVersion='1' saxonVersion='9.9.1.5' target='JS' targetVersion='1' relocatable='true' implicit='true'>
+ <co id='0' binds='1 2 1 2 3 3 3 4 5 6 3'>
+  <template name='Q{}action-insert' flags='os' line='4035' module='saxon-xforms.xsl' slots='21'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4036'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -10,7 +10,7 @@
       </check>
      </treat>
     </param>
-    <param line='4237' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
+    <param line='4037' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
      <empty role='select'/>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|instanceXML'>
       <check card='?' diag='8|0|XTTE0590|instanceXML'>
@@ -18,7 +18,7 @@
       </check>
      </treat>
     </param>
-    <param line='4238' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
+    <param line='4038' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -30,7 +30,7 @@
       </check>
      </treat>
     </param>
-    <let line='4240' var='Q{}ref' as='xs:string' slot='3' eval='16'>
+    <let line='4041' var='Q{}ref' as='xs:string' slot='3' eval='16'>
      <let var='Q{}relative' as='xs:string' slot='4' eval='16'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|1||xforms:resolveXPathStrings'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
@@ -44,22 +44,22 @@
         </cvUntyped>
        </check>
       </treat>
-      <choose line='843'>
+      <choose line='785'>
        <fn name='starts-with'>
         <varRef name='Q{}relative' slot='4'/>
         <str val='/'/>
        </fn>
-       <varRef line='844' name='Q{}relative' slot='4'/>
-       <fn line='846' name='starts-with'>
+       <varRef line='786' name='Q{}relative' slot='4'/>
+       <fn line='788' name='starts-with'>
         <varRef name='Q{}relative' slot='4'/>
         <str val='instance('/>
        </fn>
-       <varRef line='847' name='Q{}relative' slot='4'/>
-       <fn line='4240' name='not'>
+       <varRef line='789' name='Q{}relative' slot='4'/>
+       <fn line='4041' name='not'>
         <varRef name='Q{}nodeset' slot='2'/>
        </fn>
-       <varRef line='850' name='Q{}relative' slot='4'/>
-       <or line='852' op='or'>
+       <varRef line='792' name='Q{}relative' slot='4'/>
+       <or line='794' op='or'>
         <fn name='not'>
          <varRef name='Q{}relative' slot='4'/>
         </fn>
@@ -68,9 +68,9 @@
          <str val='.'/>
         </vc>
        </or>
-       <varRef line='4240' name='Q{}nodeset' slot='2'/>
+       <varRef line='4041' name='Q{}nodeset' slot='2'/>
        <true/>
-       <let line='857' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
+       <let line='799' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
         <choose>
          <fn name='contains'>
           <varRef name='Q{}relative' slot='4'/>
@@ -97,30 +97,30 @@
          <true/>
          <int val='0'/>
         </choose>
-        <let line='860' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
+        <let line='802' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
          <choose>
-          <fn line='4240' name='contains'>
+          <fn line='4041' name='contains'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
           </fn>
           <fn name='index-of'>
            <fn name='string-to-codepoints'>
-            <varRef line='4240' name='Q{}nodeset' slot='2'/>
+            <varRef line='4041' name='Q{}nodeset' slot='2'/>
            </fn>
            <int val='47'/>
           </fn>
           <true/>
           <int val='0'/>
          </choose>
-         <choose line='892'>
+         <choose line='834'>
           <compareToInt op='gt' val='0'>
            <varRef name='Q{}parentCallCount' slot='5'/>
           </compareToInt>
-          <fn line='896' name='concat'>
+          <fn line='838' name='concat'>
            <fn name='substring'>
-            <varRef line='4240' name='Q{}nodeset' slot='2'/>
+            <varRef line='4041' name='Q{}nodeset' slot='2'/>
             <int val='1'/>
-            <choose line='871'>
+            <choose line='813'>
              <and op='and'>
               <vc op='ge' onEmpty='0' comp='CAVC'>
                <fn name='count'>
@@ -132,7 +132,7 @@
                <varRef name='Q{}parentCallCount' slot='5'/>
               </compareToInt>
              </and>
-             <let line='872' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='7' eval='13'>
+             <let line='814' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='7' eval='13'>
               <arith op='-' calc='i-i'>
                <varRef name='Q{}parentCallCount' slot='5'/>
                <int val='1'/>
@@ -148,7 +148,7 @@
               </check>
              </let>
              <true/>
-             <check line='875' card='1' diag='3|0|XTTE0570|parentSlash'>
+             <check line='817' card='1' diag='3|0|XTTE0570|parentSlash'>
               <lastOf>
                <varRef name='Q{}slashes' slot='6'/>
               </lastOf>
@@ -163,17 +163,17 @@
            </fn>
           </fn>
           <true/>
-          <fn line='4240' name='concat'>
+          <fn line='4041' name='concat'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
-           <varRef line='899' name='Q{}relative' slot='4'/>
+           <varRef line='841' name='Q{}relative' slot='4'/>
           </fn>
          </choose>
         </let>
        </let>
       </choose>
      </let>
-     <let line='4241' var='Q{}at' as='xs:string?' slot='8' eval='7'>
+     <let line='4042' var='Q{}at' as='xs:string?' slot='8' eval='7'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|at'>
        <check card='?' diag='3|0|XTTE0570|at'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|at'>
@@ -186,7 +186,7 @@
         </cvUntyped>
        </check>
       </treat>
-      <let line='4242' var='Q{}position' as='xs:string?' slot='9' eval='7'>
+      <let line='4043' var='Q{}position' as='xs:string?' slot='9' eval='7'>
        <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|position'>
         <check card='?' diag='3|0|XTTE0570|position'>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|position'>
@@ -199,7 +199,7 @@
          </cvUntyped>
         </check>
        </treat>
-       <let line='4243' var='Q{}origin-ref' as='xs:string?' slot='10' eval='7'>
+       <let line='4044' var='Q{}origin-ref' as='xs:string?' slot='10' eval='7'>
         <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|origin-ref'>
          <check card='?' diag='3|0|XTTE0570|origin-ref'>
           <cvUntyped to='xs:string' diag='3|0|XTTE0570|origin-ref'>
@@ -212,12 +212,12 @@
           </cvUntyped>
          </check>
         </treat>
-        <let line='4257' var='Q{}instance-id' as='xs:string' slot='11' eval='16'>
+        <let line='4058' var='Q{}instance-id' as='xs:string' slot='11' eval='16'>
          <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='6'>
           <varRef name='Q{}ref' slot='3'/>
          </ufCall>
-         <let line='4259' var='Q{}instanceXML2' as='element()' slot='12' eval='16'>
-          <choose line='4261'>
+         <let line='4060' var='Q{}instanceXML2' as='element()' slot='12' eval='16'>
+          <choose line='4062'>
            <and op='and'>
             <vc op='eq' onEmpty='0' comp='CCC'>
              <varRef name='Q{}instance-id' slot='11'/>
@@ -227,24 +227,24 @@
              <varRef name='Q{}instanceXML' slot='1'/>
             </fn>
            </and>
-           <check line='4262' card='1' diag='3|0|XTTE0570|instanceXML2'>
+           <check line='4063' card='1' diag='3|0|XTTE0570|instanceXML2'>
             <varRef name='Q{}instanceXML' slot='1'/>
            </check>
            <true/>
-           <check line='4265' card='1' diag='3|0|XTTE0570|instanceXML2'>
+           <check line='4066' card='1' diag='3|0|XTTE0570|instanceXML2'>
             <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='6'>
              <varRef name='Q{}instance-id' slot='11'/>
             </ufCall>
            </check>
           </choose>
-          <let line='4278' var='Q{}instance-id-origin' as='xs:string' slot='13' eval='16'>
+          <let line='4079' var='Q{}instance-id-origin' as='xs:string' slot='13' eval='16'>
            <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='2' eval='16'>
             <check card='1' diag='0|0||xforms:getInstanceId'>
              <varRef name='Q{}origin-ref' slot='10'/>
             </check>
            </ufCall>
-           <let line='4280' var='Q{}instanceXML-origin' as='element()' slot='14' eval='16'>
-            <choose line='4282'>
+           <let line='4081' var='Q{}instanceXML-origin' as='element()' slot='14' eval='16'>
+            <choose line='4083'>
              <and op='and'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <varRef name='Q{}instance-id-origin' slot='13'/>
@@ -254,18 +254,18 @@
                <varRef name='Q{}instanceXML' slot='1'/>
               </fn>
              </and>
-             <check line='4283' card='1' diag='3|0|XTTE0570|instanceXML-origin'>
+             <check line='4084' card='1' diag='3|0|XTTE0570|instanceXML-origin'>
               <varRef name='Q{}instanceXML' slot='1'/>
              </check>
              <true/>
-             <check line='4286' card='1' diag='3|0|XTTE0570|instanceXML-origin'>
+             <check line='4087' card='1' diag='3|0|XTTE0570|instanceXML-origin'>
               <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='3' eval='6'>
                <varRef name='Q{}instance-id-origin' slot='13'/>
               </ufCall>
              </check>
             </choose>
-            <let line='4291' var='Q{}origin-node' as='node()?' slot='15' eval='7'>
-             <treat line='4292' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|origin-node'>
+            <let line='4092' var='Q{}origin-node' as='node()?' slot='15' eval='7'>
+             <treat line='4093' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|origin-node'>
               <check card='?' diag='3|0|XTTE0570|origin-node'>
                <evaluate dxns=''>
                 <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='4' eval='16'>
@@ -281,13 +281,13 @@
                </evaluate>
               </check>
              </treat>
-             <let line='4295' var='Q{}insert-node-location' as='node()?' slot='16' eval='7'>
-              <treat line='4296' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|insert-node-location'>
+             <let line='4096' var='Q{}insert-node-location' as='node()?' slot='16' eval='7'>
+              <treat line='4097' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|insert-node-location'>
                <check card='?' diag='3|0|XTTE0570|insert-node-location'>
                 <evaluate dxns=''>
                  <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='5' eval='16'>
                   <check card='1' diag='0|0||xforms:impose'>
-                   <choose line='4255'>
+                   <choose line='4056'>
                     <vc op='ne' onEmpty='0' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
                      <varRef name='Q{}ref' slot='3'/>
                      <str val=''/>
@@ -316,14 +316,14 @@
                 </evaluate>
                </check>
               </treat>
-              <let line='4299' var='Q{}context-node' as='node()' slot='17' eval='16'>
-               <treat line='4300' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|context-node'>
+              <let line='4100' var='Q{}context-node' as='node()' slot='17' eval='16'>
+               <treat line='4101' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|context-node'>
                 <check card='1' diag='3|0|XTTE0570|context-node'>
                  <evaluate dxns=''>
                   <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='6' eval='16'>
-                   <treat line='4244' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|context'>
-                    <check line='4300' card='1' diag='0|0||xforms:impose'>
-                     <check line='4244' card='?' diag='3|0|XTTE0570|context'>
+                   <treat line='4045' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|context'>
+                    <check line='4101' card='1' diag='0|0||xforms:impose'>
+                     <check line='4045' card='?' diag='3|0|XTTE0570|context'>
                       <cvUntyped to='xs:string' diag='3|0|XTTE0570|context'>
                        <data>
                         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
@@ -344,13 +344,13 @@
                  </evaluate>
                 </check>
                </treat>
-               <let line='4317' var='Q{}instance-with-insert' as='element()' slot='18' eval='16'>
-                <treat line='4318' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-insert'>
+               <let line='4118' var='Q{}instance-with-insert' as='element()' slot='18' eval='16'>
+                <treat line='4119' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-insert'>
                  <check card='1' diag='3|0|XTTE0570|instance-with-insert'>
                   <applyT mode='Q{}insert-node' bSlot='7'>
                    <varRef role='select' name='Q{}instanceXML2' slot='12'/>
                    <withParam name='Q{}insert-node-location' flags='t' as='node()?'>
-                    <choose line='4319'>
+                    <choose line='4120'>
                      <fn name='exists'>
                       <varRef name='Q{}insert-node-location' slot='16'/>
                      </fn>
@@ -360,21 +360,21 @@
                     </choose>
                    </withParam>
                    <withParam name='Q{}node-to-insert' flags='t' as='node()?'>
-                    <choose line='4306'>
+                    <choose line='4107'>
                      <fn name='exists'>
                       <varRef name='Q{}origin-node' slot='15'/>
                      </fn>
-                     <copyOf line='4307' flags='vc'>
+                     <copyOf line='4108' flags='vc'>
                       <varRef name='Q{}origin-node' slot='15'/>
                      </copyOf>
                      <true/>
-                     <copyOf line='4310' flags='vc'>
+                     <copyOf line='4111' flags='vc'>
                       <varRef name='Q{}insert-node-location' slot='16'/>
                      </copyOf>
                     </choose>
                    </withParam>
                    <withParam name='Q{}position-relative' flags='t' as='xs:string?'>
-                    <choose line='4321'>
+                    <choose line='4122'>
                      <fn name='exists'>
                       <varRef name='Q{}insert-node-location' slot='16'/>
                      </fn>
@@ -386,25 +386,25 @@
                   </applyT>
                  </check>
                 </treat>
-                <sequence line='4327'>
+                <sequence line='4128'>
                  <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='8' eval='6 6'>
                   <varRef name='Q{}ref' slot='3'/>
                   <varRef name='Q{}instance-with-insert' slot='18'/>
                  </ufCall>
-                 <choose line='4331'>
+                 <choose line='4132'>
                   <fn name='matches'>
                    <varRef name='Q{}at' slot='8'/>
                    <str val='index\s*\('/>
                    <str val=''/>
                   </fn>
-                  <let line='4332' var='Q{}repeat-id' as='xs:string?' slot='19' eval='7'>
+                  <let line='4133' var='Q{}repeat-id' as='xs:string?' slot='19' eval='7'>
                    <ufCall name='Q{http://www.w3.org/2002/xforms}getRepeatID' tailCall='false' bSlot='9' eval='16'>
                     <check card='1' diag='0|0||xforms:getRepeatID'>
                      <varRef name='Q{}at' slot='8'/>
                     </check>
                    </ufCall>
-                   <let line='4333' var='Q{}at-position' as='xs:integer' slot='20' eval='16'>
-                    <treat line='4334' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|at-position'>
+                   <let line='4134' var='Q{}at-position' as='xs:integer' slot='20' eval='16'>
+                    <treat line='4135' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|at-position'>
                      <check card='1' diag='3|0|XTTE0570|at-position'>
                       <cvUntyped to='xs:integer' diag='3|0|XTTE0570|at-position'>
                        <data>
@@ -423,16 +423,16 @@
                       </cvUntyped>
                      </check>
                     </treat>
-                    <choose line='4339'>
+                    <choose line='4140'>
                      <fn name='exists'>
                       <varRef name='Q{}repeat-id' slot='19'/>
                      </fn>
-                     <choose line='4341'>
+                     <choose line='4142'>
                       <vc op='eq' onEmpty='0' comp='CCC'>
                        <varRef name='Q{}position' slot='9'/>
                        <str val='before'/>
                       </vc>
-                      <ifCall line='4342' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                      <ifCall line='4143' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                        <check card='1' diag='0|0||ixsl:call'>
                         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                        </check>
@@ -443,7 +443,7 @@
                        </arrayBlock>
                       </ifCall>
                       <true/>
-                      <ifCall line='4345' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                      <ifCall line='4146' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                        <check card='1' diag='0|0||ixsl:call'>
                         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                        </check>
@@ -461,7 +461,37 @@
                    </let>
                   </let>
                  </choose>
-                 <callT line='4355' name='Q{}xforms-recalculate' bSlot='11' flags='t'/>
+                 <choose line='4153'>
+                  <vc op='eq' onEmpty='0' comp='CCC'>
+                   <treat line='4040' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|handler-status'>
+                    <check card='1' diag='3|0|XTTE0570|handler-status'>
+                     <cvUntyped to='xs:string' diag='3|0|XTTE0570|handler-status'>
+                      <data>
+                       <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                        <varRef name='Q{}action-map' slot='0'/>
+                        <str val='handler-status'/>
+                       </ifCall>
+                      </data>
+                     </cvUntyped>
+                    </check>
+                   </treat>
+                   <str val='inner'/>
+                  </vc>
+                  <ifCall line='4154' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                   <check card='1' diag='0|0||ixsl:call'>
+                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                   </check>
+                   <str val='setDeferredUpdateFlags'/>
+                   <array size='1'>
+                    <literal count='4'>
+                     <str val='rebuild'/>
+                     <str val='recalculate'/>
+                     <str val='revalidate'/>
+                     <str val='refresh'/>
+                    </literal>
+                   </array>
+                  </ifCall>
+                 </choose>
                 </sequence>
                </let>
               </let>
@@ -478,9 +508,9 @@
    </sequence>
   </template>
  </co>
- <co id='8' binds='1 2 3 3 9 5 7'>
-  <template name='Q{}action-delete' flags='os' line='4367' module='saxon-xforms.xsl' slots='16'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4368'>
+ <co id='7' binds='1 2 3 3 8 5'>
+  <template name='Q{}action-delete' flags='os' line='4167' module='saxon-xforms.xsl' slots='16'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4168'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -488,14 +518,14 @@
       </check>
      </treat>
     </param>
-    <param line='4369' name='Q{}instanceXML' slot='1' flags='ti' as='element()'>
+    <param line='4169' name='Q{}instanceXML' slot='1' flags='ti' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|instanceXML'>
       <check card='1' diag='8|0|XTTE0590|instanceXML'>
        <supplied slot='1'/>
       </check>
      </treat>
     </param>
-    <param line='4370' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
+    <param line='4170' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -507,7 +537,7 @@
       </check>
      </treat>
     </param>
-    <let line='4372' var='Q{}ref' as='xs:string' slot='3' eval='16'>
+    <let line='4173' var='Q{}ref' as='xs:string' slot='3' eval='16'>
      <let var='Q{}relative' as='xs:string' slot='4' eval='16'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|1||xforms:resolveXPathStrings'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
@@ -521,22 +551,22 @@
         </cvUntyped>
        </check>
       </treat>
-      <choose line='843'>
+      <choose line='785'>
        <fn name='starts-with'>
         <varRef name='Q{}relative' slot='4'/>
         <str val='/'/>
        </fn>
-       <varRef line='844' name='Q{}relative' slot='4'/>
-       <fn line='846' name='starts-with'>
+       <varRef line='786' name='Q{}relative' slot='4'/>
+       <fn line='788' name='starts-with'>
         <varRef name='Q{}relative' slot='4'/>
         <str val='instance('/>
        </fn>
-       <varRef line='847' name='Q{}relative' slot='4'/>
-       <fn line='4372' name='not'>
+       <varRef line='789' name='Q{}relative' slot='4'/>
+       <fn line='4173' name='not'>
         <varRef name='Q{}nodeset' slot='2'/>
        </fn>
-       <varRef line='850' name='Q{}relative' slot='4'/>
-       <or line='852' op='or'>
+       <varRef line='792' name='Q{}relative' slot='4'/>
+       <or line='794' op='or'>
         <fn name='not'>
          <varRef name='Q{}relative' slot='4'/>
         </fn>
@@ -545,9 +575,9 @@
          <str val='.'/>
         </vc>
        </or>
-       <varRef line='4372' name='Q{}nodeset' slot='2'/>
+       <varRef line='4173' name='Q{}nodeset' slot='2'/>
        <true/>
-       <let line='857' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
+       <let line='799' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
         <choose>
          <fn name='contains'>
           <varRef name='Q{}relative' slot='4'/>
@@ -574,30 +604,30 @@
          <true/>
          <int val='0'/>
         </choose>
-        <let line='860' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
+        <let line='802' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
          <choose>
-          <fn line='4372' name='contains'>
+          <fn line='4173' name='contains'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
           </fn>
           <fn name='index-of'>
            <fn name='string-to-codepoints'>
-            <varRef line='4372' name='Q{}nodeset' slot='2'/>
+            <varRef line='4173' name='Q{}nodeset' slot='2'/>
            </fn>
            <int val='47'/>
           </fn>
           <true/>
           <int val='0'/>
          </choose>
-         <choose line='892'>
+         <choose line='834'>
           <compareToInt op='gt' val='0'>
            <varRef name='Q{}parentCallCount' slot='5'/>
           </compareToInt>
-          <fn line='896' name='concat'>
+          <fn line='838' name='concat'>
            <fn name='substring'>
-            <varRef line='4372' name='Q{}nodeset' slot='2'/>
+            <varRef line='4173' name='Q{}nodeset' slot='2'/>
             <int val='1'/>
-            <choose line='871'>
+            <choose line='813'>
              <and op='and'>
               <vc op='ge' onEmpty='0' comp='CAVC'>
                <fn name='count'>
@@ -609,7 +639,7 @@
                <varRef name='Q{}parentCallCount' slot='5'/>
               </compareToInt>
              </and>
-             <let line='872' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='7' eval='13'>
+             <let line='814' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='7' eval='13'>
               <arith op='-' calc='i-i'>
                <varRef name='Q{}parentCallCount' slot='5'/>
                <int val='1'/>
@@ -625,7 +655,7 @@
               </check>
              </let>
              <true/>
-             <check line='875' card='1' diag='3|0|XTTE0570|parentSlash'>
+             <check line='817' card='1' diag='3|0|XTTE0570|parentSlash'>
               <lastOf>
                <varRef name='Q{}slashes' slot='6'/>
               </lastOf>
@@ -640,17 +670,17 @@
            </fn>
           </fn>
           <true/>
-          <fn line='4372' name='concat'>
+          <fn line='4173' name='concat'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
-           <varRef line='899' name='Q{}relative' slot='4'/>
+           <varRef line='841' name='Q{}relative' slot='4'/>
           </fn>
          </choose>
         </let>
        </let>
       </choose>
      </let>
-     <let line='4373' var='Q{}at' as='xs:string?' slot='8' eval='7'>
+     <let line='4174' var='Q{}at' as='xs:string?' slot='8' eval='7'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|at'>
        <check card='?' diag='3|0|XTTE0570|at'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|at'>
@@ -663,7 +693,7 @@
         </cvUntyped>
        </check>
       </treat>
-      <let line='4383' var='Q{}ref-qualified' as='xs:string' slot='9' eval='16'>
+      <let line='4184' var='Q{}ref-qualified' as='xs:string' slot='9' eval='16'>
        <choose>
         <fn name='exists'>
          <varRef name='Q{}at' slot='8'/>
@@ -677,36 +707,36 @@
         <true/>
         <varRef name='Q{}ref' slot='3'/>
        </choose>
-       <let line='4385' var='Q{}instance-id' as='xs:string' slot='10' eval='16'>
+       <let line='4186' var='Q{}instance-id' as='xs:string' slot='10' eval='16'>
         <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='6'>
          <varRef name='Q{}ref' slot='3'/>
         </ufCall>
-        <let line='4387' var='Q{}instanceXML2' as='element()' slot='11' eval='16'>
-         <choose line='4389'>
+        <let line='4188' var='Q{}instanceXML2' as='element()' slot='11' eval='16'>
+         <choose line='4190'>
           <vc op='eq' onEmpty='0' comp='CCC'>
            <varRef name='Q{}instance-id' slot='10'/>
            <str val='saxon-forms-default'/>
           </vc>
-          <varRef line='4390' name='Q{}instanceXML' slot='1'/>
+          <varRef line='4191' name='Q{}instanceXML' slot='1'/>
           <true/>
-          <check line='4393' card='1' diag='3|0|XTTE0570|instanceXML2'>
+          <check line='4194' card='1' diag='3|0|XTTE0570|instanceXML2'>
            <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='6'>
             <varRef name='Q{}instance-id' slot='10'/>
            </ufCall>
           </check>
          </choose>
-         <let line='4398' var='Q{}ifVar' as='xs:string?' slot='12' eval='7'>
-          <choose line='798'>
+         <let line='4199' var='Q{}ifVar' as='xs:string?' slot='12' eval='7'>
+          <choose line='740'>
            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
-            <varRef line='4398' name='Q{}action-map' slot='0'/>
+            <varRef line='4199' name='Q{}action-map' slot='0'/>
             <str val='@if'/>
            </ifCall>
-           <treat line='799' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
+           <treat line='741' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
             <check card='?' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
              <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
               <data>
                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                <varRef line='4398' name='Q{}action-map' slot='0'/>
+                <varRef line='4199' name='Q{}action-map' slot='0'/>
                 <str val='@if'/>
                </ifCall>
               </data>
@@ -714,8 +744,8 @@
             </check>
            </treat>
           </choose>
-          <let line='4401' var='Q{}delete-node' as='node()*' slot='13' eval='8'>
-           <choose line='4403'>
+          <let line='4202' var='Q{}delete-node' as='node()*' slot='13' eval='8'>
+           <choose line='4204'>
             <and op='and'>
              <fn name='exists'>
               <varRef name='Q{}ref-qualified' slot='9'/>
@@ -725,7 +755,7 @@
               <str val=''/>
              </vc>
             </and>
-            <treat line='4404' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|delete-node'>
+            <treat line='4205' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|delete-node'>
              <evaluate dxns=''>
               <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
                <check card='1' diag='0|0||xforms:impose'>
@@ -740,12 +770,12 @@
              </evaluate>
             </treat>
            </choose>
-           <let line='4409' var='Q{}ifExecuted' as='xs:boolean' slot='14' eval='16'>
-            <choose line='4411'>
+           <let line='4210' var='Q{}ifExecuted' as='xs:boolean' slot='14' eval='16'>
+            <choose line='4212'>
              <fn name='exists'>
               <varRef name='Q{}ifVar' slot='12'/>
              </fn>
-             <treat line='4412' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|ifExecuted'>
+             <treat line='4213' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|ifExecuted'>
               <check card='1' diag='3|0|XTTE0570|ifExecuted'>
                <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|ifExecuted'>
                 <data>
@@ -772,25 +802,55 @@
              <true/>
              <true/>
             </choose>
-            <choose line='4420'>
+            <choose line='4221'>
              <varRef name='Q{}ifExecuted' slot='14'/>
-             <let line='4421' var='Q{}instance-with-delete' as='element()' slot='15' eval='16'>
-              <treat line='4422' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-delete'>
+             <let line='4222' var='Q{}instance-with-delete' as='element()' slot='15' eval='16'>
+              <treat line='4223' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-delete'>
                <check card='1' diag='3|0|XTTE0570|instance-with-delete'>
                 <applyT mode='Q{}delete-node' bSlot='4'>
                  <varRef role='select' name='Q{}instanceXML2' slot='11'/>
                  <withParam name='Q{}delete-node' flags='t' as='node()*'>
-                  <varRef line='4423' name='Q{}delete-node' slot='13'/>
+                  <varRef line='4224' name='Q{}delete-node' slot='13'/>
                  </withParam>
                 </applyT>
                </check>
               </treat>
-              <sequence line='4429'>
+              <sequence line='4230'>
                <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='5' eval='6 6'>
                 <varRef name='Q{}ref' slot='3'/>
                 <varRef name='Q{}instance-with-delete' slot='15'/>
                </ufCall>
-               <callT line='4458' name='Q{}xforms-recalculate' bSlot='6' flags='t'/>
+               <choose line='4258'>
+                <vc op='eq' onEmpty='0' comp='CCC'>
+                 <treat line='4172' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|handler-status'>
+                  <check card='1' diag='3|0|XTTE0570|handler-status'>
+                   <cvUntyped to='xs:string' diag='3|0|XTTE0570|handler-status'>
+                    <data>
+                     <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                      <varRef name='Q{}action-map' slot='0'/>
+                      <str val='handler-status'/>
+                     </ifCall>
+                    </data>
+                   </cvUntyped>
+                  </check>
+                 </treat>
+                 <str val='inner'/>
+                </vc>
+                <ifCall line='4259' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <check card='1' diag='0|0||ixsl:call'>
+                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                 </check>
+                 <str val='setDeferredUpdateFlags'/>
+                 <array size='1'>
+                  <literal count='4'>
+                   <str val='rebuild'/>
+                   <str val='recalculate'/>
+                   <str val='revalidate'/>
+                   <str val='refresh'/>
+                  </literal>
+                 </array>
+                </ifCall>
+               </choose>
               </sequence>
              </let>
             </choose>
@@ -805,9 +865,9 @@
    </sequence>
   </template>
  </co>
- <co id='10' binds='11'>
-  <template name='Q{}action-send' flags='os' line='4517' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4518'>
+ <co id='9' binds='10'>
+  <template name='Q{}action-send' flags='os' line='4322' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4323'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -815,9 +875,9 @@
       </check>
      </treat>
     </param>
-    <callT line='4524' name='Q{}xforms-submit' bSlot='0' flags='t'>
+    <callT line='4329' name='Q{}xforms-submit' bSlot='0' flags='t'>
      <withParam name='Q{}submission' flags='c' as='xs:string'>
-      <treat line='4522' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|submission'>
+      <treat line='4327' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|submission'>
        <check card='1' diag='3|0|XTTE0570|submission'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|submission'>
          <data>
@@ -834,11 +894,11 @@
    </sequence>
   </template>
  </co>
- <co id='12' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}usesIndexFunction' line='2527' module='saxon-xforms.xsl' eval='8' flags='pU' as='xs:boolean' slots='1'>
+ <co id='11' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}usesIndexFunction' line='2246' module='saxon-xforms.xsl' eval='8' flags='pU' as='xs:boolean' slots='1'>
    <arg name='Q{}this' as='element()'/>
-   <fn role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2563' name='exists'>
-    <sequence line='2538'>
+   <fn role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2282' name='exists'>
+    <sequence line='2257'>
      <analyzeString>
       <cvUntyped role='select' to='xs:string'>
        <data>
@@ -850,7 +910,7 @@
       </cvUntyped>
       <str role='regex' val='\i\c*\('/>
       <str role='flags' val=''/>
-      <choose role='matching' line='2541'>
+      <choose role='matching' line='2260'>
        <vc op='eq' onEmpty='0' comp='CCC'>
         <fn name='substring-before'>
          <dot type='xs:string'/>
@@ -862,7 +922,7 @@
       </choose>
       <empty role='nonMatching'/>
      </analyzeString>
-     <analyzeString line='2550'>
+     <analyzeString line='2269'>
       <cvUntyped role='select' to='xs:string'>
        <data>
         <slash simple='1'>
@@ -873,7 +933,7 @@
       </cvUntyped>
       <str role='regex' val='\i\c*\('/>
       <str role='flags' val=''/>
-      <choose role='matching' line='2553'>
+      <choose role='matching' line='2272'>
        <vc op='eq' onEmpty='0' comp='CCC'>
         <fn name='substring-before'>
          <dot type='xs:string'/>
@@ -889,594 +949,33 @@
    </fn>
   </function>
  </co>
- <co id='13' binds='14 13 14 15 13 13 15'>
-  <mode name='Q{}form-check' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='27' rank='0' minImp='0' slots='12' flags='s' line='2183' module='saxon-xforms.xsl'>
-    <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2184'>
-     <param name='Q{}curPath' slot='0'>
-      <str role='select' val=''/>
-      <supplied role='conversion' slot='0'/>
-     </param>
-     <param line='2185' name='Q{}position' slot='1'>
-      <int role='select' val='0'/>
-      <supplied role='conversion' slot='1'/>
-     </param>
-     <param line='2186' name='Q{}pendingUpdates' slot='2' flags='t' as='map(xs:string, xs:string)?'>
-      <empty role='select'/>
-      <treat role='conversion' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|pendingUpdates'>
-       <check card='?' diag='8|0|XTTE0590|pendingUpdates'>
-        <supplied slot='2'/>
-       </check>
-      </treat>
-     </param>
-     <param line='2187' name='Q{}updated-node' slot='3' flags='t' as='node()?'>
-      <empty role='select'/>
-      <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|updated-node'>
-       <check card='?' diag='8|0|XTTE0590|updated-node'>
-        <supplied slot='3'/>
-       </check>
-      </treat>
-     </param>
-     <param line='2188' name='Q{}value' slot='4' flags='t' as='xs:string?'>
-      <empty role='select'/>
-      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|value'>
-       <check card='?' diag='8|0|XTTE0590|value'>
-        <cvUntyped to='xs:string' diag='8|0|XTTE0590|value'>
-         <data>
-          <supplied slot='4'/>
-         </data>
-        </cvUntyped>
-       </check>
-      </treat>
-     </param>
-     <let line='2209' var='Q{}updatedPath' as='xs:string' slot='5' eval='16'>
-      <choose>
-       <gc op='&gt;' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
-        <data>
-         <varRef name='Q{}position' slot='1'/>
-        </data>
-        <int val='0'/>
-       </gc>
-       <fn name='concat'>
-        <atomSing card='?' diag='0|0||fn:concat'>
-         <varRef name='Q{}curPath' slot='0'/>
-        </atomSing>
-        <fn name='name'>
-         <dot type='element()'/>
-        </fn>
-        <str val='['/>
-        <atomSing card='?' diag='0|3||fn:concat'>
-         <varRef name='Q{}position' slot='1'/>
-        </atomSing>
-        <str val=']'/>
-       </fn>
-       <true/>
-       <fn name='concat'>
-        <atomSing card='?' diag='0|0||fn:concat'>
-         <varRef name='Q{}curPath' slot='0'/>
-        </atomSing>
-        <fn name='name'>
-         <dot type='element()'/>
-        </fn>
-       </fn>
-      </choose>
-      <sequence line='2215'>
-       <message>
-        <sequence role='select'>
-         <valueOf>
-          <str val='[form-check] looking for form control for XPath &#39;'/>
-         </valueOf>
-         <varRef name='Q{}updatedPath' slot='5'/>
-         <valueOf flags='S'>
-          <str val='&#39;'/>
-         </valueOf>
-        </sequence>
-        <str role='terminate' val='no'/>
-        <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-       </message>
-       <forEach line='2216'>
-        <filter flags='b'>
-         <slash simple='1'>
-          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
-          <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-         </slash>
-         <or op='or'>
-          <or op='or'>
-           <fn name='exists'>
-            <axis name='self' nodeTest='element(Q{}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
-           </fn>
-           <fn name='exists'>
-            <axis name='self' nodeTest='element(Q{}select)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;select&#39;;'/>
-           </fn>
-          </or>
-          <fn name='exists'>
-           <axis name='self' nodeTest='element(Q{}textarea)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;textarea&#39;;'/>
-          </fn>
-         </or>
-        </filter>
-        <sequence line='2217'>
-         <message>
-          <sequence role='select'>
-           <valueOf>
-            <str val='[form-check] checking '/>
-           </valueOf>
-           <fn name='name'>
-            <dot type='element()'/>
-           </fn>
-           <valueOf>
-            <str val=', @data-ref = &#39;'/>
-           </valueOf>
-           <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
-           <valueOf flags='S'>
-            <str val='&#39;'/>
-           </valueOf>
-          </sequence>
-          <str role='terminate' val='no'/>
-          <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-         </message>
-         <message line='2218'>
-          <sequence role='select'>
-           <valueOf>
-            <str val='[form-check] resolved @data-ref = &#39;'/>
-           </valueOf>
-           <ufCall name='Q{http://www.w3.org/2002/xforms}resolve-index' tailCall='false' bSlot='0' eval='16'>
-            <check card='1' diag='0|0||xforms:resolve-index'>
-             <cvUntyped to='xs:string'>
-              <attVal name='Q{}data-ref' chk='0'/>
-             </cvUntyped>
-            </check>
-           </ufCall>
-           <valueOf flags='S'>
-            <str val='&#39;'/>
-           </valueOf>
-          </sequence>
-          <str role='terminate' val='no'/>
-          <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-         </message>
-        </sequence>
-       </forEach>
-       <copy line='2223' flags='cin'>
-        <sequence role='content'>
-         <applyT mode='Q{}form-check' bSlot='1'>
-          <axis role='select' name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
-          <withParam name='Q{}curPath' as='xs:string'>
-           <fn line='2224' name='concat'>
-            <varRef name='Q{}updatedPath' slot='5'/>
-            <str val='/'/>
-           </fn>
-          </withParam>
-         </applyT>
-         <let line='2230' var='Q{}associated-form-control' as='element()*' slot='6' eval='8'>
-          <filter flags='b'>
-           <filter flags='b'>
-            <slash simple='1'>
-             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
-             <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-            </slash>
-            <or op='or'>
-             <or op='or'>
-              <fn name='exists'>
-               <axis name='self' nodeTest='element(Q{}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
-              </fn>
-              <fn name='exists'>
-               <axis name='self' nodeTest='element(Q{}select)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;select&#39;;'/>
-              </fn>
-             </or>
-             <fn name='exists'>
-              <axis name='self' nodeTest='element(Q{}textarea)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;textarea&#39;;'/>
-             </fn>
-            </or>
-           </filter>
-           <vc op='eq' onEmpty='0' comp='CCC'>
-            <ufCall name='Q{http://www.w3.org/2002/xforms}resolve-index' tailCall='false' bSlot='2' eval='16'>
-             <check card='1' diag='0|0||xforms:resolve-index'>
-              <cvUntyped to='xs:string'>
-               <attVal name='Q{}data-ref' chk='0'/>
-              </cvUntyped>
-             </check>
-            </ufCall>
-            <varRef name='Q{}updatedPath' slot='5'/>
-           </vc>
-          </filter>
-          <sequence line='2232'>
-           <choose>
-            <fn name='exists'>
-             <tail start='2'>
-              <varRef name='Q{}associated-form-control' slot='6'/>
-             </tail>
-            </fn>
-            <message line='2233'>
-             <sequence role='select'>
-              <valueOf>
-               <str val='[form-check] More than one form element controls the value of XForm node at '/>
-              </valueOf>
-              <valueOf>
-               <varRef name='Q{}updatedPath' slot='5'/>
-              </valueOf>
-              <valueOf>
-               <str val='; Saxon-Forms will apply the value of the first'/>
-              </valueOf>
-             </sequence>
-             <str role='terminate' val='no'/>
-             <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-            </message>
-           </choose>
-           <choose line='2237'>
-            <is op='is'>
-             <varRef name='Q{}updated-node' slot='3'/>
-             <dot type='element()'/>
-            </is>
-            <sequence line='2238'>
-             <message>
-              <valueOf role='select'>
-               <str val='&#xA;                        [form-check] Matched node!!&#xA;                    '/>
-              </valueOf>
-              <str role='terminate' val='no'/>
-              <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-             </message>
-             <valueOf line='2241' flags='l'>
-              <varRef name='Q{}value' slot='4'/>
-             </valueOf>
-            </sequence>
-            <fn line='2243' name='exists'>
-             <varRef name='Q{}associated-form-control' slot='6'/>
-            </fn>
-            <valueOf line='2247' flags='l'>
-             <fn name='string-join'>
-              <convert from='xs:anyAtomicType' to='xs:string'>
-               <data>
-                <mergeAdj>
-                 <applyT mode='Q{}get-field' bSlot='3'>
-                  <first role='select'>
-                   <varRef name='Q{}associated-form-control' slot='6'/>
-                  </first>
-                 </applyT>
-                </mergeAdj>
-               </data>
-              </convert>
-              <str val=''/>
-             </fn>
-            </valueOf>
-            <and line='2250' op='and'>
-             <fn name='exists'>
-              <varRef name='Q{}pendingUpdates' slot='2'/>
-             </fn>
-             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
-              <check card='1' diag='0|0||map:contains'>
-               <varRef name='Q{}pendingUpdates' slot='2'/>
-              </check>
-              <varRef name='Q{}updatedPath' slot='5'/>
-             </ifCall>
-            </and>
-            <valueOf line='2258' flags='l'>
-             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-              <check card='1' diag='0|0||map:get'>
-               <varRef name='Q{}pendingUpdates' slot='2'/>
-              </check>
-              <varRef name='Q{}updatedPath' slot='5'/>
-             </ifCall>
-            </valueOf>
-            <true/>
-            <valueOf line='2267' flags='l'>
-             <fn name='normalize-space'>
-              <fn name='string-join'>
-               <data>
-                <axis name='child' nodeTest='text()' jsTest='return item.nodeType===3;'/>
-               </data>
-               <str val=''/>
-              </fn>
-             </fn>
-            </valueOf>
-           </choose>
-           <forEachGroup line='2272' algorithm='by'>
-            <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-            <fn role='key' name='local-name'>
-             <dot type='element()'/>
-            </fn>
-            <str role='collation' val='http://www.w3.org/2005/xpath-functions/collation/codepoint'/>
-            <let role='content' line='2274' var='Q{}updatedChildPath' as='xs:string' slot='7' eval='8'>
-             <fn name='concat'>
-              <varRef name='Q{}updatedPath' slot='5'/>
-              <str val='/'/>
-              <check card='?' diag='0|2||fn:concat'>
-               <currentGroupingKey/>
-              </check>
-             </fn>
-             <let line='2279' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='8' eval='13'>
-              <fn name='concat'>
-               <varRef name='Q{}updatedChildPath' slot='7'/>
-               <str val='['/>
-              </fn>
-              <let var='Q{}dataRefWithFilter' as='element()*' slot='9' eval='8'>
-               <filter flags='b'>
-                <slash simple='1'>
-                 <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
-                 <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-                </slash>
-                <fn name='starts-with'>
-                 <cvUntyped to='xs:string'>
-                  <attVal name='Q{}data-ref' chk='0'/>
-                 </cvUntyped>
-                 <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='8'/>
-                </fn>
-               </filter>
-               <choose line='2282'>
-                <or op='or'>
-                 <fn name='exists'>
-                  <tail start='2'>
-                   <currentGroup/>
-                  </tail>
-                 </fn>
-                 <fn name='exists'>
-                  <varRef name='Q{}dataRefWithFilter' slot='9'/>
-                 </fn>
-                </or>
-                <let line='2285' var='Q{http://saxon.sf.net/generated-variable}v1' as='xs:string' slot='10' eval='13'>
-                 <fn name='concat'>
-                  <varRef name='Q{}updatedPath' slot='5'/>
-                  <str val='/'/>
-                 </fn>
-                 <forEach line='2283'>
-                  <currentGroup/>
-                  <applyT line='2284' mode='Q{}form-check' bSlot='4'>
-                   <dot role='select'/>
-                   <withParam name='Q{}curPath' as='xs:string'>
-                    <varRef line='2285' name='Q{http://saxon.sf.net/generated-variable}v1' slot='10'/>
-                   </withParam>
-                   <withParam name='Q{}position' as='xs:integer'>
-                    <fn line='2286' name='position'/>
-                   </withParam>
-                  </applyT>
-                 </forEach>
-                </let>
-                <true/>
-                <let line='2294' var='Q{http://saxon.sf.net/generated-variable}v2' as='xs:string' slot='11' eval='13'>
-                 <fn name='concat'>
-                  <varRef name='Q{}updatedPath' slot='5'/>
-                  <str val='/'/>
-                 </fn>
-                 <forEach line='2292'>
-                  <currentGroup/>
-                  <applyT line='2293' mode='Q{}form-check' bSlot='5'>
-                   <dot role='select'/>
-                   <withParam name='Q{}curPath' as='xs:string'>
-                    <varRef line='2294' name='Q{http://saxon.sf.net/generated-variable}v2' slot='11'/>
-                   </withParam>
-                  </applyT>
-                 </forEach>
-                </let>
-               </choose>
-              </let>
-             </let>
-            </let>
-           </forEachGroup>
-          </sequence>
-         </let>
-        </sequence>
-       </copy>
-      </sequence>
-     </let>
-    </sequence>
-   </templateRule>
-   <templateRule prec='0' prio='-0.5' seq='30' rank='0' minImp='0' slots='4' flags='s' line='2370' module='saxon-xforms.xsl'>
-    <p.nodeTest role='match' test='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2371'>
-     <param name='Q{}curPath' slot='0'>
-      <str role='select' val=''/>
-      <supplied role='conversion' slot='0'/>
-     </param>
-     <param line='2372' name='Q{}pendingUpdates' slot='1' flags='t' as='map(xs:string, xs:string)?'>
-      <empty role='select'/>
-      <treat role='conversion' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|pendingUpdates'>
-       <check card='?' diag='8|0|XTTE0590|pendingUpdates'>
-        <supplied slot='1'/>
-       </check>
-      </treat>
-     </param>
-     <let line='2373' var='Q{}updatedPath' as='xs:string' slot='2' eval='8'>
-      <fn name='concat'>
-       <atomSing card='?' diag='0|0||fn:concat'>
-        <varRef name='Q{}curPath' slot='0'/>
-       </atomSing>
-       <str val='@'/>
-       <fn name='local-name'>
-        <dot type='attribute()'/>
-       </fn>
-      </fn>
-      <let line='2382' var='Q{}associated-form-control' as='element()*' slot='3' eval='8'>
-       <filter flags='b'>
-        <slash simple='1'>
-         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
-         <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-        </slash>
-        <vc op='eq' onEmpty='0' comp='CCC'>
-         <cast as='xs:string' emptiable='1'>
-          <attVal name='Q{}data-ref' chk='0'/>
-         </cast>
-         <varRef name='Q{}updatedPath' slot='2'/>
-        </vc>
-       </filter>
-       <choose line='2385'>
-        <fn name='exists'>
-         <varRef name='Q{}associated-form-control' slot='3'/>
-        </fn>
-        <compAtt line='2388'>
-         <fn role='name' name='local-name'>
-          <dot type='attribute()'/>
-         </fn>
-         <fn role='select' line='2389' name='string-join'>
-          <convert from='xs:anyAtomicType' to='xs:string'>
-           <data>
-            <mergeAdj>
-             <applyT mode='Q{}get-field' bSlot='6'>
-              <varRef role='select' name='Q{}associated-form-control' slot='3'/>
-             </applyT>
-            </mergeAdj>
-           </data>
-          </convert>
-          <str val=''/>
-         </fn>
-        </compAtt>
-        <and line='2392' op='and'>
-         <fn name='exists'>
-          <varRef name='Q{}pendingUpdates' slot='1'/>
-         </fn>
-         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
-          <check card='1' diag='0|0||map:contains'>
-           <varRef name='Q{}pendingUpdates' slot='1'/>
-          </check>
-          <varRef name='Q{}updatedPath' slot='2'/>
-         </ifCall>
-        </and>
-        <compAtt line='2393'>
-         <fn role='name' name='local-name'>
-          <dot type='attribute()'/>
-         </fn>
-         <ifCall role='select' line='2394' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-          <check card='1' diag='0|0||map:get'>
-           <varRef name='Q{}pendingUpdates' slot='1'/>
-          </check>
-          <varRef name='Q{}updatedPath' slot='2'/>
-         </ifCall>
-        </compAtt>
-        <true/>
-        <forEach line='2398'>
-         <dot type='attribute()'/>
-         <copyOf flags='vsc'>
-          <dot type='attribute()'/>
-         </copyOf>
-        </forEach>
-       </choose>
-      </let>
-     </let>
-    </sequence>
-   </templateRule>
-  </mode>
- </co>
- <co id='16' binds='13 13'>
-  <mode name='Q{}form-check-initial' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='26' rank='0' minImp='0' slots='6' flags='s' line='2121' module='saxon-xforms.xsl'>
-    <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2122'>
-     <param name='Q{}instance-id' slot='0' as='xs:string'>
-      <str role='select' val='saxon-forms-default'/>
-      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|instance-id'>
-       <check card='1' diag='8|0|XTTE0590|instance-id'>
-        <cvUntyped to='xs:string' diag='8|0|XTTE0590|instance-id'>
-         <data>
-          <supplied slot='0'/>
-         </data>
-        </cvUntyped>
-       </check>
-      </treat>
-     </param>
-     <param line='2123' name='Q{}pendingUpdates' slot='1' flags='t' as='map(xs:string, xs:string)?'>
-      <empty role='select'/>
-      <treat role='conversion' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|pendingUpdates'>
-       <check card='?' diag='8|0|XTTE0590|pendingUpdates'>
-        <supplied slot='1'/>
-       </check>
-      </treat>
-     </param>
-     <let line='2129' var='Q{}curPath' as='xs:string' slot='2' eval='16'>
-      <choose line='2131'>
-       <vc op='eq' onEmpty='0' comp='CCC'>
-        <varRef name='Q{}instance-id' slot='0'/>
-        <str val='saxon-forms-default'/>
-       </vc>
-       <str val=''/>
-       <true/>
-       <cvUntyped line='2135' to='xs:string' diag='3|0|XTTE0570|curPath'>
-        <cast as='xs:untypedAtomic' emptiable='0'>
-         <fn name='concat'>
-          <str val='instance(&#39;'/>
-          <varRef name='Q{}instance-id' slot='0'/>
-          <str val='&#39;)/'/>
-         </fn>
-        </cast>
-       </cvUntyped>
-      </choose>
-      <copy line='2142' flags='cin'>
-       <forEachGroup role='content' algorithm='by'>
-        <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-        <fn role='key' name='local-name'>
-         <dot type='element()'/>
-        </fn>
-        <str role='collation' val='http://www.w3.org/2005/xpath-functions/collation/codepoint'/>
-        <let role='content' line='2144' var='Q{}updatedChildPath' as='xs:string' slot='3' eval='8'>
-         <fn name='concat'>
-          <varRef name='Q{}curPath' slot='2'/>
-          <check card='?' diag='0|1||fn:concat'>
-           <currentGroupingKey/>
-          </check>
-         </fn>
-         <let line='2149' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='4' eval='13'>
-          <fn name='concat'>
-           <varRef name='Q{}updatedChildPath' slot='3'/>
-           <str val='['/>
-          </fn>
-          <let var='Q{}dataRefWithFilter' as='element()*' slot='5' eval='8'>
-           <filter flags='b'>
-            <slash simple='1'>
-             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
-             <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-            </slash>
-            <fn name='starts-with'>
-             <cvUntyped to='xs:string'>
-              <attVal name='Q{}data-ref' chk='0'/>
-             </cvUntyped>
-             <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='4'/>
-            </fn>
-           </filter>
-           <choose line='2151'>
-            <or op='or'>
-             <fn name='exists'>
-              <tail start='2'>
-               <currentGroup/>
-              </tail>
-             </fn>
-             <fn name='exists'>
-              <varRef name='Q{}dataRefWithFilter' slot='5'/>
-             </fn>
-            </or>
-            <forEach line='2152'>
-             <currentGroup/>
-             <applyT line='2153' mode='Q{}form-check' bSlot='0'>
-              <dot role='select'/>
-              <withParam name='Q{}curPath' as='xs:string'>
-               <varRef line='2154' name='Q{}curPath' slot='2'/>
-              </withParam>
-              <withParam name='Q{}position' as='xs:integer'>
-               <fn line='2155' name='position'/>
-              </withParam>
-             </applyT>
-            </forEach>
-            <true/>
-            <forEach line='2161'>
-             <currentGroup/>
-             <applyT line='2162' mode='Q{}form-check' bSlot='1'>
-              <dot role='select'/>
-              <withParam name='Q{}curPath' as='xs:string'>
-               <varRef line='2163' name='Q{}curPath' slot='2'/>
-              </withParam>
-             </applyT>
-            </forEach>
-           </choose>
-          </let>
-         </let>
-        </let>
-       </forEachGroup>
-      </copy>
-     </let>
-    </sequence>
-   </templateRule>
-  </mode>
+ <co id='12' binds='13'>
+  <template name='Q{}action-recalculate' flags='os' line='4369' module='saxon-xforms.xsl' slots='0'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4370'>
+    <message>
+     <valueOf role='select'>
+      <str val='[action-recalculate] START'/>
+     </valueOf>
+     <str role='terminate' val='no'/>
+     <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+    </message>
+    <callT line='4372' name='Q{}xforms-recalculate' bSlot='0'/>
+    <ifCall line='4373' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+     <check card='1' diag='0|0||ixsl:call'>
+      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+     </check>
+     <str val='clearDeferredUpdateFlag'/>
+     <array size='1'>
+      <str val='recalculate'/>
+     </array>
+    </ifCall>
+   </sequence>
+  </template>
  </co>
  <co id='6' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}getRepeatID' line='771' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
+  <function name='Q{http://www.w3.org/2002/xforms}getRepeatID' line='713' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
    <arg name='Q{}string-to-parse' as='xs:string'/>
-   <treat role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='774' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getRepeatID#1'>
+   <treat role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='716' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getRepeatID#1'>
     <check card='?' diag='5|0|XTTE0780|xforms:getRepeatID#1'>
      <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getRepeatID#1'>
       <data>
@@ -1484,10 +983,10 @@
         <varRef role='select' name='Q{}string-to-parse' slot='0'/>
         <str role='regex' val='^.*index\s*\(\s*&#39;([^&#39;]+)&#39;\s*\).*$'/>
         <str role='flags' val=''/>
-        <fn role='matching' line='776' name='regex-group'>
+        <fn role='matching' line='718' name='regex-group'>
          <int val='1'/>
         </fn>
-        <message role='nonMatching' line='779'>
+        <message role='nonMatching' line='721'>
          <sequence role='select'>
           <valueOf>
            <str val='[xforms:getRepeatID] No repeat identifiable from value &#39;'/>
@@ -1509,9 +1008,9 @@
    </treat>
   </function>
  </co>
- <co id='17' binds=''>
-  <template name='Q{}action-reset' flags='os' line='4564' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4565'>
+ <co id='14' binds=''>
+  <template name='Q{}action-reset' flags='os' line='4394' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4395'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -1519,216 +1018,46 @@
       </check>
      </treat>
     </param>
-    <message line='4567'>
+    <message line='4397'>
      <valueOf role='select'>
       <str val='[action-reset] Reset triggered!'/>
      </valueOf>
      <str role='terminate' val='no'/>
      <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
     </message>
+    <ifCall line='4399' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+     <check card='1' diag='0|0||ixsl:call'>
+      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+     </check>
+     <str val='clearDeferredUpdateFlags'/>
+     <array size='0'/>
+    </ifCall>
    </sequence>
   </template>
  </co>
- <co id='18' binds='1 2 3 15 19 5 20 7 21'>
-  <template name='Q{}xforms-value-changed' flags='os' line='3737' module='saxon-xforms.xsl' slots='9'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3738'>
-    <param name='Q{}form-control' slot='0' flags='i' as='node()'>
-     <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|form-control'>
-      <check card='1' diag='8|0|XTTE0590|form-control'>
-       <supplied slot='0'/>
-      </check>
+ <co id='15' binds='16'>
+  <template name='Q{}xforms-value-changed' flags='os' line='3517' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3518'>
+    <param name='Q{}when-value-changed' slot='0' flags='t' as='map(*)*'>
+     <empty role='select'/>
+     <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|when-value-changed'>
+      <supplied slot='0'/>
      </treat>
     </param>
-    <let line='3740' var='Q{}refi' as='attribute(Q{}data-ref)?' slot='1' eval='8'>
-     <slash simple='1'>
-      <varRef name='Q{}form-control' slot='0'/>
-      <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
-     </slash>
-     <let line='3743' var='Q{}instance-id' as='xs:string' slot='2' eval='16'>
-      <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='16'>
-       <check card='1' diag='0|0||xforms:getInstanceId'>
-        <cvUntyped to='xs:string'>
-         <data>
-          <varRef name='Q{}refi' slot='1'/>
-         </data>
-        </cvUntyped>
-       </check>
-      </ufCall>
-      <let line='3744' var='Q{}actions' as='item()?' slot='3' eval='8'>
-       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-        <check card='1' diag='0|0||ixsl:call'>
-         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-        </check>
-        <str val='getAction'/>
-        <arrayBlock>
-         <fn name='string'>
-          <slash simple='1'>
-           <varRef name='Q{}form-control' slot='0'/>
-           <axis name='attribute' nodeTest='attribute(Q{}data-action)' jsTest='return item.name===&#39;data-action&#39;'/>
-          </slash>
-         </fn>
-        </arrayBlock>
-       </ifCall>
-       <let line='3757' var='Q{}instanceXML' as='element()' slot='4' eval='16'>
-        <check card='1' diag='3|0|XTTE0570|instanceXML'>
-         <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='6'>
-          <varRef name='Q{}instance-id' slot='2'/>
-         </ufCall>
-        </check>
-        <let line='3758' var='Q{}updatedNode' as='node()' slot='5' eval='16'>
-         <treat line='3759' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|updatedNode'>
-          <check card='1' diag='3|0|XTTE0570|updatedNode'>
-           <evaluate dxns=''>
-            <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
-             <check card='1' diag='0|0||xforms:impose'>
-              <cvUntyped to='xs:string'>
-               <data>
-                <varRef name='Q{}refi' slot='1'/>
-               </data>
-              </cvUntyped>
-             </check>
-            </ufCall>
-            <varRef role='cxt' name='Q{}instanceXML' slot='4'/>
-            <varRef role='nsCxt' name='Q{}instanceXML' slot='4'/>
-            <str role='sa' val='no'/>
-            <map role='options' size='0'/>
-            <map role='wp' size='0'/>
-           </evaluate>
-          </check>
-         </treat>
-         <let line='3761' var='Q{}new-value' as='xs:string' slot='6' eval='16'>
-          <treat line='3762' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-value'>
-           <check card='1' diag='3|0|XTTE0570|new-value'>
-            <cvUntyped to='xs:string' diag='3|0|XTTE0570|new-value'>
-             <data>
-              <applyT mode='Q{}get-field' bSlot='3'>
-               <varRef role='select' name='Q{}form-control' slot='0'/>
-              </applyT>
-             </data>
-            </cvUntyped>
-           </check>
-          </treat>
-          <let line='3764' var='Q{}updatedInstanceXML' as='element()' slot='7' eval='16'>
-           <treat line='3765' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
-            <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
-             <applyT mode='Q{}recalculate' bSlot='4'>
-              <varRef role='select' name='Q{}instanceXML' slot='4'/>
-              <withParam name='Q{}instance-id' as='xs:string'>
-               <varRef line='3766' name='Q{}instance-id' slot='2'/>
-              </withParam>
-              <withParam name='Q{}updated-nodes' flags='t' as='node()'>
-               <varRef line='3767' name='Q{}updatedNode' slot='5'/>
-              </withParam>
-              <withParam name='Q{}updated-values' flags='t' as='xs:string'>
-               <varRef line='3768' name='Q{}new-value' slot='6'/>
-              </withParam>
-             </applyT>
-            </check>
-           </treat>
-           <sequence line='3775'>
-            <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='5' eval='16 6'>
-             <check card='1' diag='0|0||xforms:setInstance-JS'>
-              <cvUntyped to='xs:string'>
-               <data>
-                <varRef name='Q{}refi' slot='1'/>
-               </data>
-              </cvUntyped>
-             </check>
-             <varRef name='Q{}updatedInstanceXML' slot='7'/>
-            </ufCall>
-            <ifCall line='3782' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-             <check card='1' diag='0|0||ixsl:call'>
-              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-             </check>
-             <str val='setPendingUpdates'/>
-             <arrayBlock>
-              <treat line='3779' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||pendingInstanceUpdates'>
-               <map size='0'/>
-              </treat>
-             </arrayBlock>
-            </ifCall>
-            <ifCall line='3783' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-             <check card='1' diag='0|0||ixsl:call'>
-              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-             </check>
-             <str val='setUpdates'/>
-             <arrayBlock>
-              <treat line='3780' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||instanceUpdates'>
-               <map size='0'/>
-              </treat>
-             </arrayBlock>
-            </ifCall>
-            <forEach line='3785'>
-             <varRef name='Q{}actions' slot='3'/>
-             <let line='3786' var='Q{}action-map' as='item()' slot='8' eval='16'>
-              <dot/>
-              <choose line='3788'>
-               <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
-                <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:contains'>
-                 <varRef name='Q{}action-map' slot='8'/>
-                </treat>
-                <str val='@event'/>
-               </ifCall>
-               <choose line='3789'>
-                <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
-                 <data>
-                  <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                   <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:get'>
-                    <varRef name='Q{}action-map' slot='8'/>
-                   </treat>
-                   <str val='@event'/>
-                  </ifCall>
-                 </data>
-                 <str val='xforms-value-changed'/>
-                </gc>
-                <callT line='3791' name='Q{}applyActions' bSlot='6'>
-                 <withParam name='Q{}action-map' flags='t' as='item()'>
-                  <varRef line='3792' name='Q{}action-map' slot='8'/>
-                 </withParam>
-                 <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                  <check line='3793' card='1' diag='8|0|XTTE0590|nodeset'>
-                   <cvUntyped to='xs:string' diag='8|0|XTTE0590|nodeset'>
-                    <data>
-                     <varRef name='Q{}refi' slot='1'/>
-                    </data>
-                   </cvUntyped>
-                  </check>
-                 </withParam>
-                 <withParam name='Q{}instanceXML' flags='t' as='element()'>
-                  <varRef line='3794' name='Q{}updatedInstanceXML' slot='7'/>
-                 </withParam>
-                </callT>
-               </choose>
-              </choose>
-             </let>
-            </forEach>
-            <callT line='3800' name='Q{}xforms-recalculate' bSlot='7'/>
-            <ufCall line='3802' name='Q{http://www.w3.org/2002/xforms}checkRelevantFields' tailCall='false' bSlot='8' eval='16'>
-             <check card='1' diag='0|0||xforms:checkRelevantFields'>
-              <cvUntyped to='xs:string'>
-               <data>
-                <slash line='3741' simple='1'>
-                 <varRef name='Q{}form-control' slot='0'/>
-                 <axis name='attribute' nodeTest='attribute(Q{}data-element)' jsTest='return item.name===&#39;data-element&#39;'/>
-                </slash>
-               </data>
-              </cvUntyped>
-             </check>
-            </ufCall>
-           </sequence>
-          </let>
-         </let>
-        </let>
-       </let>
-      </let>
-     </let>
-    </let>
+    <forEach line='3520'>
+     <varRef name='Q{}when-value-changed' slot='0'/>
+     <callT line='3523' name='Q{}applyActions' bSlot='0'>
+      <withParam name='Q{}action-map' flags='t' as='item()'>
+       <dot line='3521' type='map(*)'/>
+      </withParam>
+     </callT>
+    </forEach>
    </sequence>
   </template>
  </co>
- <co id='22' binds='23 2 3 24 2'>
-  <template name='Q{}getReferencedInstanceField' flags='os' line='2961' module='saxon-xforms.xsl' slots='4'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2962'>
+ <co id='17' binds='18 2 3 19 2'>
+  <template name='Q{}getReferencedInstanceField' flags='os' line='2680' module='saxon-xforms.xsl' slots='4'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2681'>
     <param name='Q{}refi' slot='0' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|refi'>
@@ -1741,29 +1070,29 @@
       </check>
      </treat>
     </param>
-    <let line='2964' var='Q{}field' as='node()*' slot='1' eval='8'>
-     <choose line='2966'>
+    <let line='2683' var='Q{}field' as='node()*' slot='1' eval='8'>
+     <choose line='2685'>
       <varRef name='Q{}refi' slot='0'/>
-      <let line='2967' var='Q{}instance-map' as='map(xs:string, xs:string)' slot='2' eval='16'>
+      <let line='2686' var='Q{}instance-map' as='map(xs:string, xs:string)' slot='2' eval='16'>
        <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='0' eval='6'>
         <varRef name='Q{}refi' slot='0'/>
        </ufCall>
-       <let line='2970' var='Q{}this-instance' as='element()?' slot='3' eval='7'>
+       <let line='2689' var='Q{}this-instance' as='element()?' slot='3' eval='7'>
         <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='16'>
-         <check line='2969' card='1' diag='3|0|XTTE0570|this-instance-id'>
+         <check line='2688' card='1' diag='3|0|XTTE0570|this-instance-id'>
           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
            <varRef name='Q{}instance-map' slot='2'/>
            <str val='instance-id'/>
           </ifCall>
          </check>
         </ufCall>
-        <choose line='2974'>
+        <choose line='2693'>
          <fn name='exists'>
           <varRef name='Q{}this-instance' slot='3'/>
          </fn>
-         <treat line='2976' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|field'>
+         <treat line='2695' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|field'>
           <evaluate dxns=''>
-           <ufCall role='xpath' line='2975' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
+           <ufCall role='xpath' line='2694' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
             <check card='1' diag='0|0||xforms:impose'>
              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
               <varRef name='Q{}instance-map' slot='2'/>
@@ -1781,10 +1110,10 @@
           </evaluate>
          </treat>
          <true/>
-         <treat line='2979' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|field'>
+         <treat line='2698' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|field'>
           <callT name='Q{}logToPage' bSlot='3'>
            <withParam name='Q{}message' flags='c' as='xs:string'>
-            <fn line='2980' name='concat'>
+            <fn line='2699' name='concat'>
              <str val='[getReferencedInstanceField] Unable to locate XForms instance relating to reference '/>
              <varRef name='Q{}refi' slot='0'/>
             </fn>
@@ -1798,18 +1127,41 @@
        </let>
       </let>
       <true/>
-      <ufCall line='2989' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='4' eval='0'>
+      <ufCall line='2708' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='4' eval='0'>
        <str val='saxon-forms-default'/>
       </ufCall>
      </choose>
-     <varRef line='2994' name='Q{}field' slot='1'/>
+     <varRef line='2713' name='Q{}field' slot='1'/>
     </let>
    </sequence>
   </template>
  </co>
- <co id='25' binds='24'>
-  <template name='Q{}action-message' flags='os' line='4471' module='saxon-xforms.xsl' slots='3'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4472'>
+ <co id='20' binds='21'>
+  <template name='Q{}action-refresh' flags='os' line='4381' module='saxon-xforms.xsl' slots='0'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4382'>
+    <message>
+     <valueOf role='select'>
+      <str val='[action-refresh] START'/>
+     </valueOf>
+     <str role='terminate' val='no'/>
+     <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+    </message>
+    <callT line='4384' name='Q{}xforms-refresh' bSlot='0'/>
+    <ifCall line='4385' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+     <check card='1' diag='0|0||ixsl:call'>
+      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+     </check>
+     <str val='clearDeferredUpdateFlag'/>
+     <array size='1'>
+      <str val='refresh'/>
+     </array>
+    </ifCall>
+   </sequence>
+  </template>
+ </co>
+ <co id='22' binds='19'>
+  <template name='Q{}action-message' flags='os' line='4273' module='saxon-xforms.xsl' slots='3'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4274'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -1817,7 +1169,7 @@
       </check>
      </treat>
     </param>
-    <let line='4474' var='Q{}message-value' as='xs:string' slot='1' eval='16'>
+    <let line='4276' var='Q{}message-value' as='xs:string' slot='1' eval='16'>
      <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|message-value'>
       <check card='1' diag='3|0|XTTE0570|message-value'>
        <cvUntyped to='xs:string' diag='3|0|XTTE0570|message-value'>
@@ -1830,7 +1182,7 @@
        </cvUntyped>
       </check>
      </treat>
-     <let line='4476' var='Q{}message-level' as='xs:string' slot='2' eval='16'>
+     <let line='4278' var='Q{}message-level' as='xs:string' slot='2' eval='16'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|message-level'>
        <check card='1' diag='3|0|XTTE0570|message-level'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|message-level'>
@@ -1848,7 +1200,7 @@
         </cvUntyped>
        </check>
       </treat>
-      <sequence line='4478'>
+      <sequence line='4280'>
        <message>
         <sequence role='select'>
          <valueOf>
@@ -1870,14 +1222,14 @@
         <str role='terminate' val='no'/>
         <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
        </message>
-       <choose line='4482'>
+       <choose line='4284'>
         <vc op='eq' onEmpty='0' comp='CCC'>
          <varRef name='Q{}message-level' slot='2'/>
          <str val='ephemeral'/>
         </vc>
-        <callT line='4483' name='Q{}logToPage' bSlot='0' flags='t'>
+        <callT line='4285' name='Q{}logToPage' bSlot='0' flags='t'>
          <withParam name='Q{}message' flags='c' as='xs:string'>
-          <varRef line='4484' name='Q{}message-value' slot='1'/>
+          <varRef line='4286' name='Q{}message-value' slot='1'/>
          </withParam>
         </callT>
        </choose>
@@ -1887,26 +1239,26 @@
    </sequence>
   </template>
  </co>
- <co id='26' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}resolveXPathStrings' line='836' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:string' slots='5'>
+ <co id='23' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}resolveXPathStrings' line='778' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:string' slots='5'>
    <arg name='Q{}base' as='xs:string'/>
    <arg name='Q{}relative' as='xs:string'/>
-   <choose role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='843'>
+   <choose role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='785'>
     <fn name='starts-with'>
      <varRef name='Q{}relative' slot='1'/>
      <str val='/'/>
     </fn>
-    <varRef line='844' name='Q{}relative' slot='1'/>
-    <fn line='846' name='starts-with'>
+    <varRef line='786' name='Q{}relative' slot='1'/>
+    <fn line='788' name='starts-with'>
      <varRef name='Q{}relative' slot='1'/>
      <str val='instance('/>
     </fn>
-    <varRef line='847' name='Q{}relative' slot='1'/>
-    <fn line='849' name='not'>
+    <varRef line='789' name='Q{}relative' slot='1'/>
+    <fn line='791' name='not'>
      <varRef name='Q{}base' slot='0'/>
     </fn>
-    <varRef line='850' name='Q{}relative' slot='1'/>
-    <or line='852' op='or'>
+    <varRef line='792' name='Q{}relative' slot='1'/>
+    <or line='794' op='or'>
      <fn name='not'>
       <varRef name='Q{}relative' slot='1'/>
      </fn>
@@ -1915,9 +1267,9 @@
       <str val='.'/>
      </vc>
     </or>
-    <varRef line='853' name='Q{}base' slot='0'/>
+    <varRef line='795' name='Q{}base' slot='0'/>
     <true/>
-    <let line='857' var='Q{}parentCallCount' as='xs:integer' slot='2' eval='16'>
+    <let line='799' var='Q{}parentCallCount' as='xs:integer' slot='2' eval='16'>
      <choose>
       <fn name='contains'>
        <varRef name='Q{}relative' slot='1'/>
@@ -1944,7 +1296,7 @@
       <true/>
       <int val='0'/>
      </choose>
-     <let line='860' var='Q{}slashes' as='xs:integer*' slot='3' eval='4'>
+     <let line='802' var='Q{}slashes' as='xs:integer*' slot='3' eval='4'>
       <choose>
        <fn name='contains'>
         <varRef name='Q{}base' slot='0'/>
@@ -1959,15 +1311,15 @@
        <true/>
        <int val='0'/>
       </choose>
-      <choose line='892'>
+      <choose line='834'>
        <compareToInt op='gt' val='0'>
         <varRef name='Q{}parentCallCount' slot='2'/>
        </compareToInt>
-       <fn line='896' name='concat'>
+       <fn line='838' name='concat'>
         <fn name='substring'>
          <varRef name='Q{}base' slot='0'/>
          <int val='1'/>
-         <choose line='871'>
+         <choose line='813'>
           <and op='and'>
            <vc op='ge' onEmpty='0' comp='CAVC'>
             <fn name='count'>
@@ -1979,7 +1331,7 @@
             <varRef name='Q{}parentCallCount' slot='2'/>
            </compareToInt>
           </and>
-          <let line='872' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='4' eval='13'>
+          <let line='814' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='4' eval='13'>
            <arith op='-' calc='i-i'>
             <varRef name='Q{}parentCallCount' slot='2'/>
             <int val='1'/>
@@ -1995,7 +1347,7 @@
            </check>
           </let>
           <true/>
-          <check line='875' card='1' diag='3|0|XTTE0570|parentSlash'>
+          <check line='817' card='1' diag='3|0|XTTE0570|parentSlash'>
            <lastOf>
             <varRef name='Q{}slashes' slot='3'/>
            </lastOf>
@@ -2010,7 +1362,7 @@
         </fn>
        </fn>
        <true/>
-       <fn line='899' name='concat'>
+       <fn line='841' name='concat'>
         <varRef name='Q{}base' slot='0'/>
         <str val='/'/>
         <varRef name='Q{}relative' slot='1'/>
@@ -2021,7 +1373,7 @@
    </choose>
   </function>
  </co>
- <co id='27' binds=''>
+ <co id='24' binds=''>
   <function name='Q{http://saxonica.com/ns/forms-local}current-date' line='119' module='xforms-function-library.xsl' eval='16' flags='pU' as='xs:string' slots='0'>
    <treat role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='120' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|today'>
     <check card='1' diag='3|0|XTTE0570|today'>
@@ -2040,7 +1392,7 @@
    </treat>
   </function>
  </co>
- <co id='14' binds='28'>
+ <co id='25' binds='26'>
   <function name='Q{http://www.w3.org/2002/xforms}resolve-index' line='73' module='xforms-function-library.xsl' eval='8' flags='pU' as='xs:string' slots='2'>
    <arg name='Q{}input' as='xs:string'/>
    <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='75' var='Q{}parts' as='xs:string*' slot='1' eval='8'>
@@ -2063,9 +1415,9 @@
    </let>
   </function>
  </co>
- <co id='29' binds='3'>
-  <template name='Q{}action-setindex' flags='os' line='4537' module='saxon-xforms.xsl' slots='2'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4538'>
+ <co id='27' binds='28 3'>
+  <template name='Q{}action-setindex' flags='os' line='4342' module='saxon-xforms.xsl' slots='2'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4343'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -2073,14 +1425,15 @@
       </check>
      </treat>
     </param>
-    <let line='4544' var='Q{}new-index' as='xs:integer' slot='1' eval='16'>
-     <treat line='4545' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|new-index'>
+    <callT line='4346' name='Q{}outermost-action-handler' bSlot='0'/>
+    <let line='4352' var='Q{}new-index' as='xs:integer' slot='1' eval='16'>
+     <treat line='4353' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='3|0|XTTE0570|new-index'>
       <check card='1' diag='3|0|XTTE0570|new-index'>
        <cvUntyped to='xs:integer' diag='3|0|XTTE0570|new-index'>
         <data>
          <evaluate dxns=''>
-          <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='0' eval='16'>
-           <treat line='4541' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-index-ref'>
+          <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='1' eval='16'>
+           <treat line='4349' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-index-ref'>
             <check card='1' diag='3|0|XTTE0570|new-index-ref'>
              <cvUntyped to='xs:string' diag='3|0|XTTE0570|new-index-ref'>
               <data>
@@ -2102,13 +1455,13 @@
        </cvUntyped>
       </check>
      </treat>
-     <ifCall line='4550' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+     <ifCall line='4358' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
       <check card='1' diag='0|0||ixsl:call'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
       </check>
       <str val='setRepeatIndex'/>
       <arrayBlock>
-       <treat line='4540' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|repeatID'>
+       <treat line='4348' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|repeatID'>
         <check card='1' diag='3|0|XTTE0570|repeatID'>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|repeatID'>
           <data>
@@ -2127,9 +1480,9 @@
    </sequence>
   </template>
  </co>
- <co id='30' binds='31'>
-  <template name='Q{}action-setfocus' flags='os' line='4499' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4500'>
+ <co id='29' binds='28 30'>
+  <template name='Q{}action-setfocus' flags='os' line='4301' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4302'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -2137,9 +1490,10 @@
       </check>
      </treat>
     </param>
-    <callT line='4504' name='Q{}xforms-focus' bSlot='0' flags='t'>
+    <callT line='4305' name='Q{}outermost-action-handler' bSlot='0'/>
+    <callT line='4309' name='Q{}xforms-focus' bSlot='1' flags='t'>
      <withParam name='Q{}control' flags='c' as='xs:string'>
-      <treat line='4502' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|control'>
+      <treat line='4307' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|control'>
        <check card='1' diag='3|0|XTTE0570|control'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|control'>
          <data>
@@ -2156,9 +1510,9 @@
    </sequence>
   </template>
  </co>
- <co id='32' binds='1 3 3 33 16 34 5 35'>
-  <template name='Q{}action-setvalue' flags='os' line='4147' module='saxon-xforms.xsl' slots='14'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4148'>
+ <co id='31' binds='1 32 3 3 33'>
+  <template name='Q{}action-setvalue' flags='os' line='3912' module='saxon-xforms.xsl' slots='13'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3913'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -2166,7 +1520,7 @@
       </check>
      </treat>
     </param>
-    <param line='4149' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
+    <param line='3914' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
      <empty role='select'/>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|instanceXML'>
       <check card='?' diag='8|0|XTTE0590|instanceXML'>
@@ -2174,7 +1528,7 @@
       </check>
      </treat>
     </param>
-    <param line='4150' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
+    <param line='3915' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -2186,7 +1540,14 @@
       </check>
      </treat>
     </param>
-    <let line='4154' var='Q{}refz' as='xs:string' slot='3' eval='16'>
+    <message line='3917'>
+     <valueOf role='select'>
+      <str val='[action-setvalue] START'/>
+     </valueOf>
+     <str role='terminate' val='no'/>
+     <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+    </message>
+    <let line='3921' var='Q{}refz' as='xs:string' slot='3' eval='16'>
      <let var='Q{}relative' as='xs:string' slot='4' eval='16'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|1||xforms:resolveXPathStrings'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
@@ -2200,22 +1561,22 @@
         </cvUntyped>
        </check>
       </treat>
-      <choose line='843'>
+      <choose line='785'>
        <fn name='starts-with'>
         <varRef name='Q{}relative' slot='4'/>
         <str val='/'/>
        </fn>
-       <varRef line='844' name='Q{}relative' slot='4'/>
-       <fn line='846' name='starts-with'>
+       <varRef line='786' name='Q{}relative' slot='4'/>
+       <fn line='788' name='starts-with'>
         <varRef name='Q{}relative' slot='4'/>
         <str val='instance('/>
        </fn>
-       <varRef line='847' name='Q{}relative' slot='4'/>
-       <fn line='4154' name='not'>
+       <varRef line='789' name='Q{}relative' slot='4'/>
+       <fn line='3921' name='not'>
         <varRef name='Q{}nodeset' slot='2'/>
        </fn>
-       <varRef line='850' name='Q{}relative' slot='4'/>
-       <or line='852' op='or'>
+       <varRef line='792' name='Q{}relative' slot='4'/>
+       <or line='794' op='or'>
         <fn name='not'>
          <varRef name='Q{}relative' slot='4'/>
         </fn>
@@ -2224,9 +1585,9 @@
          <str val='.'/>
         </vc>
        </or>
-       <varRef line='4154' name='Q{}nodeset' slot='2'/>
+       <varRef line='3921' name='Q{}nodeset' slot='2'/>
        <true/>
-       <let line='857' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
+       <let line='799' var='Q{}parentCallCount' as='xs:integer' slot='5' eval='16'>
         <choose>
          <fn name='contains'>
           <varRef name='Q{}relative' slot='4'/>
@@ -2253,30 +1614,30 @@
          <true/>
          <int val='0'/>
         </choose>
-        <let line='860' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
+        <let line='802' var='Q{}slashes' as='xs:integer*' slot='6' eval='4'>
          <choose>
-          <fn line='4154' name='contains'>
+          <fn line='3921' name='contains'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
           </fn>
           <fn name='index-of'>
            <fn name='string-to-codepoints'>
-            <varRef line='4154' name='Q{}nodeset' slot='2'/>
+            <varRef line='3921' name='Q{}nodeset' slot='2'/>
            </fn>
            <int val='47'/>
           </fn>
           <true/>
           <int val='0'/>
          </choose>
-         <choose line='892'>
+         <choose line='834'>
           <compareToInt op='gt' val='0'>
            <varRef name='Q{}parentCallCount' slot='5'/>
           </compareToInt>
-          <fn line='896' name='concat'>
+          <fn line='838' name='concat'>
            <fn name='substring'>
-            <varRef line='4154' name='Q{}nodeset' slot='2'/>
+            <varRef line='3921' name='Q{}nodeset' slot='2'/>
             <int val='1'/>
-            <choose line='871'>
+            <choose line='813'>
              <and op='and'>
               <vc op='ge' onEmpty='0' comp='CAVC'>
                <fn name='count'>
@@ -2288,7 +1649,7 @@
                <varRef name='Q{}parentCallCount' slot='5'/>
               </compareToInt>
              </and>
-             <let line='872' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='7' eval='13'>
+             <let line='814' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='7' eval='13'>
               <arith op='-' calc='i-i'>
                <varRef name='Q{}parentCallCount' slot='5'/>
                <int val='1'/>
@@ -2304,7 +1665,7 @@
               </check>
              </let>
              <true/>
-             <check line='875' card='1' diag='3|0|XTTE0570|parentSlash'>
+             <check line='817' card='1' diag='3|0|XTTE0570|parentSlash'>
               <lastOf>
                <varRef name='Q{}slashes' slot='6'/>
               </lastOf>
@@ -2319,238 +1680,164 @@
            </fn>
           </fn>
           <true/>
-          <fn line='4154' name='concat'>
+          <fn line='3921' name='concat'>
            <varRef name='Q{}nodeset' slot='2'/>
            <str val='/'/>
-           <varRef line='899' name='Q{}relative' slot='4'/>
+           <varRef line='841' name='Q{}relative' slot='4'/>
           </fn>
          </choose>
         </let>
        </let>
       </choose>
      </let>
-     <let line='4156' var='Q{}instance-id' as='xs:string' slot='8' eval='16'>
+     <let line='3923' var='Q{}instance-id' as='xs:string' slot='8' eval='16'>
       <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='6'>
        <varRef name='Q{}refz' slot='3'/>
       </ufCall>
-      <let line='4169' var='Q{}valuez' as='document-node()' slot='9' eval='16'>
-       <doc line='4171' validation='preserve'>
-        <choose>
-         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
-          <varRef name='Q{}action-map' slot='0'/>
-          <str val='@value'/>
-         </ifCall>
-         <let line='4172' var='Q{}contexti' as='node()' slot='10' eval='8'>
-          <evaluate line='4173' as='node()' dxns=''>
-           <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='1' eval='6'>
-            <varRef name='Q{}nodeset' slot='2'/>
-           </ufCall>
-           <varRef role='cxt' name='Q{}instanceXML' slot='1'/>
-           <check role='nsCxt' card='1' diag='4|0|XTTE3170|xsl:evaluate/namespace-context'>
-            <varRef name='Q{}instanceXML' slot='1'/>
-           </check>
-           <str role='sa' val='no'/>
-           <map role='options' size='0'/>
-           <map role='wp' size='0'/>
-          </evaluate>
-          <evaluate line='4176' dxns=''>
-           <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
-            <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:impose'>
-             <check card='1' diag='0|0||xforms:impose'>
-              <cvUntyped to='xs:string'>
-               <data>
-                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                 <varRef name='Q{}action-map' slot='0'/>
-                 <str val='@value'/>
-                </ifCall>
-               </data>
-              </cvUntyped>
-             </check>
-            </treat>
-           </ufCall>
-           <varRef role='cxt' name='Q{}contexti' slot='10'/>
-           <varRef role='nsCxt' name='Q{}contexti' slot='10'/>
-           <str role='sa' val='no'/>
-           <map role='options' size='0'/>
-           <map role='wp' size='0'/>
-          </evaluate>
-         </let>
-         <ifCall line='4179' name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
-          <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:contains'>
-           <dot flags='a'/>
-          </treat>
-          <str val='value'/>
-         </ifCall>
-         <ifCall line='4180' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-          <varRef name='Q{}action-map' slot='0'/>
-          <str val='value'/>
-         </ifCall>
-         <true/>
-         <str val=''/>
-        </choose>
-       </doc>
-       <sequence line='4190'>
-        <let line='4192' var='Q{}associated-form-control' as='element()?' slot='11' eval='7'>
-         <check card='?' diag='3|0|XTTE0570|associated-form-control'>
-          <filter flags='b'>
-           <slash simple='1'>
-            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
-            <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-           </slash>
-           <vc op='eq' onEmpty='0' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
-            <cast as='xs:string' emptiable='1'>
-             <attVal name='Q{}data-ref' chk='0'/>
-            </cast>
-            <varRef name='Q{}refz' slot='3'/>
-           </vc>
-          </filter>
-         </check>
-         <choose line='4194'>
-          <fn name='exists'>
-           <varRef name='Q{}associated-form-control' slot='11'/>
-          </fn>
-          <sequence line='4195'>
-           <applyT mode='Q{}set-field' bSlot='3'>
-            <varRef role='select' name='Q{}associated-form-control' slot='11'/>
-            <withParam name='Q{}value' flags='t' as='xs:string'>
-             <cast line='4196' as='xs:string' emptiable='0'>
-              <data>
-               <varRef name='Q{}valuez' slot='9'/>
-              </data>
-             </cast>
-            </withParam>
-           </applyT>
-           <ifCall line='4198' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-            <check card='1' diag='0|0||ixsl:call'>
-             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-            </check>
-            <str val='setUpdates'/>
-            <arrayBlock>
-             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}put' type='map(*)'>
-              <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:put'>
-               <check card='1' diag='0|0||map:put'>
-                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                 <check card='1' diag='0|0||ixsl:call'>
-                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-                 </check>
-                 <str val='getUpdates'/>
-                 <array size='0'/>
-                </ifCall>
-               </check>
-              </treat>
-              <varRef name='Q{}refz' slot='3'/>
-              <cast as='xs:string' emptiable='0'>
-               <data>
-                <varRef name='Q{}valuez' slot='9'/>
-               </data>
-              </cast>
-             </ifCall>
-            </arrayBlock>
-           </ifCall>
-          </sequence>
-          <true/>
-          <ifCall line='4201' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-           <check card='1' diag='0|0||ixsl:call'>
-            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-           </check>
-           <str val='setPendingUpdates'/>
-           <arrayBlock>
-            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}put' type='map(*)'>
-             <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:put'>
-              <check card='1' diag='0|0||map:put'>
-               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                <check card='1' diag='0|0||ixsl:call'>
-                 <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-                </check>
-                <str val='getPendingUpdates'/>
-                <array size='0'/>
-               </ifCall>
-              </check>
-             </treat>
-             <varRef name='Q{}refz' slot='3'/>
-             <cast as='xs:string' emptiable='0'>
-              <data>
-               <varRef name='Q{}valuez' slot='9'/>
-              </data>
-             </cast>
-            </ifCall>
-           </arrayBlock>
-          </ifCall>
-         </choose>
-        </let>
-        <choose line='4207'>
-         <vc op='ne' onEmpty='1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
-          <varRef name='Q{}refz' slot='3'/>
-          <str val=''/>
+      <let line='3925' var='Q{}instanceXML2' as='element()' slot='9' eval='16'>
+       <choose line='3927'>
+        <and op='and'>
+         <vc op='eq' onEmpty='0' comp='CCC'>
+          <varRef name='Q{}instance-id' slot='8'/>
+          <str val='saxon-forms-default'/>
          </vc>
-         <let line='4209' var='Q{}pendingUpdates' as='map(xs:string, xs:string)?' slot='12' eval='7'>
-          <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|pendingUpdates'>
+         <fn name='exists'>
+          <varRef name='Q{}instanceXML' slot='1'/>
+         </fn>
+        </and>
+        <check line='3928' card='1' diag='3|0|XTTE0570|instanceXML2'>
+         <varRef name='Q{}instanceXML' slot='1'/>
+        </check>
+        <true/>
+        <check line='3931' card='1' diag='3|0|XTTE0570|instanceXML2'>
+         <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='1' eval='6'>
+          <varRef name='Q{}refz' slot='3'/>
+         </ufCall>
+        </check>
+       </choose>
+       <let line='3939' var='Q{}updated-node' as='node()' slot='10' eval='8'>
+        <evaluate line='3940' as='node()' dxns=''>
+         <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='6'>
+          <varRef name='Q{}refz' slot='3'/>
+         </ufCall>
+         <varRef role='cxt' name='Q{}instanceXML2' slot='9'/>
+         <varRef role='nsCxt' name='Q{}instanceXML2' slot='9'/>
+         <str role='sa' val='no'/>
+         <map role='options' size='0'/>
+         <map role='wp' size='0'/>
+        </evaluate>
+        <let line='3943' var='Q{}updated-value' as='xs:string' slot='11' eval='16'>
+         <choose line='3945'>
+          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+           <varRef name='Q{}action-map' slot='0'/>
+           <str val='@value'/>
+          </ifCall>
+          <treat line='3947' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|updated-value'>
+           <check card='1' diag='3|0|XTTE0570|updated-value'>
+            <cvUntyped to='xs:string' diag='3|0|XTTE0570|updated-value'>
+             <data>
+              <evaluate dxns=''>
+               <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='3' eval='16'>
+                <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:impose'>
+                 <check card='1' diag='0|0||xforms:impose'>
+                  <cvUntyped to='xs:string'>
+                   <data>
+                    <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                     <varRef name='Q{}action-map' slot='0'/>
+                     <str val='@value'/>
+                    </ifCall>
+                   </data>
+                  </cvUntyped>
+                 </check>
+                </treat>
+               </ufCall>
+               <varRef role='cxt' name='Q{}updated-node' slot='10'/>
+               <varRef role='nsCxt' name='Q{}updated-node' slot='10'/>
+               <str role='sa' val='no'/>
+               <map role='options' size='0'/>
+               <map role='wp' size='0'/>
+              </evaluate>
+             </data>
+            </cvUntyped>
+           </check>
+          </treat>
+          <ifCall line='3950' name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
+           <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:contains'>
+            <dot flags='a'/>
+           </treat>
+           <str val='value'/>
+          </ifCall>
+          <treat line='3951' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|updated-value'>
+           <check card='1' diag='3|0|XTTE0570|updated-value'>
+            <cvUntyped to='xs:string' diag='3|0|XTTE0570|updated-value'>
+             <data>
+              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+               <varRef name='Q{}action-map' slot='0'/>
+               <str val='value'/>
+              </ifCall>
+             </data>
+            </cvUntyped>
+           </check>
+          </treat>
+          <true/>
+          <str val=''/>
+         </choose>
+         <let line='3960' var='Q{}updatedInstanceXML' as='element()' slot='12' eval='16'>
+          <treat line='3961' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+           <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
+            <applyT mode='Q{}recalculate' bSlot='4'>
+             <varRef role='select' name='Q{}instanceXML2' slot='9'/>
+             <withParam name='Q{}updated-nodes' flags='t' as='node()'>
+              <varRef line='3962' name='Q{}updated-node' slot='10'/>
+             </withParam>
+             <withParam name='Q{}updated-values' flags='t' as='xs:string'>
+              <varRef line='3963' name='Q{}updated-value' slot='11'/>
+             </withParam>
+            </applyT>
+           </check>
+          </treat>
+          <sequence line='3967'>
            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
             <check card='1' diag='0|0||ixsl:call'>
              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
             </check>
-            <str val='getPendingUpdates'/>
-            <array size='0'/>
+            <str val='setInstance'/>
+            <arrayBlock>
+             <varRef name='Q{}instance-id' slot='8'/>
+             <varRef name='Q{}updatedInstanceXML' slot='12'/>
+            </arrayBlock>
            </ifCall>
-          </treat>
-          <let line='4211' var='Q{}updatedInstanceXML' as='element()' slot='13' eval='16'>
-           <treat line='4212' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
-            <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
-             <applyT mode='Q{}form-check-initial' bSlot='4'>
-              <choose role='select' line='4160'>
-               <and op='and'>
-                <vc op='eq' onEmpty='0' comp='CCC'>
-                 <varRef name='Q{}instance-id' slot='8'/>
-                 <str val='saxon-forms-default'/>
-                </vc>
-                <fn name='exists'>
-                 <varRef name='Q{}instanceXML' slot='1'/>
-                </fn>
-               </and>
-               <check line='4161' card='1' diag='3|0|XTTE0570|instanceXML2'>
-                <varRef name='Q{}instanceXML' slot='1'/>
-               </check>
-               <true/>
-               <check line='4164' card='1' diag='3|0|XTTE0570|instanceXML2'>
-                <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='5' eval='6'>
-                 <varRef name='Q{}refz' slot='3'/>
-                </ufCall>
-               </check>
-              </choose>
-              <withParam name='Q{}instance-id' as='xs:string'>
-               <varRef line='4213' name='Q{}instance-id' slot='8'/>
-              </withParam>
-              <withParam name='Q{}pendingUpdates' flags='t' as='map(xs:string, xs:string)?'>
-               <varRef line='4214' name='Q{}pendingUpdates' slot='12'/>
-              </withParam>
-             </applyT>
+           <ifCall line='3969' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+            <check card='1' diag='0|0||ixsl:call'>
+             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
             </check>
-           </treat>
-           <sequence line='4219'>
-            <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='6' eval='6 6'>
-             <varRef name='Q{}refz' slot='3'/>
-             <varRef name='Q{}updatedInstanceXML' slot='13'/>
-            </ufCall>
-            <callT line='4220' name='Q{}refreshOutputs-JS' bSlot='7' flags='t'/>
-           </sequence>
-          </let>
+            <str val='setDeferredUpdateFlags'/>
+            <array size='1'>
+             <literal count='3'>
+              <str val='recalculate'/>
+              <str val='revalidate'/>
+              <str val='refresh'/>
+             </literal>
+            </array>
+           </ifCall>
+          </sequence>
          </let>
-        </choose>
-       </sequence>
+        </let>
+       </let>
       </let>
      </let>
     </let>
    </sequence>
   </template>
  </co>
- <co id='36' binds=''>
-  <globalVariable name='Q{}default-submission-id' type='xs:string' line='83' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
+ <co id='34' binds=''>
+  <globalVariable name='Q{}default-submission-id' type='xs:string' line='85' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
    <str val='saxon-forms-default-submission'/>
   </globalVariable>
  </co>
- <co id='20' binds='1 34 3 3 3 32 0 8 29 30 37 7 17 10 25 20'>
-  <template name='Q{}applyActions' flags='os' line='3206' module='saxon-xforms.xsl' slots='15'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3207'>
+ <co id='16' binds='1 32 3 3 3 31 0 7 27 29 35 13 20 14 9 22 16 28'>
+  <template name='Q{}applyActions' flags='os' line='2956' module='saxon-xforms.xsl' slots='15'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2957'>
     <param name='Q{}action-map' slot='0' flags='tr' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|action-map'>
       <check card='1' diag='8|0|XTTE0590|action-map'>
@@ -2558,7 +1845,7 @@
       </check>
      </treat>
     </param>
-    <param line='3208' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
+    <param line='2958' name='Q{}instanceXML' slot='1' flags='t' as='element()?'>
      <empty role='select'/>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|instanceXML'>
       <check card='?' diag='8|0|XTTE0590|instanceXML'>
@@ -2566,7 +1853,7 @@
       </check>
      </treat>
     </param>
-    <param line='3209' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
+    <param line='2959' name='Q{}nodeset' slot='2' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -2578,7 +1865,7 @@
       </check>
      </treat>
     </param>
-    <let line='3211' var='Q{}ref' as='xs:string?' slot='3' eval='7'>
+    <let line='2962' var='Q{}ref' as='xs:string?' slot='3' eval='7'>
      <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|ref'>
       <check card='?' diag='3|0|XTTE0570|ref'>
        <cvUntyped to='xs:string' diag='3|0|XTTE0570|ref'>
@@ -2591,7 +1878,7 @@
        </cvUntyped>
       </check>
      </treat>
-     <let line='3212' var='Q{}at' as='xs:string?' slot='4' eval='7'>
+     <let line='2963' var='Q{}at' as='xs:string?' slot='4' eval='7'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|at'>
        <check card='?' diag='3|0|XTTE0570|at'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|at'>
@@ -2604,7 +1891,7 @@
         </cvUntyped>
        </check>
       </treat>
-      <let line='3214' var='Q{}context' as='xs:string?' slot='5' eval='7'>
+      <let line='2965' var='Q{}context' as='xs:string?' slot='5' eval='7'>
        <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|context'>
         <check card='?' diag='3|0|XTTE0570|context'>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|context'>
@@ -2617,7 +1904,7 @@
          </cvUntyped>
         </check>
        </treat>
-       <let line='3225' var='Q{}ref-qualified' as='xs:string?' slot='6' eval='7'>
+       <let line='2976' var='Q{}ref-qualified' as='xs:string?' slot='6' eval='7'>
         <choose>
          <and op='and'>
           <fn name='exists'>
@@ -2639,14 +1926,14 @@
           <varRef name='Q{}ref' slot='3'/>
          </choose>
         </choose>
-        <let line='3227' var='Q{}instance-id' as='xs:string' slot='7' eval='16'>
+        <let line='2978' var='Q{}instance-id' as='xs:string' slot='7' eval='16'>
          <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='16'>
           <check card='1' diag='0|0||xforms:getInstanceId'>
            <varRef name='Q{}ref' slot='3'/>
           </check>
          </ufCall>
-         <let line='3229' var='Q{}instanceXML2' as='element()?' slot='8' eval='7'>
-          <choose line='3231'>
+         <let line='2980' var='Q{}instanceXML2' as='element()?' slot='8' eval='7'>
+          <choose line='2982'>
            <and op='and'>
             <vc op='eq' onEmpty='0' comp='CCC'>
              <varRef name='Q{}instance-id' slot='7'/>
@@ -2656,18 +1943,18 @@
              <varRef name='Q{}instanceXML' slot='1'/>
             </fn>
            </and>
-           <varRef line='3232' name='Q{}instanceXML' slot='1'/>
-           <fn line='3234' name='exists'>
+           <varRef line='2983' name='Q{}instanceXML' slot='1'/>
+           <fn line='2985' name='exists'>
             <varRef name='Q{}ref-qualified' slot='6'/>
            </fn>
-           <ufCall line='3235' name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='1' eval='16'>
+           <ufCall line='2986' name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='1' eval='16'>
             <check card='1' diag='0|0||xforms:getInstance-JS'>
              <varRef name='Q{}ref-qualified' slot='6'/>
             </check>
            </ufCall>
           </choose>
-          <let line='3243' var='Q{}ref-node' as='node()*' slot='9' eval='8'>
-           <choose line='3245'>
+          <let line='2994' var='Q{}ref-node' as='node()*' slot='9' eval='8'>
+           <choose line='2996'>
             <and op='and'>
              <and op='and'>
               <fn name='exists'>
@@ -2682,7 +1969,7 @@
               <varRef name='Q{}instanceXML2' slot='8'/>
              </fn>
             </and>
-            <treat line='3246' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|ref-node'>
+            <treat line='2997' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|ref-node'>
              <evaluate dxns=''>
               <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
                <check card='1' diag='0|0||xforms:impose'>
@@ -2699,8 +1986,8 @@
              </evaluate>
             </treat>
            </choose>
-           <let line='3251' var='Q{}context-node' as='node()?' slot='10' eval='7'>
-            <choose line='3253'>
+           <let line='3002' var='Q{}context-node' as='node()?' slot='10' eval='7'>
+            <choose line='3004'>
              <and op='and'>
               <and op='and'>
                <fn name='exists'>
@@ -2715,7 +2002,7 @@
                <varRef name='Q{}instanceXML2' slot='8'/>
               </fn>
              </and>
-             <treat line='3254' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|context-node'>
+             <treat line='3005' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|context-node'>
               <check card='?' diag='3|0|XTTE0570|context-node'>
                <evaluate dxns=''>
                 <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='3' eval='16'>
@@ -2734,7 +2021,7 @@
               </check>
              </treat>
             </choose>
-            <let line='3259' var='Q{}context' as='node()?' slot='11' eval='7'>
+            <let line='3010' var='Q{}context' as='node()?' slot='11' eval='7'>
              <first>
               <sequence>
                <varRef name='Q{}context-node' slot='10'/>
@@ -2742,18 +2029,18 @@
                <varRef name='Q{}instanceXML2' slot='8'/>
               </sequence>
              </first>
-             <let line='3265' var='Q{}ifVar' as='xs:string?' slot='12' eval='7'>
-              <choose line='798'>
+             <let line='3016' var='Q{}ifVar' as='xs:string?' slot='12' eval='7'>
+              <choose line='740'>
                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
-                <varRef line='3265' name='Q{}action-map' slot='0'/>
+                <varRef line='3016' name='Q{}action-map' slot='0'/>
                 <str val='@if'/>
                </ifCall>
-               <treat line='799' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
+               <treat line='741' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
                 <check card='?' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
                  <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
                   <data>
                    <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                    <varRef line='3265' name='Q{}action-map' slot='0'/>
+                    <varRef line='3016' name='Q{}action-map' slot='0'/>
                     <str val='@if'/>
                    </ifCall>
                   </data>
@@ -2761,8 +2048,8 @@
                 </check>
                </treat>
               </choose>
-              <let line='3269' var='Q{}ifExecuted' as='xs:boolean' slot='13' eval='16'>
-               <choose line='3271'>
+              <let line='3020' var='Q{}ifExecuted' as='xs:boolean' slot='13' eval='16'>
+               <choose line='3022'>
                 <and op='and'>
                  <fn name='exists'>
                   <varRef name='Q{}ifVar' slot='12'/>
@@ -2771,7 +2058,7 @@
                   <varRef name='Q{}context' slot='11'/>
                  </fn>
                 </and>
-                <treat line='3272' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|ifExecuted'>
+                <treat line='3023' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|ifExecuted'>
                  <check card='1' diag='3|0|XTTE0570|ifExecuted'>
                   <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|ifExecuted'>
                    <data>
@@ -2796,9 +2083,9 @@
                 <true/>
                 <true/>
                </choose>
-               <choose line='3282'>
+               <choose line='3033'>
                 <varRef name='Q{}ifExecuted' slot='13'/>
-                <let line='3283' var='Q{}action-name' as='xs:string' slot='14' eval='16'>
+                <let line='3034' var='Q{}action-name' as='xs:string' slot='14' eval='16'>
                  <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|action-name'>
                   <check card='1' diag='3|0|XTTE0570|action-name'>
                    <cvUntyped to='xs:string' diag='3|0|XTTE0570|action-name'>
@@ -2811,98 +2098,103 @@
                    </cvUntyped>
                   </check>
                  </treat>
-                 <sequence line='3286'>
+                 <sequence line='3037'>
                   <choose>
                    <vc op='eq' onEmpty='0' comp='CCC'>
                     <varRef name='Q{}action-name' slot='14'/>
                     <str val='action'/>
                    </vc>
                    <empty/>
-                   <vc line='3289' op='eq' onEmpty='0' comp='CCC'>
+                   <vc line='3040' op='eq' onEmpty='0' comp='CCC'>
                     <varRef name='Q{}action-name' slot='14'/>
                     <str val='setvalue'/>
                    </vc>
-                   <callT line='3290' name='Q{}action-setvalue' bSlot='5'>
+                   <callT line='3041' name='Q{}action-setvalue' bSlot='5'>
                     <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                     <check line='3291' card='1' diag='8|0|XTTE0590|nodeset'>
+                     <check line='3042' card='1' diag='8|0|XTTE0590|nodeset'>
                       <varRef name='Q{}ref' slot='3'/>
                      </check>
                     </withParam>
                     <withParam name='Q{}instanceXML' flags='t' as='element()'>
-                     <check line='3292' card='1' diag='8|0|XTTE0590|instanceXML'>
+                     <check line='3043' card='1' diag='8|0|XTTE0590|instanceXML'>
                       <varRef name='Q{}instanceXML2' slot='8'/>
                      </check>
                     </withParam>
                    </callT>
-                   <vc line='3295' op='eq' onEmpty='0' comp='CCC'>
+                   <vc line='3046' op='eq' onEmpty='0' comp='CCC'>
                     <varRef name='Q{}action-name' slot='14'/>
                     <str val='insert'/>
                    </vc>
-                   <callT line='3296' name='Q{}action-insert' bSlot='6'>
+                   <callT line='3047' name='Q{}action-insert' bSlot='6'>
                     <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                     <check line='3297' card='1' diag='8|0|XTTE0590|nodeset'>
+                     <check line='3048' card='1' diag='8|0|XTTE0590|nodeset'>
                       <varRef name='Q{}ref-qualified' slot='6'/>
                      </check>
                     </withParam>
                     <withParam name='Q{}instanceXML' flags='t' as='element()'>
-                     <check line='3298' card='1' diag='8|0|XTTE0590|instanceXML'>
+                     <check line='3049' card='1' diag='8|0|XTTE0590|instanceXML'>
                       <varRef name='Q{}instanceXML2' slot='8'/>
                      </check>
                     </withParam>
                    </callT>
-                   <vc line='3301' op='eq' onEmpty='0' comp='CCC'>
+                   <vc line='3052' op='eq' onEmpty='0' comp='CCC'>
                     <varRef name='Q{}action-name' slot='14'/>
                     <str val='delete'/>
                    </vc>
-                   <callT line='3302' name='Q{}action-delete' bSlot='7'>
+                   <callT line='3053' name='Q{}action-delete' bSlot='7'>
                     <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                     <check line='3303' card='1' diag='8|0|XTTE0590|nodeset'>
+                     <check line='3054' card='1' diag='8|0|XTTE0590|nodeset'>
                       <varRef name='Q{}ref-qualified' slot='6'/>
                      </check>
                     </withParam>
                     <withParam name='Q{}instanceXML' flags='t' as='element()'>
-                     <check line='3304' card='1' diag='8|0|XTTE0590|instanceXML'>
+                     <check line='3055' card='1' diag='8|0|XTTE0590|instanceXML'>
                       <varRef name='Q{}instanceXML2' slot='8'/>
                      </check>
                     </withParam>
                    </callT>
-                   <vc line='3307' op='eq' onEmpty='0' comp='CCC'>
+                   <vc line='3058' op='eq' onEmpty='0' comp='CCC'>
                     <varRef name='Q{}action-name' slot='14'/>
                     <str val='setindex'/>
                    </vc>
-                   <callT line='3308' name='Q{}action-setindex' bSlot='8'/>
-                   <vc line='3313' op='eq' onEmpty='0' comp='CCC'>
+                   <callT line='3059' name='Q{}action-setindex' bSlot='8'/>
+                   <vc line='3064' op='eq' onEmpty='0' comp='CCC'>
                     <varRef name='Q{}action-name' slot='14'/>
                     <str val='setfocus'/>
                    </vc>
-                   <callT line='3314' name='Q{}action-setfocus' bSlot='9'/>
-                   <vc line='3319' op='eq' onEmpty='0' comp='CCC'>
+                   <callT line='3065' name='Q{}action-setfocus' bSlot='9'/>
+                   <vc line='3070' op='eq' onEmpty='0' comp='CCC'>
                     <varRef name='Q{}action-name' slot='14'/>
                     <str val='rebuild'/>
                    </vc>
-                   <callT line='3320' name='Q{}xforms-rebuild' bSlot='10'/>
-                   <vc line='3322' op='eq' onEmpty='0' comp='CCC'>
+                   <callT line='3071' name='Q{}xforms-rebuild' bSlot='10'/>
+                   <vc line='3073' op='eq' onEmpty='0' comp='CCC'>
                     <varRef name='Q{}action-name' slot='14'/>
                     <str val='recalculate'/>
                    </vc>
-                   <callT line='3323' name='Q{}xforms-recalculate' bSlot='11'/>
-                   <vc line='3331' op='eq' onEmpty='0' comp='CCC'>
+                   <callT line='3074' name='Q{}xforms-recalculate' bSlot='11'/>
+                   <vc line='3079' op='eq' onEmpty='0' comp='CCC'>
+                    <varRef name='Q{}action-name' slot='14'/>
+                    <str val='refresh'/>
+                   </vc>
+                   <callT line='3080' name='Q{}action-refresh' bSlot='12'/>
+                   <vc line='3082' op='eq' onEmpty='0' comp='CCC'>
                     <varRef name='Q{}action-name' slot='14'/>
                     <str val='reset'/>
                    </vc>
-                   <callT line='3332' name='Q{}action-reset' bSlot='12'/>
-                   <vc line='3337' op='eq' onEmpty='0' comp='CCC'>
+                   <callT line='3083' name='Q{}action-reset' bSlot='13'/>
+                   <vc line='3088' op='eq' onEmpty='0' comp='CCC'>
                     <varRef name='Q{}action-name' slot='14'/>
                     <str val='send'/>
                    </vc>
-                   <callT line='3338' name='Q{}action-send' bSlot='13'/>
-                   <vc line='3340' op='eq' onEmpty='0' comp='CCC'>
+                   <callT line='3089' name='Q{}action-send' bSlot='14'/>
+                   <vc line='3091' op='eq' onEmpty='0' comp='CCC'>
                     <varRef name='Q{}action-name' slot='14'/>
                     <str val='message'/>
                    </vc>
-                   <callT line='3341' name='Q{}action-message' bSlot='14'/>
+                   <callT line='3092' name='Q{}action-message' bSlot='15'/>
                    <true/>
-                   <message line='3344'>
+                   <message line='3095'>
                     <sequence role='select'>
                      <valueOf>
                       <str val='[applyActions] action &#39;'/>
@@ -2918,8 +2210,8 @@
                     <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
                    </message>
                   </choose>
-                  <forEach line='3353'>
-                   <ifCall line='3349' name='Q{http://www.w3.org/2005/xpath-functions/array}flatten' type='item()*'>
+                  <forEach line='3104'>
+                   <ifCall line='3100' name='Q{http://www.w3.org/2005/xpath-functions/array}flatten' type='item()*'>
                     <treat as='array(map(*))' jsTest='function v(item) {return SaxonJS.U.isMap(item)};function c(n) {return n==1;};return SaxonJS.U.isArray(item) &amp;&amp; SaxonJS.U.ForArray(item.value).every(function(seq){return c(seq.length) &amp;&amp; SaxonJS.U.ForArray(seq).every(v)});' diag='3|0|XTTE0570|nested-actions-array'>
                      <check card='?' diag='3|0|XTTE0570|nested-actions-array'>
                       <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
@@ -2929,12 +2221,30 @@
                      </check>
                     </treat>
                    </ifCall>
-                   <callT line='3354' name='Q{}applyActions' bSlot='15'>
+                   <callT line='3105' name='Q{}applyActions' bSlot='16'>
                     <withParam name='Q{}action-map' flags='t' as='item()'>
-                     <dot line='3355'/>
+                     <dot line='3106'/>
                     </withParam>
                    </callT>
                   </forEach>
+                  <choose line='3110'>
+                   <vc op='eq' onEmpty='0' comp='CCC'>
+                    <treat line='2961' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|handler-status'>
+                     <check card='1' diag='3|0|XTTE0570|handler-status'>
+                      <cvUntyped to='xs:string' diag='3|0|XTTE0570|handler-status'>
+                       <data>
+                        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                         <varRef name='Q{}action-map' slot='0'/>
+                         <str val='handler-status'/>
+                        </ifCall>
+                       </data>
+                      </cvUntyped>
+                     </check>
+                    </treat>
+                    <str val='outermost'/>
+                   </vc>
+                   <callT line='3111' name='Q{}outermost-action-handler' bSlot='17' flags='t'/>
+                  </choose>
                  </sequence>
                 </let>
                </choose>
@@ -2954,9 +2264,9 @@
  </co>
  <co id='4' binds='4'>
   <mode name='Q{}insert-node' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='21' rank='0' minImp='0' slots='3' flags='s' line='1932' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='21' rank='0' minImp='0' slots='3' flags='s' line='1884' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1933'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1885'>
      <param name='Q{}insert-node-location' slot='0' flags='ti' as='node()'>
       <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|insert-node-location'>
        <check card='1' diag='8|0|XTTE0590|insert-node-location'>
@@ -2964,14 +2274,14 @@
        </check>
       </treat>
      </param>
-     <param line='1934' name='Q{}node-to-insert' slot='1' flags='ti' as='node()'>
+     <param line='1886' name='Q{}node-to-insert' slot='1' flags='ti' as='node()'>
       <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|node-to-insert'>
        <check card='1' diag='8|0|XTTE0590|node-to-insert'>
         <supplied slot='1'/>
        </check>
       </treat>
      </param>
-     <param line='1935' name='Q{}position-relative' slot='2' flags='t' as='xs:string?'>
+     <param line='1887' name='Q{}position-relative' slot='2' flags='t' as='xs:string?'>
       <str role='select' val='after'/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|position-relative'>
        <check card='?' diag='8|0|XTTE0590|position-relative'>
@@ -2983,7 +2293,7 @@
        </check>
       </treat>
      </param>
-     <choose line='1938'>
+     <choose line='1890'>
       <and op='and'>
        <is op='is'>
         <dot type='element()'/>
@@ -2994,16 +2304,16 @@
         <str val='before'/>
        </vc>
       </and>
-      <copyOf line='1940' flags='vc'>
+      <copyOf line='1892' flags='vc'>
        <varRef name='Q{}node-to-insert' slot='1'/>
       </copyOf>
      </choose>
-     <copy line='1943' flags='cin'>
+     <copy line='1895' flags='cin'>
       <sequence role='content'>
        <copyOf flags='vc'>
         <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
        </copyOf>
-       <choose line='1948'>
+       <choose line='1900'>
         <and op='and'>
          <is op='is'>
           <dot type='element()'/>
@@ -3014,16 +2324,16 @@
           <str val='child'/>
          </vc>
         </and>
-        <copyOf line='1949' flags='vc'>
+        <copyOf line='1901' flags='vc'>
          <varRef name='Q{}node-to-insert' slot='1'/>
         </copyOf>
        </choose>
-       <applyT line='1951' mode='Q{}insert-node' bSlot='0'>
+       <applyT line='1903' mode='Q{}insert-node' bSlot='0'>
         <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
        </applyT>
       </sequence>
      </copy>
-     <choose line='1953'>
+     <choose line='1905'>
       <and op='and'>
        <is op='is'>
         <dot type='element()'/>
@@ -3034,7 +2344,7 @@
         <str val='after'/>
        </vc>
       </and>
-      <copyOf line='1954' flags='vc'>
+      <copyOf line='1906' flags='vc'>
        <varRef name='Q{}node-to-insert' slot='1'/>
       </copyOf>
      </choose>
@@ -3042,11 +2352,11 @@
    </templateRule>
   </mode>
  </co>
- <co id='38' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}hasClass' line='2611' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:boolean' slots='2'>
+ <co id='36' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}hasClass' line='2330' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:boolean' slots='2'>
    <arg name='Q{}element' as='element()'/>
    <arg name='Q{}string' as='xs:string'/>
-   <gc role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2615' op='=' card='N:1' comp='CCC'>
+   <gc role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2334' op='=' card='N:1' comp='CCC'>
     <fn name='tokenize'>
      <cvUntyped to='xs:string' diag='3|0|XTTE0570|class'>
       <data>
@@ -3057,24 +2367,24 @@
       </data>
      </cvUntyped>
     </fn>
-    <varRef line='2618' name='Q{}string' slot='1'/>
+    <varRef line='2337' name='Q{}string' slot='1'/>
    </gc>
   </function>
  </co>
- <co id='39' binds=''>
-  <globalParam name='Q{}xforms-instance-id' type='xs:string' line='70' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
+ <co id='37' binds=''>
+  <globalParam name='Q{}xforms-instance-id' type='xs:string' line='72' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
    <str val='xforms-jinstance'/>
   </globalParam>
  </co>
- <co id='40' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}getIfStatement' line='795' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
+ <co id='38' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}getIfStatement' line='737' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
    <arg name='Q{}map' as='map(*)'/>
-   <choose role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='798'>
+   <choose role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='740'>
     <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
      <varRef name='Q{}map' slot='0'/>
      <str val='@if'/>
     </ifCall>
-    <treat line='799' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
+    <treat line='741' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
      <check card='?' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
       <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getIfStatement#1'>
        <data>
@@ -3089,18 +2399,18 @@
    </choose>
   </function>
  </co>
- <co id='41' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}getClass' line='2632' module='saxon-xforms.xsl' eval='7' flags='pU' as='attribute(Q{}class)?' slots='3'>
+ <co id='39' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}getClass' line='2351' module='saxon-xforms.xsl' eval='7' flags='pU' as='attribute(Q{}class)?' slots='3'>
    <arg name='Q{}element' as='element()'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2635' var='Q{}class' as='xs:string?' slot='1' eval='7'>
-    <choose line='2636'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2354' var='Q{}class' as='xs:string?' slot='1' eval='7'>
+    <choose line='2355'>
      <fn name='exists'>
       <slash simple='1'>
        <varRef name='Q{}element' slot='0'/>
        <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
       </slash>
      </fn>
-     <cvUntyped line='2637' to='xs:string' diag='3|0|XTTE0570|class'>
+     <cvUntyped line='2356' to='xs:string' diag='3|0|XTTE0570|class'>
       <cast as='xs:untypedAtomic' emptiable='0'>
        <fn name='string'>
         <convert from='xs:untypedAtomic' to='xs:string'>
@@ -3115,15 +2425,15 @@
       </cast>
      </cvUntyped>
     </choose>
-    <let line='2640' var='Q{}class-mod' as='xs:string?' slot='2' eval='7'>
-     <choose line='2642'>
+    <let line='2359' var='Q{}class-mod' as='xs:string?' slot='2' eval='7'>
+     <choose line='2361'>
       <fn name='exists'>
        <slash simple='1'>
         <varRef name='Q{}element' slot='0'/>
         <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
        </slash>
       </fn>
-      <cvUntyped line='2643' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+      <cvUntyped line='2362' to='xs:string' diag='3|0|XTTE0570|class-mod'>
        <cast as='xs:untypedAtomic' emptiable='0'>
         <fn name='string-join'>
          <sequence>
@@ -3135,13 +2445,13 @@
        </cast>
       </cvUntyped>
       <true/>
-      <varRef line='2646' name='Q{}class' slot='1'/>
+      <varRef line='2365' name='Q{}class' slot='1'/>
      </choose>
-     <choose line='2650'>
+     <choose line='2369'>
       <fn name='exists'>
        <varRef name='Q{}class-mod' slot='2'/>
       </fn>
-      <treat line='2651' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+      <treat line='2370' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
        <att name='class'>
         <varRef name='Q{}class-mod' slot='2'/>
        </att>
@@ -3151,9 +2461,9 @@
    </let>
   </function>
  </co>
- <co id='42' binds='2 23 43 44'>
-  <template name='Q{}refreshRepeats-JS' flags='os' line='3082' module='saxon-xforms.xsl' slots='8'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3084'>
+ <co id='40' binds='2 18 41 42'>
+  <template name='Q{}refreshRepeats-JS' flags='os' line='2801' module='saxon-xforms.xsl' slots='8'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2803'>
     <message>
      <valueOf role='select'>
       <str val='[refreshRepeats-JS] START refreshRepeats'/>
@@ -3161,7 +2471,7 @@
      <str role='terminate' val='no'/>
      <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
     </message>
-    <let line='3087' var='Q{}repeat-keys' as='item()?' slot='0' eval='8'>
+    <let line='2806' var='Q{}repeat-keys' as='item()?' slot='0' eval='8'>
      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
       <check card='1' diag='0|0||ixsl:call'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -3169,9 +2479,9 @@
       <str val='getRepeatKeys'/>
       <array size='0'/>
      </ifCall>
-     <forEach line='3089'>
+     <forEach line='2808'>
       <varRef name='Q{}repeat-keys' slot='0'/>
-      <let line='3090' var='Q{}this-key' as='xs:string' slot='1' eval='16'>
+      <let line='2809' var='Q{}this-key' as='xs:string' slot='1' eval='16'>
        <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|this-key'>
         <check card='1' diag='3|0|XTTE0570|this-key'>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|this-key'>
@@ -3181,7 +2491,7 @@
          </cvUntyped>
         </check>
        </treat>
-       <let line='3091' var='Q{}this-repeat-nodeset' as='xs:string' slot='2' eval='16'>
+       <let line='2810' var='Q{}this-repeat-nodeset' as='xs:string' slot='2' eval='16'>
         <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|this-repeat-nodeset'>
          <check card='1' diag='3|0|XTTE0570|this-repeat-nodeset'>
           <cvUntyped to='xs:string' diag='3|0|XTTE0570|this-repeat-nodeset'>
@@ -3199,7 +2509,7 @@
           </cvUntyped>
          </check>
         </treat>
-        <sequence line='3093'>
+        <sequence line='2812'>
          <message>
           <sequence role='select'>
            <valueOf>
@@ -3213,9 +2523,9 @@
           <str role='terminate' val='no'/>
           <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
          </message>
-         <let line='3104' var='Q{}contexti' as='element()?' slot='3' eval='7'>
-          <ufCall line='3105' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='0' eval='16'>
-           <check line='3097' card='1' diag='3|0|XTTE0570|this-instance-id'>
+         <let line='2823' var='Q{}contexti' as='element()?' slot='3' eval='7'>
+          <ufCall line='2824' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='0' eval='16'>
+           <check line='2816' card='1' diag='3|0|XTTE0570|this-instance-id'>
             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
              <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='1' eval='6'>
               <varRef name='Q{}this-repeat-nodeset' slot='2'/>
@@ -3224,7 +2534,7 @@
             </ifCall>
            </check>
           </ufCall>
-          <let line='3112' var='Q{}namespace-context-item' as='element()' slot='4' eval='16'>
+          <let line='2831' var='Q{}namespace-context-item' as='element()' slot='4' eval='16'>
            <choose>
             <fn name='exists'>
              <varRef name='Q{}contexti' slot='3'/>
@@ -3245,7 +2555,7 @@
              </check>
             </treat>
            </choose>
-           <let line='3114' var='Q{}page-element' as='element()?' slot='5' eval='7'>
+           <let line='2833' var='Q{}page-element' as='element()?' slot='5' eval='7'>
             <check card='?' diag='3|0|XTTE0570|page-element'>
              <filter flags='b'>
               <slash simple='1'>
@@ -3260,11 +2570,11 @@
               </vc>
              </filter>
             </check>
-            <choose line='3117'>
+            <choose line='2836'>
              <fn name='exists'>
               <varRef name='Q{}page-element' slot='5'/>
              </fn>
-             <let line='3118' var='Q{}instance-keys' as='item()?' slot='6' eval='8'>
+             <let line='2837' var='Q{}instance-keys' as='item()?' slot='6' eval='8'>
               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                <check card='1' diag='0|0||ixsl:call'>
                 <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -3272,12 +2582,12 @@
                <str val='getInstanceKeys'/>
                <array size='0'/>
               </ifCall>
-              <let line='3119' var='Q{}instances' as='map(xs:string, element())' slot='7' eval='16'>
-               <treat line='3121' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances'>
+              <let line='2838' var='Q{}instances' as='map(xs:string, element())' slot='7' eval='16'>
+               <treat line='2840' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances'>
                 <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
                  <forEach>
                   <varRef name='Q{}instance-keys' slot='6'/>
-                  <ifCall line='3122' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                  <ifCall line='2841' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                    <atomSing diag='0|0||map:entry'>
                     <dot/>
                    </atomSing>
@@ -3300,12 +2610,12 @@
                  </map>
                 </ifCall>
                </treat>
-               <resultDoc line='3126' global='#&#xD;&#xA;#Sat Apr 04 13:28:45 BST 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Sat Apr 04 13:28:45 BST 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
+               <resultDoc line='2845' global='#&#xD;&#xA;#Sun Apr 05 16:19:18 BST 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Sun Apr 05 16:19:18 BST 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
                 <fn role='href' name='concat'>
                  <str val='#'/>
                  <varRef name='Q{}this-key' slot='1'/>
                 </fn>
-                <applyT role='content' line='3127' bSlot='2'>
+                <applyT role='content' line='2846' bSlot='2'>
                  <filter role='select' flags='b'>
                   <slash simple='1'>
                    <treat as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='1|0|XPTY0019|/'>
@@ -3334,7 +2644,7 @@
                   <true/>
                  </withParam>
                  <withParam name='Q{}instances' flags='t' as='map(xs:string, element())'>
-                  <varRef line='3128' name='Q{}instances' slot='7'/>
+                  <varRef line='2847' name='Q{}instances' slot='7'/>
                  </withParam>
                 </applyT>
                </resultDoc>
@@ -3352,9 +2662,9 @@
    </sequence>
   </template>
  </co>
- <co id='35' binds='3 2 23 23'>
-  <template name='Q{}refreshOutputs-JS' flags='os' line='3003' module='saxon-xforms.xsl' slots='8'>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3010' var='Q{}output-keys' as='item()?' slot='0' eval='8'>
+ <co id='43' binds='3 2 18 18'>
+  <template name='Q{}refreshOutputs-JS' flags='os' line='2722' module='saxon-xforms.xsl' slots='8'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2729' var='Q{}output-keys' as='item()?' slot='0' eval='8'>
     <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
      <check card='1' diag='0|0||ixsl:call'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -3362,9 +2672,9 @@
      <str val='getOutputKeys'/>
      <array size='0'/>
     </ifCall>
-    <forEach line='3012'>
+    <forEach line='2731'>
      <varRef name='Q{}output-keys' slot='0'/>
-     <let line='3013' var='Q{}this-key' as='xs:string' slot='1' eval='16'>
+     <let line='2732' var='Q{}this-key' as='xs:string' slot='1' eval='16'>
       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|this-key'>
        <check card='1' diag='3|0|XTTE0570|this-key'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|this-key'>
@@ -3374,7 +2684,7 @@
         </cvUntyped>
        </check>
       </treat>
-      <let line='3014' var='Q{}this-output' as='map(*)' slot='2' eval='16'>
+      <let line='2733' var='Q{}this-output' as='map(*)' slot='2' eval='16'>
        <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|this-output'>
         <check card='1' diag='3|0|XTTE0570|this-output'>
          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
@@ -3388,7 +2698,7 @@
          </ifCall>
         </check>
        </treat>
-       <sequence line='3016'>
+       <sequence line='2735'>
         <message>
          <sequence role='select'>
           <valueOf>
@@ -3402,14 +2712,14 @@
          <str role='terminate' val='no'/>
          <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
         </message>
-        <let line='3033' var='Q{}xpath-mod' as='xs:string' slot='3' eval='16'>
+        <let line='2752' var='Q{}xpath-mod' as='xs:string' slot='3' eval='16'>
          <ufCall name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='0' eval='16'>
-          <choose line='3021'>
+          <choose line='2740'>
            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
             <varRef name='Q{}this-output' slot='2'/>
             <str val='@value'/>
            </ifCall>
-           <treat line='3022' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|xpath'>
+           <treat line='2741' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|xpath'>
             <check card='1' diag='3|0|XTTE0570|xpath'>
              <cvUntyped to='xs:string' diag='3|0|XTTE0570|xpath'>
               <data>
@@ -3421,11 +2731,11 @@
              </cvUntyped>
             </check>
            </treat>
-           <ifCall line='3024' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+           <ifCall line='2743' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
             <varRef name='Q{}this-output' slot='2'/>
             <str val='@ref'/>
            </ifCall>
-           <treat line='3025' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|xpath'>
+           <treat line='2744' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|xpath'>
             <check card='1' diag='3|0|XTTE0570|xpath'>
              <cvUntyped to='xs:string' diag='3|0|XTTE0570|xpath'>
               <data>
@@ -3441,7 +2751,7 @@
            <str val=''/>
           </choose>
          </ufCall>
-         <sequence line='3035'>
+         <sequence line='2754'>
           <message>
            <sequence role='select'>
             <valueOf>
@@ -3455,21 +2765,21 @@
            <str role='terminate' val='no'/>
            <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
           </message>
-          <let line='3051' var='Q{}contexti' as='element()?' slot='4' eval='7'>
-           <ufCall line='3052' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='16'>
-            <check line='3039' card='1' diag='3|0|XTTE0570|this-instance-id'>
+          <let line='2770' var='Q{}contexti' as='element()?' slot='4' eval='7'>
+           <ufCall line='2771' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='16'>
+            <check line='2758' card='1' diag='3|0|XTTE0570|this-instance-id'>
              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
               <choose>
                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
                 <varRef name='Q{}this-output' slot='2'/>
                 <str val='@ref'/>
                </ifCall>
-               <ufCall line='3041' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='2' eval='16'>
+               <ufCall line='2760' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='2' eval='16'>
                 <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:getInstanceMap'>
                  <check card='1' diag='0|0||xforms:getInstanceMap'>
                   <cvUntyped to='xs:string'>
                    <data>
-                    <ifCall line='3040' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                    <ifCall line='2759' name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
                      <varRef name='Q{}this-output' slot='2'/>
                      <str val='@ref'/>
                     </ifCall>
@@ -3479,7 +2789,7 @@
                 </treat>
                </ufCall>
                <true/>
-               <ufCall line='3044' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='3' eval='0'>
+               <ufCall line='2763' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='3' eval='0'>
                 <str val='saxon-forms-default'/>
                </ufCall>
               </choose>
@@ -3487,7 +2797,7 @@
              </ifCall>
             </check>
            </ufCall>
-           <let line='3059' var='Q{}namespace-context-item' as='element()' slot='5' eval='16'>
+           <let line='2778' var='Q{}namespace-context-item' as='element()' slot='5' eval='16'>
             <choose>
              <fn name='exists'>
               <varRef name='Q{}contexti' slot='4'/>
@@ -3508,8 +2818,8 @@
               </check>
              </treat>
             </choose>
-            <let line='3061' var='Q{}value' as='xs:string?' slot='6' eval='7'>
-             <treat line='3062' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|value'>
+            <let line='2780' var='Q{}value' as='xs:string?' slot='6' eval='7'>
+             <treat line='2781' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|value'>
               <check card='?' diag='3|0|XTTE0570|value'>
                <cvUntyped to='xs:string' diag='3|0|XTTE0570|value'>
                 <data>
@@ -3525,7 +2835,7 @@
                </cvUntyped>
               </check>
              </treat>
-             <let line='3065' var='Q{}associated-form-control' as='element()?' slot='7' eval='7'>
+             <let line='2784' var='Q{}associated-form-control' as='element()?' slot='7' eval='7'>
               <check card='?' diag='3|0|XTTE0570|associated-form-control'>
                <filter flags='b'>
                 <slash simple='1'>
@@ -3540,16 +2850,16 @@
                 </vc>
                </filter>
               </check>
-              <choose line='3068'>
+              <choose line='2787'>
                <fn name='exists'>
                 <varRef name='Q{}associated-form-control' slot='7'/>
                </fn>
-               <resultDoc line='3069' global='#&#xD;&#xA;#Sat Apr 04 13:28:45 BST 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Sat Apr 04 13:28:45 BST 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
+               <resultDoc line='2788' global='#&#xD;&#xA;#Sun Apr 05 16:19:18 BST 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Sun Apr 05 16:19:18 BST 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
                 <fn role='href' name='concat'>
                  <str val='#'/>
                  <varRef name='Q{}this-key' slot='1'/>
                 </fn>
-                <valueOf role='content' line='3070'>
+                <valueOf role='content' line='2789'>
                  <varRef name='Q{}value' slot='6'/>
                 </valueOf>
                </resultDoc>
@@ -3567,9 +2877,9 @@
    </let>
   </template>
  </co>
- <co id='31' binds=''>
-  <template name='Q{}xforms-focus' flags='os' line='3813' module='saxon-xforms.xsl' slots='5'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3814'>
+ <co id='30' binds=''>
+  <template name='Q{}xforms-focus' flags='os' line='3538' module='saxon-xforms.xsl' slots='5'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3539'>
     <param name='Q{}control' slot='0' flags='i' as='xs:string'>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|control'>
       <check card='1' diag='8|0|XTTE0590|control'>
@@ -3581,7 +2891,7 @@
       </check>
      </treat>
     </param>
-    <let line='3815' var='Q{}xforms-control' as='element()' slot='1' eval='16'>
+    <let line='3541' var='Q{}xforms-control' as='element()' slot='1' eval='16'>
      <check card='1' diag='3|0|XTTE0570|xforms-control'>
       <filter flags='b'>
        <slash simple='1'>
@@ -3604,19 +2914,19 @@
        </vc>
       </filter>
      </check>
-     <choose line='3820'>
+     <choose line='3546'>
       <fn name='exists'>
        <slash simple='1'>
         <varRef name='Q{}xforms-control' slot='1'/>
         <axis name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
        </slash>
       </fn>
-      <let line='3824' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='2' eval='13'>
+      <let line='3550' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='2' eval='13'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
        </check>
-       <let line='3821' var='Q{}context-indexes' as='xs:double*' slot='3' eval='8'>
-        <convert line='3822' from='xs:anyAtomicType' to='xs:double' flags='p' diag='3|0|XTTE0570|context-indexes'>
+       <let line='3547' var='Q{}context-indexes' as='xs:double*' slot='3' eval='8'>
+        <convert line='3548' from='xs:anyAtomicType' to='xs:double' flags='p' diag='3|0|XTTE0570|context-indexes'>
          <cvUntyped to='xs:double' diag='3|0|XTTE0570|context-indexes'>
           <data>
            <forEach>
@@ -3627,7 +2937,7 @@
                <axis name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
               </fn>
              </slash>
-             <sortKey line='3823' comp='DESC|NC11'>
+             <sortKey line='3549' comp='DESC|NC11'>
               <fn role='select' name='position'/>
               <str role='order' val='descending'/>
               <str role='dataType' val='number'/>
@@ -3637,7 +2947,7 @@
               <str role='collation' val='http://www.w3.org/2005/xpath-functions/collation/codepoint'/>
              </sortKey>
             </sort>
-            <ifCall line='3824' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+            <ifCall line='3550' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
              <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='2'/>
              <str val='getRepeatIndex'/>
              <arrayBlock>
@@ -3650,12 +2960,12 @@
           </data>
          </cvUntyped>
         </convert>
-        <let line='3828' var='Q{}control-index' as='xs:string' slot='4' eval='8'>
+        <let line='3554' var='Q{}control-index' as='xs:string' slot='4' eval='8'>
          <fn name='string-join'>
           <varRef name='Q{}context-indexes' slot='3'/>
           <str val='.'/>
          </fn>
-         <sequence line='3829'>
+         <sequence line='3555'>
           <message>
            <sequence role='select'>
             <valueOf>
@@ -3673,7 +2983,7 @@
            <str role='terminate' val='no'/>
            <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
           </message>
-          <ifCall line='3830' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+          <ifCall line='3556' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
            <check card='1' diag='0|0||ixsl:call'>
             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
            </check>
@@ -3691,7 +3001,7 @@
        </let>
       </let>
       <true/>
-      <ifCall line='3833' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+      <ifCall line='3559' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
        </check>
@@ -3705,272 +3015,12 @@
    </sequence>
   </template>
  </co>
- <co id='21' binds='34'>
-  <function name='Q{http://www.w3.org/2002/xforms}checkRelevantFields' line='638' module='saxon-xforms.xsl' eval='8' flags='pU' as='item()*' slots='13'>
-   <arg name='Q{}refElement' as='xs:string'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='641' var='Q{}pendingUpdatesi' as='map(xs:string, xs:string)?' slot='1' eval='7'>
-    <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|pendingUpdatesi'>
-     <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-      <check card='1' diag='0|0||ixsl:call'>
-       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-      </check>
-      <str val='getPendingUpdates'/>
-      <array size='0'/>
-     </ifCall>
-    </treat>
-    <let line='644' var='Q{}updatesi' as='map(xs:string, xs:string)?' slot='2' eval='7'>
-     <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|updatesi'>
-      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-       <check card='1' diag='0|0||ixsl:call'>
-        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-       </check>
-       <str val='getUpdates'/>
-       <array size='0'/>
-      </ifCall>
-     </treat>
-     <let line='647' var='Q{}relevantMap' as='map(xs:string, xs:string)' slot='3' eval='16'>
-      <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|relevantMap'>
-       <check card='1' diag='3|0|XTTE0570|relevantMap'>
-        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-         <check card='1' diag='0|0||ixsl:call'>
-          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-         </check>
-         <str val='getRelevantMap'/>
-         <array size='0'/>
-        </ifCall>
-       </check>
-      </treat>
-      <let line='648' var='Q{}mapKeys' as='xs:anyAtomicType*' slot='4' eval='4'>
-       <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
-        <varRef name='Q{}relevantMap' slot='3'/>
-       </ifCall>
-       <sequence line='678'>
-        <forEach>
-         <sequence line='651'>
-          <forEach>
-           <varRef name='Q{}mapKeys' slot='4'/>
-           <choose line='652'>
-            <fn name='matches'>
-             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-              <varRef name='Q{}relevantMap' slot='3'/>
-              <dot type='xs:anyAtomicType'/>
-             </ifCall>
-             <varRef name='Q{}refElement' slot='0'/>
-             <str val=''/>
-            </fn>
-            <dot line='653' type='xs:anyAtomicType'/>
-           </choose>
-          </forEach>
-          <forEach line='642'>
-           <choose>
-            <fn name='exists'>
-             <varRef name='Q{}pendingUpdatesi' slot='1'/>
-            </fn>
-            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
-             <check card='1' diag='0|0||map:keys'>
-              <varRef name='Q{}pendingUpdatesi' slot='1'/>
-             </check>
-            </ifCall>
-           </choose>
-           <let line='659' var='Q{}keyi' as='xs:string?' slot='5' eval='7'>
-            <lastOf>
-             <fn name='tokenize'>
-              <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||fn:tokenize'>
-               <cvUntyped to='xs:string'>
-                <dot type='xs:anyAtomicType'/>
-               </cvUntyped>
-              </treat>
-              <str val='/'/>
-              <str val=''/>
-             </fn>
-            </lastOf>
-            <let line='661' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:string' slot='6' eval='13'>
-             <check card='1' diag='0|1||fn:matches'>
-              <varRef name='Q{}keyi' slot='5'/>
-             </check>
-             <forEach line='660'>
-              <varRef name='Q{}mapKeys' slot='4'/>
-              <choose line='661'>
-               <fn name='matches'>
-                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                 <varRef name='Q{}relevantMap' slot='3'/>
-                 <dot type='xs:anyAtomicType'/>
-                </ifCall>
-                <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='6'/>
-                <str val=''/>
-               </fn>
-               <dot line='662' type='xs:anyAtomicType'/>
-              </choose>
-             </forEach>
-            </let>
-           </let>
-          </forEach>
-          <forEach line='645'>
-           <choose>
-            <fn name='exists'>
-             <varRef name='Q{}updatesi' slot='2'/>
-            </fn>
-            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
-             <check card='1' diag='0|0||map:keys'>
-              <varRef name='Q{}updatesi' slot='2'/>
-             </check>
-            </ifCall>
-           </choose>
-           <let line='668' var='Q{}keyi' as='xs:string?' slot='7' eval='7'>
-            <lastOf>
-             <fn name='tokenize'>
-              <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||fn:tokenize'>
-               <cvUntyped to='xs:string'>
-                <dot type='xs:anyAtomicType'/>
-               </cvUntyped>
-              </treat>
-              <str val='/'/>
-              <str val=''/>
-             </fn>
-            </lastOf>
-            <let line='670' var='Q{http://saxon.sf.net/generated-variable}v1' as='xs:string' slot='8' eval='13'>
-             <check card='1' diag='0|1||fn:matches'>
-              <varRef name='Q{}keyi' slot='7'/>
-             </check>
-             <forEach line='669'>
-              <varRef name='Q{}mapKeys' slot='4'/>
-              <choose line='670'>
-               <fn name='matches'>
-                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                 <varRef name='Q{}relevantMap' slot='3'/>
-                 <dot type='xs:anyAtomicType'/>
-                </ifCall>
-                <varRef name='Q{http://saxon.sf.net/generated-variable}v1' slot='8'/>
-                <str val=''/>
-               </fn>
-               <dot line='671' type='xs:anyAtomicType'/>
-              </choose>
-             </forEach>
-            </let>
-           </let>
-          </forEach>
-         </sequence>
-         <let line='679' var='Q{}keyi' as='xs:anyAtomicType' slot='9' eval='16'>
-          <dot type='xs:anyAtomicType'/>
-          <let line='680' var='Q{}context' as='element()*' slot='10' eval='8'>
-           <filter flags='b'>
-            <slash simple='1'>
-             <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
-             <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-            </slash>
-            <gc op='=' card='1:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
-             <attVal name='Q{}data-ref' chk='0'/>
-             <varRef name='Q{}keyi' slot='9'/>
-            </gc>
-           </filter>
-           <let line='681' var='Q{}updatedInstanceXML4' as='element()?' slot='11' eval='7'>
-            <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='0' eval='16'>
-             <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:getInstance-JS'>
-              <cvUntyped to='xs:string'>
-               <varRef name='Q{}keyi' slot='9'/>
-              </cvUntyped>
-             </treat>
-            </ufCall>
-            <let line='683' var='Q{}relevantCheck' as='xs:boolean' slot='12' eval='16'>
-             <treat line='684' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantCheck'>
-              <check card='1' diag='3|0|XTTE0570|relevantCheck'>
-               <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|relevantCheck'>
-                <data>
-                 <evaluate dxns=''>
-                  <fn role='xpath' name='concat'>
-                   <dot type='xs:anyAtomicType'/>
-                   <str val='/'/>
-                   <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                    <varRef name='Q{}relevantMap' slot='3'/>
-                    <dot type='xs:anyAtomicType'/>
-                   </ifCall>
-                  </fn>
-                  <varRef role='cxt' name='Q{}updatedInstanceXML4' slot='11'/>
-                  <check role='nsCxt' card='1' diag='4|0|XTTE3170|xsl:evaluate/namespace-context'>
-                   <varRef name='Q{}updatedInstanceXML4' slot='11'/>
-                  </check>
-                  <str role='sa' val='no'/>
-                  <map role='options' size='0'/>
-                  <map role='wp' size='0'/>
-                 </evaluate>
-                </data>
-               </cvUntyped>
-              </check>
-             </treat>
-             <choose line='687'>
-              <varRef name='Q{}relevantCheck' slot='12'/>
-              <ifCall line='690' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
-               <str val='style.display'/>
-               <str val='inline'/>
-               <check card='1' diag='0|2||ixsl:set-property'>
-                <conditionalSort>
-                 <fn name='exists'>
-                  <tail start='2'>
-                   <varRef name='Q{}context' slot='10'/>
-                  </tail>
-                 </fn>
-                 <docOrder intra='1'>
-                  <slash simple='2'>
-                   <varRef name='Q{}context' slot='10'/>
-                   <axis name='parent' nodeTest='(element()|document-node())' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11||item.nodeType===1);'/>
-                  </slash>
-                 </docOrder>
-                </conditionalSort>
-               </check>
-              </ifCall>
-              <true/>
-              <ifCall line='693' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
-               <str val='style.display'/>
-               <str val='none'/>
-               <check card='1' diag='0|2||ixsl:set-property'>
-                <conditionalSort>
-                 <fn name='exists'>
-                  <tail start='2'>
-                   <varRef name='Q{}context' slot='10'/>
-                  </tail>
-                 </fn>
-                 <docOrder intra='1'>
-                  <slash simple='2'>
-                   <varRef name='Q{}context' slot='10'/>
-                   <axis name='parent' nodeTest='(element()|document-node())' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11||item.nodeType===1);'/>
-                  </slash>
-                 </docOrder>
-                </conditionalSort>
-               </check>
-              </ifCall>
-             </choose>
-            </let>
-           </let>
-          </let>
-         </let>
-        </forEach>
-        <ifCall line='698' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-         <check card='1' diag='0|0||ixsl:call'>
-          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-         </check>
-         <str val='clearPendingUpdates'/>
-         <array size='0'/>
-        </ifCall>
-        <ifCall line='699' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-         <check card='1' diag='0|0||ixsl:call'>
-          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-         </check>
-         <str val='clearUpdates'/>
-         <array size='0'/>
-        </ifCall>
-       </sequence>
-      </let>
-     </let>
-    </let>
-   </let>
-  </function>
- </co>
- <co id='45' binds=''>
-  <globalParam name='Q{}xform-html-id' type='xs:string' line='74' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
+ <co id='44' binds=''>
+  <globalParam name='Q{}xform-html-id' type='xs:string' line='76' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
    <str val='xForm'/>
   </globalParam>
  </co>
- <co id='46' binds=''>
+ <co id='45' binds=''>
   <function name='Q{http://www.w3.org/2002/xforms}random' line='109' module='xforms-function-library.xsl' eval='16' flags='pU' as='xs:double' slots='0'>
    <check role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='110' card='1' diag='3|0|XTTE0570|randomNumber'>
     <convert from='xs:anyAtomicType' to='xs:double' flags='p' diag='3|0|XTTE0570|randomNumber'>
@@ -3989,13 +3039,13 @@
    </check>
   </function>
  </co>
- <co id='7' binds='1 2 3 3 19 35 42 47'>
-  <template name='Q{}xforms-recalculate' flags='os' line='3665' module='saxon-xforms.xsl' slots='11'>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3718' var='Q{http://saxon.sf.net/generated-variable}v1' as='item()' slot='0' eval='13'>
+ <co id='13' binds='1 2 3 3 33'>
+  <template name='Q{}xforms-recalculate' flags='os' line='3431' module='saxon-xforms.xsl' slots='11'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3484' var='Q{http://saxon.sf.net/generated-variable}v1' as='item()' slot='0' eval='13'>
     <check card='1' diag='0|0||ixsl:call'>
      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
     </check>
-    <sequence line='3666'>
+    <sequence line='3432'>
      <message>
       <valueOf role='select'>
        <str val='[xforms-recalculate] START'/>
@@ -4003,7 +3053,7 @@
       <str role='terminate' val='no'/>
       <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
      </message>
-     <let line='3667' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
+     <let line='3433' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -4011,7 +3061,7 @@
        <str val='getInstanceKeys'/>
        <array size='0'/>
       </ifCall>
-      <let line='3668' var='Q{}calculationMap' as='map(xs:string, xs:string)' slot='2' eval='16'>
+      <let line='3434' var='Q{}calculationMap' as='map(xs:string, xs:string)' slot='2' eval='16'>
        <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|calculationMap'>
         <check card='1' diag='3|0|XTTE0570|calculationMap'>
          <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
@@ -4023,8 +3073,8 @@
          </ifCall>
         </check>
        </treat>
-       <let line='3670' var='Q{}instances-with-calculations' as='map(xs:string, map(*)*)' slot='3' eval='16'>
-        <treat line='3672' as='map(xs:string, map(*)*)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isMap(item)};function c() {return true;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances-with-calculations'>
+       <let line='3436' var='Q{}instances-with-calculations' as='map(xs:string, map(*)*)' slot='3' eval='16'>
+        <treat line='3438' as='map(xs:string, map(*)*)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isMap(item)};function c() {return true;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances-with-calculations'>
          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
           <forEachGroup algorithm='by'>
            <ifCall role='select' name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
@@ -4038,13 +3088,13 @@
             </treat>
            </ufCall>
            <str role='collation' val='http://www.w3.org/2005/xpath-functions/collation/codepoint'/>
-           <ifCall role='content' line='3673' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall role='content' line='3439' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <check card='1' diag='0|0||map:entry'>
              <currentGroupingKey/>
             </check>
-            <forEach line='3674'>
+            <forEach line='3440'>
              <currentGroup/>
-             <ifCall line='3676' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+             <ifCall line='3442' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
               <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                <dot type='xs:anyAtomicType'/>
                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
@@ -4070,128 +3120,123 @@
           </map>
          </ifCall>
         </treat>
-        <sequence line='3684'>
-         <forEach>
-          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
-           <varRef name='Q{}instances-with-calculations' slot='3'/>
-          </ifCall>
-          <let line='3685' var='Q{}instanceXML' as='element()' slot='4' eval='16'>
-           <check card='1' diag='3|0|XTTE0570|instanceXML'>
-            <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='16'>
-             <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:instance'>
-              <cvUntyped to='xs:string'>
-               <dot type='xs:anyAtomicType'/>
-              </cvUntyped>
-             </treat>
-            </ufCall>
-           </check>
-           <let line='3687' var='Q{}calculations' as='map(xs:string, xs:string)*' slot='5' eval='4'>
-            <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|calculations'>
-             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-              <varRef name='Q{}instances-with-calculations' slot='3'/>
+        <forEach line='3450'>
+         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
+          <varRef name='Q{}instances-with-calculations' slot='3'/>
+         </ifCall>
+         <let line='3451' var='Q{}instanceXML' as='element()' slot='4' eval='16'>
+          <check card='1' diag='3|0|XTTE0570|instanceXML'>
+           <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='16'>
+            <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:instance'>
+             <cvUntyped to='xs:string'>
               <dot type='xs:anyAtomicType'/>
-             </ifCall>
+             </cvUntyped>
             </treat>
-            <let line='3701' var='Q{http://saxon.sf.net/generated-variable}v0' as='map(xs:string, xs:string)' slot='6' eval='13'>
-             <check card='1' diag='0|0||map:get'>
-              <varRef name='Q{}calculations' slot='5'/>
-             </check>
-             <let line='3690' var='Q{}calculated-nodes' as='node()*' slot='7' eval='8'>
-              <treat line='3691' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|calculated-nodes'>
-               <forEach>
-                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
-                 <check card='1' diag='0|0||map:keys'>
-                  <varRef name='Q{}calculations' slot='5'/>
-                 </check>
-                </ifCall>
-                <evaluate line='3692' dxns=''>
-                 <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
-                  <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:impose'>
-                   <cvUntyped to='xs:string'>
-                    <dot type='xs:anyAtomicType'/>
-                   </cvUntyped>
-                  </treat>
-                 </ufCall>
-                 <varRef role='cxt' name='Q{}instanceXML' slot='4'/>
-                 <varRef role='nsCxt' name='Q{}instanceXML' slot='4'/>
-                 <str role='sa' val='no'/>
-                 <map role='options' size='0'/>
-                 <map role='wp' size='0'/>
-                </evaluate>
-               </forEach>
-              </treat>
-              <let line='3697' var='Q{}calculated-values' as='xs:string*' slot='8' eval='8'>
-               <forEach line='3698'>
-                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
-                 <check card='1' diag='0|0||map:keys'>
-                  <varRef name='Q{}calculations' slot='5'/>
-                 </check>
-                </ifCall>
-                <let line='3700' var='Q{}value' as='xs:string?' slot='9' eval='7'>
-                 <treat line='3701' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|value'>
-                  <check card='?' diag='3|0|XTTE0570|value'>
-                   <cvUntyped to='xs:string' diag='3|0|XTTE0570|value'>
-                    <data>
-                     <evaluate dxns=''>
-                      <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='3' eval='16'>
-                       <check card='1' diag='0|0||xforms:impose'>
-                        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                         <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='6'/>
-                         <dot type='xs:anyAtomicType'/>
-                        </ifCall>
-                       </check>
-                      </ufCall>
-                      <varRef role='cxt' name='Q{}instanceXML' slot='4'/>
-                      <varRef role='nsCxt' name='Q{}instanceXML' slot='4'/>
-                      <str role='sa' val='no'/>
-                      <map role='options' size='0'/>
-                      <map role='wp' size='0'/>
-                     </evaluate>
-                    </data>
-                   </cvUntyped>
-                  </check>
+           </ufCall>
+          </check>
+          <let line='3453' var='Q{}calculations' as='map(xs:string, xs:string)*' slot='5' eval='4'>
+           <treat as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|calculations'>
+            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+             <varRef name='Q{}instances-with-calculations' slot='3'/>
+             <dot type='xs:anyAtomicType'/>
+            </ifCall>
+           </treat>
+           <let line='3467' var='Q{http://saxon.sf.net/generated-variable}v0' as='map(xs:string, xs:string)' slot='6' eval='13'>
+            <check card='1' diag='0|0||map:get'>
+             <varRef name='Q{}calculations' slot='5'/>
+            </check>
+            <let line='3456' var='Q{}calculated-nodes' as='node()*' slot='7' eval='8'>
+             <treat line='3457' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|calculated-nodes'>
+              <forEach>
+               <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
+                <check card='1' diag='0|0||map:keys'>
+                 <varRef name='Q{}calculations' slot='5'/>
+                </check>
+               </ifCall>
+               <evaluate line='3458' dxns=''>
+                <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
+                 <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:impose'>
+                  <cvUntyped to='xs:string'>
+                   <dot type='xs:anyAtomicType'/>
+                  </cvUntyped>
                  </treat>
-                 <first line='3707'>
-                  <sequence>
-                   <varRef name='Q{}value' slot='9'/>
-                   <str val=''/>
-                  </sequence>
-                 </first>
-                </let>
-               </forEach>
-               <let line='3711' var='Q{}updatedInstanceXML' as='element()' slot='10' eval='16'>
-                <treat line='3712' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
-                 <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
-                  <applyT mode='Q{}recalculate' bSlot='4'>
-                   <varRef role='select' name='Q{}instanceXML' slot='4'/>
-                   <withParam name='Q{}updated-nodes' flags='t' as='node()*'>
-                    <varRef line='3713' name='Q{}calculated-nodes' slot='7'/>
-                   </withParam>
-                   <withParam name='Q{}updated-values' flags='t' as='xs:string*'>
-                    <varRef line='3714' name='Q{}calculated-values' slot='8'/>
-                   </withParam>
-                  </applyT>
+                </ufCall>
+                <varRef role='cxt' name='Q{}instanceXML' slot='4'/>
+                <varRef role='nsCxt' name='Q{}instanceXML' slot='4'/>
+                <str role='sa' val='no'/>
+                <map role='options' size='0'/>
+                <map role='wp' size='0'/>
+               </evaluate>
+              </forEach>
+             </treat>
+             <let line='3463' var='Q{}calculated-values' as='xs:string*' slot='8' eval='8'>
+              <forEach line='3464'>
+               <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
+                <check card='1' diag='0|0||map:keys'>
+                 <varRef name='Q{}calculations' slot='5'/>
+                </check>
+               </ifCall>
+               <let line='3466' var='Q{}value' as='xs:string?' slot='9' eval='7'>
+                <treat line='3467' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|value'>
+                 <check card='?' diag='3|0|XTTE0570|value'>
+                  <cvUntyped to='xs:string' diag='3|0|XTTE0570|value'>
+                   <data>
+                    <evaluate dxns=''>
+                     <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='3' eval='16'>
+                      <check card='1' diag='0|0||xforms:impose'>
+                       <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                        <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='6'/>
+                        <dot type='xs:anyAtomicType'/>
+                       </ifCall>
+                      </check>
+                     </ufCall>
+                     <varRef role='cxt' name='Q{}instanceXML' slot='4'/>
+                     <varRef role='nsCxt' name='Q{}instanceXML' slot='4'/>
+                     <str role='sa' val='no'/>
+                     <map role='options' size='0'/>
+                     <map role='wp' size='0'/>
+                    </evaluate>
+                   </data>
+                  </cvUntyped>
                  </check>
                 </treat>
-                <ifCall line='3718' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                 <varRef name='Q{http://saxon.sf.net/generated-variable}v1' slot='0'/>
-                 <str val='setInstance'/>
-                 <arrayBlock>
-                  <dot type='xs:anyAtomicType'/>
-                  <varRef name='Q{}updatedInstanceXML' slot='10'/>
-                 </arrayBlock>
-                </ifCall>
+                <first line='3473'>
+                 <sequence>
+                  <varRef name='Q{}value' slot='9'/>
+                  <str val=''/>
+                 </sequence>
+                </first>
                </let>
+              </forEach>
+              <let line='3477' var='Q{}updatedInstanceXML' as='element()' slot='10' eval='16'>
+               <treat line='3478' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+                <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
+                 <applyT mode='Q{}recalculate' bSlot='4'>
+                  <varRef role='select' name='Q{}instanceXML' slot='4'/>
+                  <withParam name='Q{}updated-nodes' flags='t' as='node()*'>
+                   <varRef line='3479' name='Q{}calculated-nodes' slot='7'/>
+                  </withParam>
+                  <withParam name='Q{}updated-values' flags='t' as='xs:string*'>
+                   <varRef line='3480' name='Q{}calculated-values' slot='8'/>
+                  </withParam>
+                 </applyT>
+                </check>
+               </treat>
+               <ifCall line='3484' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                <varRef name='Q{http://saxon.sf.net/generated-variable}v1' slot='0'/>
+                <str val='setInstance'/>
+                <arrayBlock>
+                 <dot type='xs:anyAtomicType'/>
+                 <varRef name='Q{}updatedInstanceXML' slot='10'/>
+                </arrayBlock>
+               </ifCall>
               </let>
              </let>
             </let>
            </let>
           </let>
-         </forEach>
-         <callT line='3722' name='Q{}refreshOutputs-JS' bSlot='5'/>
-         <callT line='3723' name='Q{}refreshRepeats-JS' bSlot='6'/>
-         <callT line='3724' name='Q{}refreshElementsUsingIndexFunction-JS' bSlot='7' flags='t'/>
-        </sequence>
+         </let>
+        </forEach>
        </let>
       </let>
      </let>
@@ -4199,24 +3244,24 @@
    </let>
   </template>
  </co>
- <co id='48' binds=''>
-  <globalParam name='Q{}xforms-file-global' type='xs:string?' line='76' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n&lt;=1;};'>
+ <co id='46' binds=''>
+  <globalParam name='Q{}xforms-file-global' type='xs:string?' line='78' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n&lt;=1;};'>
    <empty/>
   </globalParam>
  </co>
- <co id='49' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}addNamespaceDeclarations' line='2571' module='saxon-xforms.xsl' eval='16' flags='pU' as='element()' slots='1'>
+ <co id='47' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}addNamespaceDeclarations' line='2290' module='saxon-xforms.xsl' eval='16' flags='pU' as='element()' slots='1'>
    <arg name='Q{}this' as='element()'/>
-   <compElem role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2573'>
+   <compElem role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2292'>
     <fn role='name' name='name'>
      <varRef name='Q{}this' slot='0'/>
     </fn>
-    <sequence role='content' line='2574'>
+    <sequence role='content' line='2293'>
      <namespace flags='l'>
       <str role='name' val='xforms'/>
       <str role='select' val='http://www.w3.org/2002/xforms'/>
      </namespace>
-     <forEach line='2575'>
+     <forEach line='2294'>
       <filter flags='b'>
        <filter flags='b'>
         <slash simple='1'>
@@ -4255,21 +3300,21 @@
         </gc>
        </fn>
       </filter>
-      <namespace line='2578' flags='l'>
-       <fn role='name' line='2577' name='substring-before'>
+      <namespace line='2297' flags='l'>
+       <fn role='name' line='2296' name='substring-before'>
         <fn name='name'>
          <dot type='element()'/>
         </fn>
         <str val=':'/>
        </fn>
        <convert role='select' from='xs:anyURI' to='xs:string'>
-        <fn line='2576' name='namespace-uri'>
+        <fn line='2295' name='namespace-uri'>
          <dot type='element()'/>
         </fn>
        </convert>
       </namespace>
      </forEach>
-     <copyOf line='2580' flags='vc'>
+     <copyOf line='2299' flags='vc'>
       <sequence>
        <slash simple='1'>
         <varRef name='Q{}this' slot='0'/>
@@ -4285,9 +3330,9 @@
    </compElem>
   </function>
  </co>
- <co id='11' binds='2 1 3 15 19 50 51 3 52 20 24'>
-  <template name='Q{}xforms-submit' flags='os' line='3846' module='saxon-xforms.xsl' slots='21'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3847'>
+ <co id='10' binds='2 1 3 48 33 49 50 3 51 19'>
+  <template name='Q{}xforms-submit' flags='os' line='3572' module='saxon-xforms.xsl' slots='20'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3573'>
     <param name='Q{}submission' slot='0' flags='i' as='xs:string'>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|submission'>
       <check card='1' diag='8|0|XTTE0590|submission'>
@@ -4299,7 +3344,7 @@
       </check>
      </treat>
     </param>
-    <let line='3849' var='Q{}submission-map' as='map(*)' slot='1' eval='16'>
+    <let line='3575' var='Q{}submission-map' as='map(*)' slot='1' eval='16'>
      <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|submission-map'>
       <check card='1' diag='3|0|XTTE0570|submission-map'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
@@ -4313,7 +3358,7 @@
        </ifCall>
       </check>
      </treat>
-     <let line='3850' var='Q{}actions' as='map(*)?' slot='2' eval='7'>
+     <let line='3576' var='Q{}actions' as='map(*)?' slot='2' eval='7'>
       <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
         <check card='1' diag='0|0||ixsl:call'>
@@ -4325,642 +3370,567 @@
         </arrayBlock>
        </ifCall>
       </treat>
-      <sequence line='3852'>
-       <message>
-        <sequence role='select'>
-         <valueOf>
-          <str val='[xforms-submit] Submitting: '/>
-         </valueOf>
-         <valueOf>
-          <fn name='serialize'>
-           <varRef name='Q{}submission-map' slot='1'/>
+      <let line='3584' var='Q{}refi' as='xs:string?' slot='3' eval='7'>
+       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <check card='?' diag='3|0|XTTE0570|refi'>
+         <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
+          <data>
+           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+            <varRef name='Q{}submission-map' slot='1'/>
+            <str val='@ref'/>
+           </ifCall>
+          </data>
+         </cvUntyped>
+        </check>
+       </treat>
+       <let line='3586' var='Q{}instance-id' as='xs:string' slot='4' eval='16'>
+        <choose line='3588'>
+         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+          <varRef name='Q{}submission-map' slot='1'/>
+          <str val='@instance'/>
+         </ifCall>
+         <treat line='3589' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|instance-id'>
+          <check card='1' diag='3|0|XTTE0570|instance-id'>
+           <cvUntyped to='xs:string' diag='3|0|XTTE0570|instance-id'>
+            <data>
+             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+              <varRef name='Q{}submission-map' slot='1'/>
+              <str val='@instance'/>
+             </ifCall>
+            </data>
+           </cvUntyped>
+          </check>
+         </treat>
+         <true/>
+         <str val='saxon-forms-default'/>
+        </choose>
+        <let line='3601' var='Q{}instanceXML' as='element()?' slot='5' eval='7'>
+         <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='0' eval='6'>
+          <varRef name='Q{}instance-id' slot='4'/>
+         </ufCall>
+         <choose line='3604'>
+          <fn name='exists'>
+           <varRef name='Q{}instanceXML' slot='5'/>
           </fn>
-         </valueOf>
-        </sequence>
-        <str role='terminate' val='no'/>
-        <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-       </message>
-       <let line='3858' var='Q{}refi' as='xs:string?' slot='3' eval='7'>
-        <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
-         <check card='?' diag='3|0|XTTE0570|refi'>
-          <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
-           <data>
-            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-             <varRef name='Q{}submission-map' slot='1'/>
-             <str val='@ref'/>
-            </ifCall>
-           </data>
-          </cvUntyped>
-         </check>
-        </treat>
-        <let line='3860' var='Q{}instance-id' as='xs:string' slot='4' eval='16'>
-         <choose line='3862'>
-          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-           <varRef name='Q{}submission-map' slot='1'/>
-           <str val='@instance'/>
-          </ifCall>
-          <treat line='3863' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|instance-id'>
-           <check card='1' diag='3|0|XTTE0570|instance-id'>
-            <cvUntyped to='xs:string' diag='3|0|XTTE0570|instance-id'>
+          <let line='3606' var='Q{}updatedInstanceXML' as='element()' slot='6' eval='16'>
+           <choose line='3608'>
+            <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
              <data>
-              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-               <varRef name='Q{}submission-map' slot='1'/>
-               <str val='@instance'/>
+              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+               <check card='1' diag='0|0||ixsl:call'>
+                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+               </check>
+               <str val='getDeferredUpdateFlag'/>
+               <array size='1'>
+                <str val='recalculate'/>
+               </array>
               </ifCall>
              </data>
-            </cvUntyped>
-           </check>
-          </treat>
-          <true/>
-          <str val='saxon-forms-default'/>
-         </choose>
-         <let line='3875' var='Q{}instanceXML' as='element()?' slot='5' eval='7'>
-          <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='0' eval='6'>
-           <varRef name='Q{}instance-id' slot='4'/>
-          </ufCall>
-          <choose line='3878'>
-           <fn name='exists'>
-            <varRef name='Q{}instanceXML' slot='5'/>
-           </fn>
-           <let line='3884' var='Q{http://saxon.sf.net/generated-variable}v0' as='element()' slot='6' eval='13'>
-            <check card='1' diag='4|0|XTTE3170|xsl:evaluate/namespace-context'>
-             <varRef name='Q{}instanceXML' slot='5'/>
-            </check>
-            <let line='3879' var='Q{}data-fields' as='element()*' slot='7' eval='8'>
-             <filter flags='b'>
+             <str val='true'/>
+            </gc>
+            <let line='3614' var='Q{http://saxon.sf.net/generated-variable}v0' as='element()' slot='7' eval='13'>
+             <check card='1' diag='4|0|XTTE3170|xsl:evaluate/namespace-context'>
+              <varRef name='Q{}instanceXML' slot='5'/>
+             </check>
+             <let line='3609' var='Q{}data-fields' as='element()*' slot='8' eval='8'>
               <filter flags='b'>
                <filter flags='b'>
-                <slash simple='1'>
-                 <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
-                 <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-                </slash>
-                <or op='or'>
+                <filter flags='b'>
+                 <slash simple='1'>
+                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
+                  <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+                 </slash>
                  <or op='or'>
+                  <or op='or'>
+                   <fn name='exists'>
+                    <axis name='self' nodeTest='element(Q{}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
+                   </fn>
+                   <fn name='exists'>
+                    <axis name='self' nodeTest='element(Q{}select)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;select&#39;;'/>
+                   </fn>
+                  </or>
                   <fn name='exists'>
-                   <axis name='self' nodeTest='element(Q{}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
-                  </fn>
-                  <fn name='exists'>
-                   <axis name='self' nodeTest='element(Q{}select)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;select&#39;;'/>
+                   <axis name='self' nodeTest='element(Q{}textarea)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;textarea&#39;;'/>
                   </fn>
                  </or>
-                 <fn name='exists'>
-                  <axis name='self' nodeTest='element(Q{}textarea)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;textarea&#39;;'/>
-                 </fn>
-                </or>
+                </filter>
+                <fn name='exists'>
+                 <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
+                </fn>
                </filter>
-               <fn name='exists'>
-                <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
-               </fn>
+               <vc op='eq' onEmpty='0' comp='CCC'>
+                <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='1' eval='16'>
+                 <check card='1' diag='0|0||xforms:getInstanceId'>
+                  <cvUntyped to='xs:string'>
+                   <attVal name='Q{}data-ref' chk='0'/>
+                  </cvUntyped>
+                 </check>
+                </ufCall>
+                <varRef name='Q{}instance-id' slot='4'/>
+               </vc>
               </filter>
-              <vc op='eq' onEmpty='0' comp='CCC'>
-               <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='1' eval='16'>
-                <check card='1' diag='0|0||xforms:getInstanceId'>
-                 <cvUntyped to='xs:string'>
-                  <attVal name='Q{}data-ref' chk='0'/>
-                 </cvUntyped>
-                </check>
-               </ufCall>
-               <varRef name='Q{}instance-id' slot='4'/>
-              </vc>
-             </filter>
-             <let line='3882' var='Q{}calculated-nodes' as='node()*' slot='8' eval='8'>
-              <treat line='3883' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|calculated-nodes'>
-               <forEach>
-                <varRef name='Q{}data-fields' slot='7'/>
-                <evaluate line='3884' dxns=''>
-                 <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
-                  <fn name='string'>
-                   <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
-                  </fn>
-                 </ufCall>
-                 <varRef role='cxt' name='Q{}instanceXML' slot='5'/>
-                 <varRef role='nsCxt' name='Q{http://saxon.sf.net/generated-variable}v0' slot='6'/>
-                 <str role='sa' val='no'/>
-                 <map role='options' size='0'/>
-                 <map role='wp' size='0'/>
-                </evaluate>
-               </forEach>
-              </treat>
-              <let line='3889' var='Q{}calculated-values' as='xs:string*' slot='9' eval='3'>
-               <forEach line='3890'>
-                <varRef name='Q{}data-fields' slot='7'/>
-                <let line='3892' var='Q{}value' as='xs:string' slot='10' eval='8'>
-                 <cvUntyped line='3894' to='xs:string' diag='3|0|XTTE0570|value'>
-                  <cast as='xs:untypedAtomic' emptiable='0'>
-                   <fn name='string-join'>
-                    <convert from='xs:anyAtomicType' to='xs:string'>
-                     <data>
-                      <mergeAdj>
-                       <applyT mode='Q{}get-field' bSlot='3'>
-                        <dot role='select' type='element()'/>
-                       </applyT>
-                      </mergeAdj>
-                     </data>
-                    </convert>
-                    <str val=''/>
+              <let line='3612' var='Q{}calculated-nodes' as='node()*' slot='9' eval='8'>
+               <treat line='3613' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|calculated-nodes'>
+                <forEach>
+                 <varRef name='Q{}data-fields' slot='8'/>
+                 <evaluate line='3614' dxns=''>
+                  <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
+                   <fn name='string'>
+                    <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
                    </fn>
-                  </cast>
-                 </cvUntyped>
-                 <first line='3901'>
-                  <sequence>
-                   <varRef name='Q{}value' slot='10'/>
-                   <str val=''/>
-                  </sequence>
-                 </first>
-                </let>
-               </forEach>
-               <let line='3905' var='Q{}updatedInstanceXML' as='element()' slot='11' eval='16'>
-                <treat line='3906' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
-                 <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
-                  <applyT mode='Q{}recalculate' bSlot='4'>
-                   <varRef role='select' name='Q{}instanceXML' slot='5'/>
-                   <withParam name='Q{}updated-nodes' flags='t' as='node()*'>
-                    <varRef line='3907' name='Q{}calculated-nodes' slot='8'/>
-                   </withParam>
-                   <withParam name='Q{}updated-values' flags='t' as='xs:string*'>
-                    <varRef line='3908' name='Q{}calculated-values' slot='9'/>
-                   </withParam>
-                  </applyT>
+                  </ufCall>
+                  <varRef role='cxt' name='Q{}instanceXML' slot='5'/>
+                  <varRef role='nsCxt' name='Q{http://saxon.sf.net/generated-variable}v0' slot='7'/>
+                  <str role='sa' val='no'/>
+                  <map role='options' size='0'/>
+                  <map role='wp' size='0'/>
+                 </evaluate>
+                </forEach>
+               </treat>
+               <let line='3619' var='Q{}calculated-values' as='xs:string*' slot='10' eval='3'>
+                <forEach line='3620'>
+                 <varRef name='Q{}data-fields' slot='8'/>
+                 <let line='3622' var='Q{}value' as='xs:string' slot='11' eval='8'>
+                  <cvUntyped line='3624' to='xs:string' diag='3|0|XTTE0570|value'>
+                   <cast as='xs:untypedAtomic' emptiable='0'>
+                    <fn name='string-join'>
+                     <convert from='xs:anyAtomicType' to='xs:string'>
+                      <data>
+                       <mergeAdj>
+                        <applyT mode='Q{}get-field' bSlot='3'>
+                         <dot role='select' type='element()'/>
+                        </applyT>
+                       </mergeAdj>
+                      </data>
+                     </convert>
+                     <str val=''/>
+                    </fn>
+                   </cast>
+                  </cvUntyped>
+                  <first line='3631'>
+                   <sequence>
+                    <varRef name='Q{}value' slot='11'/>
+                    <str val=''/>
+                   </sequence>
+                  </first>
+                 </let>
+                </forEach>
+                <check line='3635' card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
+                 <sequence>
+                  <treat as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+                   <applyT mode='Q{}recalculate' bSlot='4'>
+                    <varRef role='select' name='Q{}instanceXML' slot='5'/>
+                    <withParam name='Q{}updated-nodes' flags='t' as='node()*'>
+                     <varRef line='3636' name='Q{}calculated-nodes' slot='9'/>
+                    </withParam>
+                    <withParam name='Q{}updated-values' flags='t' as='xs:string*'>
+                     <varRef line='3637' name='Q{}calculated-values' slot='10'/>
+                    </withParam>
+                   </applyT>
+                  </treat>
+                  <treat line='3640' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                    <check card='1' diag='0|0||ixsl:call'>
+                     <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                    </check>
+                    <str val='clearDeferredUpdateFlag'/>
+                    <array size='1'>
+                     <str val='recalculate'/>
+                    </array>
+                   </ifCall>
+                  </treat>
+                 </sequence>
+                </check>
+               </let>
+              </let>
+             </let>
+            </let>
+            <true/>
+            <check line='3643' card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
+             <varRef name='Q{}instanceXML' slot='5'/>
+            </check>
+           </choose>
+           <let line='3654' var='Q{}required-fields-check' as='element()*' slot='12' eval='3'>
+            <ufCall name='Q{http://www.w3.org/2002/xforms}check-required-fields' tailCall='false' bSlot='5' eval='6'>
+             <varRef name='Q{}updatedInstanceXML' slot='6'/>
+            </ufCall>
+            <let line='3655' var='Q{}constrained-fields-check' as='item()*' slot='13' eval='3'>
+             <ufCall name='Q{http://www.w3.org/2002/xforms}check-constraints-on-fields' tailCall='false' bSlot='6' eval='6'>
+              <varRef name='Q{}updatedInstanceXML' slot='6'/>
+             </ufCall>
+             <choose line='3662'>
+              <and op='and'>
+               <fn name='empty'>
+                <varRef name='Q{}required-fields-check' slot='12'/>
+               </fn>
+               <fn name='empty'>
+                <varRef name='Q{}constrained-fields-check' slot='13'/>
+               </fn>
+              </and>
+              <let line='3664' var='Q{}requestBody' as='node()?' slot='14' eval='7'>
+               <choose line='3666'>
+                <varRef name='Q{}refi' slot='3'/>
+                <treat line='3667' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|requestBody'>
+                 <check card='?' diag='3|0|XTTE0570|requestBody'>
+                  <evaluate dxns=''>
+                   <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='7' eval='16'>
+                    <check card='1' diag='0|0||xforms:impose'>
+                     <varRef name='Q{}refi' slot='3'/>
+                    </check>
+                   </ufCall>
+                   <varRef role='cxt' name='Q{}instanceXML' slot='5'/>
+                   <check role='nsCxt' card='1' diag='4|0|XTTE3170|xsl:evaluate/namespace-context'>
+                    <varRef name='Q{}instanceXML' slot='5'/>
+                   </check>
+                   <str role='sa' val='no'/>
+                   <map role='options' size='0'/>
+                   <map role='wp' size='0'/>
+                  </evaluate>
                  </check>
                 </treat>
-                <let line='3913' var='Q{}required-fields-check' as='element()*' slot='12' eval='3'>
-                 <ufCall name='Q{http://www.w3.org/2002/xforms}check-required-fields' tailCall='false' bSlot='5' eval='6'>
-                  <varRef name='Q{}updatedInstanceXML' slot='11'/>
-                 </ufCall>
-                 <let line='3914' var='Q{}constrained-fields-check' as='item()*' slot='13' eval='3'>
-                  <ufCall name='Q{http://www.w3.org/2002/xforms}check-constraints-on-fields' tailCall='false' bSlot='6' eval='6'>
-                   <varRef name='Q{}updatedInstanceXML' slot='11'/>
-                  </ufCall>
-                  <choose line='3921'>
-                   <and op='and'>
-                    <fn name='empty'>
-                     <varRef name='Q{}required-fields-check' slot='12'/>
-                    </fn>
-                    <fn name='empty'>
-                     <varRef name='Q{}constrained-fields-check' slot='13'/>
-                    </fn>
-                   </and>
-                   <let line='3922' var='Q{}requestBody' as='node()' slot='14' eval='16'>
-                    <choose line='3924'>
-                     <varRef name='Q{}refi' slot='3'/>
-                     <treat line='3925' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|requestBody'>
-                      <check card='1' diag='3|0|XTTE0570|requestBody'>
-                       <evaluate dxns=''>
-                        <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='7' eval='16'>
-                         <check card='1' diag='0|0||xforms:impose'>
-                          <varRef name='Q{}refi' slot='3'/>
-                         </check>
-                        </ufCall>
-                        <varRef role='cxt' name='Q{}instanceXML' slot='5'/>
-                        <check role='nsCxt' card='1' diag='4|0|XTTE3170|xsl:evaluate/namespace-context'>
-                         <varRef name='Q{}instanceXML' slot='5'/>
-                        </check>
-                        <str role='sa' val='no'/>
-                        <map role='options' size='0'/>
-                        <map role='wp' size='0'/>
-                       </evaluate>
-                      </check>
-                     </treat>
-                     <true/>
-                     <varRef line='3928' name='Q{}updatedInstanceXML' slot='11'/>
-                    </choose>
-                    <sequence line='3933'>
-                     <message>
-                      <sequence role='select'>
-                       <valueOf>
-                        <str val='[xforms-submit] Request body: '/>
-                       </valueOf>
-                       <fn name='serialize'>
+                <true/>
+                <varRef line='3670' name='Q{}updatedInstanceXML' slot='6'/>
+               </choose>
+               <let line='3677' var='Q{}requestBodyDoc' as='document-node()?' slot='15' eval='7'>
+                <choose line='3678'>
+                 <fn name='exists'>
+                  <filter flags='b'>
+                   <varRef name='Q{}requestBody' slot='14'/>
+                   <fn name='exists'>
+                    <axis name='self' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+                   </fn>
+                  </filter>
+                 </fn>
+                 <doc line='3679'>
+                  <varRef line='3680' name='Q{}requestBody' slot='14'/>
+                 </doc>
+                </choose>
+                <let line='3685' var='Q{}method' as='xs:string' slot='16' eval='16'>
+                 <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|method'>
+                  <check card='1' diag='3|0|XTTE0570|method'>
+                   <cvUntyped to='xs:string' diag='3|0|XTTE0570|method'>
+                    <data>
+                     <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                      <varRef name='Q{}submission-map' slot='1'/>
+                      <str val='@method'/>
+                     </ifCall>
+                    </data>
+                   </cvUntyped>
+                  </check>
+                 </treat>
+                 <let line='3687' var='Q{}serialization' as='xs:string?' slot='17' eval='7'>
+                  <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|serialization'>
+                   <check card='?' diag='3|0|XTTE0570|serialization'>
+                    <cvUntyped to='xs:string' diag='3|0|XTTE0570|serialization'>
+                     <data>
+                      <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                       <varRef name='Q{}submission-map' slot='1'/>
+                       <str val='@serialization'/>
+                      </ifCall>
+                     </data>
+                    </cvUntyped>
+                   </check>
+                  </treat>
+                  <let line='3689' var='Q{}query-parameters' as='xs:string?' slot='18' eval='7'>
+                   <choose line='3690'>
+                    <and op='and'>
+                     <fn name='exists'>
+                      <varRef name='Q{}serialization' slot='17'/>
+                     </fn>
+                     <vc op='eq' onEmpty='0' comp='CCC'>
+                      <varRef name='Q{}serialization' slot='17'/>
+                      <str val='application/x-www-form-urlencoded'/>
+                     </vc>
+                    </and>
+                    <fn line='3708' name='string-join'>
+                     <choose line='3694'>
+                      <fn name='exists'>
+                       <varRef name='Q{}requestBodyDoc' slot='15'/>
+                      </fn>
+                      <forEach line='3695'>
+                       <slash simple='1'>
                         <varRef name='Q{}requestBody' slot='14'/>
+                        <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+                       </slash>
+                       <fn line='3696' name='concat'>
+                        <fn name='local-name'>
+                         <dot type='element()'/>
+                        </fn>
+                        <str val='='/>
+                        <fn name='string'>
+                         <dot type='element()'/>
+                        </fn>
                        </fn>
-                      </sequence>
-                      <str role='terminate' val='no'/>
-                      <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-                     </message>
-                     <let line='3935' var='Q{}requestBodyDoc' as='document-node()?' slot='15' eval='7'>
-                      <choose line='3936'>
-                       <fn name='exists'>
-                        <filter flags='b'>
-                         <varRef name='Q{}requestBody' slot='14'/>
-                         <fn name='exists'>
-                          <axis name='self' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-                         </fn>
-                        </filter>
-                       </fn>
-                       <doc line='3937'>
-                        <varRef line='3938' name='Q{}requestBody' slot='14'/>
-                       </doc>
-                      </choose>
-                      <let line='3943' var='Q{}method' as='xs:string' slot='16' eval='16'>
-                       <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|method'>
-                        <check card='1' diag='3|0|XTTE0570|method'>
-                         <cvUntyped to='xs:string' diag='3|0|XTTE0570|method'>
+                      </forEach>
+                     </choose>
+                     <str val='&amp;'/>
+                    </fn>
+                   </choose>
+                   <let line='3712' var='Q{}href-base' as='xs:string' slot='19' eval='16'>
+                    <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|href-base'>
+                     <check card='1' diag='3|0|XTTE0570|href-base'>
+                      <cvUntyped to='xs:string' diag='3|0|XTTE0570|href-base'>
+                       <data>
+                        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                         <varRef name='Q{}submission-map' slot='1'/>
+                         <str val='@resource'/>
+                        </ifCall>
+                       </data>
+                      </cvUntyped>
+                     </check>
+                    </treat>
+                    <ifCall line='3757' name='Q{http://saxonica.com/ns/interactiveXSLT}schedule-action' type='item()*'>
+                     <int val='0'/>
+                     <empty/>
+                     <callT name='Q{}HTTPsubmit' bSlot='8'>
+                      <withParam name='Q{}instance-id' flags='c' as='xs:string'>
+                       <varRef line='3758' name='Q{}instance-id' slot='4'/>
+                      </withParam>
+                      <withParam name='Q{}targetref' flags='c' as='xs:string?'>
+                       <treat line='3759' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|targetref'>
+                        <check card='?' diag='8|0|XTTE0590|targetref'>
+                         <cvUntyped to='xs:string' diag='8|0|XTTE0590|targetref'>
                           <data>
                            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
                             <varRef name='Q{}submission-map' slot='1'/>
-                            <str val='@method'/>
+                            <str val='@targetref'/>
                            </ifCall>
                           </data>
                          </cvUntyped>
                         </check>
                        </treat>
-                       <let line='3945' var='Q{}serialization' as='xs:string?' slot='17' eval='7'>
-                        <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|serialization'>
-                         <check card='?' diag='3|0|XTTE0570|serialization'>
-                          <cvUntyped to='xs:string' diag='3|0|XTTE0570|serialization'>
-                           <data>
-                            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                             <varRef name='Q{}submission-map' slot='1'/>
-                             <str val='@serialization'/>
-                            </ifCall>
-                           </data>
-                          </cvUntyped>
-                         </check>
-                        </treat>
-                        <let line='3947' var='Q{}query-parameters' as='xs:string?' slot='18' eval='7'>
-                         <choose line='3948'>
-                          <and op='and'>
-                           <fn name='exists'>
-                            <varRef name='Q{}serialization' slot='17'/>
-                           </fn>
-                           <vc op='eq' onEmpty='0' comp='CCC'>
-                            <varRef name='Q{}serialization' slot='17'/>
-                            <str val='application/x-www-form-urlencoded'/>
-                           </vc>
-                          </and>
-                          <fn line='3966' name='string-join'>
-                           <choose line='3952'>
-                            <fn name='exists'>
-                             <varRef name='Q{}requestBodyDoc' slot='15'/>
-                            </fn>
-                            <forEach line='3953'>
-                             <slash simple='1'>
-                              <varRef name='Q{}requestBody' slot='14'/>
-                              <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-                             </slash>
-                             <fn line='3954' name='concat'>
-                              <fn name='local-name'>
-                               <dot type='element()'/>
-                              </fn>
-                              <str val='='/>
-                              <fn name='string'>
-                               <dot type='element()'/>
-                              </fn>
-                             </fn>
-                            </forEach>
-                           </choose>
-                           <str val='&amp;'/>
+                      </withParam>
+                      <withParam name='Q{}replace' flags='c' as='xs:string?'>
+                       <treat line='3760' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|replace'>
+                        <check card='?' diag='8|0|XTTE0590|replace'>
+                         <cvUntyped to='xs:string' diag='8|0|XTTE0590|replace'>
+                          <data>
+                           <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                            <varRef name='Q{}submission-map' slot='1'/>
+                            <str val='@replace'/>
+                           </ifCall>
+                          </data>
+                         </cvUntyped>
+                        </check>
+                       </treat>
+                      </withParam>
+                      <withParam name='Q{}when-done' flags='t' as='map(*)?'>
+                       <filter line='3761' flags='b'>
+                        <varRef name='Q{}actions' slot='2'/>
+                        <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+                         <data>
+                          <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                           <dot type='map(*)'/>
+                           <str val='@event'/>
+                          </ifCall>
+                         </data>
+                         <str val='xforms-submit-done'/>
+                        </gc>
+                       </filter>
+                      </withParam>
+                     </callT>
+                     <ifCall line='3733' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+                      <sequence>
+                       <choose>
+                        <vc op='ne' onEmpty='1' comp='CCC'>
+                         <fn name='upper-case'>
+                          <varRef name='Q{}method' slot='16'/>
+                         </fn>
+                         <str val='GET'/>
+                        </vc>
+                        <sequence line='3735'>
+                         <choose>
+                          <fn name='exists'>
+                           <varRef name='Q{}requestBodyDoc' slot='15'/>
                           </fn>
+                          <ifCall line='3736' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                           <str val='body'/>
+                           <varRef name='Q{}requestBodyDoc' slot='15'/>
+                          </ifCall>
+                          <true/>
+                          <ifCall line='3739' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                           <str val='body'/>
+                           <varRef name='Q{}requestBody' slot='14'/>
+                          </ifCall>
                          </choose>
-                         <let line='3970' var='Q{}href-base' as='xs:string' slot='19' eval='16'>
-                          <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|href-base'>
-                           <check card='1' diag='3|0|XTTE0570|href-base'>
-                            <cvUntyped to='xs:string' diag='3|0|XTTE0570|href-base'>
+                         <ifCall line='3742' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                          <str val='media-type'/>
+                          <treat line='3728' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|mediatype'>
+                           <check card='1' diag='3|0|XTTE0570|mediatype'>
+                            <cvUntyped to='xs:string' diag='3|0|XTTE0570|mediatype'>
                              <data>
                               <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
                                <varRef name='Q{}submission-map' slot='1'/>
-                               <str val='@resource'/>
+                               <str val='@mediatype'/>
                               </ifCall>
                              </data>
                             </cvUntyped>
                            </check>
                           </treat>
-                          <sequence line='4015'>
-                           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}schedule-action' type='item()*'>
-                            <int val='0'/>
-                            <empty/>
-                            <callT name='Q{}HTTPsubmit' bSlot='8'>
-                             <withParam name='Q{}instance-id' flags='c' as='xs:string'>
-                              <varRef line='4016' name='Q{}instance-id' slot='4'/>
-                             </withParam>
-                             <withParam name='Q{}targetref' flags='c' as='xs:string?'>
-                              <treat line='4017' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|targetref'>
-                               <check card='?' diag='8|0|XTTE0590|targetref'>
-                                <cvUntyped to='xs:string' diag='8|0|XTTE0590|targetref'>
-                                 <data>
-                                  <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                                   <varRef name='Q{}submission-map' slot='1'/>
-                                   <str val='@targetref'/>
-                                  </ifCall>
-                                 </data>
-                                </cvUntyped>
-                               </check>
-                              </treat>
-                             </withParam>
-                             <withParam name='Q{}replace' flags='c' as='xs:string?'>
-                              <treat line='4018' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|replace'>
-                               <check card='?' diag='8|0|XTTE0590|replace'>
-                                <cvUntyped to='xs:string' diag='8|0|XTTE0590|replace'>
-                                 <data>
-                                  <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                                   <varRef name='Q{}submission-map' slot='1'/>
-                                   <str val='@replace'/>
-                                  </ifCall>
-                                 </data>
-                                </cvUntyped>
-                               </check>
-                              </treat>
-                             </withParam>
-                            </callT>
-                            <ifCall line='3991' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
-                             <sequence>
-                              <choose>
-                               <vc op='ne' onEmpty='1' comp='CCC'>
-                                <fn name='upper-case'>
-                                 <varRef name='Q{}method' slot='16'/>
-                                </fn>
-                                <str val='GET'/>
-                               </vc>
-                               <sequence line='3993'>
-                                <choose>
-                                 <fn name='exists'>
-                                  <varRef name='Q{}requestBodyDoc' slot='15'/>
-                                 </fn>
-                                 <ifCall line='3994' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
-                                  <str val='body'/>
-                                  <varRef name='Q{}requestBodyDoc' slot='15'/>
-                                 </ifCall>
-                                 <true/>
-                                 <ifCall line='3997' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
-                                  <str val='body'/>
-                                  <varRef name='Q{}requestBody' slot='14'/>
-                                 </ifCall>
-                                </choose>
-                                <ifCall line='4000' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
-                                 <str val='media-type'/>
-                                 <treat line='3986' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|mediatype'>
-                                  <check card='1' diag='3|0|XTTE0570|mediatype'>
-                                   <cvUntyped to='xs:string' diag='3|0|XTTE0570|mediatype'>
-                                    <data>
-                                     <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                                      <varRef name='Q{}submission-map' slot='1'/>
-                                      <str val='@mediatype'/>
-                                     </ifCall>
-                                    </data>
-                                   </cvUntyped>
-                                  </check>
-                                 </treat>
-                                </ifCall>
-                               </sequence>
-                              </choose>
-                              <ifCall line='4003' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
-                               <str val='method'/>
-                               <varRef name='Q{}method' slot='16'/>
-                              </ifCall>
-                              <ifCall line='4004' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
-                               <str val='href'/>
-                               <choose line='3974'>
-                                <fn name='exists'>
-                                 <varRef name='Q{}query-parameters' slot='18'/>
-                                </fn>
-                                <fn line='3975' name='concat'>
-                                 <varRef name='Q{}href-base' slot='19'/>
-                                 <str val='?'/>
-                                 <varRef name='Q{}query-parameters' slot='18'/>
-                                </fn>
-                                <fn line='3977' name='exists'>
-                                 <filter flags='b'>
-                                  <varRef name='Q{}requestBody' slot='14'/>
-                                  <fn name='exists'>
-                                   <axis name='self' nodeTest='text()' jsTest='return item.nodeType===3;'/>
-                                  </fn>
-                                 </filter>
-                                </fn>
-                                <fn line='3978' name='concat'>
-                                 <varRef name='Q{}href-base' slot='19'/>
-                                 <str val='/'/>
-                                 <data>
-                                  <varRef name='Q{}requestBody' slot='14'/>
-                                 </data>
-                                </fn>
-                                <true/>
-                                <varRef line='3981' name='Q{}href-base' slot='19'/>
-                               </choose>
-                              </ifCall>
-                             </sequence>
-                             <map size='2'>
-                              <str val='duplicates'/>
-                              <str val='reject'/>
-                              <str val='duplicates-error-code'/>
-                              <str val='XTDE3365'/>
-                             </map>
-                            </ifCall>
-                           </ifCall>
-                           <forEach line='4022'>
-                            <varRef name='Q{}actions' slot='2'/>
-                            <let line='4023' var='Q{}action-map' as='map(*)' slot='20' eval='16'>
-                             <dot type='map(*)'/>
-                             <choose line='4026'>
-                              <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
-                               <varRef name='Q{}action-map' slot='20'/>
-                               <str val='@event'/>
-                              </ifCall>
-                              <choose line='4027'>
-                               <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
-                                <data>
-                                 <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-                                  <varRef name='Q{}action-map' slot='20'/>
-                                  <str val='@event'/>
-                                 </ifCall>
-                                </data>
-                                <str val='xforms-submit-done'/>
-                               </gc>
-                               <callT line='4028' name='Q{}applyActions' bSlot='9' flags='t'>
-                                <withParam name='Q{}action-map' flags='t' as='item()'>
-                                 <varRef line='4029' name='Q{}action-map' slot='20'/>
-                                </withParam>
-                                <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                                 <check line='4030' card='1' diag='8|0|XTTE0590|nodeset'>
-                                  <varRef name='Q{}refi' slot='3'/>
-                                 </check>
-                                </withParam>
-                                <withParam name='Q{}instanceXML' flags='t' as='element()'>
-                                 <check line='4031' card='1' diag='8|0|XTTE0590|instanceXML'>
-                                  <varRef name='Q{}instanceXML' slot='5'/>
-                                 </check>
-                                </withParam>
-                               </callT>
-                              </choose>
-                             </choose>
-                            </let>
-                           </forEach>
-                          </sequence>
-                         </let>
-                        </let>
-                       </let>
-                      </let>
-                     </let>
-                    </sequence>
+                         </ifCall>
+                        </sequence>
+                       </choose>
+                       <ifCall line='3745' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                        <str val='method'/>
+                        <varRef name='Q{}method' slot='16'/>
+                       </ifCall>
+                       <ifCall line='3746' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                        <str val='href'/>
+                        <choose line='3716'>
+                         <fn name='exists'>
+                          <varRef name='Q{}query-parameters' slot='18'/>
+                         </fn>
+                         <fn line='3717' name='concat'>
+                          <varRef name='Q{}href-base' slot='19'/>
+                          <str val='?'/>
+                          <varRef name='Q{}query-parameters' slot='18'/>
+                         </fn>
+                         <fn line='3719' name='exists'>
+                          <filter flags='b'>
+                           <varRef name='Q{}requestBody' slot='14'/>
+                           <fn name='exists'>
+                            <axis name='self' nodeTest='text()' jsTest='return item.nodeType===3;'/>
+                           </fn>
+                          </filter>
+                         </fn>
+                         <fn line='3720' name='concat'>
+                          <varRef name='Q{}href-base' slot='19'/>
+                          <str val='/'/>
+                          <data>
+                           <varRef name='Q{}requestBody' slot='14'/>
+                          </data>
+                         </fn>
+                         <true/>
+                         <varRef line='3723' name='Q{}href-base' slot='19'/>
+                        </choose>
+                       </ifCall>
+                      </sequence>
+                      <map size='2'>
+                       <str val='duplicates'/>
+                       <str val='reject'/>
+                       <str val='duplicates-error-code'/>
+                       <str val='XTDE3365'/>
+                      </map>
+                     </ifCall>
+                    </ifCall>
                    </let>
-                   <fn line='4038' name='exists'>
-                    <varRef name='Q{}constrained-fields-check' slot='13'/>
-                   </fn>
-                   <ifCall line='4045' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                    <check card='1' diag='0|0||ixsl:call'>
-                     <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-                    </check>
-                    <str val='alert'/>
-                    <arrayBlock>
-                     <fn name='serialize'>
-                      <doc line='4040' flags='t' validation='preserve'>
-                       <forEach>
-                        <varRef name='Q{}constrained-fields-check' slot='13'/>
-                        <valueOf line='4042' flags='l'>
-                         <fn name='concat'>
-                          <str val='Invalid field value: '/>
-                          <fn name='serialize'>
-                           <slash simple='1'>
-                            <treat as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='1|0|XPTY0019|/'>
-                             <dot line='4041'/>
-                            </treat>
-                            <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
-                           </slash>
-                          </fn>
-                          <str val='&#xA;'/>
-                         </fn>
-                        </valueOf>
-                       </forEach>
-                      </doc>
-                     </fn>
-                    </arrayBlock>
-                   </ifCall>
-                   <true/>
-                   <ifCall line='4054' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                    <check card='1' diag='0|0||ixsl:call'>
-                     <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-                    </check>
-                    <str val='alert'/>
-                    <arrayBlock>
-                     <fn name='serialize'>
-                      <doc line='4049' flags='t' validation='preserve'>
-                       <forEach>
-                        <varRef name='Q{}required-fields-check' slot='12'/>
-                        <valueOf line='4051' flags='l'>
-                         <fn name='concat'>
-                          <str val='Required field is empty: '/>
-                          <fn name='serialize'>
-                           <slash line='4050' simple='1'>
-                            <dot type='element()'/>
-                            <axis line='4051' name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
-                           </slash>
-                          </fn>
-                          <str val='&#xA;'/>
-                         </fn>
-                        </valueOf>
-                       </forEach>
-                      </doc>
-                     </fn>
-                    </arrayBlock>
-                   </ifCall>
-                  </choose>
+                  </let>
                  </let>
                 </let>
                </let>
               </let>
-             </let>
+              <true/>
+              <ifCall line='3779' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+               <check card='1' diag='0|0||ixsl:call'>
+                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+               </check>
+               <str val='alert'/>
+               <arrayBlock>
+                <fn name='serialize'>
+                 <doc line='3770' flags='t' validation='preserve'>
+                  <sequence>
+                   <forEach>
+                    <varRef name='Q{}constrained-fields-check' slot='13'/>
+                    <valueOf line='3772' flags='l'>
+                     <fn name='concat'>
+                      <str val='Invalid field value: '/>
+                      <fn name='serialize'>
+                       <slash simple='1'>
+                        <treat as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='1|0|XPTY0019|/'>
+                         <dot line='3771'/>
+                        </treat>
+                        <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
+                       </slash>
+                      </fn>
+                      <str val='&#xA;'/>
+                     </fn>
+                    </valueOf>
+                   </forEach>
+                   <forEach line='3774'>
+                    <varRef name='Q{}required-fields-check' slot='12'/>
+                    <valueOf line='3776' flags='l'>
+                     <fn name='concat'>
+                      <str val='Required field is empty: '/>
+                      <fn name='serialize'>
+                       <slash line='3775' simple='1'>
+                        <dot type='element()'/>
+                        <axis line='3776' name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
+                       </slash>
+                      </fn>
+                      <str val='&#xA;'/>
+                     </fn>
+                    </valueOf>
+                   </forEach>
+                  </sequence>
+                 </doc>
+                </fn>
+               </arrayBlock>
+              </ifCall>
+             </choose>
             </let>
            </let>
-           <true/>
-           <callT line='4060' name='Q{}logToPage' bSlot='10' flags='t'>
-            <withParam name='Q{}message' flags='c' as='xs:string'>
-             <fn line='4061' name='concat'>
-              <str val='Unable to locate XForms instance relating to submission '/>
-              <fn name='serialize'>
-               <varRef name='Q{}submission-map' slot='1'/>
-              </fn>
+          </let>
+          <true/>
+          <callT line='3785' name='Q{}logToPage' bSlot='9' flags='t'>
+           <withParam name='Q{}message' flags='c' as='xs:string'>
+            <fn line='3786' name='concat'>
+             <str val='Unable to locate XForms instance relating to submission '/>
+             <fn name='serialize'>
+              <varRef name='Q{}submission-map' slot='1'/>
              </fn>
-            </withParam>
-            <withParam name='Q{}level' flags='c' as='xs:string'>
-             <str val='error'/>
-            </withParam>
-           </callT>
-          </choose>
-         </let>
+            </fn>
+           </withParam>
+           <withParam name='Q{}level' flags='c' as='xs:string'>
+            <str val='error'/>
+           </withParam>
+          </callT>
+         </choose>
         </let>
        </let>
-      </sequence>
+      </let>
      </let>
     </let>
    </sequence>
   </template>
  </co>
- <co id='37' binds='34 53'>
-  <template name='Q{}xforms-rebuild' flags='os' line='3641' module='saxon-xforms.xsl' slots='2'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3642'>
-    <message>
-     <valueOf role='select'>
-      <str val='[xforms-rebuild] START'/>
-     </valueOf>
-     <str role='terminate' val='no'/>
-     <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-    </message>
-    <let line='3643' var='Q{}instanceDocs' as='map(xs:anyAtomicType, element()?)' slot='0' eval='8'>
-     <let line='3644' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
-      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-       <check card='1' diag='0|0||ixsl:call'>
-        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-       </check>
-       <str val='getInstanceKeys'/>
-       <array size='0'/>
-      </ifCall>
-      <ifCall line='3646' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
-       <forEach>
-        <varRef name='Q{}instance-keys' slot='1'/>
-        <ifCall line='3648' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
-         <atomSing diag='0|0||map:entry'>
-          <dot/>
-         </atomSing>
-         <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='0' eval='16'>
-          <fn line='3647' name='concat'>
-           <str val='instance(&#39;'/>
-           <atomSing card='?' diag='0|1||fn:concat'>
-            <dot/>
-           </atomSing>
-           <str val='&#39;)/'/>
-          </fn>
-         </ufCall>
-        </ifCall>
-       </forEach>
-       <map size='2'>
-        <str val='duplicates'/>
-        <str val='reject'/>
-        <str val='duplicates-error-code'/>
-        <str val='XTDE3365'/>
-       </map>
-      </ifCall>
-     </let>
-     <callT line='3653' name='Q{}xformsjs-main' bSlot='1' flags='t'>
-      <withParam name='Q{}instance-docs' flags='c' as='map(*)'>
-       <varRef line='3654' name='Q{}instanceDocs' slot='0'/>
-      </withParam>
-     </callT>
-    </let>
+ <co id='21' binds='43 40 52 53'>
+  <template name='Q{}xforms-refresh' flags='os' line='3504' module='saxon-xforms.xsl' slots='0'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3505'>
+    <callT name='Q{}refreshOutputs-JS' bSlot='0'/>
+    <callT line='3506' name='Q{}refreshRepeats-JS' bSlot='1'/>
+    <callT line='3507' name='Q{}refreshElementsUsingIndexFunction-JS' bSlot='2'/>
+    <callT line='3508' name='Q{}refreshRelevantFields-JS' bSlot='3' flags='t'/>
    </sequence>
   </template>
  </co>
- <co id='33' binds=''>
+ <co id='35' binds=''>
+  <template name='Q{}xforms-rebuild' flags='os' line='3405' module='saxon-xforms.xsl' slots='0'>
+   <empty role='body'/>
+  </template>
+ </co>
+ <co id='54' binds=''>
   <mode name='Q{}set-field' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.25' seq='37' rank='0' minImp='0' slots='1' flags='s' line='2503' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='34' rank='0' minImp='0' slots='1' flags='s' line='2222' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:textarea' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;textarea&#39;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2504'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2223'>
      <param name='Q{}value' slot='0' flags='t'>
       <str role='select' val=''/>
       <supplied role='conversion' slot='0'/>
      </param>
-     <ifCall line='2508' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+     <ifCall line='2227' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
       <dot type='*:textarea'/>
       <str val='value'/>
      </ifCall>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='-0.25' seq='36' rank='0' minImp='0' slots='1' flags='s' line='2489' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='33' rank='0' minImp='0' slots='1' flags='s' line='2208' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:select' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;select&#39;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2490'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2209'>
      <param name='Q{}value' slot='0' flags='t'>
       <str role='select' val=''/>
       <supplied role='conversion' slot='0'/>
      </param>
-     <forEach line='2492'>
+     <forEach line='2211'>
       <filter flags='b'>
        <axis name='child' nodeTest='element(Q{}option)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;option&#39;;'/>
        <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
@@ -4970,7 +3940,7 @@
         <attVal name='Q{}value' chk='0'/>
        </gc>
       </filter>
-      <ifCall line='2493' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+      <ifCall line='2212' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
        <str val='selected'/>
        <true/>
        <dot type='element(Q{}option)'/>
@@ -4978,14 +3948,14 @@
      </forEach>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='-0.25' seq='35' rank='0' minImp='0' slots='1' flags='s' line='2468' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='32' rank='0' minImp='0' slots='1' flags='s' line='2187' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:input' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;input&#39;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2469'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2188'>
      <param name='Q{}value' slot='0' flags='t'>
       <str role='select' val=''/>
       <supplied role='conversion' slot='0'/>
      </param>
-     <choose line='2473'>
+     <choose line='2192'>
       <and op='and'>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}type)' jsTest='return item.name===&#39;type&#39;'/>
@@ -4997,7 +3967,7 @@
         <str val='checkbox'/>
        </vc>
       </and>
-      <ifCall line='2474' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+      <ifCall line='2193' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
        <str val='checked'/>
        <choose>
         <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
@@ -5015,7 +3985,7 @@
        <dot type='*:input'/>
       </ifCall>
       <true/>
-      <ifCall line='2477' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+      <ifCall line='2196' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
        <str val='value'/>
        <check card='?' diag='0|1||ixsl:set-property'>
         <varRef name='Q{}value' slot='0'/>
@@ -5027,9 +3997,9 @@
    </templateRule>
   </mode>
  </co>
- <co id='47' binds='43'>
-  <template name='Q{}refreshElementsUsingIndexFunction-JS' flags='os' line='3146' module='saxon-xforms.xsl' slots='6'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3147'>
+ <co id='52' binds='41'>
+  <template name='Q{}refreshElementsUsingIndexFunction-JS' flags='os' line='2896' module='saxon-xforms.xsl' slots='6'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2897'>
     <message>
      <valueOf role='select'>
       <str val='[refreshElementsUsingIndexFunction-JS] START'/>
@@ -5037,7 +4007,7 @@
      <str role='terminate' val='no'/>
      <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
     </message>
-    <let line='3148' var='Q{}ElementsUsingIndexFunction-keys' as='item()?' slot='0' eval='8'>
+    <let line='2898' var='Q{}ElementsUsingIndexFunction-keys' as='item()?' slot='0' eval='8'>
      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
       <check card='1' diag='0|0||ixsl:call'>
        <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -5045,7 +4015,7 @@
       <str val='getElementsUsingIndexFunctionKeys'/>
       <array size='0'/>
      </ifCall>
-     <let line='3150' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
+     <let line='2900' var='Q{}instance-keys' as='item()?' slot='1' eval='8'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -5053,12 +4023,12 @@
        <str val='getInstanceKeys'/>
        <array size='0'/>
       </ifCall>
-      <let line='3151' var='Q{}instances' as='map(xs:string, element())' slot='2' eval='16'>
-       <treat line='3153' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances'>
+      <let line='2901' var='Q{}instances' as='map(xs:string, element())' slot='2' eval='16'>
+       <treat line='2903' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|instances'>
         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
          <forEach>
           <varRef name='Q{}instance-keys' slot='1'/>
-          <ifCall line='3154' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <ifCall line='2904' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
            <atomSing diag='0|0||map:entry'>
             <dot/>
            </atomSing>
@@ -5081,9 +4051,9 @@
          </map>
         </ifCall>
        </treat>
-       <forEach line='3160'>
+       <forEach line='2910'>
         <varRef name='Q{}ElementsUsingIndexFunction-keys' slot='0'/>
-        <let line='3161' var='Q{}this-key' as='xs:string' slot='3' eval='16'>
+        <let line='2911' var='Q{}this-key' as='xs:string' slot='3' eval='16'>
          <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|this-key'>
           <check card='1' diag='3|0|XTTE0570|this-key'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|this-key'>
@@ -5093,7 +4063,7 @@
            </cvUntyped>
           </check>
          </treat>
-         <sequence line='3163'>
+         <sequence line='2913'>
           <message>
            <sequence role='select'>
             <valueOf>
@@ -5107,7 +4077,7 @@
            <str role='terminate' val='no'/>
            <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
           </message>
-          <let line='3165' var='Q{}this-element' as='element()' slot='4' eval='16'>
+          <let line='2915' var='Q{}this-element' as='element()' slot='4' eval='16'>
            <treat as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|this-element'>
             <check card='1' diag='3|0|XTTE0570|this-element'>
              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
@@ -5121,8 +4091,8 @@
              </ifCall>
             </check>
            </treat>
-           <let line='3166' var='Q{}this-element-refi' as='xs:string?' slot='5' eval='7'>
-            <choose line='3168'>
+           <let line='2916' var='Q{}this-element-refi' as='xs:string?' slot='5' eval='7'>
+            <choose line='2918'>
              <fn name='exists'>
               <slash simple='1'>
                <varRef name='Q{}this-element' slot='4'/>
@@ -5137,13 +4107,13 @@
                </slash>
               </data>
              </cvUntyped>
-             <fn line='3169' name='exists'>
+             <fn line='2919' name='exists'>
               <slash simple='1'>
                <varRef name='Q{}this-element' slot='4'/>
                <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
               </slash>
              </fn>
-             <cvUntyped line='3169' to='xs:string' diag='3|0|XTTE0570|this-element-refi'>
+             <cvUntyped line='2919' to='xs:string' diag='3|0|XTTE0570|this-element-refi'>
               <data>
                <slash simple='1'>
                 <varRef name='Q{}this-element' slot='4'/>
@@ -5152,12 +4122,12 @@
               </data>
              </cvUntyped>
             </choose>
-            <resultDoc line='3173' global='#&#xD;&#xA;#Sat Apr 04 13:28:45 BST 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Sat Apr 04 13:28:45 BST 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
+            <resultDoc line='2923' global='#&#xD;&#xA;#Sun Apr 05 16:19:18 BST 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Sun Apr 05 16:19:18 BST 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
              <fn role='href' name='concat'>
               <str val='#'/>
               <varRef name='Q{}this-key' slot='3'/>
              </fn>
-             <applyT role='content' line='3174' bSlot='0'>
+             <applyT role='content' line='2924' bSlot='0'>
               <slash role='select' simple='1'>
                <varRef name='Q{}this-element' slot='4'/>
                <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
@@ -5166,10 +4136,10 @@
                <true/>
               </withParam>
               <withParam name='Q{}instances' flags='t' as='map(xs:string, element())'>
-               <varRef line='3175' name='Q{}instances' slot='2'/>
+               <varRef line='2925' name='Q{}instances' slot='2'/>
               </withParam>
               <withParam name='Q{}nodeset' flags='t' as='xs:string?'>
-               <choose line='3176'>
+               <choose line='2926'>
                 <fn name='exists'>
                  <varRef name='Q{}this-element-refi' slot='5'/>
                 </fn>
@@ -5191,8 +4161,8 @@
    </sequence>
   </template>
  </co>
- <co id='54' binds=''>
-  <globalVariable name='Q{}xforms-actions' type='xs:string+' line='102' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n&gt;=1;};'>
+ <co id='55' binds=''>
+  <globalVariable name='Q{}xforms-actions' type='xs:string+' line='104' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n&gt;=1;};'>
    <literal count='15'>
     <str val='setvalue'/>
     <str val='insert'/>
@@ -5212,7 +4182,7 @@
    </literal>
   </globalVariable>
  </co>
- <co id='55' binds=''>
+ <co id='56' binds=''>
   <function name='Q{http://www.w3.org/2002/xforms}foo' line='91' module='xforms-function-library.xsl' eval='16' flags='pU' as='xs:boolean' slots='1'>
    <arg name='Q{}num' as='xs:integer'/>
    <compareToInt role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='94' op='lt' val='5'>
@@ -5220,9 +4190,9 @@
    </compareToInt>
   </function>
  </co>
- <co id='56' binds='57 57'>
-  <globalVariable name='Q{}LOGLEVEL_INT' type='xs:integer' line='68' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.integer.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
-   <choose ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='68'>
+ <co id='57' binds='58 58'>
+  <globalVariable name='Q{}LOGLEVEL_INT' type='xs:integer' line='70' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.integer.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
+   <choose ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='70'>
     <castable as='xs:integer' emptiable='0'>
      <gVarRef name='Q{}LOGLEVEL' bSlot='0'/>
     </castable>
@@ -5234,8 +4204,8 @@
    </choose>
   </globalVariable>
  </co>
- <co id='58' binds=''>
-  <globalParam name='Q{}xforms-cache-id' type='xs:string' line='71' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
+ <co id='59' binds=''>
+  <globalParam name='Q{}xforms-cache-id' type='xs:string' line='73' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
    <str val='xforms-cache'/>
   </globalParam>
  </co>
@@ -5295,7 +4265,7 @@
    </let>
   </function>
  </co>
- <co id='59' binds=''>
+ <co id='60' binds=''>
   <globalVariable name='Q{}xform-functions' type='xs:string+' line='20' module='xforms-function-library.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n&gt;=1;};'>
    <literal count='6'>
     <str val='instance'/>
@@ -5307,15 +4277,35 @@
    </literal>
   </globalVariable>
  </co>
- <co id='57' binds=''>
-  <globalParam name='Q{}LOGLEVEL' type='xs:string' line='67' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
+ <co id='61' binds='16'>
+  <template name='Q{}xforms-submit-done' flags='os' line='3802' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3803'>
+    <param name='Q{}when-done' slot='0' flags='t' as='map(*)*'>
+     <empty role='select'/>
+     <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|when-done'>
+      <supplied slot='0'/>
+     </treat>
+    </param>
+    <forEach line='3805'>
+     <varRef name='Q{}when-done' slot='0'/>
+     <callT line='3808' name='Q{}applyActions' bSlot='0'>
+      <withParam name='Q{}action-map' flags='t' as='item()'>
+       <dot line='3806' type='map(*)'/>
+      </withParam>
+     </callT>
+    </forEach>
+   </sequence>
+  </template>
+ </co>
+ <co id='58' binds=''>
+  <globalParam name='Q{}LOGLEVEL' type='xs:string' line='69' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
    <str val='40'/>
   </globalParam>
  </co>
- <co id='50' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}check-required-fields' line='941' module='saxon-xforms.xsl' eval='8' flags='pU' as='item()*' slots='3'>
+ <co id='49' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}check-required-fields' line='883' module='saxon-xforms.xsl' eval='8' flags='pU' as='item()*' slots='3'>
    <arg name='Q{}instanceXML' as='element()'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='944' var='Q{}required-fieldsi' as='element()*' slot='1' eval='8'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='886' var='Q{}required-fieldsi' as='element()*' slot='1' eval='8'>
     <filter flags='b'>
      <slash simple='1'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
@@ -5325,10 +4315,10 @@
       <axis name='attribute' nodeTest='attribute(Q{}data-required)' jsTest='return item.name===&#39;data-required&#39;'/>
      </fn>
     </filter>
-    <forEach line='946'>
+    <forEach line='888'>
      <varRef name='Q{}required-fieldsi' slot='1'/>
-     <let line='947' var='Q{}resulti' as='xs:boolean' slot='2' eval='16'>
-      <treat line='950' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|resulti'>
+     <let line='889' var='Q{}resulti' as='xs:boolean' slot='2' eval='16'>
+      <treat line='892' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|resulti'>
        <check card='1' diag='3|0|XTTE0570|resulti'>
         <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|resulti'>
          <data>
@@ -5344,7 +4334,7 @@
         </cvUntyped>
        </check>
       </treat>
-      <sequence line='953'>
+      <sequence line='895'>
        <message>
         <sequence role='select'>
          <valueOf>
@@ -5355,7 +4345,7 @@
         <str role='terminate' val='no'/>
         <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
        </message>
-       <message line='954'>
+       <message line='896'>
         <sequence role='select'>
          <valueOf>
           <str val='[xforms:check-required-fields] XPath result: '/>
@@ -5365,7 +4355,7 @@
         <str role='terminate' val='no'/>
         <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
        </message>
-       <choose line='955'>
+       <choose line='897'>
         <fn name='not'>
          <varRef name='Q{}resulti' slot='2'/>
         </fn>
@@ -5377,7 +4367,7 @@
    </let>
   </function>
  </co>
- <co id='28' binds=''>
+ <co id='26' binds=''>
   <function name='Q{http://www.w3.org/2002/xforms}index' line='98' module='xforms-function-library.xsl' eval='16' flags='pU' as='xs:integer' slots='2'>
    <arg name='Q{}repeatID' as='xs:string'/>
    <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ map=~' line='102' var='Q{}repeat-index' as='xs:double?' slot='1' eval='7'>
@@ -5413,18 +4403,18 @@
    </let>
   </function>
  </co>
- <co id='9' binds='9'>
+ <co id='8' binds='8'>
   <mode name='Q{}delete-node' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='22' rank='0' minImp='0' slots='2' flags='s' line='1966' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='22' rank='0' minImp='0' slots='2' flags='s' line='1918' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1967'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1919'>
      <param name='Q{}delete-node' slot='0' flags='t' as='node()*'>
       <empty role='select'/>
       <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|delete-node'>
        <supplied slot='0'/>
       </treat>
      </param>
-     <choose line='1970'>
+     <choose line='1922'>
       <some var='Q{}n' slot='1'>
        <varRef name='Q{}delete-node' slot='0'/>
        <is op='is'>
@@ -5434,12 +4424,12 @@
       </some>
       <empty/>
       <true/>
-      <copy line='1975' flags='cin'>
+      <copy line='1927' flags='cin'>
        <sequence role='content'>
         <copyOf flags='vc'>
          <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
         </copyOf>
-        <applyT line='1976' mode='Q{}delete-node' bSlot='0'>
+        <applyT line='1928' mode='Q{}delete-node' bSlot='0'>
          <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
         </applyT>
        </sequence>
@@ -5449,18 +4439,18 @@
    </templateRule>
   </mode>
  </co>
- <co id='15' binds=''>
+ <co id='48' binds=''>
   <mode name='Q{}get-field' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.25' seq='34' rank='0' minImp='0' slots='0' flags='s' line='2455' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='31' rank='0' minImp='0' slots='0' flags='s' line='2174' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:textarea' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;textarea&#39;'/>
-    <ifCall role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2458' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+    <ifCall role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2177' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
      <dot type='*:textarea'/>
      <str val='value'/>
     </ifCall>
    </templateRule>
-   <templateRule prec='0' prio='-0.25' seq='33' rank='0' minImp='0' slots='0' flags='s' line='2445' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='30' rank='0' minImp='0' slots='0' flags='s' line='2164' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:select' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;select&#39;'/>
-    <ifCall role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2447' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+    <ifCall role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2166' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
      <check card='?' diag='0|0||ixsl:get'>
       <filter flags='b'>
        <axis name='child' nodeTest='element(Q{}option)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;option&#39;;'/>
@@ -5478,9 +4468,9 @@
      <str val='value'/>
     </ifCall>
    </templateRule>
-   <templateRule prec='0' prio='-0.25' seq='32' rank='0' minImp='0' slots='0' flags='s' line='2426' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.25' seq='29' rank='0' minImp='0' slots='0' flags='s' line='2145' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='*:input' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;input&#39;'/>
-    <choose role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2430'>
+    <choose role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2149'>
      <and op='and'>
       <fn name='exists'>
        <axis name='attribute' nodeTest='attribute(Q{}type)' jsTest='return item.name===&#39;type&#39;'/>
@@ -5492,7 +4482,7 @@
        <str val='checkbox'/>
       </vc>
      </and>
-     <choose line='2431'>
+     <choose line='2150'>
       <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
        <data>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
@@ -5507,7 +4497,7 @@
       <str val=''/>
      </choose>
      <true/>
-     <ifCall line='2434' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
+     <ifCall line='2153' name='Q{http://saxonica.com/ns/interactiveXSLT}get' type='item()*'>
       <dot type='*:input'/>
       <str val='value'/>
      </ifCall>
@@ -5515,20 +4505,20 @@
    </templateRule>
   </mode>
  </co>
- <co id='43' binds='53 45 60 61 62 22 3 63 43 43 43 61 62 22 63 61 62 22 63 43 43 61 62 22 43 61 62 63 43 61 62 22 3 3 43 43 43 43 43'>
+ <co id='41' binds='62 44 63 64 65 17 3 66 41 41 64 65 17 66 64 65 17 66 41 41 64 65 17 41 41 64 65 66 41 64 65 17 3 3 41 41 41 41 41'>
   <mode onNo='TC' flags='dW' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='7' rank='0' minImp='0' slots='0' flags='s' line='1094' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='7' rank='0' minImp='0' slots='0' flags='s' line='1041' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='document-node()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);'/>
-    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1095' name='Q{}xformsjs-main' bSlot='0' flags='t'>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1042' name='Q{}xformsjs-main' bSlot='0' flags='t'>
      <withParam name='Q{}xFormsId' flags='c' as='xs:string'>
-      <gVarRef line='1096' name='Q{}xform-html-id' bSlot='1'/>
+      <gVarRef line='1043' name='Q{}xform-html-id' bSlot='1'/>
      </withParam>
     </callT>
    </templateRule>
-   <templateRule prec='0' prio='0.5' seq='25' part='1' rank='2' minImp='0' slots='1' flags='s' line='2083' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.5' seq='25' part='1' rank='2' minImp='0' slots='1' flags='s' line='2035' module='saxon-xforms.xsl'>
     <p.withPredicate role='match'>
      <p.nodeTest test='Q{http://www.w3.org/2002/xforms}*' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.uri===&#39;http://www.w3.org/2002/xforms&#39;'/>
-     <gc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2083' op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+     <gc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2035' op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
       <literal count='15'>
        <str val='setvalue'/>
        <str val='insert'/>
@@ -5551,22 +4541,22 @@
       </fn>
      </gc>
     </p.withPredicate>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2091' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2092' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2043' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2044' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
       <check card='1' diag='3|0|XTTE0570|action-map'>
        <callT name='Q{}setAction' bSlot='2'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2093' type='element()'/>
+         <dot line='2045' type='element()'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <varRef line='2106' name='Q{}action-map' slot='0'/>
+     <varRef line='2058' name='Q{}action-map' slot='0'/>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='10' rank='1' minImp='0' slots='17' flags='s' line='1260' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='10' rank='1' minImp='0' slots='17' flags='s' line='1212' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1261'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1213'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -5579,7 +4569,7 @@
        </check>
       </treat>
      </param>
-     <param line='1262' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1214' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -5591,7 +4581,7 @@
        </check>
       </treat>
      </param>
-     <let line='1264' var='Q{}string-position' as='xs:string' slot='2' eval='16'>
+     <let line='1216' var='Q{}string-position' as='xs:string' slot='2' eval='16'>
       <choose>
        <varRef name='Q{}context-position' slot='1'/>
        <varRef name='Q{}context-position' slot='1'/>
@@ -5600,7 +4590,7 @@
         <varRef name='Q{}position' slot='0'/>
        </fn>
       </choose>
-      <let line='1266' var='Q{}myid' as='xs:string' slot='3' eval='16'>
+      <let line='1218' var='Q{}myid' as='xs:string' slot='3' eval='16'>
        <choose>
         <fn name='exists'>
          <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -5619,13 +4609,13 @@
          <varRef name='Q{}string-position' slot='2'/>
         </fn>
        </choose>
-       <sequence line='1268'>
+       <sequence line='1220'>
         <choose>
          <and op='and'>
           <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}input)' slot='4' eval='16'>
            <dot type='element(Q{http://www.w3.org/2002/xforms}input)'/>
-           <fn line='2563' name='exists'>
-            <sequence line='2538'>
+           <fn line='2282' name='exists'>
+            <sequence line='2257'>
              <analyzeString>
               <cvUntyped role='select' to='xs:string'>
                <data>
@@ -5637,7 +4627,7 @@
               </cvUntyped>
               <str role='regex' val='\i\c*\('/>
               <str role='flags' val=''/>
-              <choose role='matching' line='2541'>
+              <choose role='matching' line='2260'>
                <vc op='eq' onEmpty='0' comp='CCC'>
                 <fn name='substring-before'>
                  <dot type='xs:string'/>
@@ -5649,7 +4639,7 @@
               </choose>
               <empty role='nonMatching'/>
              </analyzeString>
-             <analyzeString line='2550'>
+             <analyzeString line='2269'>
               <cvUntyped role='select' to='xs:string'>
                <data>
                 <slash simple='1'>
@@ -5660,7 +4650,7 @@
               </cvUntyped>
               <str role='regex' val='\i\c*\('/>
               <str role='flags' val=''/>
-              <choose role='matching' line='2553'>
+              <choose role='matching' line='2272'>
                <vc op='eq' onEmpty='0' comp='CCC'>
                 <fn name='substring-before'>
                  <dot type='xs:string'/>
@@ -5683,8 +4673,8 @@
             </slash>
             <let var='Q{}this' as='element()' slot='5' eval='16'>
              <dot type='element()'/>
-             <fn line='2563' name='exists'>
-              <sequence line='2538'>
+             <fn line='2282' name='exists'>
+              <sequence line='2257'>
                <analyzeString>
                 <cvUntyped role='select' to='xs:string'>
                  <data>
@@ -5696,7 +4686,7 @@
                 </cvUntyped>
                 <str role='regex' val='\i\c*\('/>
                 <str role='flags' val=''/>
-                <choose role='matching' line='2541'>
+                <choose role='matching' line='2260'>
                  <vc op='eq' onEmpty='0' comp='CCC'>
                   <fn name='substring-before'>
                    <dot type='xs:string'/>
@@ -5708,7 +4698,7 @@
                 </choose>
                 <empty role='nonMatching'/>
                </analyzeString>
-               <analyzeString line='2550'>
+               <analyzeString line='2269'>
                 <cvUntyped role='select' to='xs:string'>
                  <data>
                   <slash simple='1'>
@@ -5719,7 +4709,7 @@
                 </cvUntyped>
                 <str role='regex' val='\i\c*\('/>
                 <str role='flags' val=''/>
-                <choose role='matching' line='2553'>
+                <choose role='matching' line='2272'>
                  <vc op='eq' onEmpty='0' comp='CCC'>
                   <fn name='substring-before'>
                    <dot type='xs:string'/>
@@ -5737,7 +4727,7 @@
            </filter>
           </fn>
          </and>
-         <ifCall line='1269' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+         <ifCall line='1221' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
           <check card='1' diag='0|0||ixsl:call'>
            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
           </check>
@@ -5748,45 +4738,45 @@
           </arrayBlock>
          </ifCall>
         </choose>
-        <let line='1277' var='Q{}bindingi' as='node()?' slot='6' eval='7'>
-         <treat line='1278' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+        <let line='1229' var='Q{}bindingi' as='node()?' slot='6' eval='7'>
+         <treat line='1230' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
           <check card='?' diag='3|0|XTTE0570|bindingi'>
            <callT name='Q{}getBinding' bSlot='3'>
             <withParam name='Q{}this' flags='c' as='element()'>
-             <dot line='1279' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
+             <dot line='1231' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
             </withParam>
            </callT>
           </check>
          </treat>
-         <let line='1287' var='Q{}refi' as='xs:string' slot='7' eval='16'>
-          <treat line='1288' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+         <let line='1239' var='Q{}refi' as='xs:string' slot='7' eval='16'>
+          <treat line='1240' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
            <check card='1' diag='3|0|XTTE0570|refi'>
             <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
              <data>
               <callT name='Q{}getDataRef' bSlot='4'>
                <withParam name='Q{}this' flags='c' as='element()'>
-                <dot line='1289' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
+                <dot line='1241' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
                </withParam>
                <withParam name='Q{}bindingi' flags='c' as='node()?'>
-                <varRef line='1290' name='Q{}bindingi' slot='6'/>
+                <varRef line='1242' name='Q{}bindingi' slot='6'/>
                </withParam>
               </callT>
              </data>
             </cvUntyped>
            </check>
           </treat>
-          <let line='1297' var='Q{}instanceField' as='node()?' slot='8' eval='7'>
-           <treat line='1298' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+          <let line='1249' var='Q{}instanceField' as='node()?' slot='8' eval='7'>
+           <treat line='1250' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
             <check card='?' diag='3|0|XTTE0570|instanceField'>
              <callT name='Q{}getReferencedInstanceField' bSlot='5'>
               <withParam name='Q{}refi' flags='c' as='xs:string'>
-               <varRef line='1299' name='Q{}refi' slot='7'/>
+               <varRef line='1251' name='Q{}refi' slot='7'/>
               </withParam>
              </callT>
             </check>
            </treat>
-           <let line='1313' var='Q{}relevantVar' as='xs:boolean' slot='9' eval='16'>
-            <choose line='1315'>
+           <let line='1265' var='Q{}relevantVar' as='xs:boolean' slot='9' eval='16'>
+            <choose line='1267'>
              <and op='and'>
               <and op='and'>
                <fn name='exists'>
@@ -5803,7 +4793,7 @@
                <varRef name='Q{}instanceField' slot='8'/>
               </fn>
              </and>
-             <treat line='1316' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantVar'>
+             <treat line='1268' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantVar'>
               <check card='1' diag='3|0|XTTE0570|relevantVar'>
                <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|relevantVar'>
                 <data>
@@ -5821,7 +4811,7 @@
                    </check>
                   </ufCall>
                   <varRef role='cxt' name='Q{}instanceField' slot='8'/>
-                  <choose role='nsCxt' line='1308'>
+                  <choose role='nsCxt' line='1260'>
                    <fn name='exists'>
                     <varRef name='Q{}instanceField' slot='8'/>
                    </fn>
@@ -5838,16 +4828,16 @@
                       <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
                      </slash>
                     </check>
-                    <compElem line='2573'>
+                    <compElem line='2292'>
                      <fn role='name' name='name'>
                       <varRef name='Q{}this' slot='10'/>
                      </fn>
-                     <sequence role='content' line='2574'>
+                     <sequence role='content' line='2293'>
                       <namespace flags='l'>
                        <str role='name' val='xforms'/>
                        <str role='select' val='http://www.w3.org/2002/xforms'/>
                       </namespace>
-                      <forEach line='2575'>
+                      <forEach line='2294'>
                        <filter flags='b'>
                         <filter flags='b'>
                          <slash simple='1'>
@@ -5886,21 +4876,21 @@
                          </gc>
                         </fn>
                        </filter>
-                       <namespace line='2578' flags='l'>
-                        <fn role='name' line='2577' name='substring-before'>
+                       <namespace line='2297' flags='l'>
+                        <fn role='name' line='2296' name='substring-before'>
                          <fn name='name'>
                           <dot type='element()'/>
                          </fn>
                          <str val=':'/>
                         </fn>
                         <convert role='select' from='xs:anyURI' to='xs:string'>
-                         <fn line='2576' name='namespace-uri'>
+                         <fn line='2295' name='namespace-uri'>
                           <dot type='element()'/>
                          </fn>
                         </convert>
                        </namespace>
                       </forEach>
-                      <copyOf line='2580' flags='vc'>
+                      <copyOf line='2299' flags='vc'>
                        <sequence>
                         <slash simple='1'>
                          <varRef name='Q{}this' slot='10'/>
@@ -5927,23 +4917,23 @@
              <true/>
              <true/>
             </choose>
-            <let line='1326' var='Q{}actions' as='map(*)*' slot='11' eval='8'>
-             <treat line='1327' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+            <let line='1278' var='Q{}actions' as='map(*)*' slot='11' eval='8'>
+             <treat line='1279' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
               <callT name='Q{}setActions' bSlot='7'>
                <withParam name='Q{}this' flags='c' as='element()'>
-                <dot line='1328' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
+                <dot line='1280' type='element(Q{http://www.w3.org/2002/xforms}input)'/>
                </withParam>
                <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                <varRef line='1329' name='Q{}refi' slot='7'/>
+                <varRef line='1281' name='Q{}refi' slot='7'/>
                </withParam>
               </callT>
              </treat>
-             <sequence line='1334'>
+             <sequence line='1286'>
               <choose>
                <fn name='exists'>
                 <varRef name='Q{}actions' slot='11'/>
                </fn>
-               <ifCall line='1335' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+               <ifCall line='1287' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                 <check card='1' diag='0|0||ixsl:call'>
                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                 </check>
@@ -5954,12 +4944,12 @@
                 </arrayBlock>
                </ifCall>
               </choose>
-              <elem line='1340' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+              <elem line='1292' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
                <sequence>
                 <att name='class' flags='l'>
                  <str val='xforms-input'/>
                 </att>
-                <att line='1341' name='style' flags='l'>
+                <att line='1293' name='style' flags='l'>
                  <choose>
                   <varRef name='Q{}relevantVar' slot='9'/>
                   <str val='display:block'/>
@@ -5967,27 +4957,27 @@
                   <str val='display:none'/>
                  </choose>
                 </att>
-                <applyT line='1343' bSlot='8'>
+                <applyT line='1295' bSlot='8'>
                  <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
                 </applyT>
-                <let line='1345' var='Q{}hints' as='text()*' slot='12' eval='4'>
+                <let line='1297' var='Q{}hints' as='text()*' slot='12' eval='4'>
                  <slash simple='2'>
                   <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}hint)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;hint&#39;;'/>
                   <axis name='child' nodeTest='text()' jsTest='return item.nodeType===3;'/>
                  </slash>
-                 <elem line='1349' name='input' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
-                  <sequence line='1350'>
+                 <elem line='1301' name='input' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
+                  <sequence line='1302'>
                    <let var='Q{}element' as='element(Q{http://www.w3.org/2002/xforms}input)' slot='13' eval='16'>
                     <dot type='element(Q{http://www.w3.org/2002/xforms}input)'/>
-                    <let line='2635' var='Q{}class' as='xs:string?' slot='14' eval='7'>
-                     <choose line='2636'>
+                    <let line='2354' var='Q{}class' as='xs:string?' slot='14' eval='7'>
+                     <choose line='2355'>
                       <fn name='exists'>
                        <slash simple='1'>
                         <varRef name='Q{}element' slot='13'/>
                         <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
                        </slash>
                       </fn>
-                      <cvUntyped line='2637' to='xs:string' diag='3|0|XTTE0570|class'>
+                      <cvUntyped line='2356' to='xs:string' diag='3|0|XTTE0570|class'>
                        <cast as='xs:untypedAtomic' emptiable='0'>
                         <fn name='string'>
                          <convert from='xs:untypedAtomic' to='xs:string'>
@@ -6002,15 +4992,15 @@
                        </cast>
                       </cvUntyped>
                      </choose>
-                     <let line='2640' var='Q{}class-mod' as='xs:string?' slot='15' eval='7'>
-                      <choose line='2642'>
+                     <let line='2359' var='Q{}class-mod' as='xs:string?' slot='15' eval='7'>
+                      <choose line='2361'>
                        <fn name='exists'>
                         <slash simple='1'>
                          <varRef name='Q{}element' slot='13'/>
                          <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
                         </slash>
                        </fn>
-                       <cvUntyped line='2643' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                       <cvUntyped line='2362' to='xs:string' diag='3|0|XTTE0570|class-mod'>
                         <cast as='xs:untypedAtomic' emptiable='0'>
                          <fn name='string-join'>
                           <sequence>
@@ -6022,13 +5012,13 @@
                         </cast>
                        </cvUntyped>
                        <true/>
-                       <varRef line='2646' name='Q{}class' slot='14'/>
+                       <varRef line='2365' name='Q{}class' slot='14'/>
                       </choose>
-                      <choose line='2650'>
+                      <choose line='2369'>
                        <fn name='exists'>
                         <varRef name='Q{}class-mod' slot='15'/>
                        </fn>
-                       <treat line='2651' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                       <treat line='2370' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
                         <att name='class' flags='l'>
                          <varRef name='Q{}class-mod' slot='15'/>
                         </att>
@@ -6037,14 +5027,14 @@
                      </let>
                     </let>
                    </let>
-                   <att line='1351' name='id' flags='l'>
+                   <att line='1303' name='id' flags='l'>
                     <varRef name='Q{}myid' slot='3'/>
                    </att>
-                   <att line='1353' name='data-ref' flags='l'>
+                   <att line='1305' name='data-ref' flags='l'>
                     <varRef name='Q{}refi' slot='7'/>
                    </att>
-                   <att line='1354' name='data-element' flags='l'>
-                    <lastOf line='1347'>
+                   <att line='1306' name='data-element' flags='l'>
+                    <lastOf line='1299'>
                      <fn name='tokenize'>
                       <varRef name='Q{}refi' slot='7'/>
                       <str val='/'/>
@@ -6052,7 +5042,7 @@
                      </fn>
                     </lastOf>
                    </att>
-                   <choose line='1356'>
+                   <choose line='1308'>
                     <and op='and'>
                      <fn name='exists'>
                       <varRef name='Q{}bindingi' slot='6'/>
@@ -6064,7 +5054,7 @@
                       </slash>
                      </fn>
                     </and>
-                    <att line='1357' name='data-required' flags='l'>
+                    <att line='1309' name='data-required' flags='l'>
                      <convert from='xs:untypedAtomic' to='xs:string'>
                       <data>
                        <slash simple='1'>
@@ -6075,7 +5065,7 @@
                      </convert>
                     </att>
                    </choose>
-                   <choose line='1359'>
+                   <choose line='1311'>
                     <and op='and'>
                      <fn name='exists'>
                       <varRef name='Q{}bindingi' slot='6'/>
@@ -6087,7 +5077,7 @@
                       </slash>
                      </fn>
                     </and>
-                    <att line='1360' name='data-constraint' flags='l'>
+                    <att line='1312' name='data-constraint' flags='l'>
                      <convert from='xs:untypedAtomic' to='xs:string'>
                       <data>
                        <slash simple='1'>
@@ -6098,15 +5088,15 @@
                      </convert>
                     </att>
                    </choose>
-                   <choose line='1362'>
+                   <choose line='1314'>
                     <fn name='exists'>
                      <varRef name='Q{}actions' slot='11'/>
                     </fn>
-                    <att line='1363' name='data-action' flags='l'>
+                    <att line='1315' name='data-action' flags='l'>
                      <varRef name='Q{}myid' slot='3'/>
                     </att>
                    </choose>
-                   <choose line='1366'>
+                   <choose line='1318'>
                     <and op='and'>
                      <fn name='exists'>
                       <varRef name='Q{}bindingi' slot='6'/>
@@ -6118,7 +5108,7 @@
                       </slash>
                      </fn>
                     </and>
-                    <att line='1367' name='data-relevant' flags='l'>
+                    <att line='1319' name='data-relevant' flags='l'>
                      <convert from='xs:untypedAtomic' to='xs:string'>
                       <data>
                        <slash simple='1'>
@@ -6129,12 +5119,12 @@
                      </convert>
                     </att>
                    </choose>
-                   <let line='1370' var='Q{}input-value' as='xs:string' slot='16' eval='16'>
-                    <choose line='1372'>
+                   <let line='1322' var='Q{}input-value' as='xs:string' slot='16' eval='16'>
+                    <choose line='1324'>
                      <fn name='exists'>
                       <varRef name='Q{}instanceField' slot='8'/>
                      </fn>
-                     <cvUntyped line='1373' to='xs:string' diag='3|0|XTTE0570|input-value'>
+                     <cvUntyped line='1325' to='xs:string' diag='3|0|XTTE0570|input-value'>
                       <cast as='xs:untypedAtomic' emptiable='0'>
                        <fn name='string'>
                         <convert from='xs:anyAtomicType' to='xs:string'>
@@ -6148,7 +5138,7 @@
                      <true/>
                      <str val=''/>
                     </choose>
-                    <sequence line='1387'>
+                    <sequence line='1339'>
                      <choose>
                       <choose>
                        <fn name='exists'>
@@ -6168,18 +5158,18 @@
                        <true/>
                        <false/>
                       </choose>
-                      <sequence line='1388'>
+                      <sequence line='1340'>
                        <att name='data-type' flags='l'>
                         <str val='date'/>
                        </att>
-                       <att line='1390' name='type' flags='l'>
+                       <att line='1342' name='type' flags='l'>
                         <str val='date'/>
                        </att>
-                       <att line='1392' name='value' flags='l'>
+                       <att line='1344' name='value' flags='l'>
                         <varRef name='Q{}input-value' slot='16'/>
                        </att>
                       </sequence>
-                      <choose line='1399'>
+                      <choose line='1351'>
                        <fn name='exists'>
                         <varRef name='Q{}bindingi' slot='6'/>
                        </fn>
@@ -6197,18 +5187,18 @@
                        <true/>
                        <false/>
                       </choose>
-                      <sequence line='1400'>
+                      <sequence line='1352'>
                        <att name='data-type' flags='l'>
                         <str val='time'/>
                        </att>
-                       <att line='1402' name='type' flags='l'>
+                       <att line='1354' name='type' flags='l'>
                         <str val='time'/>
                        </att>
-                       <att line='1405' name='value' flags='l'>
+                       <att line='1357' name='value' flags='l'>
                         <varRef name='Q{}input-value' slot='16'/>
                        </att>
                       </sequence>
-                      <choose line='1412'>
+                      <choose line='1364'>
                        <fn name='exists'>
                         <varRef name='Q{}bindingi' slot='6'/>
                        </fn>
@@ -6226,48 +5216,48 @@
                        <true/>
                        <false/>
                       </choose>
-                      <sequence line='1413'>
+                      <sequence line='1365'>
                        <att name='data-type' flags='l'>
                         <str val='checkbox'/>
                        </att>
-                       <att line='1415' name='type' flags='l'>
+                       <att line='1367' name='type' flags='l'>
                         <str val='checkbox'/>
                        </att>
-                       <choose line='1420'>
+                       <choose line='1372'>
                         <fn name='exists'>
                          <varRef name='Q{}instanceField' slot='8'/>
                         </fn>
-                        <choose line='1421'>
+                        <choose line='1373'>
                          <and op='and'>
                           <varRef name='Q{}input-value' slot='16'/>
                           <cast as='xs:boolean' emptiable='0'>
                            <varRef name='Q{}input-value' slot='16'/>
                           </cast>
                          </and>
-                         <att line='1422' name='checked' flags='l'>
+                         <att line='1374' name='checked' flags='l'>
                           <varRef name='Q{}input-value' slot='16'/>
                          </att>
                         </choose>
                        </choose>
                       </sequence>
                       <true/>
-                      <sequence line='1428'>
+                      <sequence line='1380'>
                        <choose>
                         <varRef name='Q{}relevantVar' slot='9'/>
-                        <att line='1429' name='type' flags='l'>
+                        <att line='1381' name='type' flags='l'>
                          <str val='text'/>
                         </att>
                        </choose>
-                       <att line='1431' name='value' flags='l'>
+                       <att line='1383' name='value' flags='l'>
                         <varRef name='Q{}input-value' slot='16'/>
                        </att>
                       </sequence>
                      </choose>
-                     <choose line='1435'>
+                     <choose line='1387'>
                       <fn name='exists'>
                        <varRef name='Q{}hints' slot='12'/>
                       </fn>
-                      <att line='1436' name='title' flags='l'>
+                      <att line='1388' name='title' flags='l'>
                        <fn name='string-join'>
                         <convert from='xs:untypedAtomic' to='xs:string'>
                          <data>
@@ -6280,11 +5270,11 @@
                        </fn>
                       </att>
                      </choose>
-                     <choose line='1438'>
+                     <choose line='1390'>
                       <fn name='exists'>
                        <axis name='attribute' nodeTest='attribute(Q{}size)' jsTest='return item.name===&#39;size&#39;'/>
                       </fn>
-                      <att line='1439' name='size' flags='l'>
+                      <att line='1391' name='size' flags='l'>
                        <convert from='xs:untypedAtomic' to='xs:string'>
                         <attVal name='Q{}size' chk='0'/>
                        </convert>
@@ -6308,9 +5298,9 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='20' rank='1' minImp='0' slots='3' flags='s' line='1884' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='20' rank='1' minImp='0' slots='3' flags='s' line='1836' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}submit)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;submit&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1885'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1837'>
      <param name='Q{}submissions' slot='0' flags='t' as='map(xs:string, map(*))'>
       <map role='select' size='0'/>
       <treat role='conversion' as='map(xs:string, map(*))' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isMap(item)};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|submissions'>
@@ -6319,16 +5309,8 @@
        </check>
       </treat>
      </param>
-     <let line='1892' var='Q{}submission-id' as='xs:string' slot='1' eval='16'>
+     <let line='1844' var='Q{}submission-id' as='xs:string' slot='1' eval='16'>
       <choose>
-       <fn name='exists'>
-        <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
-       </fn>
-       <check card='1' diag='3|0|XTTE0570|submission-id'>
-        <cast as='xs:string' emptiable='1'>
-         <attVal name='Q{}id' chk='0'/>
-        </cast>
-       </check>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}submission)' jsTest='return item.name===&#39;submission&#39;'/>
        </fn>
@@ -6337,34 +5319,42 @@
          <attVal name='Q{}submission' chk='0'/>
         </cast>
        </check>
+       <fn name='exists'>
+        <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
+       </fn>
+       <check card='1' diag='3|0|XTTE0570|submission-id'>
+        <cast as='xs:string' emptiable='1'>
+         <attVal name='Q{}id' chk='0'/>
+        </cast>
+       </check>
        <true/>
        <str val='saxon-forms-default-submission'/>
       </choose>
-      <let line='1898' var='Q{}innerbody' as='document-node()' slot='2' eval='16'>
-       <doc line='1899' validation='preserve'>
+      <let line='1850' var='Q{}innerbody' as='document-node()' slot='2' eval='16'>
+       <doc line='1851' validation='preserve'>
         <applyT bSlot='9'>
          <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
         </applyT>
        </doc>
-       <choose line='1903'>
+       <choose line='1855'>
         <vc op='eq' onEmpty='0' comp='CCC'>
          <cast as='xs:string' emptiable='1'>
           <attVal name='Q{}appearance' chk='0'/>
          </cast>
          <str val='minimal'/>
         </vc>
-        <elem line='1904' name='a' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
-         <copyOf line='1905' flags='vc'>
+        <elem line='1856' name='a' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+         <copyOf line='1857' flags='vc'>
           <varRef name='Q{}innerbody' slot='2'/>
          </copyOf>
         </elem>
         <true/>
-        <elem line='1909' name='button' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+        <elem line='1861' name='button' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
          <sequence>
           <att name='type' flags='l'>
            <str val='button'/>
           </att>
-          <copyOf line='1910' flags='vc'>
+          <copyOf line='1862' flags='vc'>
            <filter flags='b'>
             <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
             <vc op='ne' onEmpty='0' comp='CCC'>
@@ -6375,16 +5365,16 @@
             </vc>
            </filter>
           </copyOf>
-          <choose line='1912'>
+          <choose line='1864'>
            <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
             <varRef name='Q{}submissions' slot='0'/>
             <varRef name='Q{}submission-id' slot='1'/>
            </ifCall>
-           <att line='1914' name='data-submit' flags='l'>
+           <att line='1866' name='data-submit' flags='l'>
             <varRef name='Q{}submission-id' slot='1'/>
            </att>
           </choose>
-          <copyOf line='1916' flags='vc'>
+          <copyOf line='1868' flags='vc'>
            <varRef name='Q{}innerbody' slot='2'/>
           </copyOf>
          </sequence>
@@ -6394,89 +5384,9 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='8' part='1' rank='1' minImp='0' slots='0' flags='s' line='1110' module='saxon-xforms.xsl'>
-    <p.nodeTest role='match' test='element(Q{}html)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;html&#39;;'/>
-    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1111' name='html' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
-     <sequence line='1112'>
-      <copyOf flags='vc'>
-       <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
-      </copyOf>
-      <elem line='1113' name='head' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
-       <sequence line='1114'>
-        <copyOf flags='vc'>
-         <union op='|'>
-          <slash simple='2'>
-           <axis name='child' nodeTest='element(Q{http://www.w3.org/1999/xhtml}head)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/1999/xhtml&#39;&amp;&amp;q.local===&#39;head&#39;;'/>
-           <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
-          </slash>
-          <slash simple='2'>
-           <axis name='child' nodeTest='element(Q{}head)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;head&#39;;'/>
-           <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
-          </slash>
-         </union>
-        </copyOf>
-        <elem line='1115' name='meta' nsuri='' flags='l'>
-         <sequence>
-          <att name='http-equiv' flags='l'>
-           <str val='Content-Type'/>
-          </att>
-          <att name='content' flags='l'>
-           <str val='text/html;charset=utf-8'/>
-          </att>
-         </sequence>
-        </elem>
-        <forEach line='1117'>
-         <union op='|'>
-          <filter flags='b'>
-           <slash simple='2'>
-            <axis name='child' nodeTest='element(Q{http://www.w3.org/1999/xhtml}head)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/1999/xhtml&#39;&amp;&amp;q.local===&#39;head&#39;;'/>
-            <axis name='child' nodeTest='element(Q{http://www.w3.org/1999/xhtml}meta)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/1999/xhtml&#39;&amp;&amp;q.local===&#39;meta&#39;;'/>
-           </slash>
-           <vc op='ne' onEmpty='0' comp='CCC'>
-            <fn name='string'>
-             <axis name='attribute' nodeTest='attribute(Q{}http-equiv)' jsTest='return item.name===&#39;http-equiv&#39;'/>
-            </fn>
-            <str val='Content-Type'/>
-           </vc>
-          </filter>
-          <filter flags='b'>
-           <slash simple='2'>
-            <axis name='child' nodeTest='element(Q{}head)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;head&#39;;'/>
-            <axis name='child' nodeTest='element(Q{}meta)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;meta&#39;;'/>
-           </slash>
-           <vc op='ne' onEmpty='0' comp='CCC'>
-            <fn name='string'>
-             <axis name='attribute' nodeTest='attribute(Q{}http-equiv)' jsTest='return item.name===&#39;http-equiv&#39;'/>
-            </fn>
-            <str val='Content-Type'/>
-           </vc>
-          </filter>
-         </union>
-         <elem line='1118' name='meta' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
-          <copyOf line='1119' flags='vc'>
-           <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
-          </copyOf>
-         </elem>
-        </forEach>
-        <copyOf line='1124' flags='vc'>
-         <axis name='child' nodeTest='element(Q{}script)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;script&#39;;'/>
-        </copyOf>
-       </sequence>
-      </elem>
-      <elem line='1126' name='body' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
-       <applyT line='1127' bSlot='10'>
-        <slash role='select' simple='2'>
-         <axis name='child' nodeTest='element(Q{}body)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;body&#39;;'/>
-         <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
-        </slash>
-       </applyT>
-      </elem>
-     </sequence>
-    </elem>
-   </templateRule>
-   <templateRule prec='0' prio='2.0' seq='11' rank='3' minImp='0' slots='10' flags='s' line='1457' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='2.0' seq='11' rank='3' minImp='0' slots='10' flags='s' line='1409' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}textarea)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;textarea&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1458'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1410'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -6489,7 +5399,7 @@
        </check>
       </treat>
      </param>
-     <param line='1459' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1411' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -6501,7 +5411,7 @@
        </check>
       </treat>
      </param>
-     <let line='1463' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='1415' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -6517,7 +5427,7 @@
          <dot type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
         </fn>
         <str val='-'/>
-        <choose line='1461'>
+        <choose line='1413'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -6527,13 +5437,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1465'>
+      <sequence line='1417'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}textarea)' slot='3' eval='16'>
           <dot type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
-          <fn line='2563' name='exists'>
-           <sequence line='2538'>
+          <fn line='2282' name='exists'>
+           <sequence line='2257'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -6545,7 +5455,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2541'>
+             <choose role='matching' line='2260'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -6557,7 +5467,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='2550'>
+            <analyzeString line='2269'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -6568,7 +5478,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2553'>
+             <choose role='matching' line='2272'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -6591,8 +5501,8 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='2563' name='exists'>
-             <sequence line='2538'>
+            <fn line='2282' name='exists'>
+             <sequence line='2257'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
@@ -6604,7 +5514,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2541'>
+               <choose role='matching' line='2260'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -6616,7 +5526,7 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
-              <analyzeString line='2550'>
+              <analyzeString line='2269'>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
@@ -6627,7 +5537,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2553'>
+               <choose role='matching' line='2272'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -6645,7 +5555,7 @@
           </filter>
          </fn>
         </and>
-        <ifCall line='1466' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1418' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -6656,60 +5566,60 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1470' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='1471' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='1422' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1423' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
-          <callT name='Q{}getBinding' bSlot='11'>
+          <callT name='Q{}getBinding' bSlot='10'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='1472' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
+            <dot line='1424' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='1477' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='1478' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='1429' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1430' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
-             <callT name='Q{}getDataRef' bSlot='12'>
+             <callT name='Q{}getDataRef' bSlot='11'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='1479' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
+               <dot line='1431' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='1480' name='Q{}bindingi' slot='5'/>
+               <varRef line='1432' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='1485' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
-          <treat line='1486' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+         <let line='1437' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
+          <treat line='1438' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
            <check card='?' diag='3|0|XTTE0570|instanceField'>
-            <callT name='Q{}getReferencedInstanceField' bSlot='13'>
+            <callT name='Q{}getReferencedInstanceField' bSlot='12'>
              <withParam name='Q{}refi' flags='c' as='xs:string'>
-              <varRef line='1487' name='Q{}refi' slot='6'/>
+              <varRef line='1439' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </check>
           </treat>
-          <let line='1492' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
-           <treat line='1493' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
-            <callT name='Q{}setActions' bSlot='14'>
+          <let line='1444' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
+           <treat line='1445' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+            <callT name='Q{}setActions' bSlot='13'>
              <withParam name='Q{}this' flags='c' as='element()'>
-              <dot line='1494' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
+              <dot line='1446' type='element(Q{http://www.w3.org/2002/xforms}textarea)'/>
              </withParam>
              <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-              <varRef line='1495' name='Q{}refi' slot='6'/>
+              <varRef line='1447' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </treat>
-           <sequence line='1499'>
+           <sequence line='1451'>
             <choose>
              <fn name='exists'>
               <varRef name='Q{}actions' slot='8'/>
              </fn>
-             <ifCall line='1500' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+             <ifCall line='1452' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
               <check card='1' diag='0|0||ixsl:call'>
                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
               </check>
@@ -6720,13 +5630,13 @@
               </arrayBlock>
              </ifCall>
             </choose>
-            <let line='1505' var='Q{}hints' as='text()*' slot='9' eval='4'>
+            <let line='1457' var='Q{}hints' as='text()*' slot='9' eval='4'>
              <slash simple='2'>
               <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}hint)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;hint&#39;;'/>
               <axis name='child' nodeTest='text()' jsTest='return item.nodeType===3;'/>
              </slash>
-             <elem line='1507' name='textarea' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
-              <sequence line='1508'>
+             <elem line='1459' name='textarea' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+              <sequence line='1460'>
                <copyOf flags='vc'>
                 <filter flags='b'>
                  <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
@@ -6738,8 +5648,8 @@
                  </vc>
                 </filter>
                </copyOf>
-               <att line='1509' name='data-element' flags='l'>
-                <lastOf line='1503'>
+               <att line='1461' name='data-element' flags='l'>
+                <lastOf line='1455'>
                  <fn name='tokenize'>
                   <varRef name='Q{}refi' slot='6'/>
                   <str val='/'/>
@@ -6747,14 +5657,14 @@
                  </fn>
                 </lastOf>
                </att>
-               <att line='1510' name='data-ref' flags='l'>
+               <att line='1462' name='data-ref' flags='l'>
                 <varRef name='Q{}refi' slot='6'/>
                </att>
-               <choose line='1512'>
+               <choose line='1464'>
                 <fn name='exists'>
                  <varRef name='Q{}instanceField' slot='7'/>
                 </fn>
-                <valueOf line='1513' flags='l'>
+                <valueOf line='1465' flags='l'>
                  <convert from='xs:anyAtomicType' to='xs:string'>
                   <data>
                    <varRef name='Q{}instanceField' slot='7'/>
@@ -6762,7 +5672,7 @@
                  </convert>
                 </valueOf>
                 <true/>
-                <sequence line='1515'>
+                <sequence line='1467'>
                  <valueOf flags='Sl'>
                   <str val=''/>
                  </valueOf>
@@ -6771,11 +5681,11 @@
                  </valueOf>
                 </sequence>
                </choose>
-               <choose line='1518'>
+               <choose line='1470'>
                 <fn name='exists'>
                  <varRef name='Q{}hints' slot='9'/>
                 </fn>
-                <att line='1519' name='title' flags='l'>
+                <att line='1471' name='title' flags='l'>
                  <fn name='string-join'>
                   <convert from='xs:untypedAtomic' to='xs:string'>
                    <data>
@@ -6800,24 +5710,24 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='25' part='5' rank='1' minImp='0' slots='1' flags='s' line='2083' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='25' part='5' rank='1' minImp='0' slots='1' flags='s' line='2035' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}unload)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;unload&#39;;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2091' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2092' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2043' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2044' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
       <check card='1' diag='3|0|XTTE0570|action-map'>
        <callT name='Q{}setAction' bSlot='2'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2093' type='element()'/>
+         <dot line='2045' type='element()'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <varRef line='2106' name='Q{}action-map' slot='0'/>
+     <varRef line='2058' name='Q{}action-map' slot='0'/>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='13' part='1' rank='1' minImp='0' slots='12' flags='s' line='1542' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='13' part='1' rank='1' minImp='0' slots='12' flags='s' line='1494' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}select)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;select&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1543'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1495'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -6830,7 +5740,7 @@
        </check>
       </treat>
      </param>
-     <param line='1544' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1496' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -6842,7 +5752,7 @@
        </check>
       </treat>
      </param>
-     <let line='1548' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='1500' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -6858,7 +5768,7 @@
          <dot type='element()'/>
         </fn>
         <str val='-'/>
-        <choose line='1546'>
+        <choose line='1498'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -6868,13 +5778,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1550'>
+      <sequence line='1502'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element()' slot='3' eval='16'>
           <dot type='element()'/>
-          <fn line='2563' name='exists'>
-           <sequence line='2538'>
+          <fn line='2282' name='exists'>
+           <sequence line='2257'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -6886,7 +5796,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2541'>
+             <choose role='matching' line='2260'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -6898,7 +5808,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='2550'>
+            <analyzeString line='2269'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -6909,7 +5819,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2553'>
+             <choose role='matching' line='2272'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -6932,8 +5842,8 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='2563' name='exists'>
-             <sequence line='2538'>
+            <fn line='2282' name='exists'>
+             <sequence line='2257'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
@@ -6945,7 +5855,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2541'>
+               <choose role='matching' line='2260'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -6957,7 +5867,7 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
-              <analyzeString line='2550'>
+              <analyzeString line='2269'>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
@@ -6968,7 +5878,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2553'>
+               <choose role='matching' line='2272'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -6986,7 +5896,7 @@
           </filter>
          </fn>
         </and>
-        <ifCall line='1551' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1503' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -6997,60 +5907,60 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1558' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='1559' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='1510' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1511' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
-          <callT name='Q{}getBinding' bSlot='15'>
+          <callT name='Q{}getBinding' bSlot='14'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='1560' type='element()'/>
+            <dot line='1512' type='element()'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='1565' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='1566' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='1517' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1518' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
-             <callT name='Q{}getDataRef' bSlot='16'>
+             <callT name='Q{}getDataRef' bSlot='15'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='1567' type='element()'/>
+               <dot line='1519' type='element()'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='1568' name='Q{}bindingi' slot='5'/>
+               <varRef line='1520' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='1573' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
-          <treat line='1574' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+         <let line='1525' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
+          <treat line='1526' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
            <check card='?' diag='3|0|XTTE0570|instanceField'>
-            <callT name='Q{}getReferencedInstanceField' bSlot='17'>
+            <callT name='Q{}getReferencedInstanceField' bSlot='16'>
              <withParam name='Q{}refi' flags='c' as='xs:string'>
-              <varRef line='1575' name='Q{}refi' slot='6'/>
+              <varRef line='1527' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </check>
           </treat>
-          <let line='1580' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
-           <treat line='1581' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
-            <callT name='Q{}setActions' bSlot='18'>
+          <let line='1532' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
+           <treat line='1533' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+            <callT name='Q{}setActions' bSlot='17'>
              <withParam name='Q{}this' flags='c' as='element()'>
-              <dot line='1582' type='element()'/>
+              <dot line='1534' type='element()'/>
              </withParam>
              <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-              <varRef line='1583' name='Q{}refi' slot='6'/>
+              <varRef line='1535' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </treat>
-           <sequence line='1587'>
+           <sequence line='1539'>
             <choose>
              <fn name='exists'>
               <varRef name='Q{}actions' slot='8'/>
              </fn>
-             <ifCall line='1588' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+             <ifCall line='1540' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
               <check card='1' diag='0|0||ixsl:call'>
                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
               </check>
@@ -7061,27 +5971,27 @@
               </arrayBlock>
              </ifCall>
             </choose>
-            <elem line='1605' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+            <elem line='1557' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
              <sequence>
               <att name='class' flags='l'>
                <str val='xforms-select'/>
               </att>
-              <applyT line='1606' bSlot='19'>
+              <applyT line='1558' bSlot='18'>
                <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
               </applyT>
-              <elem line='1608' name='select' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
-               <sequence line='1609'>
+              <elem line='1560' name='select' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
+               <sequence line='1561'>
                 <let var='Q{}element' as='element()' slot='9' eval='16'>
                  <dot type='element()'/>
-                 <let line='2635' var='Q{}class' as='xs:string?' slot='10' eval='7'>
-                  <choose line='2636'>
+                 <let line='2354' var='Q{}class' as='xs:string?' slot='10' eval='7'>
+                  <choose line='2355'>
                    <fn name='exists'>
                     <slash simple='1'>
                      <varRef name='Q{}element' slot='9'/>
                      <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
                     </slash>
                    </fn>
-                   <cvUntyped line='2637' to='xs:string' diag='3|0|XTTE0570|class'>
+                   <cvUntyped line='2356' to='xs:string' diag='3|0|XTTE0570|class'>
                     <cast as='xs:untypedAtomic' emptiable='0'>
                      <fn name='string'>
                       <convert from='xs:untypedAtomic' to='xs:string'>
@@ -7096,15 +6006,15 @@
                     </cast>
                    </cvUntyped>
                   </choose>
-                  <let line='2640' var='Q{}class-mod' as='xs:string?' slot='11' eval='7'>
-                   <choose line='2642'>
+                  <let line='2359' var='Q{}class-mod' as='xs:string?' slot='11' eval='7'>
+                   <choose line='2361'>
                     <fn name='exists'>
                      <slash simple='1'>
                       <varRef name='Q{}element' slot='9'/>
                       <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
                      </slash>
                     </fn>
-                    <cvUntyped line='2643' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                    <cvUntyped line='2362' to='xs:string' diag='3|0|XTTE0570|class-mod'>
                      <cast as='xs:untypedAtomic' emptiable='0'>
                       <fn name='string-join'>
                        <sequence>
@@ -7116,13 +6026,13 @@
                      </cast>
                     </cvUntyped>
                     <true/>
-                    <varRef line='2646' name='Q{}class' slot='10'/>
+                    <varRef line='2365' name='Q{}class' slot='10'/>
                    </choose>
-                   <choose line='2650'>
+                   <choose line='2369'>
                     <fn name='exists'>
                      <varRef name='Q{}class-mod' slot='11'/>
                     </fn>
-                    <treat line='2651' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                    <treat line='2370' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
                      <att name='class' flags='l'>
                       <varRef name='Q{}class-mod' slot='11'/>
                      </att>
@@ -7131,7 +6041,7 @@
                   </let>
                  </let>
                 </let>
-                <copyOf line='1610' flags='vc'>
+                <copyOf line='1562' flags='vc'>
                  <except op='except'>
                   <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
                   <docOrder intra='1'>
@@ -7143,11 +6053,11 @@
                   </docOrder>
                  </except>
                 </copyOf>
-                <att line='1612' name='data-ref' flags='l'>
+                <att line='1564' name='data-ref' flags='l'>
                  <varRef name='Q{}refi' slot='6'/>
                 </att>
-                <att line='1613' name='data-element' flags='l'>
-                 <lastOf line='1603'>
+                <att line='1565' name='data-element' flags='l'>
+                 <lastOf line='1555'>
                   <fn name='tokenize'>
                    <varRef name='Q{}refi' slot='6'/>
                    <str val='/'/>
@@ -7155,7 +6065,7 @@
                   </fn>
                  </lastOf>
                 </att>
-                <choose line='1615'>
+                <choose line='1567'>
                  <and op='and'>
                   <fn name='exists'>
                    <varRef name='Q{}bindingi' slot='5'/>
@@ -7167,7 +6077,7 @@
                    </slash>
                   </fn>
                  </and>
-                 <att line='1616' name='data-constraint' flags='l'>
+                 <att line='1568' name='data-constraint' flags='l'>
                   <convert from='xs:untypedAtomic' to='xs:string'>
                    <data>
                     <slash simple='1'>
@@ -7178,19 +6088,19 @@
                   </convert>
                  </att>
                 </choose>
-                <choose line='1619'>
+                <choose line='1571'>
                  <vc op='eq' onEmpty='0' comp='CCC'>
                   <fn name='local-name'>
                    <dot type='element()'/>
                   </fn>
                   <str val='select'/>
                  </vc>
-                 <sequence line='1620'>
+                 <sequence line='1572'>
                   <att name='multiple' flags='l'>
                    <str val='true'/>
                   </att>
-                  <att line='1621' name='size' flags='l'>
-                   <convert line='1622' from='xs:integer' to='xs:string'>
+                  <att line='1573' name='size' flags='l'>
+                   <convert line='1574' from='xs:integer' to='xs:string'>
                     <fn name='count'>
                      <axis name='descendant' nodeTest='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
                     </fn>
@@ -7198,22 +6108,22 @@
                   </att>
                  </sequence>
                 </choose>
-                <choose line='1625'>
+                <choose line='1577'>
                  <fn name='exists'>
                   <varRef name='Q{}actions' slot='8'/>
                  </fn>
-                 <att line='1626' name='data-action' flags='l'>
+                 <att line='1578' name='data-action' flags='l'>
                   <varRef name='Q{}myid' slot='2'/>
                  </att>
                 </choose>
-                <applyT line='1629' bSlot='20'>
+                <applyT line='1581' bSlot='19'>
                  <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
                  <withParam name='Q{}selectedValue' as='xs:string'>
-                  <choose line='1594'>
+                  <choose line='1546'>
                    <fn name='exists'>
                     <varRef name='Q{}instanceField' slot='7'/>
                    </fn>
-                   <cvUntyped line='1595' to='xs:string' diag='3|0|XTTE0570|selectedValue'>
+                   <cvUntyped line='1547' to='xs:string' diag='3|0|XTTE0570|selectedValue'>
                     <cast as='xs:untypedAtomic' emptiable='0'>
                      <fn name='string'>
                       <convert from='xs:anyAtomicType' to='xs:string'>
@@ -7242,24 +6152,24 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='25' part='2' rank='1' minImp='0' slots='1' flags='s' line='2083' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='25' part='2' rank='1' minImp='0' slots='1' flags='s' line='2035' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}show)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;show&#39;;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2091' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2092' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2043' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2044' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
       <check card='1' diag='3|0|XTTE0570|action-map'>
        <callT name='Q{}setAction' bSlot='2'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2093' type='element()'/>
+         <dot line='2045' type='element()'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <varRef line='2106' name='Q{}action-map' slot='0'/>
+     <varRef line='2058' name='Q{}action-map' slot='0'/>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='19' rank='1' minImp='0' slots='15' flags='s' line='1751' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='19' rank='1' minImp='0' slots='15' flags='s' line='1703' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1752'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1704'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -7272,7 +6182,7 @@
        </check>
       </treat>
      </param>
-     <param line='1753' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1705' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -7284,7 +6194,7 @@
        </check>
       </treat>
      </param>
-     <param line='1754' name='Q{}recalculate' slot='2' as='xs:boolean'>
+     <param line='1706' name='Q{}recalculate' slot='2' as='xs:boolean'>
       <false role='select'/>
       <treat role='conversion' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='8|0|XTTE0590|recalculate'>
        <check card='1' diag='8|0|XTTE0590|recalculate'>
@@ -7296,7 +6206,7 @@
        </check>
       </treat>
      </param>
-     <param line='1755' name='Q{}refreshRepeats' slot='3' as='xs:boolean'>
+     <param line='1707' name='Q{}refreshRepeats' slot='3' as='xs:boolean'>
       <false role='select'/>
       <treat role='conversion' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='8|0|XTTE0590|refreshRepeats'>
        <check card='1' diag='8|0|XTTE0590|refreshRepeats'>
@@ -7308,7 +6218,7 @@
        </check>
       </treat>
      </param>
-     <let line='1759' var='Q{}myid' as='xs:string' slot='4' eval='16'>
+     <let line='1711' var='Q{}myid' as='xs:string' slot='4' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -7324,7 +6234,7 @@
          <dot type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
         </fn>
         <str val='-'/>
-        <choose line='1757'>
+        <choose line='1709'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -7334,27 +6244,27 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1767'>
+      <sequence line='1719'>
        <choose>
         <varRef name='Q{}recalculate' slot='2'/>
         <empty/>
         <true/>
-        <ifCall line='1786' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1738' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
          <str val='setRepeatIndex'/>
          <arrayBlock>
           <varRef name='Q{}myid' slot='4'/>
-          <choose line='1773'>
+          <choose line='1725'>
            <fn name='empty'>
             <axis name='attribute' nodeTest='attribute(Q{}startindex)' jsTest='return item.name===&#39;startindex&#39;'/>
            </fn>
            <dbl val='1'/>
-           <castable line='1776' as='xs:double' emptiable='0'>
+           <castable line='1728' as='xs:double' emptiable='0'>
             <axis name='attribute' nodeTest='attribute(Q{}startindex)' jsTest='return item.name===&#39;startindex&#39;'/>
            </castable>
-           <cvUntyped line='1777' to='xs:double' diag='3|0|XTTE0570|this-index'>
+           <cvUntyped line='1729' to='xs:double' diag='3|0|XTTE0570|this-index'>
             <convert from='xs:double' to='xs:untypedAtomic'>
              <fn name='number'>
               <attVal name='Q{}startindex' chk='0'/>
@@ -7367,67 +6277,67 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1793' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='1794' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='1745' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1746' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
-          <callT name='Q{}getBinding' bSlot='21'>
+          <callT name='Q{}getBinding' bSlot='20'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='1795' type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
+            <dot line='1747' type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='1800' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='1801' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='1752' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1753' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
-             <callT name='Q{}getDataRef' bSlot='22'>
+             <callT name='Q{}getDataRef' bSlot='21'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='1802' type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
+               <dot line='1754' type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='1803' name='Q{}bindingi' slot='5'/>
+               <varRef line='1755' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='1809' var='Q{}selectedRepeatVar' as='element()*' slot='7' eval='8'>
-          <treat line='1811' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|selectedRepeatVar'>
-           <callT name='Q{}getReferencedInstanceField' bSlot='23'>
+         <let line='1761' var='Q{}selectedRepeatVar' as='element()*' slot='7' eval='8'>
+          <treat line='1763' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|selectedRepeatVar'>
+           <callT name='Q{}getReferencedInstanceField' bSlot='22'>
             <withParam name='Q{}refi' flags='c' as='xs:string'>
-             <varRef line='1812' name='Q{}refi' slot='6'/>
+             <varRef line='1764' name='Q{}refi' slot='6'/>
             </withParam>
            </callT>
           </treat>
-          <let line='1827' var='Q{}repeat-items' as='element(Q{}div, Q{http://www.w3.org/2001/XMLSchema}untyped)*' slot='8' eval='3'>
-           <let line='1828' var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}repeat)' slot='9' eval='16'>
+          <let line='1779' var='Q{}repeat-items' as='element(Q{}div, Q{http://www.w3.org/2001/XMLSchema}untyped)*' slot='8' eval='3'>
+           <let line='1780' var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}repeat)' slot='9' eval='16'>
             <dot type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
-            <let line='1833' var='Q{http://saxon.sf.net/generated-variable}v0' as='element()*' slot='10' eval='4'>
+            <let line='1785' var='Q{http://saxon.sf.net/generated-variable}v0' as='element()*' slot='10' eval='4'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='9'/>
               <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
              </slash>
-             <forEach line='1829'>
+             <forEach line='1781'>
               <varRef name='Q{}selectedRepeatVar' slot='7'/>
-              <let line='1830' var='Q{}string-position' as='xs:string' slot='11' eval='8'>
+              <let line='1782' var='Q{}string-position' as='xs:string' slot='11' eval='8'>
                <fn name='string'>
                 <fn name='position'/>
                </fn>
-               <elem line='1832' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+               <elem line='1784' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
                 <sequence>
                  <att name='data-repeat-item' flags='l'>
                   <str val='true'/>
                  </att>
-                 <applyT line='1833' bSlot='24'>
+                 <applyT line='1785' bSlot='23'>
                   <varRef role='select' name='Q{http://saxon.sf.net/generated-variable}v0' slot='10'/>
                   <withParam name='Q{}position' as='xs:integer'>
-                   <fn line='1835' name='position'/>
+                   <fn line='1787' name='position'/>
                   </withParam>
                   <withParam name='Q{}context-position' as='xs:string'>
-                   <choose line='1831'>
+                   <choose line='1783'>
                     <varRef name='Q{}context-position' slot='1'/>
                     <fn name='concat'>
                      <varRef name='Q{}context-position' slot='1'/>
@@ -7439,7 +6349,7 @@
                    </choose>
                   </withParam>
                   <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-                   <fn line='1834' name='concat'>
+                   <fn line='1786' name='concat'>
                     <varRef name='Q{}refi' slot='6'/>
                     <str val='['/>
                     <fn name='position'/>
@@ -7453,24 +6363,24 @@
              </forEach>
             </let>
            </let>
-           <sequence line='1844'>
+           <sequence line='1796'>
             <choose>
              <varRef name='Q{}refreshRepeats' slot='3'/>
-             <varRef line='1845' name='Q{}repeat-items' slot='8'/>
+             <varRef line='1797' name='Q{}repeat-items' slot='8'/>
              <true/>
-             <elem line='1848' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
-              <sequence line='1849'>
+             <elem line='1800' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+              <sequence line='1801'>
                <let var='Q{}element' as='element(Q{http://www.w3.org/2002/xforms}repeat)' slot='12' eval='16'>
                 <dot type='element(Q{http://www.w3.org/2002/xforms}repeat)'/>
-                <let line='2635' var='Q{}class' as='xs:string?' slot='13' eval='7'>
-                 <choose line='2636'>
+                <let line='2354' var='Q{}class' as='xs:string?' slot='13' eval='7'>
+                 <choose line='2355'>
                   <fn name='exists'>
                    <slash simple='1'>
                     <varRef name='Q{}element' slot='12'/>
                     <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
                    </slash>
                   </fn>
-                  <cvUntyped line='2637' to='xs:string' diag='3|0|XTTE0570|class'>
+                  <cvUntyped line='2356' to='xs:string' diag='3|0|XTTE0570|class'>
                    <cast as='xs:untypedAtomic' emptiable='0'>
                     <fn name='string'>
                      <convert from='xs:untypedAtomic' to='xs:string'>
@@ -7485,15 +6395,15 @@
                    </cast>
                   </cvUntyped>
                  </choose>
-                 <let line='2640' var='Q{}class-mod' as='xs:string?' slot='14' eval='7'>
-                  <choose line='2642'>
+                 <let line='2359' var='Q{}class-mod' as='xs:string?' slot='14' eval='7'>
+                  <choose line='2361'>
                    <fn name='exists'>
                     <slash simple='1'>
                      <varRef name='Q{}element' slot='12'/>
                      <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
                     </slash>
                    </fn>
-                   <cvUntyped line='2643' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                   <cvUntyped line='2362' to='xs:string' diag='3|0|XTTE0570|class-mod'>
                     <cast as='xs:untypedAtomic' emptiable='0'>
                      <fn name='string-join'>
                       <sequence>
@@ -7505,13 +6415,13 @@
                     </cast>
                    </cvUntyped>
                    <true/>
-                   <varRef line='2646' name='Q{}class' slot='13'/>
+                   <varRef line='2365' name='Q{}class' slot='13'/>
                   </choose>
-                  <choose line='2650'>
+                  <choose line='2369'>
                    <fn name='exists'>
                     <varRef name='Q{}class-mod' slot='14'/>
                    </fn>
-                   <treat line='2651' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                   <treat line='2370' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
                     <att name='class' flags='l'>
                      <varRef name='Q{}class-mod' slot='14'/>
                     </att>
@@ -7520,24 +6430,24 @@
                  </let>
                 </let>
                </let>
-               <att line='1851' name='data-repeatable-context' flags='l'>
+               <att line='1803' name='data-repeatable-context' flags='l'>
                 <varRef name='Q{}refi' slot='6'/>
                </att>
-               <att line='1852' name='data-count' flags='l'>
+               <att line='1804' name='data-count' flags='l'>
                 <convert from='xs:integer' to='xs:string'>
                  <fn name='count'>
                   <varRef name='Q{}selectedRepeatVar' slot='7'/>
                  </fn>
                 </convert>
                </att>
-               <att line='1853' name='id' flags='l'>
+               <att line='1805' name='id' flags='l'>
                 <varRef name='Q{}myid' slot='4'/>
                </att>
-               <varRef line='1855' name='Q{}repeat-items' slot='8'/>
+               <varRef line='1807' name='Q{}repeat-items' slot='8'/>
               </sequence>
              </elem>
             </choose>
-            <choose line='1863'>
+            <choose line='1815'>
              <and op='and'>
               <fn name='not'>
                <varRef name='Q{}recalculate' slot='2'/>
@@ -7549,7 +6459,7 @@
                </slash>
               </fn>
              </and>
-             <ifCall line='1867' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+             <ifCall line='1819' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
               <check card='1' diag='0|0||ixsl:call'>
                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
               </check>
@@ -7560,7 +6470,7 @@
               </arrayBlock>
              </ifCall>
             </choose>
-            <ifCall line='1871' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+            <ifCall line='1823' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
              <check card='1' diag='0|0||ixsl:call'>
               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
              </check>
@@ -7581,15 +6491,15 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='8' rank='1' minImp='0' slots='0' flags='s' line='1110' module='saxon-xforms.xsl'>
-    <p.nodeTest role='match' test='element(Q{http://www.w3.org/1999/xhtml}html)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/1999/xhtml&#39;&amp;&amp;q.local===&#39;html&#39;;'/>
-    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1111' name='html' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
-     <sequence line='1112'>
+   <templateRule prec='0' prio='0.0' seq='8' part='1' rank='1' minImp='0' slots='0' flags='s' line='1057' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{}html)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;html&#39;;'/>
+    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1058' name='html' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+     <sequence line='1059'>
       <copyOf flags='vc'>
        <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
       </copyOf>
-      <elem line='1113' name='head' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
-       <sequence line='1114'>
+      <elem line='1060' name='head' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
+       <sequence line='1061'>
         <copyOf flags='vc'>
          <union op='|'>
           <slash simple='2'>
@@ -7602,7 +6512,7 @@
           </slash>
          </union>
         </copyOf>
-        <elem line='1115' name='meta' nsuri='' flags='l'>
+        <elem line='1062' name='meta' nsuri='' flags='l'>
          <sequence>
           <att name='http-equiv' flags='l'>
            <str val='Content-Type'/>
@@ -7612,7 +6522,7 @@
           </att>
          </sequence>
         </elem>
-        <forEach line='1117'>
+        <forEach line='1064'>
          <union op='|'>
           <filter flags='b'>
            <slash simple='2'>
@@ -7639,19 +6549,19 @@
            </vc>
           </filter>
          </union>
-         <elem line='1118' name='meta' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
-          <copyOf line='1119' flags='vc'>
+         <elem line='1065' name='meta' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
+          <copyOf line='1066' flags='vc'>
            <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
           </copyOf>
          </elem>
         </forEach>
-        <copyOf line='1124' flags='vc'>
+        <copyOf line='1071' flags='vc'>
          <axis name='child' nodeTest='element(Q{}script)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;script&#39;;'/>
         </copyOf>
        </sequence>
       </elem>
-      <elem line='1126' name='body' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
-       <applyT line='1127' bSlot='10'>
+      <elem line='1073' name='body' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
+       <applyT line='1074' bSlot='24'>
         <slash role='select' simple='2'>
          <axis name='child' nodeTest='element(Q{}body)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;body&#39;;'/>
          <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
@@ -7661,9 +6571,89 @@
      </sequence>
     </elem>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='24' rank='1' minImp='0' slots='9' flags='s' line='2002' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='8' rank='1' minImp='0' slots='0' flags='s' line='1057' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='element(Q{http://www.w3.org/1999/xhtml}html)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/1999/xhtml&#39;&amp;&amp;q.local===&#39;html&#39;;'/>
+    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1058' name='html' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+     <sequence line='1059'>
+      <copyOf flags='vc'>
+       <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+      </copyOf>
+      <elem line='1060' name='head' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
+       <sequence line='1061'>
+        <copyOf flags='vc'>
+         <union op='|'>
+          <slash simple='2'>
+           <axis name='child' nodeTest='element(Q{http://www.w3.org/1999/xhtml}head)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/1999/xhtml&#39;&amp;&amp;q.local===&#39;head&#39;;'/>
+           <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+          </slash>
+          <slash simple='2'>
+           <axis name='child' nodeTest='element(Q{}head)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;head&#39;;'/>
+           <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+          </slash>
+         </union>
+        </copyOf>
+        <elem line='1062' name='meta' nsuri='' flags='l'>
+         <sequence>
+          <att name='http-equiv' flags='l'>
+           <str val='Content-Type'/>
+          </att>
+          <att name='content' flags='l'>
+           <str val='text/html;charset=utf-8'/>
+          </att>
+         </sequence>
+        </elem>
+        <forEach line='1064'>
+         <union op='|'>
+          <filter flags='b'>
+           <slash simple='2'>
+            <axis name='child' nodeTest='element(Q{http://www.w3.org/1999/xhtml}head)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/1999/xhtml&#39;&amp;&amp;q.local===&#39;head&#39;;'/>
+            <axis name='child' nodeTest='element(Q{http://www.w3.org/1999/xhtml}meta)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/1999/xhtml&#39;&amp;&amp;q.local===&#39;meta&#39;;'/>
+           </slash>
+           <vc op='ne' onEmpty='0' comp='CCC'>
+            <fn name='string'>
+             <axis name='attribute' nodeTest='attribute(Q{}http-equiv)' jsTest='return item.name===&#39;http-equiv&#39;'/>
+            </fn>
+            <str val='Content-Type'/>
+           </vc>
+          </filter>
+          <filter flags='b'>
+           <slash simple='2'>
+            <axis name='child' nodeTest='element(Q{}head)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;head&#39;;'/>
+            <axis name='child' nodeTest='element(Q{}meta)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;meta&#39;;'/>
+           </slash>
+           <vc op='ne' onEmpty='0' comp='CCC'>
+            <fn name='string'>
+             <axis name='attribute' nodeTest='attribute(Q{}http-equiv)' jsTest='return item.name===&#39;http-equiv&#39;'/>
+            </fn>
+            <str val='Content-Type'/>
+           </vc>
+          </filter>
+         </union>
+         <elem line='1065' name='meta' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
+          <copyOf line='1066' flags='vc'>
+           <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
+          </copyOf>
+         </elem>
+        </forEach>
+        <copyOf line='1071' flags='vc'>
+         <axis name='child' nodeTest='element(Q{}script)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;script&#39;;'/>
+        </copyOf>
+       </sequence>
+      </elem>
+      <elem line='1073' name='body' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
+       <applyT line='1074' bSlot='24'>
+        <slash role='select' simple='2'>
+         <axis name='child' nodeTest='element(Q{}body)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;body&#39;;'/>
+         <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+        </slash>
+       </applyT>
+      </elem>
+     </sequence>
+    </elem>
+   </templateRule>
+   <templateRule prec='0' prio='0.0' seq='24' rank='1' minImp='0' slots='9' flags='s' line='1954' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}trigger)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;trigger&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2003'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1955'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -7676,7 +6666,7 @@
        </check>
       </treat>
      </param>
-     <param line='2004' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1956' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -7688,7 +6678,7 @@
        </check>
       </treat>
      </param>
-     <let line='2008' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='1960' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -7704,7 +6694,7 @@
          <dot type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
         </fn>
         <str val='-'/>
-        <choose line='2006'>
+        <choose line='1958'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -7714,13 +6704,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='2010'>
+      <sequence line='1962'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}trigger)' slot='3' eval='16'>
           <dot type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
-          <fn line='2563' name='exists'>
-           <sequence line='2538'>
+          <fn line='2282' name='exists'>
+           <sequence line='2257'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -7732,7 +6722,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2541'>
+             <choose role='matching' line='2260'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -7744,7 +6734,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='2550'>
+            <analyzeString line='2269'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -7755,7 +6745,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2553'>
+             <choose role='matching' line='2272'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -7778,8 +6768,8 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='2563' name='exists'>
-             <sequence line='2538'>
+            <fn line='2282' name='exists'>
+             <sequence line='2257'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
@@ -7791,7 +6781,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2541'>
+               <choose role='matching' line='2260'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -7803,7 +6793,7 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
-              <analyzeString line='2550'>
+              <analyzeString line='2269'>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
@@ -7814,7 +6804,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2553'>
+               <choose role='matching' line='2272'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -7832,7 +6822,7 @@
           </filter>
          </fn>
         </and>
-        <ifCall line='2011' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1963' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -7843,50 +6833,50 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='2015' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='2016' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='1967' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1968' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
           <callT name='Q{}getBinding' bSlot='25'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='2017' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
+            <dot line='1969' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='2022' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='2023' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='1974' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1975' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
              <callT name='Q{}getDataRef' bSlot='26'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='2024' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
+               <dot line='1976' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='2025' name='Q{}bindingi' slot='5'/>
+               <varRef line='1977' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='2032' var='Q{}actions' as='map(*)*' slot='7' eval='8'>
-          <treat line='2033' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+         <let line='1984' var='Q{}actions' as='map(*)*' slot='7' eval='8'>
+          <treat line='1985' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
            <callT name='Q{}setActions' bSlot='27'>
             <withParam name='Q{}this' flags='c' as='element()'>
-             <dot line='2034' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
+             <dot line='1986' type='element(Q{http://www.w3.org/2002/xforms}trigger)'/>
             </withParam>
             <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-             <varRef line='2035' name='Q{}refi' slot='6'/>
+             <varRef line='1987' name='Q{}refi' slot='6'/>
             </withParam>
            </callT>
           </treat>
-          <sequence line='2039'>
+          <sequence line='1991'>
            <choose>
             <fn name='exists'>
              <varRef name='Q{}actions' slot='7'/>
             </fn>
-            <ifCall line='2040' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+            <ifCall line='1992' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
              <check card='1' diag='0|0||ixsl:call'>
               <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
              </check>
@@ -7897,28 +6887,28 @@
              </arrayBlock>
             </ifCall>
            </choose>
-           <let line='2043' var='Q{}innerbody' as='document-node()' slot='8' eval='16'>
-            <doc line='2045' validation='preserve'>
+           <let line='1995' var='Q{}innerbody' as='document-node()' slot='8' eval='16'>
+            <doc line='1997' validation='preserve'>
              <choose>
               <fn name='exists'>
                <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
               </fn>
-              <applyT line='2046' bSlot='28'>
+              <applyT line='1998' bSlot='28'>
                <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
               </applyT>
               <true/>
-              <valueOf line='2048' flags='l'>
+              <valueOf line='2000' flags='l'>
                <str val=' '/>
               </valueOf>
              </choose>
             </doc>
-            <elem line='2052' name='span' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+            <elem line='2004' name='span' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
              <sequence>
               <att name='style' flags='l'>
                <str val='display:&#39;inline&#39;'/>
               </att>
-              <compElem line='2063' flags='l'>
-               <choose role='name' line='2055'>
+              <compElem line='2015' flags='l'>
+               <choose role='name' line='2007'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <cast as='xs:string' emptiable='1'>
                   <attVal name='Q{}appearance' chk='0'/>
@@ -7929,7 +6919,7 @@
                 <true/>
                 <str val='button'/>
                </choose>
-               <sequence role='content' line='2064'>
+               <sequence role='content' line='2016'>
                 <choose>
                  <vc op='eq' onEmpty='0' comp='CCC'>
                   <cast as='xs:string' emptiable='1'>
@@ -7937,17 +6927,17 @@
                   </cast>
                   <str val='minimal'/>
                  </vc>
-                 <att line='2065' name='type' flags='l'>
+                 <att line='2017' name='type' flags='l'>
                   <str val='button'/>
                  </att>
                 </choose>
-                <att line='2068' name='data-ref' flags='l'>
+                <att line='2020' name='data-ref' flags='l'>
                  <varRef name='Q{}refi' slot='6'/>
                 </att>
-                <att line='2069' name='data-action' flags='l'>
+                <att line='2021' name='data-action' flags='l'>
                  <varRef name='Q{}myid' slot='2'/>
                 </att>
-                <copyOf line='2070' flags='vc'>
+                <copyOf line='2022' flags='vc'>
                  <varRef name='Q{}innerbody' slot='8'/>
                 </copyOf>
                </sequence>
@@ -7963,9 +6953,9 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='9' rank='1' minImp='0' slots='15' flags='s' line='1142' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='9' rank='1' minImp='0' slots='15' flags='s' line='1089' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}output)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;output&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1143'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1090'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -7978,7 +6968,7 @@
        </check>
       </treat>
      </param>
-     <param line='1144' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1091' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -7990,7 +6980,7 @@
        </check>
       </treat>
      </param>
-     <let line='1148' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='1095' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -8006,7 +6996,7 @@
          <dot type='element(Q{http://www.w3.org/2002/xforms}output)'/>
         </fn>
         <str val='-'/>
-        <choose line='1146'>
+        <choose line='1093'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -8016,13 +7006,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1150'>
+      <sequence line='1097'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}output)' slot='3' eval='16'>
           <dot type='element(Q{http://www.w3.org/2002/xforms}output)'/>
-          <fn line='2563' name='exists'>
-           <sequence line='2538'>
+          <fn line='2282' name='exists'>
+           <sequence line='2257'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -8034,7 +7024,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2541'>
+             <choose role='matching' line='2260'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -8046,7 +7036,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='2550'>
+            <analyzeString line='2269'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -8057,7 +7047,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2553'>
+             <choose role='matching' line='2272'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -8080,8 +7070,8 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='2563' name='exists'>
-             <sequence line='2538'>
+            <fn line='2282' name='exists'>
+             <sequence line='2257'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
@@ -8093,7 +7083,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2541'>
+               <choose role='matching' line='2260'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -8105,7 +7095,7 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
-              <analyzeString line='2550'>
+              <analyzeString line='2269'>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
@@ -8116,7 +7106,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2553'>
+               <choose role='matching' line='2272'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -8134,7 +7124,7 @@
           </filter>
          </fn>
         </and>
-        <ifCall line='1151' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1098' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -8145,44 +7135,44 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1156' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='1157' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='1103' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1104' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
           <callT name='Q{}getBinding' bSlot='29'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='1158' type='element(Q{http://www.w3.org/2002/xforms}output)'/>
+            <dot line='1105' type='element(Q{http://www.w3.org/2002/xforms}output)'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='1163' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='1164' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='1110' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1111' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
              <callT name='Q{}getDataRef' bSlot='30'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='1165' type='element(Q{http://www.w3.org/2002/xforms}output)'/>
+               <dot line='1112' type='element(Q{http://www.w3.org/2002/xforms}output)'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='1166' name='Q{}bindingi' slot='5'/>
+               <varRef line='1113' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='1171' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
-          <treat line='1172' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+         <let line='1118' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
+          <treat line='1119' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
            <check card='?' diag='3|0|XTTE0570|instanceField'>
             <callT name='Q{}getReferencedInstanceField' bSlot='31'>
              <withParam name='Q{}refi' flags='c' as='xs:string'>
-              <varRef line='1173' name='Q{}refi' slot='6'/>
+              <varRef line='1120' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </check>
           </treat>
-          <let line='1184' var='Q{}namespace-context-item' as='element()' slot='8' eval='16'>
+          <let line='1131' var='Q{}namespace-context-item' as='element()' slot='8' eval='16'>
            <choose>
             <fn name='exists'>
              <varRef name='Q{}instanceField' slot='7'/>
@@ -8217,16 +7207,16 @@
                <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
               </slash>
              </check>
-             <compElem line='2573'>
+             <compElem line='2292'>
               <fn role='name' name='name'>
                <varRef name='Q{}this' slot='9'/>
               </fn>
-              <sequence role='content' line='2574'>
+              <sequence role='content' line='2293'>
                <namespace flags='l'>
                 <str role='name' val='xforms'/>
                 <str role='select' val='http://www.w3.org/2002/xforms'/>
                </namespace>
-               <forEach line='2575'>
+               <forEach line='2294'>
                 <filter flags='b'>
                  <filter flags='b'>
                   <slash simple='1'>
@@ -8265,21 +7255,21 @@
                   </gc>
                  </fn>
                 </filter>
-                <namespace line='2578' flags='l'>
-                 <fn role='name' line='2577' name='substring-before'>
+                <namespace line='2297' flags='l'>
+                 <fn role='name' line='2296' name='substring-before'>
                   <fn name='name'>
                    <dot type='element()'/>
                   </fn>
                   <str val=':'/>
                  </fn>
                  <convert role='select' from='xs:anyURI' to='xs:string'>
-                  <fn line='2576' name='namespace-uri'>
+                  <fn line='2295' name='namespace-uri'>
                    <dot type='element()'/>
                   </fn>
                  </convert>
                 </namespace>
                </forEach>
-               <copyOf line='2580' flags='vc'>
+               <copyOf line='2299' flags='vc'>
                 <sequence>
                  <slash simple='1'>
                   <varRef name='Q{}this' slot='9'/>
@@ -8295,12 +7285,12 @@
              </compElem>
             </let>
            </choose>
-           <let line='1186' var='Q{}valueExecuted' as='xs:string' slot='10' eval='16'>
-            <choose line='1188'>
+           <let line='1133' var='Q{}valueExecuted' as='xs:string' slot='10' eval='16'>
+            <choose line='1135'>
              <fn name='exists'>
               <axis name='attribute' nodeTest='attribute(Q{}value)' jsTest='return item.name===&#39;value&#39;'/>
              </fn>
-             <evaluate line='1189' as='xs:string' dxns=''>
+             <evaluate line='1136' as='xs:string' dxns=''>
               <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='32' eval='16'>
                <check card='1' diag='0|0||xforms:impose'>
                 <cvUntyped to='xs:string'>
@@ -8315,7 +7305,7 @@
               <map role='wp' size='0'/>
              </evaluate>
              <true/>
-             <cvUntyped line='1192' to='xs:string' diag='3|0|XTTE0570|valueExecuted'>
+             <cvUntyped line='1139' to='xs:string' diag='3|0|XTTE0570|valueExecuted'>
               <cast as='xs:untypedAtomic' emptiable='0'>
                <fn name='string'>
                 <convert from='xs:anyAtomicType' to='xs:string'>
@@ -8327,8 +7317,8 @@
               </cast>
              </cvUntyped>
             </choose>
-            <let line='1198' var='Q{}relevantVar' as='xs:boolean' slot='11' eval='16'>
-             <choose line='1200'>
+            <let line='1145' var='Q{}relevantVar' as='xs:boolean' slot='11' eval='16'>
+             <choose line='1147'>
               <and op='and'>
                <and op='and'>
                 <fn name='exists'>
@@ -8345,7 +7335,7 @@
                 <varRef name='Q{}instanceField' slot='7'/>
                </fn>
               </and>
-              <treat line='1201' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantVar'>
+              <treat line='1148' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantVar'>
                <check card='1' diag='3|0|XTTE0570|relevantVar'>
                 <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|relevantVar'>
                  <data>
@@ -8375,20 +7365,20 @@
               <true/>
               <true/>
              </choose>
-             <sequence line='1212'>
+             <sequence line='1159'>
               <elem name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
-               <sequence line='1213'>
+               <sequence line='1160'>
                 <let var='Q{}element' as='element(Q{http://www.w3.org/2002/xforms}output)' slot='12' eval='16'>
                  <dot type='element(Q{http://www.w3.org/2002/xforms}output)'/>
-                 <let line='2635' var='Q{}class' as='xs:string?' slot='13' eval='7'>
-                  <choose line='2636'>
+                 <let line='2354' var='Q{}class' as='xs:string?' slot='13' eval='7'>
+                  <choose line='2355'>
                    <fn name='exists'>
                     <slash simple='1'>
                      <varRef name='Q{}element' slot='12'/>
                      <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
                     </slash>
                    </fn>
-                   <cvUntyped line='2637' to='xs:string' diag='3|0|XTTE0570|class'>
+                   <cvUntyped line='2356' to='xs:string' diag='3|0|XTTE0570|class'>
                     <cast as='xs:untypedAtomic' emptiable='0'>
                      <fn name='string'>
                       <convert from='xs:untypedAtomic' to='xs:string'>
@@ -8403,15 +7393,15 @@
                     </cast>
                    </cvUntyped>
                   </choose>
-                  <let line='2640' var='Q{}class-mod' as='xs:string?' slot='14' eval='7'>
-                   <choose line='2642'>
+                  <let line='2359' var='Q{}class-mod' as='xs:string?' slot='14' eval='7'>
+                   <choose line='2361'>
                     <fn name='exists'>
                      <slash simple='1'>
                       <varRef name='Q{}element' slot='12'/>
                       <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
                      </slash>
                     </fn>
-                    <cvUntyped line='2643' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                    <cvUntyped line='2362' to='xs:string' diag='3|0|XTTE0570|class-mod'>
                      <cast as='xs:untypedAtomic' emptiable='0'>
                       <fn name='string-join'>
                        <sequence>
@@ -8423,13 +7413,13 @@
                      </cast>
                     </cvUntyped>
                     <true/>
-                    <varRef line='2646' name='Q{}class' slot='13'/>
+                    <varRef line='2365' name='Q{}class' slot='13'/>
                    </choose>
-                   <choose line='2650'>
+                   <choose line='2369'>
                     <fn name='exists'>
                      <varRef name='Q{}class-mod' slot='14'/>
                     </fn>
-                    <treat line='2651' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                    <treat line='2370' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
                      <att name='class' flags='l'>
                       <varRef name='Q{}class-mod' slot='14'/>
                      </att>
@@ -8438,15 +7428,15 @@
                   </let>
                  </let>
                 </let>
-                <applyT line='1215' bSlot='34'>
+                <applyT line='1162' bSlot='34'>
                  <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
                 </applyT>
-                <elem line='1217' name='span' nsuri='' flags='l'>
-                 <sequence line='1218'>
+                <elem line='1164' name='span' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
+                 <sequence line='1165'>
                   <att name='id' flags='l'>
                    <varRef name='Q{}myid' slot='2'/>
                   </att>
-                  <att line='1219' name='style' flags='l'>
+                  <att line='1166' name='style' flags='l'>
                    <choose>
                     <varRef name='Q{}relevantVar' slot='11'/>
                     <str val='display:inline'/>
@@ -8454,42 +7444,65 @@
                     <str val='display:none'/>
                    </choose>
                   </att>
-                  <att line='1220' name='data-ref' flags='l'>
+                  <att line='1167' name='data-ref' flags='l'>
                    <varRef name='Q{}refi' slot='6'/>
                   </att>
-                  <varRef line='1222' name='Q{}valueExecuted' slot='10'/>
+                  <choose line='1169'>
+                   <and op='and'>
+                    <fn name='exists'>
+                     <varRef name='Q{}bindingi' slot='5'/>
+                    </fn>
+                    <fn name='exists'>
+                     <slash simple='1'>
+                      <varRef name='Q{}bindingi' slot='5'/>
+                      <axis name='attribute' nodeTest='attribute(Q{}relevant)' jsTest='return item.name===&#39;relevant&#39;'/>
+                     </slash>
+                    </fn>
+                   </and>
+                   <att line='1170' name='data-relevant' flags='l'>
+                    <convert from='xs:untypedAtomic' to='xs:string'>
+                     <data>
+                      <slash simple='1'>
+                       <varRef name='Q{}bindingi' slot='5'/>
+                       <axis name='attribute' nodeTest='attribute(Q{}relevant)' jsTest='return item.name===&#39;relevant&#39;'/>
+                      </slash>
+                     </data>
+                    </convert>
+                   </att>
+                  </choose>
+                  <varRef line='1174' name='Q{}valueExecuted' slot='10'/>
                  </sequence>
                 </elem>
                </sequence>
               </elem>
-              <choose line='1227'>
+              <choose line='1179'>
                <fn name='empty'>
                 <slash simple='1'>
                  <dot type='element(Q{http://www.w3.org/2002/xforms}output)'/>
                  <axis name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}repeat)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;repeat&#39;;'/>
                 </slash>
                </fn>
-               <ifCall line='1246' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+               <ifCall line='1198' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                 <check card='1' diag='0|0||ixsl:call'>
                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                 </check>
                 <str val='addOutput'/>
                 <arrayBlock>
                  <varRef name='Q{}myid' slot='2'/>
-                 <ifCall line='1230' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+                 <ifCall line='1182' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
                   <sequence>
                    <choose>
                     <varRef name='Q{}refi' slot='6'/>
-                    <ifCall line='1231' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                    <ifCall line='1183' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                      <str val='@ref'/>
                      <varRef name='Q{}refi' slot='6'/>
                     </ifCall>
                    </choose>
-                   <choose line='1234'>
+                   <choose line='1186'>
                     <fn name='exists'>
                      <axis name='attribute' nodeTest='attribute(Q{}value)' jsTest='return item.name===&#39;value&#39;'/>
                     </fn>
-                    <ifCall line='1235' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                    <ifCall line='1187' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                      <str val='@value'/>
                      <cast as='xs:string' emptiable='1'>
                       <attVal name='Q{}value' chk='0'/>
@@ -8518,13 +7531,13 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='6' rank='1' minImp='0' slots='0' flags='s' line='1085' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='6' rank='1' minImp='0' slots='0' flags='s' line='1032' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
     <empty role='action'/>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='17' rank='1' minImp='0' slots='1' flags='s' line='1686' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='17' rank='1' minImp='0' slots='1' flags='s' line='1638' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1687'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1639'>
      <param name='Q{}selectedValue' slot='0' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|selectedValue'>
@@ -8537,7 +7550,7 @@
        </check>
       </treat>
      </param>
-     <elem line='1689' name='option' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+     <elem line='1641' name='option' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
       <sequence>
        <att name='value' flags='l'>
         <fn name='string-join'>
@@ -8549,7 +7562,7 @@
          <str val=' '/>
         </fn>
        </att>
-       <choose line='1690'>
+       <choose line='1642'>
         <vc op='eq' onEmpty='0' comp='CCC'>
          <varRef name='Q{}selectedValue' slot='0'/>
          <cast as='xs:string' emptiable='1'>
@@ -8561,11 +7574,11 @@
           </atomSing>
          </cast>
         </vc>
-        <att line='1691' name='selected' flags='l'>
+        <att line='1643' name='selected' flags='l'>
          <varRef name='Q{}selectedValue' slot='0'/>
         </att>
        </choose>
-       <valueOf line='1694' flags='l'>
+       <valueOf line='1646' flags='l'>
         <fn name='string-join'>
          <convert from='xs:untypedAtomic' to='xs:string'>
           <data>
@@ -8579,28 +7592,28 @@
      </elem>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='25' part='4' rank='1' minImp='0' slots='1' flags='s' line='2083' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='25' part='4' rank='1' minImp='0' slots='1' flags='s' line='2035' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}script)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;script&#39;;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2091' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2092' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2043' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2044' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
       <check card='1' diag='3|0|XTTE0570|action-map'>
        <callT name='Q{}setAction' bSlot='2'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2093' type='element()'/>
+         <dot line='2045' type='element()'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <varRef line='2106' name='Q{}action-map' slot='0'/>
+     <varRef line='2058' name='Q{}action-map' slot='0'/>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='12' rank='1' minImp='0' slots='0' flags='s' line='1531' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='12' rank='1' minImp='0' slots='0' flags='s' line='1483' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}hint)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;hint&#39;;'/>
     <empty role='action'/>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='13' rank='1' minImp='0' slots='12' flags='s' line='1542' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='13' rank='1' minImp='0' slots='12' flags='s' line='1494' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}select1)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;select1&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1543'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1495'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -8613,7 +7626,7 @@
        </check>
       </treat>
      </param>
-     <param line='1544' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1496' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -8625,7 +7638,7 @@
        </check>
       </treat>
      </param>
-     <let line='1548' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='1500' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -8641,7 +7654,7 @@
          <dot type='element()'/>
         </fn>
         <str val='-'/>
-        <choose line='1546'>
+        <choose line='1498'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -8651,13 +7664,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1550'>
+      <sequence line='1502'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element()' slot='3' eval='16'>
           <dot type='element()'/>
-          <fn line='2563' name='exists'>
-           <sequence line='2538'>
+          <fn line='2282' name='exists'>
+           <sequence line='2257'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -8669,7 +7682,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2541'>
+             <choose role='matching' line='2260'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -8681,7 +7694,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='2550'>
+            <analyzeString line='2269'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -8692,7 +7705,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2553'>
+             <choose role='matching' line='2272'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -8715,8 +7728,8 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='2563' name='exists'>
-             <sequence line='2538'>
+            <fn line='2282' name='exists'>
+             <sequence line='2257'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
@@ -8728,7 +7741,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2541'>
+               <choose role='matching' line='2260'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -8740,7 +7753,7 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
-              <analyzeString line='2550'>
+              <analyzeString line='2269'>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
@@ -8751,7 +7764,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2553'>
+               <choose role='matching' line='2272'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -8769,7 +7782,7 @@
           </filter>
          </fn>
         </and>
-        <ifCall line='1551' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1503' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -8780,60 +7793,60 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1558' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
-        <treat line='1559' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+       <let line='1510' var='Q{}bindingi' as='node()?' slot='5' eval='7'>
+        <treat line='1511' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
          <check card='?' diag='3|0|XTTE0570|bindingi'>
-          <callT name='Q{}getBinding' bSlot='15'>
+          <callT name='Q{}getBinding' bSlot='14'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <dot line='1560' type='element()'/>
+            <dot line='1512' type='element()'/>
            </withParam>
           </callT>
          </check>
         </treat>
-        <let line='1565' var='Q{}refi' as='xs:string' slot='6' eval='16'>
-         <treat line='1566' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+        <let line='1517' var='Q{}refi' as='xs:string' slot='6' eval='16'>
+         <treat line='1518' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
           <check card='1' diag='3|0|XTTE0570|refi'>
            <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
             <data>
-             <callT name='Q{}getDataRef' bSlot='16'>
+             <callT name='Q{}getDataRef' bSlot='15'>
               <withParam name='Q{}this' flags='c' as='element()'>
-               <dot line='1567' type='element()'/>
+               <dot line='1519' type='element()'/>
               </withParam>
               <withParam name='Q{}bindingi' flags='c' as='node()?'>
-               <varRef line='1568' name='Q{}bindingi' slot='5'/>
+               <varRef line='1520' name='Q{}bindingi' slot='5'/>
               </withParam>
              </callT>
             </data>
            </cvUntyped>
           </check>
          </treat>
-         <let line='1573' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
-          <treat line='1574' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
+         <let line='1525' var='Q{}instanceField' as='node()?' slot='7' eval='7'>
+          <treat line='1526' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|instanceField'>
            <check card='?' diag='3|0|XTTE0570|instanceField'>
-            <callT name='Q{}getReferencedInstanceField' bSlot='17'>
+            <callT name='Q{}getReferencedInstanceField' bSlot='16'>
              <withParam name='Q{}refi' flags='c' as='xs:string'>
-              <varRef line='1575' name='Q{}refi' slot='6'/>
+              <varRef line='1527' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </check>
           </treat>
-          <let line='1580' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
-           <treat line='1581' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
-            <callT name='Q{}setActions' bSlot='18'>
+          <let line='1532' var='Q{}actions' as='map(*)*' slot='8' eval='8'>
+           <treat line='1533' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+            <callT name='Q{}setActions' bSlot='17'>
              <withParam name='Q{}this' flags='c' as='element()'>
-              <dot line='1582' type='element()'/>
+              <dot line='1534' type='element()'/>
              </withParam>
              <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-              <varRef line='1583' name='Q{}refi' slot='6'/>
+              <varRef line='1535' name='Q{}refi' slot='6'/>
              </withParam>
             </callT>
            </treat>
-           <sequence line='1587'>
+           <sequence line='1539'>
             <choose>
              <fn name='exists'>
               <varRef name='Q{}actions' slot='8'/>
              </fn>
-             <ifCall line='1588' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+             <ifCall line='1540' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
               <check card='1' diag='0|0||ixsl:call'>
                <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
               </check>
@@ -8844,27 +7857,27 @@
               </arrayBlock>
              </ifCall>
             </choose>
-            <elem line='1605' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+            <elem line='1557' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
              <sequence>
               <att name='class' flags='l'>
                <str val='xforms-select'/>
               </att>
-              <applyT line='1606' bSlot='19'>
+              <applyT line='1558' bSlot='18'>
                <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
               </applyT>
-              <elem line='1608' name='select' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
-               <sequence line='1609'>
+              <elem line='1560' name='select' nsuri='' flags='l' namespaces='xd rdf xhtml js in fn map array ev'>
+               <sequence line='1561'>
                 <let var='Q{}element' as='element()' slot='9' eval='16'>
                  <dot type='element()'/>
-                 <let line='2635' var='Q{}class' as='xs:string?' slot='10' eval='7'>
-                  <choose line='2636'>
+                 <let line='2354' var='Q{}class' as='xs:string?' slot='10' eval='7'>
+                  <choose line='2355'>
                    <fn name='exists'>
                     <slash simple='1'>
                      <varRef name='Q{}element' slot='9'/>
                      <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
                     </slash>
                    </fn>
-                   <cvUntyped line='2637' to='xs:string' diag='3|0|XTTE0570|class'>
+                   <cvUntyped line='2356' to='xs:string' diag='3|0|XTTE0570|class'>
                     <cast as='xs:untypedAtomic' emptiable='0'>
                      <fn name='string'>
                       <convert from='xs:untypedAtomic' to='xs:string'>
@@ -8879,15 +7892,15 @@
                     </cast>
                    </cvUntyped>
                   </choose>
-                  <let line='2640' var='Q{}class-mod' as='xs:string?' slot='11' eval='7'>
-                   <choose line='2642'>
+                  <let line='2359' var='Q{}class-mod' as='xs:string?' slot='11' eval='7'>
+                   <choose line='2361'>
                     <fn name='exists'>
                      <slash simple='1'>
                       <varRef name='Q{}element' slot='9'/>
                       <axis name='attribute' nodeTest='attribute(Q{}incremental)' jsTest='return item.name===&#39;incremental&#39;'/>
                      </slash>
                     </fn>
-                    <cvUntyped line='2643' to='xs:string' diag='3|0|XTTE0570|class-mod'>
+                    <cvUntyped line='2362' to='xs:string' diag='3|0|XTTE0570|class-mod'>
                      <cast as='xs:untypedAtomic' emptiable='0'>
                       <fn name='string-join'>
                        <sequence>
@@ -8899,13 +7912,13 @@
                      </cast>
                     </cvUntyped>
                     <true/>
-                    <varRef line='2646' name='Q{}class' slot='10'/>
+                    <varRef line='2365' name='Q{}class' slot='10'/>
                    </choose>
-                   <choose line='2650'>
+                   <choose line='2369'>
                     <fn name='exists'>
                      <varRef name='Q{}class-mod' slot='11'/>
                     </fn>
-                    <treat line='2651' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
+                    <treat line='2370' as='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;' diag='5|0|XTTE0780|xforms:getClass#1'>
                      <att name='class' flags='l'>
                       <varRef name='Q{}class-mod' slot='11'/>
                      </att>
@@ -8914,7 +7927,7 @@
                   </let>
                  </let>
                 </let>
-                <copyOf line='1610' flags='vc'>
+                <copyOf line='1562' flags='vc'>
                  <except op='except'>
                   <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
                   <docOrder intra='1'>
@@ -8926,11 +7939,11 @@
                   </docOrder>
                  </except>
                 </copyOf>
-                <att line='1612' name='data-ref' flags='l'>
+                <att line='1564' name='data-ref' flags='l'>
                  <varRef name='Q{}refi' slot='6'/>
                 </att>
-                <att line='1613' name='data-element' flags='l'>
-                 <lastOf line='1603'>
+                <att line='1565' name='data-element' flags='l'>
+                 <lastOf line='1555'>
                   <fn name='tokenize'>
                    <varRef name='Q{}refi' slot='6'/>
                    <str val='/'/>
@@ -8938,7 +7951,7 @@
                   </fn>
                  </lastOf>
                 </att>
-                <choose line='1615'>
+                <choose line='1567'>
                  <and op='and'>
                   <fn name='exists'>
                    <varRef name='Q{}bindingi' slot='5'/>
@@ -8950,7 +7963,7 @@
                    </slash>
                   </fn>
                  </and>
-                 <att line='1616' name='data-constraint' flags='l'>
+                 <att line='1568' name='data-constraint' flags='l'>
                   <convert from='xs:untypedAtomic' to='xs:string'>
                    <data>
                     <slash simple='1'>
@@ -8961,19 +7974,19 @@
                   </convert>
                  </att>
                 </choose>
-                <choose line='1619'>
+                <choose line='1571'>
                  <vc op='eq' onEmpty='0' comp='CCC'>
                   <fn name='local-name'>
                    <dot type='element()'/>
                   </fn>
                   <str val='select'/>
                  </vc>
-                 <sequence line='1620'>
+                 <sequence line='1572'>
                   <att name='multiple' flags='l'>
                    <str val='true'/>
                   </att>
-                  <att line='1621' name='size' flags='l'>
-                   <convert line='1622' from='xs:integer' to='xs:string'>
+                  <att line='1573' name='size' flags='l'>
+                   <convert line='1574' from='xs:integer' to='xs:string'>
                     <fn name='count'>
                      <axis name='descendant' nodeTest='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
                     </fn>
@@ -8981,22 +7994,22 @@
                   </att>
                  </sequence>
                 </choose>
-                <choose line='1625'>
+                <choose line='1577'>
                  <fn name='exists'>
                   <varRef name='Q{}actions' slot='8'/>
                  </fn>
-                 <att line='1626' name='data-action' flags='l'>
+                 <att line='1578' name='data-action' flags='l'>
                   <varRef name='Q{}myid' slot='2'/>
                  </att>
                 </choose>
-                <applyT line='1629' bSlot='20'>
+                <applyT line='1581' bSlot='19'>
                  <axis role='select' name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}item)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;item&#39;;'/>
                  <withParam name='Q{}selectedValue' as='xs:string'>
-                  <choose line='1594'>
+                  <choose line='1546'>
                    <fn name='exists'>
                     <varRef name='Q{}instanceField' slot='7'/>
                    </fn>
-                   <cvUntyped line='1595' to='xs:string' diag='3|0|XTTE0570|selectedValue'>
+                   <cvUntyped line='1547' to='xs:string' diag='3|0|XTTE0570|selectedValue'>
                     <cast as='xs:untypedAtomic' emptiable='0'>
                      <fn name='string'>
                       <convert from='xs:anyAtomicType' to='xs:string'>
@@ -9025,33 +8038,33 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='25' rank='1' minImp='0' slots='1' flags='s' line='2083' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='25' rank='1' minImp='0' slots='1' flags='s' line='2035' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}action)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;action&#39;;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2091' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2092' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2043' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2044' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
       <check card='1' diag='3|0|XTTE0570|action-map'>
        <callT name='Q{}setAction' bSlot='2'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2093' type='element()'/>
+         <dot line='2045' type='element()'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <varRef line='2106' name='Q{}action-map' slot='0'/>
+     <varRef line='2058' name='Q{}action-map' slot='0'/>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='16' rank='1' minImp='0' slots='0' flags='s' line='1667' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='16' rank='1' minImp='0' slots='0' flags='s' line='1619' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}label)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;label&#39;;'/>
-    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1668' name='label' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
-     <sequence line='1669'>
+    <elem role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1620' name='label' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+     <sequence line='1621'>
       <copyOf flags='vc'>
        <axis name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
       </copyOf>
-      <choose line='1671'>
+      <choose line='1623'>
        <fn name='exists'>
         <axis name='child' nodeTest='( element() | text() | comment() | processing-instruction() )' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);'/>
        </fn>
-       <applyT line='1672' bSlot='35'>
+       <applyT line='1624' bSlot='35'>
         <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
        </applyT>
        <true/>
@@ -9062,9 +8075,9 @@
      </sequence>
     </elem>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='18' rank='1' minImp='0' slots='6' flags='s' line='1707' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='18' rank='1' minImp='0' slots='6' flags='s' line='1659' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}group)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;group&#39;;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1708'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1660'>
      <param name='Q{}position' slot='0' as='xs:integer'>
       <int role='select' val='0'/>
       <treat role='conversion' as='xs:integer' jsTest='return SaxonJS.U.Atomic.integer.matches(item);' diag='8|0|XTTE0590|position'>
@@ -9077,7 +8090,7 @@
        </check>
       </treat>
      </param>
-     <param line='1709' name='Q{}context-position' slot='1' as='xs:string'>
+     <param line='1661' name='Q{}context-position' slot='1' as='xs:string'>
       <str role='select' val=''/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|context-position'>
        <check card='1' diag='8|0|XTTE0590|context-position'>
@@ -9089,7 +8102,7 @@
        </check>
       </treat>
      </param>
-     <let line='1713' var='Q{}myid' as='xs:string' slot='2' eval='16'>
+     <let line='1665' var='Q{}myid' as='xs:string' slot='2' eval='16'>
       <choose>
        <fn name='exists'>
         <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -9105,7 +8118,7 @@
          <dot type='element(Q{http://www.w3.org/2002/xforms}group)'/>
         </fn>
         <str val='-'/>
-        <choose line='1711'>
+        <choose line='1663'>
          <varRef name='Q{}context-position' slot='1'/>
          <varRef name='Q{}context-position' slot='1'/>
          <true/>
@@ -9115,13 +8128,13 @@
         </choose>
        </fn>
       </choose>
-      <sequence line='1715'>
+      <sequence line='1667'>
        <choose>
         <and op='and'>
          <let var='Q{}this' as='element(Q{http://www.w3.org/2002/xforms}group)' slot='3' eval='16'>
           <dot type='element(Q{http://www.w3.org/2002/xforms}group)'/>
-          <fn line='2563' name='exists'>
-           <sequence line='2538'>
+          <fn line='2282' name='exists'>
+           <sequence line='2257'>
             <analyzeString>
              <cvUntyped role='select' to='xs:string'>
               <data>
@@ -9133,7 +8146,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2541'>
+             <choose role='matching' line='2260'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -9145,7 +8158,7 @@
              </choose>
              <empty role='nonMatching'/>
             </analyzeString>
-            <analyzeString line='2550'>
+            <analyzeString line='2269'>
              <cvUntyped role='select' to='xs:string'>
               <data>
                <slash simple='1'>
@@ -9156,7 +8169,7 @@
              </cvUntyped>
              <str role='regex' val='\i\c*\('/>
              <str role='flags' val=''/>
-             <choose role='matching' line='2553'>
+             <choose role='matching' line='2272'>
               <vc op='eq' onEmpty='0' comp='CCC'>
                <fn name='substring-before'>
                 <dot type='xs:string'/>
@@ -9179,8 +8192,8 @@
            </slash>
            <let var='Q{}this' as='element()' slot='4' eval='16'>
             <dot type='element()'/>
-            <fn line='2563' name='exists'>
-             <sequence line='2538'>
+            <fn line='2282' name='exists'>
+             <sequence line='2257'>
               <analyzeString>
                <cvUntyped role='select' to='xs:string'>
                 <data>
@@ -9192,7 +8205,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2541'>
+               <choose role='matching' line='2260'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -9204,7 +8217,7 @@
                </choose>
                <empty role='nonMatching'/>
               </analyzeString>
-              <analyzeString line='2550'>
+              <analyzeString line='2269'>
                <cvUntyped role='select' to='xs:string'>
                 <data>
                  <slash simple='1'>
@@ -9215,7 +8228,7 @@
                </cvUntyped>
                <str role='regex' val='\i\c*\('/>
                <str role='flags' val=''/>
-               <choose role='matching' line='2553'>
+               <choose role='matching' line='2272'>
                 <vc op='eq' onEmpty='0' comp='CCC'>
                  <fn name='substring-before'>
                   <dot type='xs:string'/>
@@ -9233,7 +8246,7 @@
           </filter>
          </fn>
         </and>
-        <ifCall line='1716' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <ifCall line='1668' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
          <check card='1' diag='0|0||ixsl:call'>
           <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
          </check>
@@ -9244,38 +8257,38 @@
          </arrayBlock>
         </ifCall>
        </choose>
-       <let line='1719' var='Q{}refi' as='xs:string?' slot='5' eval='7'>
-        <choose line='1721'>
+       <let line='1671' var='Q{}refi' as='xs:string?' slot='5' eval='7'>
+        <choose line='1673'>
          <fn name='exists'>
           <axis name='attribute' nodeTest='attribute(Q{}nodeset)' jsTest='return item.name===&#39;nodeset&#39;'/>
          </fn>
          <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
           <attVal name='Q{}nodeset' chk='0'/>
          </cvUntyped>
-         <fn line='1722' name='exists'>
+         <fn line='1674' name='exists'>
           <axis name='attribute' nodeTest='attribute(Q{}ref)' jsTest='return item.name===&#39;ref&#39;'/>
          </fn>
-         <cvUntyped line='1722' to='xs:string' diag='3|0|XTTE0570|refi'>
+         <cvUntyped line='1674' to='xs:string' diag='3|0|XTTE0570|refi'>
           <attVal name='Q{}ref' chk='0'/>
          </cvUntyped>
         </choose>
-        <elem line='1728' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
-         <sequence line='1729'>
+        <elem line='1680' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+         <sequence line='1681'>
           <att name='id' flags='l'>
            <varRef name='Q{}myid' slot='2'/>
           </att>
-          <choose line='1730'>
+          <choose line='1682'>
            <fn name='exists'>
             <varRef name='Q{}refi' slot='5'/>
            </fn>
-           <att line='1731' name='data-group-ref' flags='l'>
+           <att line='1683' name='data-group-ref' flags='l'>
             <varRef name='Q{}refi' slot='5'/>
            </att>
           </choose>
-          <applyT line='1733' bSlot='36'>
+          <applyT line='1685' bSlot='36'>
            <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
            <withParam name='Q{}nodeset' flags='t' as='xs:string?'>
-            <choose line='1734'>
+            <choose line='1686'>
              <fn name='exists'>
               <varRef name='Q{}refi' slot='5'/>
              </fn>
@@ -9292,30 +8305,30 @@
      </let>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='5' rank='1' minImp='0' slots='0' flags='s' line='1075' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='5' rank='1' minImp='0' slots='0' flags='s' line='1022' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
-    <applyT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1076' flags='t' bSlot='37'>
+    <applyT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1023' flags='t' bSlot='37'>
      <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
     </applyT>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='25' part='3' rank='1' minImp='0' slots='1' flags='s' line='2083' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.0' seq='25' part='3' rank='1' minImp='0' slots='1' flags='s' line='2035' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element(Q{http://www.w3.org/2002/xforms}hide)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;hide&#39;;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2091' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
-     <treat line='2092' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2043' var='Q{}action-map' as='map(*)' slot='0' eval='16'>
+     <treat line='2044' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|action-map'>
       <check card='1' diag='3|0|XTTE0570|action-map'>
        <callT name='Q{}setAction' bSlot='2'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <dot line='2093' type='element()'/>
+         <dot line='2045' type='element()'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <varRef line='2106' name='Q{}action-map' slot='0'/>
+     <varRef line='2058' name='Q{}action-map' slot='0'/>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='-0.5' seq='14' part='1' rank='0' minImp='0' slots='0' flags='s' line='1646' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='14' part='1' rank='0' minImp='0' slots='0' flags='s' line='1598' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
-    <copy role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1648' flags='cin'>
+    <copy role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1600' flags='cin'>
      <applyT role='content' bSlot='38'>
       <sequence role='select'>
        <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
@@ -9324,16 +8337,16 @@
      </applyT>
     </copy>
    </templateRule>
-   <templateRule prec='0' prio='0.5' seq='15' rank='2' minImp='0' slots='0' flags='s' line='1657' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.5' seq='15' rank='2' minImp='0' slots='0' flags='s' line='1609' module='saxon-xforms.xsl'>
     <p.withPredicate role='match'>
      <p.nodeTest test='text()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===3;'/>
-     <axis ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1657' name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
+     <axis ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1609' name='ancestor' nodeTest='element(Q{http://www.w3.org/2002/xforms}model)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;model&#39;;'/>
     </p.withPredicate>
     <empty role='action'/>
    </templateRule>
-   <templateRule prec='0' prio='-0.5' seq='14' rank='0' minImp='0' slots='0' flags='s' line='1646' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='14' rank='0' minImp='0' slots='0' flags='s' line='1598' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='( element() | text() | comment() | processing-instruction() )' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);'/>
-    <copy role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1648' flags='cin'>
+    <copy role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1600' flags='cin'>
      <applyT role='content' bSlot='38'>
       <sequence role='select'>
        <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
@@ -9344,9 +8357,9 @@
    </templateRule>
   </mode>
  </co>
- <co id='62' binds='61'>
-  <template name='Q{}getDataRef' flags='os' line='2870' module='saxon-xforms.xsl' slots='16'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2871'>
+ <co id='65' binds='64'>
+  <template name='Q{}getDataRef' flags='os' line='2589' module='saxon-xforms.xsl' slots='16'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2590'>
     <param name='Q{}this' slot='0' flags='r' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
       <check card='1' diag='8|0|XTTE0590|this'>
@@ -9354,7 +8367,7 @@
       </check>
      </treat>
     </param>
-    <param line='2872' name='Q{}nodeset' slot='1' flags='t' as='xs:string'>
+    <param line='2591' name='Q{}nodeset' slot='1' flags='t' as='xs:string'>
      <str role='select' val=''/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|nodeset'>
       <check card='1' diag='8|0|XTTE0590|nodeset'>
@@ -9366,7 +8379,7 @@
       </check>
      </treat>
     </param>
-    <param line='2873' name='Q{}bindingi' slot='2' as='node()?'>
+    <param line='2592' name='Q{}bindingi' slot='2' as='node()?'>
      <empty role='select'/>
      <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|bindingi'>
       <check card='?' diag='8|0|XTTE0590|bindingi'>
@@ -9374,7 +8387,7 @@
       </check>
      </treat>
     </param>
-    <let line='2881' var='Q{}this-ref' as='xs:string?' slot='3' eval='7'>
+    <let line='2600' var='Q{}this-ref' as='xs:string?' slot='3' eval='7'>
      <choose>
       <fn name='exists'>
        <slash simple='1'>
@@ -9409,12 +8422,12 @@
        </cast>
       </fn>
      </choose>
-     <let line='2888' var='Q{}this-binding-ref' as='xs:string?' slot='4' eval='7'>
-      <choose line='2890'>
+     <let line='2607' var='Q{}this-binding-ref' as='xs:string?' slot='4' eval='7'>
+      <choose line='2609'>
        <fn name='exists'>
         <varRef name='Q{}bindingi' slot='2'/>
        </fn>
-       <cvUntyped line='2901' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
+       <cvUntyped line='2620' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
         <cast as='xs:untypedAtomic' emptiable='0'>
          <choose>
           <fn name='exists'>
@@ -9448,23 +8461,23 @@
         </cast>
        </cvUntyped>
        <true/>
-       <let line='2905' var='Q{}this-binding' as='node()?' slot='5' eval='7'>
-        <treat line='2906' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|this-binding'>
+       <let line='2624' var='Q{}this-binding' as='node()?' slot='5' eval='7'>
+        <treat line='2625' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|this-binding'>
          <check card='?' diag='3|0|XTTE0570|this-binding'>
           <callT name='Q{}getBinding' bSlot='0'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <treat line='2907' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+            <treat line='2626' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
              <dot flags='a'/>
             </treat>
            </withParam>
           </callT>
          </check>
         </treat>
-        <choose line='2910'>
+        <choose line='2629'>
          <fn name='exists'>
           <varRef name='Q{}this-binding' slot='5'/>
          </fn>
-         <cvUntyped line='2917' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
+         <cvUntyped line='2636' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
           <cast as='xs:untypedAtomic' emptiable='0'>
            <choose>
             <fn name='exists'>
@@ -9500,30 +8513,30 @@
         </choose>
        </let>
       </choose>
-      <choose line='2927'>
+      <choose line='2646'>
        <fn name='exists'>
         <varRef name='Q{}bindingi' slot='2'/>
        </fn>
-       <let line='2929' var='Q{}relative' as='xs:string' slot='6' eval='16'>
+       <let line='2648' var='Q{}relative' as='xs:string' slot='6' eval='16'>
         <check card='1' diag='0|1||xforms:resolveXPathStrings'>
          <varRef name='Q{}this-binding-ref' slot='4'/>
         </check>
-        <choose line='843'>
+        <choose line='785'>
          <fn name='starts-with'>
           <varRef name='Q{}relative' slot='6'/>
           <str val='/'/>
          </fn>
-         <varRef line='844' name='Q{}relative' slot='6'/>
-         <fn line='846' name='starts-with'>
+         <varRef line='786' name='Q{}relative' slot='6'/>
+         <fn line='788' name='starts-with'>
           <varRef name='Q{}relative' slot='6'/>
           <str val='instance('/>
          </fn>
-         <varRef line='847' name='Q{}relative' slot='6'/>
+         <varRef line='789' name='Q{}relative' slot='6'/>
          <true/>
-         <varRef line='850' name='Q{}relative' slot='6'/>
+         <varRef line='792' name='Q{}relative' slot='6'/>
         </choose>
        </let>
-       <and line='2931' op='and'>
+       <and line='2650' op='and'>
         <fn name='exists'>
          <varRef name='Q{}this-ref' slot='3'/>
         </fn>
@@ -9531,7 +8544,7 @@
          <varRef name='Q{}nodeset' slot='1'/>
         </fn>
        </and>
-       <let line='2886' var='Q{}base' as='xs:string' slot='7' eval='16'>
+       <let line='2605' var='Q{}base' as='xs:string' slot='7' eval='16'>
         <choose>
          <fn name='exists'>
           <slash simple='1'>
@@ -9552,26 +8565,26 @@
          <true/>
          <str val='.'/>
         </choose>
-        <let line='2932' var='Q{}relative' as='xs:string' slot='8' eval='16'>
+        <let line='2651' var='Q{}relative' as='xs:string' slot='8' eval='16'>
          <check card='1' diag='0|1||xforms:resolveXPathStrings'>
           <varRef name='Q{}this-ref' slot='3'/>
          </check>
-         <choose line='843'>
+         <choose line='785'>
           <fn name='starts-with'>
            <varRef name='Q{}relative' slot='8'/>
            <str val='/'/>
           </fn>
-          <varRef line='844' name='Q{}relative' slot='8'/>
-          <fn line='846' name='starts-with'>
+          <varRef line='786' name='Q{}relative' slot='8'/>
+          <fn line='788' name='starts-with'>
            <varRef name='Q{}relative' slot='8'/>
            <str val='instance('/>
           </fn>
-          <varRef line='847' name='Q{}relative' slot='8'/>
-          <fn line='849' name='not'>
+          <varRef line='789' name='Q{}relative' slot='8'/>
+          <fn line='791' name='not'>
            <varRef name='Q{}base' slot='7'/>
           </fn>
-          <varRef line='850' name='Q{}relative' slot='8'/>
-          <or line='852' op='or'>
+          <varRef line='792' name='Q{}relative' slot='8'/>
+          <or line='794' op='or'>
            <fn name='not'>
             <varRef name='Q{}relative' slot='8'/>
            </fn>
@@ -9580,9 +8593,9 @@
             <str val='.'/>
            </vc>
           </or>
-          <varRef line='853' name='Q{}base' slot='7'/>
+          <varRef line='795' name='Q{}base' slot='7'/>
           <true/>
-          <let line='857' var='Q{}parentCallCount' as='xs:integer' slot='9' eval='16'>
+          <let line='799' var='Q{}parentCallCount' as='xs:integer' slot='9' eval='16'>
            <choose>
             <fn name='contains'>
              <varRef name='Q{}relative' slot='8'/>
@@ -9609,7 +8622,7 @@
             <true/>
             <int val='0'/>
            </choose>
-           <let line='860' var='Q{}slashes' as='xs:integer*' slot='10' eval='4'>
+           <let line='802' var='Q{}slashes' as='xs:integer*' slot='10' eval='4'>
             <choose>
              <fn name='contains'>
               <varRef name='Q{}base' slot='7'/>
@@ -9624,15 +8637,15 @@
              <true/>
              <int val='0'/>
             </choose>
-            <choose line='892'>
+            <choose line='834'>
              <compareToInt op='gt' val='0'>
               <varRef name='Q{}parentCallCount' slot='9'/>
              </compareToInt>
-             <fn line='896' name='concat'>
+             <fn line='838' name='concat'>
               <fn name='substring'>
                <varRef name='Q{}base' slot='7'/>
                <int val='1'/>
-               <choose line='871'>
+               <choose line='813'>
                 <and op='and'>
                  <vc op='ge' onEmpty='0' comp='CAVC'>
                   <fn name='count'>
@@ -9644,7 +8657,7 @@
                   <varRef name='Q{}parentCallCount' slot='9'/>
                  </compareToInt>
                 </and>
-                <let line='872' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='11' eval='13'>
+                <let line='814' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='11' eval='13'>
                  <arith op='-' calc='i-i'>
                   <varRef name='Q{}parentCallCount' slot='9'/>
                   <int val='1'/>
@@ -9660,7 +8673,7 @@
                  </check>
                 </let>
                 <true/>
-                <check line='875' card='1' diag='3|0|XTTE0570|parentSlash'>
+                <check line='817' card='1' diag='3|0|XTTE0570|parentSlash'>
                  <lastOf>
                   <varRef name='Q{}slashes' slot='10'/>
                  </lastOf>
@@ -9675,7 +8688,7 @@
               </fn>
              </fn>
              <true/>
-             <fn line='899' name='concat'>
+             <fn line='841' name='concat'>
               <varRef name='Q{}base' slot='7'/>
               <str val='/'/>
               <varRef name='Q{}relative' slot='8'/>
@@ -9686,29 +8699,29 @@
          </choose>
         </let>
        </let>
-       <fn line='2934' name='exists'>
+       <fn line='2653' name='exists'>
         <varRef name='Q{}this-ref' slot='3'/>
        </fn>
-       <let line='2936' var='Q{}relative' as='xs:string' slot='12' eval='16'>
+       <let line='2655' var='Q{}relative' as='xs:string' slot='12' eval='16'>
         <check card='1' diag='0|1||xforms:resolveXPathStrings'>
          <varRef name='Q{}this-ref' slot='3'/>
         </check>
-        <choose line='843'>
+        <choose line='785'>
          <fn name='starts-with'>
           <varRef name='Q{}relative' slot='12'/>
           <str val='/'/>
          </fn>
-         <varRef line='844' name='Q{}relative' slot='12'/>
-         <fn line='846' name='starts-with'>
+         <varRef line='786' name='Q{}relative' slot='12'/>
+         <fn line='788' name='starts-with'>
           <varRef name='Q{}relative' slot='12'/>
           <str val='instance('/>
          </fn>
-         <varRef line='847' name='Q{}relative' slot='12'/>
-         <fn line='2936' name='not'>
+         <varRef line='789' name='Q{}relative' slot='12'/>
+         <fn line='2655' name='not'>
           <varRef name='Q{}nodeset' slot='1'/>
          </fn>
-         <varRef line='850' name='Q{}relative' slot='12'/>
-         <or line='852' op='or'>
+         <varRef line='792' name='Q{}relative' slot='12'/>
+         <or line='794' op='or'>
           <fn name='not'>
            <varRef name='Q{}relative' slot='12'/>
           </fn>
@@ -9717,9 +8730,9 @@
            <str val='.'/>
           </vc>
          </or>
-         <varRef line='2936' name='Q{}nodeset' slot='1'/>
+         <varRef line='2655' name='Q{}nodeset' slot='1'/>
          <true/>
-         <let line='857' var='Q{}parentCallCount' as='xs:integer' slot='13' eval='16'>
+         <let line='799' var='Q{}parentCallCount' as='xs:integer' slot='13' eval='16'>
           <choose>
            <fn name='contains'>
             <varRef name='Q{}relative' slot='12'/>
@@ -9746,30 +8759,30 @@
            <true/>
            <int val='0'/>
           </choose>
-          <let line='860' var='Q{}slashes' as='xs:integer*' slot='14' eval='4'>
+          <let line='802' var='Q{}slashes' as='xs:integer*' slot='14' eval='4'>
            <choose>
-            <fn line='2936' name='contains'>
+            <fn line='2655' name='contains'>
              <varRef name='Q{}nodeset' slot='1'/>
              <str val='/'/>
             </fn>
             <fn name='index-of'>
              <fn name='string-to-codepoints'>
-              <varRef line='2936' name='Q{}nodeset' slot='1'/>
+              <varRef line='2655' name='Q{}nodeset' slot='1'/>
              </fn>
              <int val='47'/>
             </fn>
             <true/>
             <int val='0'/>
            </choose>
-           <choose line='892'>
+           <choose line='834'>
             <compareToInt op='gt' val='0'>
              <varRef name='Q{}parentCallCount' slot='13'/>
             </compareToInt>
-            <fn line='896' name='concat'>
+            <fn line='838' name='concat'>
              <fn name='substring'>
-              <varRef line='2936' name='Q{}nodeset' slot='1'/>
+              <varRef line='2655' name='Q{}nodeset' slot='1'/>
               <int val='1'/>
-              <choose line='871'>
+              <choose line='813'>
                <and op='and'>
                 <vc op='ge' onEmpty='0' comp='CAVC'>
                  <fn name='count'>
@@ -9781,7 +8794,7 @@
                  <varRef name='Q{}parentCallCount' slot='13'/>
                 </compareToInt>
                </and>
-               <let line='872' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='15' eval='13'>
+               <let line='814' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='15' eval='13'>
                 <arith op='-' calc='i-i'>
                  <varRef name='Q{}parentCallCount' slot='13'/>
                  <int val='1'/>
@@ -9797,7 +8810,7 @@
                 </check>
                </let>
                <true/>
-               <check line='875' card='1' diag='3|0|XTTE0570|parentSlash'>
+               <check line='817' card='1' diag='3|0|XTTE0570|parentSlash'>
                 <lastOf>
                  <varRef name='Q{}slashes' slot='14'/>
                 </lastOf>
@@ -9812,18 +8825,18 @@
              </fn>
             </fn>
             <true/>
-            <fn line='2936' name='concat'>
+            <fn line='2655' name='concat'>
              <varRef name='Q{}nodeset' slot='1'/>
              <str val='/'/>
-             <varRef line='899' name='Q{}relative' slot='12'/>
+             <varRef line='841' name='Q{}relative' slot='12'/>
             </fn>
            </choose>
           </let>
          </let>
         </choose>
        </let>
-       <varRef line='2938' name='Q{}nodeset' slot='1'/>
-       <choose line='2941'>
+       <varRef line='2657' name='Q{}nodeset' slot='1'/>
+       <choose line='2660'>
         <fn name='starts-with'>
          <varRef name='Q{}nodeset' slot='1'/>
          <str val='/'/>
@@ -9838,7 +8851,7 @@
         <varRef name='Q{}nodeset' slot='1'/>
        </choose>
        <true/>
-       <cvUntyped line='2945' to='xs:string' diag='3|0|XTTE0570|data-ref'>
+       <cvUntyped line='2664' to='xs:string' diag='3|0|XTTE0570|data-ref'>
         <cast as='xs:untypedAtomic' emptiable='0'>
          <varRef name='Q{}nodeset' slot='1'/>
         </cast>
@@ -9849,18 +8862,109 @@
    </sequence>
   </template>
  </co>
- <co id='5' binds='23'>
-  <function name='Q{http://www.w3.org/2002/xforms}setInstance-JS' line='2806' module='saxon-xforms.xsl' eval='7' flags='pU' as='empty-sequence()' slots='2'>
+ <co id='53' binds='32 3 3'>
+  <template name='Q{}refreshRelevantFields-JS' flags='os' line='2865' module='saxon-xforms.xsl' slots='3'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2866'>
+    <message>
+     <valueOf role='select'>
+      <str val='[refreshRelevantFields-JS] START'/>
+     </valueOf>
+     <str role='terminate' val='no'/>
+     <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+    </message>
+    <forEach line='2868'>
+     <filter flags='b'>
+      <slash simple='1'>
+       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
+       <axis name='descendant' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+      </slash>
+      <fn name='exists'>
+       <axis name='attribute' nodeTest='attribute(Q{}data-relevant)' jsTest='return item.name===&#39;data-relevant&#39;'/>
+      </fn>
+     </filter>
+     <let line='2869' var='Q{}instanceXML' as='element()' slot='0' eval='16'>
+      <check card='1' diag='3|0|XTTE0570|instanceXML'>
+       <ufCall name='Q{http://www.w3.org/2002/xforms}getInstance-JS' tailCall='false' bSlot='0' eval='16'>
+        <fn name='string'>
+         <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
+        </fn>
+       </ufCall>
+      </check>
+      <let line='2870' var='Q{}context-node' as='node()' slot='1' eval='16'>
+       <treat line='2871' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|context-node'>
+        <check card='1' diag='3|0|XTTE0570|context-node'>
+         <evaluate dxns=''>
+          <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='1' eval='16'>
+           <check card='1' diag='0|0||xforms:impose'>
+            <cvUntyped to='xs:string'>
+             <attVal name='Q{}data-ref' chk='0'/>
+            </cvUntyped>
+           </check>
+          </ufCall>
+          <varRef role='cxt' name='Q{}instanceXML' slot='0'/>
+          <varRef role='nsCxt' name='Q{}instanceXML' slot='0'/>
+          <str role='sa' val='no'/>
+          <map role='options' size='0'/>
+          <map role='wp' size='0'/>
+         </evaluate>
+        </check>
+       </treat>
+       <let line='2873' var='Q{}relevantCheck' as='xs:boolean' slot='2' eval='16'>
+        <treat line='2874' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|relevantCheck'>
+         <check card='1' diag='3|0|XTTE0570|relevantCheck'>
+          <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|relevantCheck'>
+           <data>
+            <evaluate dxns=''>
+             <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
+              <check card='1' diag='0|0||xforms:impose'>
+               <cvUntyped to='xs:string'>
+                <attVal name='Q{}data-relevant' chk='0'/>
+               </cvUntyped>
+              </check>
+             </ufCall>
+             <varRef role='cxt' name='Q{}context-node' slot='1'/>
+             <varRef role='nsCxt' name='Q{}instanceXML' slot='0'/>
+             <str role='sa' val='no'/>
+             <map role='options' size='0'/>
+             <map role='wp' size='0'/>
+            </evaluate>
+           </data>
+          </cvUntyped>
+         </check>
+        </treat>
+        <choose line='2878'>
+         <varRef name='Q{}relevantCheck' slot='2'/>
+         <ifCall line='2879' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+          <str val='style.display'/>
+          <str val='inline'/>
+          <dot type='element()'/>
+         </ifCall>
+         <true/>
+         <ifCall line='2882' name='Q{http://saxonica.com/ns/interactiveXSLT}set-property' type='item()?'>
+          <str val='style.display'/>
+          <str val='none'/>
+          <dot type='element()'/>
+         </ifCall>
+        </choose>
+       </let>
+      </let>
+     </let>
+    </forEach>
+   </sequence>
+  </template>
+ </co>
+ <co id='5' binds='18'>
+  <function name='Q{http://www.w3.org/2002/xforms}setInstance-JS' line='2525' module='saxon-xforms.xsl' eval='7' flags='pU' as='empty-sequence()' slots='2'>
    <arg name='Q{}ref' as='xs:string'/>
    <arg name='Q{}updatedInstance' as='element()'/>
-   <check role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2814' card='°' diag='5|0|XTTE0780|xforms:setInstance-JS#2'>
+   <check role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2533' card='°' diag='5|0|XTTE0780|xforms:setInstance-JS#2'>
     <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
      <check card='1' diag='0|0||ixsl:call'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
      </check>
      <str val='setInstance'/>
      <arrayBlock>
-      <check line='2812' card='1' diag='3|0|XTTE0570|this-instance-id'>
+      <check line='2531' card='1' diag='3|0|XTTE0570|this-instance-id'>
        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
         <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='0' eval='6'>
          <varRef name='Q{}ref' slot='0'/>
@@ -9874,15 +8978,15 @@
    </check>
   </function>
  </co>
- <co id='34' binds='2 23'>
-  <function name='Q{http://www.w3.org/2002/xforms}getInstance-JS' line='2779' module='saxon-xforms.xsl' eval='7' flags='pU' as='element()?' slots='1'>
+ <co id='32' binds='2 18'>
+  <function name='Q{http://www.w3.org/2002/xforms}getInstance-JS' line='2498' module='saxon-xforms.xsl' eval='7' flags='pU' as='element()?' slots='1'>
    <arg name='Q{}ref' as='xs:string'/>
-   <tailCallLoop role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2783'>
+   <tailCallLoop role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2502'>
     <choose>
      <fn name='not'>
       <varRef name='Q{}ref' slot='0'/>
      </fn>
-     <treat line='2784' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='5|0|XTTE0780|xforms:getInstance-JS#1'>
+     <treat line='2503' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='5|0|XTTE0780|xforms:getInstance-JS#1'>
       <message>
        <valueOf role='select'>
         <str val='[xforms:getInstance-JS] Empty ref supplied, no instance will be returned'/>
@@ -9892,8 +8996,8 @@
       </message>
      </treat>
      <true/>
-     <ufCall line='2789' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='foreign' bSlot='0' eval='16'>
-      <check line='2787' card='1' diag='3|0|XTTE0570|this-instance-id'>
+     <ufCall line='2508' name='Q{http://www.w3.org/2002/xforms}instance' tailCall='foreign' bSlot='0' eval='16'>
+      <check line='2506' card='1' diag='3|0|XTTE0570|this-instance-id'>
        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
         <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='1' eval='6'>
          <varRef name='Q{}ref' slot='0'/>
@@ -9906,54 +9010,54 @@
    </tailCallLoop>
   </function>
  </co>
- <co id='23' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}getInstanceMap' line='2676' module='saxon-xforms.xsl' eval='8' flags='pU' as='map(xs:string, xs:string)' slots='3'>
+ <co id='18' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}getInstanceMap' line='2395' module='saxon-xforms.xsl' eval='8' flags='pU' as='map(xs:string, xs:string)' slots='3'>
    <arg name='Q{}nodeset' as='xs:string'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2697' var='Q{http://saxon.sf.net/generated-variable}v0' as='map(xs:string, xs:string)+' slot='1' eval='4'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2416' var='Q{http://saxon.sf.net/generated-variable}v0' as='map(xs:string, xs:string)+' slot='1' eval='4'>
     <sequence>
      <map size='1'>
       <str val='instance-id'/>
       <str val='saxon-forms-default'/>
      </map>
-     <ifCall line='2698' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+     <ifCall line='2417' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
       <str val='xpath'/>
       <fn name='normalize-space'>
        <varRef name='Q{}nodeset' slot='0'/>
       </fn>
      </ifCall>
     </sequence>
-    <ifCall line='2681' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+    <ifCall line='2400' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
      <analyzeString>
       <fn role='select' name='normalize-space'>
        <varRef name='Q{}nodeset' slot='0'/>
       </fn>
       <str role='regex' val='^instance\s*\(\s*&#39;([^&#39;]+)&#39;\s*\)\s*(/\s*(.*)|)$'/>
       <str role='flags' val=''/>
-      <let role='matching' line='2683' var='Q{}xpath' as='xs:string' slot='2' eval='16'>
-       <choose line='2685'>
+      <let role='matching' line='2402' var='Q{}xpath' as='xs:string' slot='2' eval='16'>
+       <choose line='2404'>
         <fn name='regex-group'>
          <int val='2'/>
         </fn>
-        <fn line='2686' name='regex-group'>
+        <fn line='2405' name='regex-group'>
          <int val='3'/>
         </fn>
         <true/>
         <str val='.'/>
        </choose>
-       <sequence line='2693'>
+       <sequence line='2412'>
         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
          <str val='instance-id'/>
          <fn name='regex-group'>
           <int val='1'/>
          </fn>
         </ifCall>
-        <ifCall line='2694' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+        <ifCall line='2413' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
          <str val='xpath'/>
          <varRef name='Q{}xpath' slot='2'/>
         </ifCall>
        </sequence>
       </let>
-      <varRef role='nonMatching' line='2697' name='Q{http://saxon.sf.net/generated-variable}v0' slot='1'/>
+      <varRef role='nonMatching' line='2416' name='Q{http://saxon.sf.net/generated-variable}v0' slot='1'/>
      </analyzeString>
      <map size='2'>
       <str val='duplicates'/>
@@ -9965,14 +9069,14 @@
    </let>
   </function>
  </co>
- <co id='1' binds='23'>
-  <function name='Q{http://www.w3.org/2002/xforms}getInstanceId' line='2663' module='saxon-xforms.xsl' eval='8' flags='pU' as='xs:string' slots='1'>
+ <co id='1' binds='18'>
+  <function name='Q{http://www.w3.org/2002/xforms}getInstanceId' line='2382' module='saxon-xforms.xsl' eval='8' flags='pU' as='xs:string' slots='1'>
    <arg name='Q{}nodeset' as='xs:string'/>
-   <cvUntyped role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2666' to='xs:string' diag='5|0|XTTE0780|xforms:getInstanceId#1'>
+   <cvUntyped role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2385' to='xs:string' diag='5|0|XTTE0780|xforms:getInstanceId#1'>
     <cast as='xs:untypedAtomic' emptiable='0'>
      <fn name='string'>
       <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
-       <ufCall line='2665' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='0' eval='6'>
+       <ufCall line='2384' name='Q{http://www.w3.org/2002/xforms}getInstanceMap' tailCall='false' bSlot='0' eval='6'>
         <varRef name='Q{}nodeset' slot='0'/>
        </ufCall>
        <str val='instance-id'/>
@@ -9982,20 +9086,120 @@
    </cvUntyped>
   </function>
  </co>
- <co id='64' binds=''>
-  <globalVariable name='Q{}debugMode' type='xs:boolean' line='80' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.boolean.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
+ <co id='28' binds='13 67 21'>
+  <template name='Q{}outermost-action-handler' flags='os' line='3819' module='saxon-xforms.xsl' slots='1'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3820' var='Q{}deferred-update-flags' as='map(*)?' slot='0' eval='7'>
+    <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|deferred-update-flags'>
+     <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+      <check card='1' diag='0|0||ixsl:call'>
+       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+      </check>
+      <str val='getDeferredUpdateFlags'/>
+      <array size='0'/>
+     </ifCall>
+    </treat>
+    <sequence line='3822'>
+     <message>
+      <valueOf role='select'>
+       <str val='[outermost-action-handler] START'/>
+      </valueOf>
+      <str role='terminate' val='no'/>
+      <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+     </message>
+     <choose line='3828'>
+      <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+       <data>
+        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+         <check card='1' diag='0|0||map:get'>
+          <varRef name='Q{}deferred-update-flags' slot='0'/>
+         </check>
+         <str val='recalculate'/>
+        </ifCall>
+       </data>
+       <str val='true'/>
+      </gc>
+      <sequence line='3829'>
+       <message>
+        <valueOf role='select'>
+         <str val='[outermost-action-handler] triggering xforms-recalculate'/>
+        </valueOf>
+        <str role='terminate' val='no'/>
+        <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+       </message>
+       <callT line='3830' name='Q{}xforms-recalculate' bSlot='0'/>
+      </sequence>
+     </choose>
+     <choose line='3832'>
+      <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+       <data>
+        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+         <check card='1' diag='0|0||map:get'>
+          <varRef name='Q{}deferred-update-flags' slot='0'/>
+         </check>
+         <str val='revalidate'/>
+        </ifCall>
+       </data>
+       <str val='true'/>
+      </gc>
+      <sequence line='3833'>
+       <message>
+        <valueOf role='select'>
+         <str val='[outermost-action-handler] triggering xforms-revalidate'/>
+        </valueOf>
+        <str role='terminate' val='no'/>
+        <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+       </message>
+       <callT line='3834' name='Q{}xforms-revalidate' bSlot='1'/>
+      </sequence>
+     </choose>
+     <choose line='3836'>
+      <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+       <data>
+        <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+         <check card='1' diag='0|0||map:get'>
+          <varRef name='Q{}deferred-update-flags' slot='0'/>
+         </check>
+         <str val='refresh'/>
+        </ifCall>
+       </data>
+       <str val='true'/>
+      </gc>
+      <sequence line='3837'>
+       <message>
+        <valueOf role='select'>
+         <str val='[outermost-action-handler] triggering xforms-refresh'/>
+        </valueOf>
+        <str role='terminate' val='no'/>
+        <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+       </message>
+       <callT line='3838' name='Q{}xforms-refresh' bSlot='2'/>
+      </sequence>
+     </choose>
+     <ifCall line='3842' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+      <check card='1' diag='0|0||ixsl:call'>
+       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+      </check>
+      <str val='clearDeferredUpdateFlags'/>
+      <array size='0'/>
+     </ifCall>
+    </sequence>
+   </let>
+  </template>
+ </co>
+ <co id='68' binds=''>
+  <globalVariable name='Q{}debugMode' type='xs:boolean' line='82' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.boolean.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
    <true/>
   </globalVariable>
  </co>
- <co id='65' binds=''>
-  <function name='Q{http://www.w3.org/2002/xforms}getWhileStatement' line='814' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
+ <co id='69' binds=''>
+  <function name='Q{http://www.w3.org/2002/xforms}getWhileStatement' line='756' module='saxon-xforms.xsl' eval='7' flags='pU' as='xs:string?' slots='1'>
    <arg name='Q{}map' as='map(*)'/>
-   <choose role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='817'>
+   <choose role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='759'>
     <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
      <varRef name='Q{}map' slot='0'/>
      <str val='@while'/>
     </ifCall>
-    <treat line='818' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
+    <treat line='760' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
      <check card='?' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
       <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
        <data>
@@ -10008,7 +9212,7 @@
      </check>
     </treat>
     <true/>
-    <treat line='821' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
+    <treat line='763' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
      <check card='?' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
       <cvUntyped to='xs:string' diag='5|0|XTTE0780|xforms:getWhileStatement#1'>
        <data>
@@ -10029,9 +9233,9 @@
    </choose>
   </function>
  </co>
- <co id='66' binds='1 2 3 15 19 20'>
-  <template name='Q{}DOMActivate' flags='os' line='4077' module='saxon-xforms.xsl' slots='9'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='4078'>
+ <co id='70' binds='1 2 3 48 33 16'>
+  <template name='Q{}DOMActivate' flags='os' line='3852' module='saxon-xforms.xsl' slots='9'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3853'>
     <param name='Q{}form-control' slot='0' flags='i' as='node()'>
      <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|form-control'>
       <check card='1' diag='8|0|XTTE0590|form-control'>
@@ -10039,7 +9243,7 @@
       </check>
      </treat>
     </param>
-    <let line='4080' var='Q{}actions' as='map(*)?' slot='1' eval='7'>
+    <let line='3855' var='Q{}actions' as='map(*)?' slot='1' eval='7'>
      <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
@@ -10056,12 +9260,12 @@
        </arrayBlock>
       </ifCall>
      </treat>
-     <let line='4082' var='Q{}refi' as='attribute(Q{}data-ref)?' slot='2' eval='8'>
+     <let line='3857' var='Q{}refi' as='attribute(Q{}data-ref)?' slot='2' eval='8'>
       <slash simple='1'>
        <varRef name='Q{}form-control' slot='0'/>
        <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
       </slash>
-      <let line='4084' var='Q{}instance-id' as='xs:string' slot='3' eval='16'>
+      <let line='3859' var='Q{}instance-id' as='xs:string' slot='3' eval='16'>
        <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='16'>
         <check card='1' diag='0|0||xforms:getInstanceId'>
          <cvUntyped to='xs:string'>
@@ -10071,12 +9275,12 @@
          </cvUntyped>
         </check>
        </ufCall>
-       <let line='4097' var='Q{}instanceXML' as='element()?' slot='4' eval='7'>
+       <let line='3862' var='Q{}instanceXML' as='element()?' slot='4' eval='7'>
         <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='6'>
          <varRef name='Q{}instance-id' slot='3'/>
         </ufCall>
-        <let line='4099' var='Q{}updatedInstanceXML' as='element()?' slot='5' eval='7'>
-         <choose line='4101'>
+        <let line='3864' var='Q{}updatedInstanceXML' as='element()?' slot='5' eval='7'>
+         <choose line='3866'>
           <and op='and'>
            <fn name='exists'>
             <varRef name='Q{}refi' slot='2'/>
@@ -10085,8 +9289,8 @@
             <varRef name='Q{}instanceXML' slot='4'/>
            </fn>
           </and>
-          <let line='4102' var='Q{}updatedNode' as='node()' slot='6' eval='16'>
-           <treat line='4103' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|updatedNode'>
+          <let line='3867' var='Q{}updatedNode' as='node()' slot='6' eval='16'>
+           <treat line='3868' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|updatedNode'>
             <check card='1' diag='3|0|XTTE0570|updatedNode'>
              <evaluate dxns=''>
               <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
@@ -10108,8 +9312,8 @@
              </evaluate>
             </check>
            </treat>
-           <let line='4105' var='Q{}new-value' as='xs:string' slot='7' eval='16'>
-            <treat line='4106' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-value'>
+           <let line='3870' var='Q{}new-value' as='xs:string' slot='7' eval='16'>
+            <treat line='3871' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-value'>
              <check card='1' diag='3|0|XTTE0570|new-value'>
               <cvUntyped to='xs:string' diag='3|0|XTTE0570|new-value'>
                <data>
@@ -10120,18 +9324,18 @@
               </cvUntyped>
              </check>
             </treat>
-            <treat line='4108' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+            <treat line='3873' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
              <check card='?' diag='3|0|XTTE0570|updatedInstanceXML'>
               <applyT mode='Q{}recalculate' bSlot='4'>
                <varRef role='select' name='Q{}instanceXML' slot='4'/>
                <withParam name='Q{}instance-id' as='xs:string'>
-                <varRef line='4109' name='Q{}instance-id' slot='3'/>
+                <varRef line='3874' name='Q{}instance-id' slot='3'/>
                </withParam>
                <withParam name='Q{}updated-nodes' flags='t' as='node()'>
-                <varRef line='4110' name='Q{}updatedNode' slot='6'/>
+                <varRef line='3875' name='Q{}updatedNode' slot='6'/>
                </withParam>
                <withParam name='Q{}updated-values' flags='t' as='xs:string'>
-                <varRef line='4111' name='Q{}new-value' slot='7'/>
+                <varRef line='3876' name='Q{}new-value' slot='7'/>
                </withParam>
               </applyT>
              </check>
@@ -10139,18 +9343,18 @@
            </let>
           </let>
           <true/>
-          <varRef line='4115' name='Q{}instanceXML' slot='4'/>
+          <varRef line='3880' name='Q{}instanceXML' slot='4'/>
          </choose>
-         <forEach line='4122'>
+         <forEach line='3887'>
           <varRef name='Q{}actions' slot='1'/>
-          <let line='4123' var='Q{}action-map' as='map(*)' slot='8' eval='16'>
+          <let line='3888' var='Q{}action-map' as='map(*)' slot='8' eval='16'>
            <dot type='map(*)'/>
-           <choose line='4126'>
+           <choose line='3891'>
             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}contains' type='xs:boolean'>
              <varRef name='Q{}action-map' slot='8'/>
              <str val='@event'/>
             </ifCall>
-            <choose line='4127'>
+            <choose line='3892'>
              <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
               <data>
                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
@@ -10160,12 +9364,12 @@
               </data>
               <str val='DOMActivate'/>
              </gc>
-             <callT line='4128' name='Q{}applyActions' bSlot='5' flags='t'>
+             <callT line='3893' name='Q{}applyActions' bSlot='5' flags='t'>
               <withParam name='Q{}action-map' flags='t' as='item()'>
-               <varRef line='4129' name='Q{}action-map' slot='8'/>
+               <varRef line='3894' name='Q{}action-map' slot='8'/>
               </withParam>
               <withParam name='Q{}instanceXML' flags='t' as='element()?'>
-               <varRef line='4130' name='Q{}updatedInstanceXML' slot='5'/>
+               <varRef line='3895' name='Q{}updatedInstanceXML' slot='5'/>
               </withParam>
              </callT>
             </choose>
@@ -10180,9 +9384,9 @@
    </sequence>
   </template>
  </co>
- <co id='63' binds='43'>
-  <template name='Q{}setActions' flags='os' line='3191' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3192'>
+ <co id='66' binds='41'>
+  <template name='Q{}setActions' flags='os' line='2941' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2942'>
     <param name='Q{}this' slot='0' flags='i' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
       <check card='1' diag='8|0|XTTE0590|this'>
@@ -10190,7 +9394,7 @@
       </check>
      </treat>
     </param>
-    <applyT line='3194' flags='t' bSlot='0'>
+    <applyT line='2944' flags='t' bSlot='0'>
      <union role='select' op='|'>
       <union op='|'>
        <union op='|'>
@@ -10253,9 +9457,9 @@
    </sequence>
   </template>
  </co>
- <co id='67' binds=''>
-  <template name='Q{}serverError' flags='os' line='1064' module='saxon-xforms.xsl' slots='1'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1065'>
+ <co id='71' binds=''>
+  <template name='Q{}serverError' flags='os' line='1011' module='saxon-xforms.xsl' slots='1'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1012'>
     <param name='Q{}responseMap' slot='0' flags='i' as='map(*)'>
      <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|responseMap'>
       <check card='1' diag='8|0|XTTE0590|responseMap'>
@@ -10263,7 +9467,7 @@
       </check>
      </treat>
     </param>
-    <message line='1066'>
+    <message line='1013'>
      <sequence role='select'>
       <valueOf>
        <str val='Server side error HTTP response - '/>
@@ -10292,9 +9496,9 @@
    </sequence>
   </template>
  </co>
- <co id='60' binds='61 62 43'>
-  <template name='Q{}setAction' flags='os' line='3371' module='saxon-xforms.xsl' slots='20'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3372'>
+ <co id='63' binds='64 65 41'>
+  <template name='Q{}setAction' flags='os' line='3128' module='saxon-xforms.xsl' slots='21'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3129'>
     <param name='Q{}this' slot='0' flags='i' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
       <check card='1' diag='8|0|XTTE0590|this'>
@@ -10302,42 +9506,46 @@
       </check>
      </treat>
     </param>
-    <param line='3373' name='Q{}nodeset' slot='1' flags='t'>
+    <param line='3130' name='Q{}nodeset' slot='1' flags='t'>
      <str role='select' val=''/>
      <supplied role='conversion' slot='1'/>
     </param>
-    <let line='3376' var='Q{}bindingi' as='node()?' slot='2' eval='7'>
-     <treat line='3377' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+    <param line='3131' name='Q{}handler-status' slot='2' flags='t'>
+     <str role='select' val='outermost'/>
+     <supplied role='conversion' slot='2'/>
+    </param>
+    <let line='3134' var='Q{}bindingi' as='node()?' slot='3' eval='7'>
+     <treat line='3135' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
       <check card='?' diag='3|0|XTTE0570|bindingi'>
        <callT name='Q{}getBinding' bSlot='0'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <treat line='3378' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+         <treat line='3136' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
           <dot flags='a'/>
          </treat>
         </withParam>
        </callT>
       </check>
      </treat>
-     <let line='3383' var='Q{}refi' as='xs:string' slot='3' eval='16'>
-      <treat line='3384' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+     <let line='3141' var='Q{}refi' as='xs:string' slot='4' eval='16'>
+      <treat line='3142' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
        <check card='1' diag='3|0|XTTE0570|refi'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
          <data>
           <callT name='Q{}getDataRef' bSlot='1'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <treat line='3385' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+            <treat line='3143' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
              <dot flags='a'/>
             </treat>
            </withParam>
            <withParam name='Q{}bindingi' flags='c' as='node()?'>
-            <varRef line='3386' name='Q{}bindingi' slot='2'/>
+            <varRef line='3144' name='Q{}bindingi' slot='3'/>
            </withParam>
           </callT>
          </data>
         </cvUntyped>
        </check>
       </treat>
-      <ifCall line='3394' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+      <ifCall line='3152' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
        <sequence>
         <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
          <str val='name'/>
@@ -10347,14 +9555,18 @@
           </treat>
          </fn>
         </ifCall>
-        <choose line='3396'>
+        <ifCall line='3154' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <str val='handler-status'/>
+         <varRef name='Q{}handler-status' slot='2'/>
+        </ifCall>
+        <choose line='3156'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}value)' jsTest='return item.name===&#39;value&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3397' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3157' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@value'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10364,7 +9576,7 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3399'>
+        <choose line='3159'>
          <and op='and'>
           <fn name='empty'>
            <slash simple='1'>
@@ -10381,25 +9593,25 @@
            </slash>
           </fn>
          </and>
-         <ifCall line='3400' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3160' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='value'/>
           <fn name='string'>
            <dot flags='a'/>
           </fn>
          </ifCall>
         </choose>
-        <ifCall line='3403' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+        <ifCall line='3163' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
          <str val='@ref'/>
-         <varRef name='Q{}refi' slot='3'/>
+         <varRef name='Q{}refi' slot='4'/>
         </ifCall>
-        <choose line='3409'>
+        <choose line='3169'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}position)' jsTest='return item.name===&#39;position&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3410' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3170' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@position'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10409,14 +9621,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3412'>
+        <choose line='3172'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}at)' jsTest='return item.name===&#39;at&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3413' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3173' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@at'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10426,14 +9638,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3417'>
+        <choose line='3177'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}if)' jsTest='return item.name===&#39;if&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3418' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3178' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@if'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10443,14 +9655,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3422'>
+        <choose line='3182'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}while)' jsTest='return item.name===&#39;while&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3423' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3183' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@while'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10460,14 +9672,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3426'>
+        <choose line='3186'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='@*:event' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===2&amp;&amp;q.local===&#39;event&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3427' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3187' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@event'/>
           <fn name='string'>
            <check card='?' diag='0|0||fn:string'>
@@ -10479,14 +9691,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3429'>
+        <choose line='3189'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}submission)' jsTest='return item.name===&#39;submission&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3430' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3190' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@submission'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10496,14 +9708,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3433'>
+        <choose line='3193'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}model)' jsTest='return item.name===&#39;model&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3434' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3194' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@model'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10513,14 +9725,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3437'>
+        <choose line='3197'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}control)' jsTest='return item.name===&#39;control&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3438' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3198' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@control'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10530,14 +9742,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3441'>
+        <choose line='3201'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}repeat)' jsTest='return item.name===&#39;repeat&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3442' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3202' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@repeat'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10547,14 +9759,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3445'>
+        <choose line='3205'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}index)' jsTest='return item.name===&#39;index&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3446' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3206' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@index'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10564,14 +9776,14 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3449'>
+        <choose line='3209'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}level)' jsTest='return item.name===&#39;level&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3450' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3210' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@level'/>
           <fn name='string'>
            <slash simple='1'>
@@ -10581,16 +9793,16 @@
           </fn>
          </ifCall>
         </choose>
-        <choose line='3453'>
+        <choose line='3213'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}origin)' jsTest='return item.name===&#39;origin&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3461' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3221' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@origin'/>
-          <let line='3457' var='Q{}base' as='xs:string' slot='4' eval='16'>
+          <let line='3217' var='Q{}base' as='xs:string' slot='5' eval='16'>
            <choose>
             <fn name='exists'>
              <slash simple='1'>
@@ -10598,7 +9810,7 @@
               <axis name='attribute' nodeTest='attribute(Q{}context)' jsTest='return item.name===&#39;context&#39;'/>
              </slash>
             </fn>
-            <let var='Q{}base' as='xs:string' slot='5' eval='16'>
+            <let var='Q{}base' as='xs:string' slot='6' eval='16'>
              <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:resolveXPathStrings'>
               <check card='1' diag='0|0||xforms:resolveXPathStrings'>
                <cvUntyped to='xs:string'>
@@ -10608,7 +9820,7 @@
                </cvUntyped>
               </check>
              </treat>
-             <let var='Q{}relative' as='xs:string' slot='6' eval='16'>
+             <let var='Q{}relative' as='xs:string' slot='7' eval='16'>
               <check card='1' diag='0|1||xforms:resolveXPathStrings'>
                <cvUntyped to='xs:string'>
                 <data>
@@ -10619,42 +9831,42 @@
                 </data>
                </cvUntyped>
               </check>
-              <choose line='843'>
+              <choose line='785'>
                <fn name='starts-with'>
-                <varRef name='Q{}relative' slot='6'/>
+                <varRef name='Q{}relative' slot='7'/>
                 <str val='/'/>
                </fn>
-               <varRef line='844' name='Q{}relative' slot='6'/>
-               <fn line='846' name='starts-with'>
-                <varRef name='Q{}relative' slot='6'/>
+               <varRef line='786' name='Q{}relative' slot='7'/>
+               <fn line='788' name='starts-with'>
+                <varRef name='Q{}relative' slot='7'/>
                 <str val='instance('/>
                </fn>
-               <varRef line='847' name='Q{}relative' slot='6'/>
-               <fn line='849' name='not'>
-                <varRef name='Q{}base' slot='5'/>
+               <varRef line='789' name='Q{}relative' slot='7'/>
+               <fn line='791' name='not'>
+                <varRef name='Q{}base' slot='6'/>
                </fn>
-               <varRef line='850' name='Q{}relative' slot='6'/>
-               <or line='852' op='or'>
+               <varRef line='792' name='Q{}relative' slot='7'/>
+               <or line='794' op='or'>
                 <fn name='not'>
-                 <varRef name='Q{}relative' slot='6'/>
+                 <varRef name='Q{}relative' slot='7'/>
                 </fn>
                 <vc op='eq' onEmpty='0' comp='CCC'>
-                 <varRef name='Q{}relative' slot='6'/>
+                 <varRef name='Q{}relative' slot='7'/>
                  <str val='.'/>
                 </vc>
                </or>
-               <varRef line='853' name='Q{}base' slot='5'/>
+               <varRef line='795' name='Q{}base' slot='6'/>
                <true/>
-               <let line='857' var='Q{}parentCallCount' as='xs:integer' slot='7' eval='16'>
+               <let line='799' var='Q{}parentCallCount' as='xs:integer' slot='8' eval='16'>
                 <choose>
                  <fn name='contains'>
-                  <varRef name='Q{}relative' slot='6'/>
+                  <varRef name='Q{}relative' slot='7'/>
                   <str val='/'/>
                  </fn>
                  <fn name='count'>
                   <filter flags='b'>
                    <fn name='tokenize'>
-                    <varRef name='Q{}relative' slot='6'/>
+                    <varRef name='Q{}relative' slot='7'/>
                     <str val='/'/>
                     <str val=''/>
                    </fn>
@@ -10665,83 +9877,83 @@
                   </filter>
                  </fn>
                  <fn name='contains'>
-                  <varRef name='Q{}relative' slot='6'/>
+                  <varRef name='Q{}relative' slot='7'/>
                   <str val='..'/>
                  </fn>
                  <int val='1'/>
                  <true/>
                  <int val='0'/>
                 </choose>
-                <let line='860' var='Q{}slashes' as='xs:integer*' slot='8' eval='4'>
+                <let line='802' var='Q{}slashes' as='xs:integer*' slot='9' eval='4'>
                  <choose>
                   <fn name='contains'>
-                   <varRef name='Q{}base' slot='5'/>
+                   <varRef name='Q{}base' slot='6'/>
                    <str val='/'/>
                   </fn>
                   <fn name='index-of'>
                    <fn name='string-to-codepoints'>
-                    <varRef name='Q{}base' slot='5'/>
+                    <varRef name='Q{}base' slot='6'/>
                    </fn>
                    <int val='47'/>
                   </fn>
                   <true/>
                   <int val='0'/>
                  </choose>
-                 <choose line='892'>
+                 <choose line='834'>
                   <compareToInt op='gt' val='0'>
-                   <varRef name='Q{}parentCallCount' slot='7'/>
+                   <varRef name='Q{}parentCallCount' slot='8'/>
                   </compareToInt>
-                  <fn line='896' name='concat'>
+                  <fn line='838' name='concat'>
                    <fn name='substring'>
-                    <varRef name='Q{}base' slot='5'/>
+                    <varRef name='Q{}base' slot='6'/>
                     <int val='1'/>
-                    <choose line='871'>
+                    <choose line='813'>
                      <and op='and'>
                       <vc op='ge' onEmpty='0' comp='CAVC'>
                        <fn name='count'>
-                        <varRef name='Q{}slashes' slot='8'/>
+                        <varRef name='Q{}slashes' slot='9'/>
                        </fn>
-                       <varRef name='Q{}parentCallCount' slot='7'/>
+                       <varRef name='Q{}parentCallCount' slot='8'/>
                       </vc>
                       <compareToInt op='gt' val='0'>
-                       <varRef name='Q{}parentCallCount' slot='7'/>
+                       <varRef name='Q{}parentCallCount' slot='8'/>
                       </compareToInt>
                      </and>
-                     <let line='872' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='9' eval='16'>
+                     <let line='814' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='10' eval='16'>
                       <arith op='-' calc='i-i'>
-                       <varRef name='Q{}parentCallCount' slot='7'/>
+                       <varRef name='Q{}parentCallCount' slot='8'/>
                        <int val='1'/>
                       </arith>
                       <check card='1' diag='3|0|XTTE0570|parentSlash'>
                        <filter flags='p'>
-                        <varRef name='Q{}slashes' slot='8'/>
+                        <varRef name='Q{}slashes' slot='9'/>
                         <arith op='-' calc='i-i'>
                          <fn name='last'/>
-                         <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='9'/>
+                         <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='10'/>
                         </arith>
                        </filter>
                       </check>
                      </let>
                      <true/>
-                     <check line='875' card='1' diag='3|0|XTTE0570|parentSlash'>
+                     <check line='817' card='1' diag='3|0|XTTE0570|parentSlash'>
                       <lastOf>
-                       <varRef name='Q{}slashes' slot='8'/>
+                       <varRef name='Q{}slashes' slot='9'/>
                       </lastOf>
                      </check>
                     </choose>
                    </fn>
                    <fn name='replace'>
-                    <varRef name='Q{}relative' slot='6'/>
+                    <varRef name='Q{}relative' slot='7'/>
                     <str val='\.\./'/>
                     <str val=''/>
                     <str val=''/>
                    </fn>
                   </fn>
                   <true/>
-                  <fn line='899' name='concat'>
-                   <varRef name='Q{}base' slot='5'/>
+                  <fn line='841' name='concat'>
+                   <varRef name='Q{}base' slot='6'/>
                    <str val='/'/>
-                   <varRef name='Q{}relative' slot='6'/>
+                   <varRef name='Q{}relative' slot='7'/>
                   </fn>
                  </choose>
                 </let>
@@ -10760,7 +9972,7 @@
              </check>
             </treat>
            </choose>
-           <let line='3459' var='Q{}relative' as='xs:string' slot='10' eval='16'>
+           <let line='3219' var='Q{}relative' as='xs:string' slot='11' eval='16'>
             <check card='1' diag='0|1||xforms:resolveXPathStrings'>
              <cvUntyped to='xs:string'>
               <data>
@@ -10771,42 +9983,42 @@
               </data>
              </cvUntyped>
             </check>
-            <choose line='843'>
+            <choose line='785'>
              <fn name='starts-with'>
-              <varRef name='Q{}relative' slot='10'/>
+              <varRef name='Q{}relative' slot='11'/>
               <str val='/'/>
              </fn>
-             <varRef line='844' name='Q{}relative' slot='10'/>
-             <fn line='846' name='starts-with'>
-              <varRef name='Q{}relative' slot='10'/>
+             <varRef line='786' name='Q{}relative' slot='11'/>
+             <fn line='788' name='starts-with'>
+              <varRef name='Q{}relative' slot='11'/>
               <str val='instance('/>
              </fn>
-             <varRef line='847' name='Q{}relative' slot='10'/>
-             <fn line='849' name='not'>
-              <varRef name='Q{}base' slot='4'/>
+             <varRef line='789' name='Q{}relative' slot='11'/>
+             <fn line='791' name='not'>
+              <varRef name='Q{}base' slot='5'/>
              </fn>
-             <varRef line='850' name='Q{}relative' slot='10'/>
-             <or line='852' op='or'>
+             <varRef line='792' name='Q{}relative' slot='11'/>
+             <or line='794' op='or'>
               <fn name='not'>
-               <varRef name='Q{}relative' slot='10'/>
+               <varRef name='Q{}relative' slot='11'/>
               </fn>
               <vc op='eq' onEmpty='0' comp='CCC'>
-               <varRef name='Q{}relative' slot='10'/>
+               <varRef name='Q{}relative' slot='11'/>
                <str val='.'/>
               </vc>
              </or>
-             <varRef line='853' name='Q{}base' slot='4'/>
+             <varRef line='795' name='Q{}base' slot='5'/>
              <true/>
-             <let line='857' var='Q{}parentCallCount' as='xs:integer' slot='11' eval='16'>
+             <let line='799' var='Q{}parentCallCount' as='xs:integer' slot='12' eval='16'>
               <choose>
                <fn name='contains'>
-                <varRef name='Q{}relative' slot='10'/>
+                <varRef name='Q{}relative' slot='11'/>
                 <str val='/'/>
                </fn>
                <fn name='count'>
                 <filter flags='b'>
                  <fn name='tokenize'>
-                  <varRef name='Q{}relative' slot='10'/>
+                  <varRef name='Q{}relative' slot='11'/>
                   <str val='/'/>
                   <str val=''/>
                  </fn>
@@ -10817,83 +10029,83 @@
                 </filter>
                </fn>
                <fn name='contains'>
-                <varRef name='Q{}relative' slot='10'/>
+                <varRef name='Q{}relative' slot='11'/>
                 <str val='..'/>
                </fn>
                <int val='1'/>
                <true/>
                <int val='0'/>
               </choose>
-              <let line='860' var='Q{}slashes' as='xs:integer*' slot='12' eval='4'>
+              <let line='802' var='Q{}slashes' as='xs:integer*' slot='13' eval='4'>
                <choose>
                 <fn name='contains'>
-                 <varRef name='Q{}base' slot='4'/>
+                 <varRef name='Q{}base' slot='5'/>
                  <str val='/'/>
                 </fn>
                 <fn name='index-of'>
                  <fn name='string-to-codepoints'>
-                  <varRef name='Q{}base' slot='4'/>
+                  <varRef name='Q{}base' slot='5'/>
                  </fn>
                  <int val='47'/>
                 </fn>
                 <true/>
                 <int val='0'/>
                </choose>
-               <choose line='892'>
+               <choose line='834'>
                 <compareToInt op='gt' val='0'>
-                 <varRef name='Q{}parentCallCount' slot='11'/>
+                 <varRef name='Q{}parentCallCount' slot='12'/>
                 </compareToInt>
-                <fn line='896' name='concat'>
+                <fn line='838' name='concat'>
                  <fn name='substring'>
-                  <varRef name='Q{}base' slot='4'/>
+                  <varRef name='Q{}base' slot='5'/>
                   <int val='1'/>
-                  <choose line='871'>
+                  <choose line='813'>
                    <and op='and'>
                     <vc op='ge' onEmpty='0' comp='CAVC'>
                      <fn name='count'>
-                      <varRef name='Q{}slashes' slot='12'/>
+                      <varRef name='Q{}slashes' slot='13'/>
                      </fn>
-                     <varRef name='Q{}parentCallCount' slot='11'/>
+                     <varRef name='Q{}parentCallCount' slot='12'/>
                     </vc>
                     <compareToInt op='gt' val='0'>
-                     <varRef name='Q{}parentCallCount' slot='11'/>
+                     <varRef name='Q{}parentCallCount' slot='12'/>
                     </compareToInt>
                    </and>
-                   <let line='872' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='13' eval='13'>
+                   <let line='814' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='14' eval='13'>
                     <arith op='-' calc='i-i'>
-                     <varRef name='Q{}parentCallCount' slot='11'/>
+                     <varRef name='Q{}parentCallCount' slot='12'/>
                      <int val='1'/>
                     </arith>
                     <check card='1' diag='3|0|XTTE0570|parentSlash'>
                      <filter flags='p'>
-                      <varRef name='Q{}slashes' slot='12'/>
+                      <varRef name='Q{}slashes' slot='13'/>
                       <arith op='-' calc='i-i'>
                        <fn name='last'/>
-                       <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='13'/>
+                       <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='14'/>
                       </arith>
                      </filter>
                     </check>
                    </let>
                    <true/>
-                   <check line='875' card='1' diag='3|0|XTTE0570|parentSlash'>
+                   <check line='817' card='1' diag='3|0|XTTE0570|parentSlash'>
                     <lastOf>
-                     <varRef name='Q{}slashes' slot='12'/>
+                     <varRef name='Q{}slashes' slot='13'/>
                     </lastOf>
                    </check>
                   </choose>
                  </fn>
                  <fn name='replace'>
-                  <varRef name='Q{}relative' slot='10'/>
+                  <varRef name='Q{}relative' slot='11'/>
                   <str val='\.\./'/>
                   <str val=''/>
                   <str val=''/>
                  </fn>
                 </fn>
                 <true/>
-                <fn line='899' name='concat'>
-                 <varRef name='Q{}base' slot='4'/>
+                <fn line='841' name='concat'>
+                 <varRef name='Q{}base' slot='5'/>
                  <str val='/'/>
-                 <varRef name='Q{}relative' slot='10'/>
+                 <varRef name='Q{}relative' slot='11'/>
                 </fn>
                </choose>
               </let>
@@ -10903,16 +10115,16 @@
           </let>
          </ifCall>
         </choose>
-        <choose line='3464'>
+        <choose line='3224'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='attribute' nodeTest='attribute(Q{}context)' jsTest='return item.name===&#39;context&#39;'/>
           </slash>
          </fn>
-         <ifCall line='3465' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3225' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='@context'/>
-          <let var='Q{}base' as='xs:string' slot='14' eval='16'>
+          <let var='Q{}base' as='xs:string' slot='15' eval='16'>
            <treat as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='0|0||xforms:resolveXPathStrings'>
             <check card='1' diag='0|0||xforms:resolveXPathStrings'>
              <cvUntyped to='xs:string'>
@@ -10922,7 +10134,7 @@
              </cvUntyped>
             </check>
            </treat>
-           <let var='Q{}relative' as='xs:string' slot='15' eval='16'>
+           <let var='Q{}relative' as='xs:string' slot='16' eval='16'>
             <check card='1' diag='0|1||xforms:resolveXPathStrings'>
              <cvUntyped to='xs:string'>
               <data>
@@ -10933,42 +10145,42 @@
               </data>
              </cvUntyped>
             </check>
-            <choose line='843'>
+            <choose line='785'>
              <fn name='starts-with'>
-              <varRef name='Q{}relative' slot='15'/>
+              <varRef name='Q{}relative' slot='16'/>
               <str val='/'/>
              </fn>
-             <varRef line='844' name='Q{}relative' slot='15'/>
-             <fn line='846' name='starts-with'>
-              <varRef name='Q{}relative' slot='15'/>
+             <varRef line='786' name='Q{}relative' slot='16'/>
+             <fn line='788' name='starts-with'>
+              <varRef name='Q{}relative' slot='16'/>
               <str val='instance('/>
              </fn>
-             <varRef line='847' name='Q{}relative' slot='15'/>
-             <fn line='849' name='not'>
-              <varRef name='Q{}base' slot='14'/>
+             <varRef line='789' name='Q{}relative' slot='16'/>
+             <fn line='791' name='not'>
+              <varRef name='Q{}base' slot='15'/>
              </fn>
-             <varRef line='850' name='Q{}relative' slot='15'/>
-             <or line='852' op='or'>
+             <varRef line='792' name='Q{}relative' slot='16'/>
+             <or line='794' op='or'>
               <fn name='not'>
-               <varRef name='Q{}relative' slot='15'/>
+               <varRef name='Q{}relative' slot='16'/>
               </fn>
               <vc op='eq' onEmpty='0' comp='CCC'>
-               <varRef name='Q{}relative' slot='15'/>
+               <varRef name='Q{}relative' slot='16'/>
                <str val='.'/>
               </vc>
              </or>
-             <varRef line='853' name='Q{}base' slot='14'/>
+             <varRef line='795' name='Q{}base' slot='15'/>
              <true/>
-             <let line='857' var='Q{}parentCallCount' as='xs:integer' slot='16' eval='16'>
+             <let line='799' var='Q{}parentCallCount' as='xs:integer' slot='17' eval='16'>
               <choose>
                <fn name='contains'>
-                <varRef name='Q{}relative' slot='15'/>
+                <varRef name='Q{}relative' slot='16'/>
                 <str val='/'/>
                </fn>
                <fn name='count'>
                 <filter flags='b'>
                  <fn name='tokenize'>
-                  <varRef name='Q{}relative' slot='15'/>
+                  <varRef name='Q{}relative' slot='16'/>
                   <str val='/'/>
                   <str val=''/>
                  </fn>
@@ -10979,83 +10191,83 @@
                 </filter>
                </fn>
                <fn name='contains'>
-                <varRef name='Q{}relative' slot='15'/>
+                <varRef name='Q{}relative' slot='16'/>
                 <str val='..'/>
                </fn>
                <int val='1'/>
                <true/>
                <int val='0'/>
               </choose>
-              <let line='860' var='Q{}slashes' as='xs:integer*' slot='17' eval='4'>
+              <let line='802' var='Q{}slashes' as='xs:integer*' slot='18' eval='4'>
                <choose>
                 <fn name='contains'>
-                 <varRef name='Q{}base' slot='14'/>
+                 <varRef name='Q{}base' slot='15'/>
                  <str val='/'/>
                 </fn>
                 <fn name='index-of'>
                  <fn name='string-to-codepoints'>
-                  <varRef name='Q{}base' slot='14'/>
+                  <varRef name='Q{}base' slot='15'/>
                  </fn>
                  <int val='47'/>
                 </fn>
                 <true/>
                 <int val='0'/>
                </choose>
-               <choose line='892'>
+               <choose line='834'>
                 <compareToInt op='gt' val='0'>
-                 <varRef name='Q{}parentCallCount' slot='16'/>
+                 <varRef name='Q{}parentCallCount' slot='17'/>
                 </compareToInt>
-                <fn line='896' name='concat'>
+                <fn line='838' name='concat'>
                  <fn name='substring'>
-                  <varRef name='Q{}base' slot='14'/>
+                  <varRef name='Q{}base' slot='15'/>
                   <int val='1'/>
-                  <choose line='871'>
+                  <choose line='813'>
                    <and op='and'>
                     <vc op='ge' onEmpty='0' comp='CAVC'>
                      <fn name='count'>
-                      <varRef name='Q{}slashes' slot='17'/>
+                      <varRef name='Q{}slashes' slot='18'/>
                      </fn>
-                     <varRef name='Q{}parentCallCount' slot='16'/>
+                     <varRef name='Q{}parentCallCount' slot='17'/>
                     </vc>
                     <compareToInt op='gt' val='0'>
-                     <varRef name='Q{}parentCallCount' slot='16'/>
+                     <varRef name='Q{}parentCallCount' slot='17'/>
                     </compareToInt>
                    </and>
-                   <let line='872' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='18' eval='13'>
+                   <let line='814' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='19' eval='13'>
                     <arith op='-' calc='i-i'>
-                     <varRef name='Q{}parentCallCount' slot='16'/>
+                     <varRef name='Q{}parentCallCount' slot='17'/>
                      <int val='1'/>
                     </arith>
                     <check card='1' diag='3|0|XTTE0570|parentSlash'>
                      <filter flags='p'>
-                      <varRef name='Q{}slashes' slot='17'/>
+                      <varRef name='Q{}slashes' slot='18'/>
                       <arith op='-' calc='i-i'>
                        <fn name='last'/>
-                       <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='18'/>
+                       <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='19'/>
                       </arith>
                      </filter>
                     </check>
                    </let>
                    <true/>
-                   <check line='875' card='1' diag='3|0|XTTE0570|parentSlash'>
+                   <check line='817' card='1' diag='3|0|XTTE0570|parentSlash'>
                     <lastOf>
-                     <varRef name='Q{}slashes' slot='17'/>
+                     <varRef name='Q{}slashes' slot='18'/>
                     </lastOf>
                    </check>
                   </choose>
                  </fn>
                  <fn name='replace'>
-                  <varRef name='Q{}relative' slot='15'/>
+                  <varRef name='Q{}relative' slot='16'/>
                   <str val='\.\./'/>
                   <str val=''/>
                   <str val=''/>
                  </fn>
                 </fn>
                 <true/>
-                <fn line='899' name='concat'>
-                 <varRef name='Q{}base' slot='14'/>
+                <fn line='841' name='concat'>
+                 <varRef name='Q{}base' slot='15'/>
                  <str val='/'/>
-                 <varRef name='Q{}relative' slot='15'/>
+                 <varRef name='Q{}relative' slot='16'/>
                 </fn>
                </choose>
               </let>
@@ -11065,29 +10277,32 @@
           </let>
          </ifCall>
         </choose>
-        <choose line='3469'>
+        <choose line='3229'>
          <fn name='exists'>
           <slash simple='1'>
            <varRef name='Q{}this' slot='0'/>
            <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
           </slash>
          </fn>
-         <ifCall line='3470' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+         <ifCall line='3230' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
           <str val='nested-actions'/>
-          <let line='3471' var='Q{}array' as='map(*)*' slot='19' eval='3'>
-           <treat line='3472' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|array'>
+          <let line='3231' var='Q{}array' as='map(*)*' slot='20' eval='3'>
+           <treat line='3232' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|array'>
             <forEach>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
              </slash>
-             <applyT line='3473' bSlot='2'>
+             <applyT line='3233' bSlot='2'>
               <dot role='select' type='element()'/>
+              <withParam name='Q{}handler-status' flags='t' as='xs:string'>
+               <str val='inner'/>
+              </withParam>
              </applyT>
             </forEach>
            </treat>
-           <ifCall line='3476' name='Q{http://www.w3.org/2005/xpath-functions/array}_from-sequence' type='array(*)'>
-            <varRef name='Q{}array' slot='19'/>
+           <ifCall line='3238' name='Q{http://www.w3.org/2005/xpath-functions/array}_from-sequence' type='array(*)'>
+            <varRef name='Q{}array' slot='20'/>
            </ifCall>
           </let>
          </ifCall>
@@ -11105,10 +10320,10 @@
    </sequence>
   </template>
  </co>
- <co id='51' binds='3 3'>
-  <function name='Q{http://www.w3.org/2002/xforms}check-constraints-on-fields' line='969' module='saxon-xforms.xsl' eval='8' flags='pU' as='item()*' slots='4'>
+ <co id='50' binds='3 3'>
+  <function name='Q{http://www.w3.org/2002/xforms}check-constraints-on-fields' line='911' module='saxon-xforms.xsl' eval='8' flags='pU' as='item()*' slots='4'>
    <arg name='Q{}instanceXML' as='element()'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='972' var='Q{}constraint-fieldsi' as='element()*' slot='1' eval='8'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='914' var='Q{}constraint-fieldsi' as='element()*' slot='1' eval='8'>
     <filter flags='b'>
      <slash simple='1'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
@@ -11118,10 +10333,10 @@
       <axis name='attribute' nodeTest='attribute(Q{}data-constraint)' jsTest='return item.name===&#39;data-constraint&#39;'/>
      </fn>
     </filter>
-    <forEach line='974'>
+    <forEach line='916'>
      <varRef name='Q{}constraint-fieldsi' slot='1'/>
-     <let line='975' var='Q{}contexti' as='node()' slot='2' eval='16'>
-      <treat line='976' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|contexti'>
+     <let line='917' var='Q{}contexti' as='node()' slot='2' eval='16'>
+      <treat line='918' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|contexti'>
        <check card='1' diag='3|0|XTTE0570|contexti'>
         <evaluate dxns=''>
          <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='0' eval='16'>
@@ -11139,72 +10354,86 @@
         </evaluate>
        </check>
       </treat>
-      <let line='979' var='Q{}resulti' as='xs:boolean' slot='3' eval='16'>
-       <treat line='980' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|resulti'>
-        <check card='1' diag='3|0|XTTE0570|resulti'>
-         <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|resulti'>
-          <data>
-           <evaluate dxns=''>
-            <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='1' eval='16'>
-             <check card='1' diag='0|0||xforms:impose'>
-              <cvUntyped to='xs:string'>
-               <attVal name='Q{}data-constraint' chk='0'/>
-              </cvUntyped>
-             </check>
-            </ufCall>
-            <varRef role='cxt' name='Q{}contexti' slot='2'/>
-            <varRef role='nsCxt' name='Q{}instanceXML' slot='0'/>
-            <str role='sa' val='no'/>
-            <map role='options' size='0'/>
-            <map role='wp' size='0'/>
-           </evaluate>
-          </data>
-         </cvUntyped>
-        </check>
-       </treat>
-       <choose line='982'>
-        <fn name='not'>
-         <varRef name='Q{}resulti' slot='3'/>
-        </fn>
-        <dot type='element()'/>
-       </choose>
-      </let>
+      <sequence line='920'>
+       <message>
+        <sequence role='select'>
+         <valueOf>
+          <str val='[xforms:check-constraints-on-fields] Evaluating XPath: '/>
+         </valueOf>
+         <fn name='serialize'>
+          <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
+         </fn>
+        </sequence>
+        <str role='terminate' val='no'/>
+        <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
+       </message>
+       <let line='922' var='Q{}resulti' as='xs:boolean' slot='3' eval='16'>
+        <treat line='923' as='xs:boolean' jsTest='return SaxonJS.U.Atomic.boolean.matches(item);' diag='3|0|XTTE0570|resulti'>
+         <check card='1' diag='3|0|XTTE0570|resulti'>
+          <cvUntyped to='xs:boolean' diag='3|0|XTTE0570|resulti'>
+           <data>
+            <evaluate dxns=''>
+             <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='1' eval='16'>
+              <check card='1' diag='0|0||xforms:impose'>
+               <cvUntyped to='xs:string'>
+                <attVal name='Q{}data-constraint' chk='0'/>
+               </cvUntyped>
+              </check>
+             </ufCall>
+             <varRef role='cxt' name='Q{}contexti' slot='2'/>
+             <varRef role='nsCxt' name='Q{}instanceXML' slot='0'/>
+             <str role='sa' val='no'/>
+             <map role='options' size='0'/>
+             <map role='wp' size='0'/>
+            </evaluate>
+           </data>
+          </cvUntyped>
+         </check>
+        </treat>
+        <choose line='925'>
+         <fn name='not'>
+          <varRef name='Q{}resulti' slot='3'/>
+         </fn>
+         <dot type='element()'/>
+        </choose>
+       </let>
+      </sequence>
      </let>
     </forEach>
    </let>
   </function>
  </co>
- <co id='68' binds='18 18'>
+ <co id='72' binds='73 73'>
   <mode name='Q{http://saxonica.com/ns/interactiveXSLT}onchange' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='0.0' seq='1' rank='0' minImp='0' slots='0' flags='s' line='717' module='saxon-xforms.xsl'>
-    <p.nodeTest role='match' test='element(Q{}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
-    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='718' name='Q{}xforms-value-changed' bSlot='0' flags='t'>
+   <templateRule prec='0' prio='-0.25' seq='2' rank='0' minImp='0' slots='0' flags='s' line='669' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='*:select' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;select&#39;'/>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='670' name='Q{}action-setvalue-form-control' bSlot='0' flags='t'>
      <withParam name='Q{}form-control' flags='c' as='node()'>
-      <dot line='719' type='element(Q{}input)'/>
+      <dot line='671' type='*:select'/>
      </withParam>
     </callT>
    </templateRule>
-   <templateRule prec='0' prio='0.0' seq='2' rank='0' minImp='0' slots='0' flags='s' line='727' module='saxon-xforms.xsl'>
-    <p.nodeTest role='match' test='element(Q{}select)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;select&#39;;'/>
-    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='728' name='Q{}xforms-value-changed' bSlot='1' flags='t'>
+   <templateRule prec='0' prio='-0.25' seq='1' rank='0' minImp='0' slots='0' flags='s' line='659' module='saxon-xforms.xsl'>
+    <p.nodeTest role='match' test='*:input' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;input&#39;'/>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='660' name='Q{}action-setvalue-form-control' bSlot='1' flags='t'>
      <withParam name='Q{}form-control' flags='c' as='node()'>
-      <dot line='729' type='element(Q{}select)'/>
+      <dot line='661' type='*:input'/>
      </withParam>
     </callT>
    </templateRule>
   </mode>
  </co>
- <co id='53' binds='45 69 69 70 58 58 71 43'>
-  <template name='Q{}xformsjs-main' flags='os' line='117' module='saxon-xforms.xsl' slots='22'>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='615' var='Q{http://saxon.sf.net/generated-variable}v1' as='item()' slot='4' eval='13'>
+ <co id='62' binds='44 74 74 75 59 59 76 41'>
+  <template name='Q{}xformsjs-main' flags='os' line='119' module='saxon-xforms.xsl' slots='22'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='620' var='Q{http://saxon.sf.net/generated-variable}v1' as='item()' slot='4' eval='13'>
     <check card='1' diag='0|0||ixsl:call'>
      <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
     </check>
-    <let line='585' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='5' eval='13'>
+    <let line='590' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='5' eval='13'>
      <check card='1' diag='0|0||ixsl:call'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
      </check>
-     <sequence line='118'>
+     <sequence line='120'>
       <param name='Q{}xforms-doc' slot='0' as='document-node()?'>
        <empty role='select'/>
        <treat role='conversion' as='document-node()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);' diag='8|0|XTTE0590|xforms-doc'>
@@ -11213,7 +10442,7 @@
         </check>
        </treat>
       </param>
-      <param line='119' name='Q{}xforms-file' slot='1' as='xs:string?'>
+      <param line='121' name='Q{}xforms-file' slot='1' as='xs:string?'>
        <empty role='select'/>
        <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|xforms-file'>
         <check card='?' diag='8|0|XTTE0590|xforms-file'>
@@ -11225,7 +10454,7 @@
         </check>
        </treat>
       </param>
-      <param line='120' name='Q{}instance-docs' slot='2' as='map(*)?'>
+      <param line='122' name='Q{}instance-docs' slot='2' as='map(*)?'>
        <empty role='select'/>
        <treat role='conversion' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='8|0|XTTE0590|instance-docs'>
         <check card='?' diag='8|0|XTTE0590|instance-docs'>
@@ -11233,7 +10462,7 @@
         </check>
        </treat>
       </param>
-      <param line='121' name='Q{}xFormsId' slot='3' as='xs:string'>
+      <param line='123' name='Q{}xFormsId' slot='3' as='xs:string'>
        <gVarRef role='select' name='Q{}xform-html-id' bSlot='0'/>
        <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|xFormsId'>
         <check card='1' diag='8|0|XTTE0590|xFormsId'>
@@ -11245,33 +10474,33 @@
         </check>
        </treat>
       </param>
-      <message line='123'>
+      <message line='125'>
        <valueOf role='select'>
         <str val='[xformsjs-main] START'/>
        </valueOf>
        <str role='terminate' val='no'/>
        <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
       </message>
-      <let line='134' var='Q{}xforms-doci' as='document-node()?' slot='6' eval='7'>
-       <choose line='136'>
+      <let line='136' var='Q{}xforms-doci' as='document-node()?' slot='6' eval='7'>
+       <choose line='138'>
         <fn name='exists'>
          <varRef name='Q{}xforms-doc' slot='0'/>
         </fn>
-        <varRef line='137' name='Q{}xforms-doc' slot='0'/>
-        <fn line='139' name='doc-available'>
+        <varRef line='139' name='Q{}xforms-doc' slot='0'/>
+        <fn line='141' name='doc-available'>
          <varRef name='Q{}xforms-file' slot='1'/>
         </fn>
-        <fn line='140' name='doc'>
+        <fn line='142' name='doc'>
          <varRef name='Q{}xforms-file' slot='1'/>
         </fn>
-        <fn line='142' name='exists'>
+        <fn line='144' name='exists'>
          <gVarRef name='Q{}xforms-doc-global' bSlot='1'/>
         </fn>
-        <gVarRef line='143' name='Q{}xforms-doc-global' bSlot='2'/>
-        <fn line='145' name='exists'>
+        <gVarRef line='145' name='Q{}xforms-doc-global' bSlot='2'/>
+        <fn line='147' name='exists'>
          <varRef name='Q{}xforms-file' slot='1'/>
         </fn>
-        <treat line='146' as='document-node()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);' diag='3|0|XTTE0570|xforms-doci'>
+        <treat line='148' as='document-node()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);' diag='3|0|XTTE0570|xforms-doci'>
          <message>
           <sequence role='select'>
            <valueOf>
@@ -11284,7 +10513,7 @@
          </message>
         </treat>
         <true/>
-        <treat line='149' as='document-node()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);' diag='3|0|XTTE0570|xforms-doci'>
+        <treat line='151' as='document-node()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);' diag='3|0|XTTE0570|xforms-doci'>
          <message>
           <valueOf role='select'>
            <str val='[xformsjs-main] Unable to locate XForm!'/>
@@ -11294,7 +10523,7 @@
          </message>
         </treat>
        </choose>
-       <let line='155' var='Q{}xform' as='element(Q{http://www.w3.org/2002/xforms}xform, Q{http://www.w3.org/2001/XMLSchema}untyped)' slot='7' eval='16'>
+       <let line='157' var='Q{}xform' as='element(Q{http://www.w3.org/2002/xforms}xform, Q{http://www.w3.org/2001/XMLSchema}untyped)' slot='7' eval='16'>
         <treat as='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;' diag='3|0|XTTE0570|xform'>
          <let var='Q{}this' as='element()' slot='8' eval='16'>
           <check card='1' diag='0|0||xforms:addNamespaceDeclarations'>
@@ -11303,16 +10532,16 @@
             <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
            </slash>
           </check>
-          <compElem line='2573'>
+          <compElem line='2292'>
            <fn role='name' name='name'>
             <varRef name='Q{}this' slot='8'/>
            </fn>
-           <sequence role='content' line='2574'>
+           <sequence role='content' line='2293'>
             <namespace flags='l'>
              <str role='name' val='xforms'/>
              <str role='select' val='http://www.w3.org/2002/xforms'/>
             </namespace>
-            <forEach line='2575'>
+            <forEach line='2294'>
              <filter flags='b'>
               <filter flags='b'>
                <slash simple='1'>
@@ -11351,21 +10580,21 @@
                </gc>
               </fn>
              </filter>
-             <namespace line='2578' flags='l'>
-              <fn role='name' line='2577' name='substring-before'>
+             <namespace line='2297' flags='l'>
+              <fn role='name' line='2296' name='substring-before'>
                <fn name='name'>
                 <dot type='element()'/>
                </fn>
                <str val=':'/>
               </fn>
               <convert role='select' from='xs:anyURI' to='xs:string'>
-               <fn line='2576' name='namespace-uri'>
+               <fn line='2295' name='namespace-uri'>
                 <dot type='element()'/>
                </fn>
               </convert>
              </namespace>
             </forEach>
-            <copyOf line='2580' flags='vc'>
+            <copyOf line='2299' flags='vc'>
              <sequence>
               <slash simple='1'>
                <varRef name='Q{}this' slot='8'/>
@@ -11381,12 +10610,12 @@
           </compElem>
          </let>
         </treat>
-        <let line='158' var='Q{}xforms-instances' as='map(xs:string, element())' slot='9' eval='16'>
-         <choose line='160'>
+        <let line='160' var='Q{}xforms-instances' as='map(xs:string, element())' slot='9' eval='16'>
+         <choose line='162'>
           <fn name='empty'>
            <varRef name='Q{}instance-docs' slot='2'/>
           </fn>
-          <let line='161' var='Q{}instances' as='element(Q{http://www.w3.org/2002/xforms}instance)*' slot='10' eval='4'>
+          <let line='163' var='Q{}instances' as='element(Q{http://www.w3.org/2002/xforms}instance)*' slot='10' eval='4'>
            <slash simple='2'>
             <slash simple='2'>
              <slash simple='1'>
@@ -11397,7 +10626,7 @@
             </slash>
             <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}instance)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;instance&#39;;'/>
            </slash>
-           <check line='162' card='1' diag='3|0|XTTE0570|xforms-instances'>
+           <check line='164' card='1' diag='3|0|XTTE0570|xforms-instances'>
             <sequence>
              <choose>
               <fn name='exists'>
@@ -11410,7 +10639,7 @@
                 </filter>
                </tail>
               </fn>
-              <treat line='164' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|xforms-instances'>
+              <treat line='166' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|xforms-instances'>
                <message>
                 <str role='select' val='[xformsjs-main] FATAL ERROR: The XForm contains more than one instance with no ID. At most one instance may have no ID.'/>
                 <str role='terminate' val='yes'/>
@@ -11418,18 +10647,18 @@
                </message>
               </treat>
              </choose>
-             <ifCall line='168' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+             <ifCall line='170' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
               <forEach>
                <varRef name='Q{}instances' slot='10'/>
-               <let line='169' var='Q{}instance-with-explicit-namespaces' as='element()' slot='11' eval='16'>
-                <treat line='170' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-explicit-namespaces'>
+               <let line='171' var='Q{}instance-with-explicit-namespaces' as='element()' slot='11' eval='16'>
+                <treat line='172' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|instance-with-explicit-namespaces'>
                  <check card='1' diag='3|0|XTTE0570|instance-with-explicit-namespaces'>
                   <applyT mode='Q{}namespace-fix' bSlot='3'>
                    <axis role='select' name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
                   </applyT>
                  </check>
                 </treat>
-                <ifCall line='179' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                <ifCall line='181' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                  <check card='1' diag='0|0||map:entry'>
                   <cast as='xs:string' emptiable='1'>
                    <choose>
@@ -11457,18 +10686,18 @@
            </check>
           </let>
           <true/>
-          <treat line='184' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|xforms-instances'>
+          <treat line='186' as='map(xs:string, element())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|xforms-instances'>
            <check card='1' diag='3|0|XTTE0570|xforms-instances'>
             <varRef name='Q{}instance-docs' slot='2'/>
            </check>
           </treat>
          </choose>
-         <let line='191' var='Q{}default-instance' as='element()' slot='12' eval='16'>
-          <choose line='193'>
+         <let line='193' var='Q{}default-instance' as='element()' slot='12' eval='16'>
+          <choose line='195'>
            <fn name='empty'>
             <varRef name='Q{}instance-docs' slot='2'/>
            </fn>
-           <choose line='195'>
+           <choose line='197'>
             <fn name='exists'>
              <filter flags='b'>
               <slash simple='2'>
@@ -11486,7 +10715,7 @@
               </fn>
              </filter>
             </fn>
-            <check line='196' card='1' diag='3|0|XTTE0570|default-instance'>
+            <check line='198' card='1' diag='3|0|XTTE0570|default-instance'>
              <slash simple='2'>
               <slash>
                <slash simple='2'>
@@ -11509,7 +10738,7 @@
              </slash>
             </check>
             <true/>
-            <check line='199' card='1' diag='3|0|XTTE0570|default-instance'>
+            <check line='201' card='1' diag='3|0|XTTE0570|default-instance'>
              <slash simple='2'>
               <slash>
                <slash simple='2'>
@@ -11528,7 +10757,7 @@
             </check>
            </choose>
            <true/>
-           <treat line='205' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|default-instance'>
+           <treat line='207' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|default-instance'>
             <check card='1' diag='3|0|XTTE0570|default-instance'>
              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
               <check card='1' diag='0|0||ixsl:call'>
@@ -11540,8 +10769,8 @@
             </check>
            </treat>
           </choose>
-          <let line='211' var='Q{}bindings' as='map(xs:string, element(Q{http://www.w3.org/2002/xforms}bind))' slot='13' eval='8'>
-           <ifCall line='213' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+          <let line='213' var='Q{}bindings' as='map(xs:string, element(Q{http://www.w3.org/2002/xforms}bind))' slot='13' eval='8'>
+           <ifCall line='215' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
             <forEach>
              <slash simple='2'>
               <slash simple='2'>
@@ -11553,7 +10782,7 @@
               </slash>
               <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}bind)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;bind&#39;;'/>
              </slash>
-             <ifCall line='221' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+             <ifCall line='223' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
               <check card='1' diag='0|0||map:entry'>
                <cast as='xs:string' emptiable='1'>
                 <choose>
@@ -11576,16 +10805,16 @@
              <str val='XTDE3365'/>
             </map>
            </ifCall>
-           <let line='235' var='Q{}bindingKeys' as='xs:anyAtomicType*' slot='14' eval='3'>
+           <let line='237' var='Q{}bindingKeys' as='xs:anyAtomicType*' slot='14' eval='3'>
             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
              <varRef name='Q{}bindings' slot='13'/>
             </ifCall>
-            <let line='237' var='Q{}RelevantBindings' as='map(xs:string, xs:string)' slot='15' eval='16'>
-             <treat line='239' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|RelevantBindings'>
+            <let line='239' var='Q{}RelevantBindings' as='map(xs:string, xs:string)' slot='15' eval='16'>
+             <treat line='241' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|RelevantBindings'>
               <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
                <forEach>
                 <varRef name='Q{}bindingKeys' slot='14'/>
-                <let line='240' var='Q{}bindingNode' as='element(Q{http://www.w3.org/2002/xforms}bind)' slot='16' eval='16'>
+                <let line='242' var='Q{}bindingNode' as='element(Q{http://www.w3.org/2002/xforms}bind)' slot='16' eval='16'>
                  <check card='1' diag='3|0|XTTE0570|bindingNode'>
                   <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
                    <varRef name='Q{}bindings' slot='13'/>
@@ -11594,7 +10823,7 @@
                    </cast>
                   </ifCall>
                  </check>
-                 <choose line='242'>
+                 <choose line='244'>
                   <fn name='exists'>
                    <filter flags='b'>
                     <varRef name='Q{}bindingNode' slot='16'/>
@@ -11603,8 +10832,8 @@
                     </fn>
                    </filter>
                   </fn>
-                  <ifCall line='244' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
-                   <check line='243' card='1' diag='3|0|XTTE0570|keyi'>
+                  <ifCall line='246' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                   <check line='245' card='1' diag='3|0|XTTE0570|keyi'>
                     <cast as='xs:string' emptiable='1'>
                      <data>
                       <slash simple='1'>
@@ -11634,12 +10863,12 @@
                </map>
               </ifCall>
              </treat>
-             <let line='253' var='Q{}CalculationBindings' as='map(xs:string, xs:string)' slot='17' eval='16'>
-              <treat line='255' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|CalculationBindings'>
+             <let line='255' var='Q{}CalculationBindings' as='map(xs:string, xs:string)' slot='17' eval='16'>
+              <treat line='257' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0|XTTE0570|CalculationBindings'>
                <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
                 <forEach>
                  <varRef name='Q{}bindingKeys' slot='14'/>
-                 <let line='256' var='Q{}bindingNode' as='element(Q{http://www.w3.org/2002/xforms}bind)' slot='18' eval='16'>
+                 <let line='258' var='Q{}bindingNode' as='element(Q{http://www.w3.org/2002/xforms}bind)' slot='18' eval='16'>
                   <check card='1' diag='3|0|XTTE0570|bindingNode'>
                    <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
                     <varRef name='Q{}bindings' slot='13'/>
@@ -11648,7 +10877,7 @@
                     </cast>
                    </ifCall>
                   </check>
-                  <choose line='258'>
+                  <choose line='260'>
                    <fn name='exists'>
                     <filter flags='b'>
                      <varRef name='Q{}bindingNode' slot='18'/>
@@ -11657,8 +10886,8 @@
                      </fn>
                     </filter>
                    </fn>
-                   <ifCall line='260' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
-                    <check line='259' card='1' diag='3|0|XTTE0570|keyi'>
+                   <ifCall line='262' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                    <check line='261' card='1' diag='3|0|XTTE0570|keyi'>
                      <cast as='xs:string' emptiable='1'>
                       <data>
                        <slash simple='1'>
@@ -11688,7 +10917,7 @@
                 </map>
                </ifCall>
               </treat>
-              <sequence line='272'>
+              <sequence line='275'>
                <choose>
                 <gc op='=' card='N:1' comp='CCC'>
                  <data>
@@ -11702,7 +10931,7 @@
                  </data>
                  <gVarRef name='Q{}xforms-cache-id' bSlot='4'/>
                 </gc>
-                <sequence line='273'>
+                <sequence line='276'>
                  <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                   <check card='1' diag='0|0||ixsl:call'>
                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -11712,7 +10941,7 @@
                    <varRef name='Q{}xforms-doci' slot='6'/>
                   </arrayBlock>
                  </ifCall>
-                 <ifCall line='274' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <ifCall line='277' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                   <check card='1' diag='0|0||ixsl:call'>
                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                   </check>
@@ -11721,7 +10950,7 @@
                    <varRef name='Q{}xform' slot='7'/>
                   </arrayBlock>
                  </ifCall>
-                 <ifCall line='275' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <ifCall line='278' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                   <check card='1' diag='0|0||ixsl:call'>
                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                   </check>
@@ -11730,7 +10959,7 @@
                    <varRef name='Q{}xFormsId' slot='3'/>
                   </arrayBlock>
                  </ifCall>
-                 <ifCall line='276' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <ifCall line='279' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                   <check card='1' diag='0|0||ixsl:call'>
                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                   </check>
@@ -11739,7 +10968,7 @@
                    <varRef name='Q{}RelevantBindings' slot='15'/>
                   </arrayBlock>
                  </ifCall>
-                 <ifCall line='277' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <ifCall line='280' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                   <check card='1' diag='0|0||ixsl:call'>
                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                   </check>
@@ -11748,17 +10977,36 @@
                    <varRef name='Q{}CalculationBindings' slot='17'/>
                   </arrayBlock>
                  </ifCall>
+                 <choose line='283'>
+                  <fn name='empty'>
+                   <varRef name='Q{}instance-docs' slot='2'/>
+                  </fn>
+                  <ifCall line='284' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                   <check card='1' diag='0|0||ixsl:call'>
+                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                   </check>
+                   <str val='setDeferredUpdateFlags'/>
+                   <array size='1'>
+                    <literal count='4'>
+                     <str val='rebuild'/>
+                     <str val='recalculate'/>
+                     <str val='revalidate'/>
+                     <str val='refresh'/>
+                    </literal>
+                   </array>
+                  </ifCall>
+                 </choose>
                 </sequence>
                 <true/>
-                <sequence line='288'>
+                <sequence line='297'>
                  <forEach>
                   <slash simple='1'>
                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}page' type='document-node()?'/>
                    <axis name='descendant' nodeTest='element(Q{}head)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;head&#39;;'/>
                   </slash>
-                  <resultDoc line='297' global='#&#xD;&#xA;#Sat Apr 04 13:28:45 BST 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Sat Apr 04 13:28:45 BST 2020&#xD;&#xA;'>
+                  <resultDoc line='306' global='#&#xD;&#xA;#Sun Apr 05 16:19:18 BST 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Sun Apr 05 16:19:18 BST 2020&#xD;&#xA;'>
                    <str role='href' val='?.'/>
-                   <elem role='content' line='298' name='script' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+                   <elem role='content' line='307' name='script' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
                     <sequence>
                      <att name='type' flags='l'>
                       <str val='text/javascript'/>
@@ -11767,19 +11015,19 @@
                       <gVarRef name='Q{}xforms-cache-id' bSlot='5'/>
                      </att>
                      <valueOf flags='l'>
-                      <str val='                &#xA;                            var XFormsDoc = null;&#xA;                            var XForm = null;&#xA;                            var defaultInstanceDoc = null;&#xA;                            &#xA;                            // MD 2018: OND&#39;s suggestion for multiple instances&#xA;                            var instanceDocs = {};&#xA;                            &#xA;                            var pendingUpdatesMap = null;&#xA;                            var updatesMap = null;&#xA;                            var XFormsID = &#39;'/>
+                      <str val='                &#xA;                            var XFormsDoc = null;&#xA;                            var XForm = null;&#xA;                            var defaultInstanceDoc = null;&#xA;                            &#xA;                            // MD 2018: OND&#39;s suggestion for multiple instances&#xA;                            var instanceDocs = {};&#xA;                            &#xA;                            var XFormsID = &#39;'/>
                      </valueOf>
-                     <valueOf line='308' flags='l'>
+                     <valueOf line='315' flags='l'>
                       <varRef name='Q{}xFormsId' slot='3'/>
                      </valueOf>
                      <valueOf flags='l'>
-                      <str val='&#39;;&#xA;                            var actions = {};&#xA;                            var submissions = {};&#xA;                            var outputs = {};&#xA;                            var repeats = {};&#xA;                            var relevantMap = {};&#xA;                            var calculationMap = {};&#xA;                            var repeatIndexMap = {};&#xA;                            var repeatSizeMap = {};&#xA;                            var elementsUsingIndexFunction = {};&#xA;                            &#xA;                            var getCurrentDate = function(){&#xA;                                var today = new Date();&#xA;                                var dd = today.getDate();&#xA;                                var mm = today.getMonth()+1; //January is 0!&#xA;                                var yyyy = today.getFullYear();&#xA;                            &#xA;                                if(dd &lt; 10) {&#xA;                                    dd = &#39;0&#39; + dd;&#xA;                                } &#xA;                            &#xA;                                if(mm &lt; 10) {&#xA;                                    mm = &#39;0&#39; + mm;&#xA;                                } &#xA;                            &#xA;                                today = yyyy + &#39;-&#39; + mm + &#39;-&#39; + dd;&#xA;                                return today;&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var setXFormsDoc = function(doc) {&#xA;                                XFormsDoc = doc;&#xA;                            }&#xA;                            &#xA;                            var getXFormsDoc = function() {&#xA;                                return XFormsDoc;&#xA;                            }&#xA;                            &#xA;                            var setXForm = function(element) {&#xA;                                XForm = element;&#xA;                            }&#xA;                            &#xA;                            var getXForm = function() {&#xA;                                return XForm;&#xA;                            }&#xA;                            &#xA;                            var setXFormsID = function(id) {&#xA;                                XFormsID = id;&#xA;                            }&#xA;                            &#xA;                            var getXFormsID = function() {&#xA;                                return XFormsID;&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var setInstance = function(name, value) {&#xA;                                instanceDocs[name] = value;&#xA;                            } &#xA;                            &#xA;                            var getInstance = function(name) {&#xA;                                return instanceDocs[name];&#xA;                            }&#xA;                            &#xA;                            &#xA;                            //[OND] Maybe we can just set the key-&gt; value without having to copy the entire instanceDocs object.&#xA;                            var updateInstance = function(instanceDocs, key, value){&#xA;                                instanceDocs[key] = value;&#xA;                                return instanceDocs;&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var setDefaultInstance = function(doc) {&#xA;                                defaultInstanceDoc = doc;&#xA;                            }&#xA;                            &#xA;                            var getDefaultInstance = function() {&#xA;                                return defaultInstanceDoc;&#xA;                            }&#xA;                            &#xA;                           &#xA;                            var getInstanceKeys = function() {&#xA;                                return Object.keys(instanceDocs);&#xA;                            }&#xA;                            &#xA;                            var getInstances = function() {&#xA;                                return instanceDocs;&#xA;                            }&#xA;                            &#xA;                            var setPendingUpdates = function(map1) {&#xA;                                pendingUpdatesMap = map1;&#xA;                            }&#xA;                            &#xA;                            var clearPendingUpdates = function() {&#xA;                                pendingUpdatesMap = null;&#xA;                            }&#xA;                            &#xA;                            var getPendingUpdates = function() {&#xA;                                return pendingUpdatesMap;&#xA;                            }&#xA;                            &#xA;                            var setUpdates = function(map1) {&#xA;                                updatesMap = map1;&#xA;                            }&#xA;                            &#xA;                            var clearUpdates = function() {&#xA;                                updatesMap = null;&#xA;                            }&#xA;                            &#xA;                            var getUpdates = function() {&#xA;                                return updatesMap;&#xA;                            }&#xA;                            &#xA;                            var addAction = function(name, value){&#xA;                                actions[name] = value;&#xA;                            }&#xA;&#xA;                            var getAction = function(name){&#xA;                                return actions[name];&#xA;                            }&#xA;                            &#xA;                            var updateAction = function(actioni, key, value){&#xA;                                actioni[key] = value;&#xA;                                return actioni;&#xA;                            }&#xA;                            &#xA;                            var addSubmission = function(name, value){&#xA;                                submissions[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getSubmission = function(name){&#xA;                                return submissions[name];&#xA;                            }     &#xA;                            &#xA;                            var addOutput = function(name, value){&#xA;                                outputs[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getOutput = function(name){&#xA;                                return outputs[name];&#xA;                            }&#xA;                            &#xA;                            var getOutputKeys = function() {&#xA;                                return Object.keys(outputs);&#xA;                            }&#xA;                            &#xA;                            // repeats is a map of HTML IDs to (parsed) xf:repeat/@nodeset values&#xA;                            var addRepeat = function(name, value){&#xA;                                repeats[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getRepeat = function(name){&#xA;                                return repeats[name];&#xA;                            }&#xA;                            &#xA;                            var getRepeatKeys = function() {&#xA;                                return Object.keys(repeats);&#xA;                            }&#xA;                            &#xA;                            var setRelevantMap = function(map1) {&#xA;                                relevantMap = map1;                            &#xA;                            }&#xA;                            &#xA;                            var getRelevantMap = function() {&#xA;                                return relevantMap;&#xA;                            }&#xA;                            &#xA;  &#xA;                            var setCalculationMap = function(map1) {&#xA;                                calculationMap = map1;                            &#xA;                            }&#xA;  &#xA;                            var getCalculationMap = function() {&#xA;                                return calculationMap;&#xA;                            }&#xA;  &#xA;                            &#xA;                            var getRepeatIndexMap = function() {&#xA;                                return repeatIndexMap;&#xA;                            }&#xA;                            &#xA;                            var setRepeatIndex = function(name, value) {&#xA;                                repeatIndexMap[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getRepeatIndex = function(name) {&#xA;                                if ( typeof(repeatIndexMap[name]) != &#39;undefined&#39; ) {&#xA;                                    return repeatIndexMap[name];&#xA;                                }&#xA;                                else {&#xA;                                    return 0;&#xA;                                }&#xA;                            } &#xA;                            &#xA;                            var setRepeatSize = function(name, value) {&#xA;                                repeatSizeMap[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getRepeatSize = function(name) {&#xA;                                if ( typeof(repeatSizeMap[name]) != &#39;undefined&#39; ) {&#xA;                                    return repeatSizeMap[name];&#xA;                                }&#xA;                                else {&#xA;                                    return 0;&#xA;                                }&#xA;                            } &#xA;                            &#xA;                            var setElementUsingIndexFunction = function(name, value) {&#xA;                                elementsUsingIndexFunction[name] = value;&#xA;                            } &#xA;                            &#xA;                            var getElementUsingIndexFunction = function(name) {&#xA;                                return elementsUsingIndexFunction[name];&#xA;                            }&#xA;                            &#xA;                            var getElementsUsingIndexFunctionKeys = function() {&#xA;                                return Object.keys(elementsUsingIndexFunction);&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var startTime = function(name) {&#xA;                                console.time(name);&#xA;                            }&#xA;                            &#xA;                            var endTime = function(name) {&#xA;                                console.timeEnd(name);&#xA;                            }&#xA;                            &#xA;                            var highlightClicked = function(id) {&#xA;                                var item = document.getElementById(id);&#xA;                                toggleClass(item);&#xA;                            }&#xA;                            &#xA;                            var toggleClass = function(element) {&#xA;                                if (element.className == &#39;selected&#39;) {&#xA;                                    element.classList.remove(&#39;selected&#39;);&#xA;                                }&#xA;                                else {&#xA;                                    var x = document.getElementsByClassName(&#39;selected&#39;);&#xA;                                    var i;&#xA;                                    for (i = 0; i &lt; x.length; i++) {&#xA;                                        x[i].classList.remove(&#39;selected&#39;);&#xA;                                    } &#xA;                                    element.classList.add(&#39;selected&#39;);&#xA;                                }&#xA;                            }&#xA;                            &#xA;                            var setFocus = function(id) {&#xA;                                var item = document.getElementById(id);&#xA;                                item.focus();&#xA;                                // alert(&#39;setFocus on &#39; + id);&#xA;                            }&#xA;                            &#xA;                        '/>
+                      <str val='&#39;;&#xA;                            var actions = {};&#xA;                            var submissions = {};&#xA;                            var outputs = {};&#xA;                            var repeats = {};&#xA;                            var relevantMap = {};&#xA;                            var calculationMap = {};&#xA;                            var repeatIndexMap = {};&#xA;                            var repeatSizeMap = {};&#xA;                            var elementsUsingIndexFunction = {};&#xA;                            &#xA;                            var deferredUpdateFlags = {};&#xA;                            &#xA;                            var getCurrentDate = function(){&#xA;                                var today = new Date();&#xA;                                var dd = today.getDate();&#xA;                                var mm = today.getMonth()+1; //January is 0!&#xA;                                var yyyy = today.getFullYear();&#xA;                            &#xA;                                if(dd &lt; 10) {&#xA;                                    dd = &#39;0&#39; + dd;&#xA;                                } &#xA;                            &#xA;                                if(mm &lt; 10) {&#xA;                                    mm = &#39;0&#39; + mm;&#xA;                                } &#xA;                            &#xA;                                today = yyyy + &#39;-&#39; + mm + &#39;-&#39; + dd;&#xA;                                return today;&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var setXFormsDoc = function(doc) {&#xA;                                XFormsDoc = doc;&#xA;                            }&#xA;                            &#xA;                            var getXFormsDoc = function() {&#xA;                                return XFormsDoc;&#xA;                            }&#xA;                            &#xA;                            var setXForm = function(element) {&#xA;                                XForm = element;&#xA;                            }&#xA;                            &#xA;                            var getXForm = function() {&#xA;                                return XForm;&#xA;                            }&#xA;                            &#xA;                            var setXFormsID = function(id) {&#xA;                                XFormsID = id;&#xA;                            }&#xA;                            &#xA;                            var getXFormsID = function() {&#xA;                                return XFormsID;&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var setInstance = function(name, value) {&#xA;                                instanceDocs[name] = value;&#xA;                            } &#xA;                            &#xA;                            var getInstance = function(name) {&#xA;                                return instanceDocs[name];&#xA;                            }&#xA;                            &#xA;                            &#xA;                            //[OND] Maybe we can just set the key-&gt; value without having to copy the entire instanceDocs object.&#xA;                            var updateInstance = function(instanceDocs, key, value){&#xA;                                instanceDocs[key] = value;&#xA;                                return instanceDocs;&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var setDefaultInstance = function(doc) {&#xA;                                defaultInstanceDoc = doc;&#xA;                            }&#xA;                            &#xA;                            var getDefaultInstance = function() {&#xA;                                return defaultInstanceDoc;&#xA;                            }&#xA;                            &#xA;                           &#xA;                            var getInstanceKeys = function() {&#xA;                                return Object.keys(instanceDocs);&#xA;                            }&#xA;                            &#xA;                            var getInstances = function() {&#xA;                                return instanceDocs;&#xA;                            }&#xA;                            &#xA;                            var setDeferredUpdateFlag = function(name) {&#xA;                                deferredUpdateFlags[name] = &#39;true&#39;;&#xA;                            } &#xA;                            var setDeferredUpdateFlags = function(names) {&#xA;                                names.forEach(setDeferredUpdateFlag);&#xA;                            } &#xA;                            &#xA;                            var clearDeferredUpdateFlag = function(name) {&#xA;                                deferredUpdateFlags[name] = null; &#xA;                            }&#xA;                            var clearDeferredUpdateFlags = function() {&#xA;                                Object.keys(deferredUpdateFlags).forEach(clearDeferredUpdateFlag); &#xA;                            }&#xA;                            &#xA;                            var getDeferredUpdateFlag = function(name) {&#xA;                                return deferredUpdateFlags[name];&#xA;                            }&#xA;                            var getDeferredUpdateFlags = function() {&#xA;                                return deferredUpdateFlags;&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var addAction = function(name, value){&#xA;                                actions[name] = value;&#xA;                            }&#xA;&#xA;                            var getAction = function(name){&#xA;                                return actions[name];&#xA;                            }&#xA;                            &#xA;                            var updateAction = function(actioni, key, value){&#xA;                                actioni[key] = value;&#xA;                                return actioni;&#xA;                            }&#xA;                            &#xA;                            var addSubmission = function(name, value){&#xA;                                submissions[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getSubmission = function(name){&#xA;                                return submissions[name];&#xA;                            }     &#xA;                            &#xA;                            var addOutput = function(name, value){&#xA;                                outputs[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getOutput = function(name){&#xA;                                return outputs[name];&#xA;                            }&#xA;                            &#xA;                            var getOutputKeys = function() {&#xA;                                return Object.keys(outputs);&#xA;                            }&#xA;                            &#xA;                            // repeats is a map of HTML IDs to (parsed) xf:repeat/@nodeset values&#xA;                            var addRepeat = function(name, value){&#xA;                                repeats[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getRepeat = function(name){&#xA;                                return repeats[name];&#xA;                            }&#xA;                            &#xA;                            var getRepeatKeys = function() {&#xA;                                return Object.keys(repeats);&#xA;                            }&#xA;                            &#xA;                            var setRelevantMap = function(map1) {&#xA;                                relevantMap = map1;                            &#xA;                            }&#xA;                            &#xA;                            var getRelevantMap = function() {&#xA;                                return relevantMap;&#xA;                            }&#xA;                            &#xA;  &#xA;                            var setCalculationMap = function(map1) {&#xA;                                calculationMap = map1;                            &#xA;                            }&#xA;  &#xA;                            var getCalculationMap = function() {&#xA;                                return calculationMap;&#xA;                            }&#xA;  &#xA;                            &#xA;                            var getRepeatIndexMap = function() {&#xA;                                return repeatIndexMap;&#xA;                            }&#xA;                            &#xA;                            var setRepeatIndex = function(name, value) {&#xA;                                repeatIndexMap[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getRepeatIndex = function(name) {&#xA;                                if ( typeof(repeatIndexMap[name]) != &#39;undefined&#39; ) {&#xA;                                    return repeatIndexMap[name];&#xA;                                }&#xA;                                else {&#xA;                                    return 0;&#xA;                                }&#xA;                            } &#xA;                            &#xA;                            var setRepeatSize = function(name, value) {&#xA;                                repeatSizeMap[name] = value;&#xA;                            }&#xA;                            &#xA;                            var getRepeatSize = function(name) {&#xA;                                if ( typeof(repeatSizeMap[name]) != &#39;undefined&#39; ) {&#xA;                                    return repeatSizeMap[name];&#xA;                                }&#xA;                                else {&#xA;                                    return 0;&#xA;                                }&#xA;                            } &#xA;                            &#xA;                            var setElementUsingIndexFunction = function(name, value) {&#xA;                                elementsUsingIndexFunction[name] = value;&#xA;                            } &#xA;                            &#xA;                            var getElementUsingIndexFunction = function(name) {&#xA;                                return elementsUsingIndexFunction[name];&#xA;                            }&#xA;                            &#xA;                            var getElementsUsingIndexFunctionKeys = function() {&#xA;                                return Object.keys(elementsUsingIndexFunction);&#xA;                            }&#xA;                            &#xA;                            &#xA;                            var startTime = function(name) {&#xA;                                console.time(name);&#xA;                            }&#xA;                            &#xA;                            var endTime = function(name) {&#xA;                                console.timeEnd(name);&#xA;                            }&#xA;                            &#xA;                            var highlightClicked = function(id) {&#xA;                                var item = document.getElementById(id);&#xA;                                toggleClass(item);&#xA;                            }&#xA;                            &#xA;                            var toggleClass = function(element) {&#xA;                                if (element.className == &#39;selected&#39;) {&#xA;                                    element.classList.remove(&#39;selected&#39;);&#xA;                                }&#xA;                                else {&#xA;                                    var x = document.getElementsByClassName(&#39;selected&#39;);&#xA;                                    var i;&#xA;                                    for (i = 0; i &lt; x.length; i++) {&#xA;                                        x[i].classList.remove(&#39;selected&#39;);&#xA;                                    } &#xA;                                    element.classList.add(&#39;selected&#39;);&#xA;                                }&#xA;                            }&#xA;                            &#xA;                            var setFocus = function(id) {&#xA;                                var item = document.getElementById(id);&#xA;                                item.focus();&#xA;                                // alert(&#39;setFocus on &#39; + id);&#xA;                            }&#xA;                            &#xA;                        '/>
                      </valueOf>
                     </sequence>
                    </elem>
                   </resultDoc>
                  </forEach>
-                 <ifCall line='564' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <ifCall line='571' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                   <check card='1' diag='0|0||ixsl:call'>
                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                   </check>
@@ -11788,7 +11036,7 @@
                    <varRef name='Q{}xforms-doci' slot='6'/>
                   </arrayBlock>
                  </ifCall>
-                 <ifCall line='565' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <ifCall line='572' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                   <check card='1' diag='0|0||ixsl:call'>
                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                   </check>
@@ -11797,7 +11045,7 @@
                    <varRef name='Q{}xform' slot='7'/>
                   </arrayBlock>
                  </ifCall>
-                 <ifCall line='566' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <ifCall line='573' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                   <check card='1' diag='0|0||ixsl:call'>
                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                   </check>
@@ -11806,7 +11054,7 @@
                    <varRef name='Q{}default-instance' slot='12'/>
                   </arrayBlock>
                  </ifCall>
-                 <ifCall line='567' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <ifCall line='574' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                   <check card='1' diag='0|0||ixsl:call'>
                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                   </check>
@@ -11815,7 +11063,7 @@
                    <varRef name='Q{}RelevantBindings' slot='15'/>
                   </arrayBlock>
                  </ifCall>
-                 <ifCall line='568' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                 <ifCall line='575' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                   <check card='1' diag='0|0||ixsl:call'>
                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
                   </check>
@@ -11824,44 +11072,41 @@
                    <varRef name='Q{}CalculationBindings' slot='17'/>
                   </arrayBlock>
                  </ifCall>
-                 <ifCall line='573' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                  <check card='1' diag='0|0||ixsl:call'>
-                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-                  </check>
-                  <str val='setPendingUpdates'/>
-                  <arrayBlock>
-                   <treat line='570' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||pendingInstanceUpdates'>
-                    <map size='0'/>
-                   </treat>
-                  </arrayBlock>
-                 </ifCall>
-                 <ifCall line='574' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
-                  <check card='1' diag='0|0||ixsl:call'>
-                   <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
-                  </check>
-                  <str val='setUpdates'/>
-                  <arrayBlock>
-                   <treat line='571' as='map(xs:string, xs:string)' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.Atomic.string.matches(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='3|0||instanceUpdates'>
-                    <map size='0'/>
-                   </treat>
-                  </arrayBlock>
-                 </ifCall>
+                 <choose line='577'>
+                  <fn name='empty'>
+                   <varRef name='Q{}instance-docs' slot='2'/>
+                  </fn>
+                  <ifCall line='578' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                   <check card='1' diag='0|0||ixsl:call'>
+                    <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+                   </check>
+                   <str val='setDeferredUpdateFlags'/>
+                   <array size='1'>
+                    <literal count='4'>
+                     <str val='rebuild'/>
+                     <str val='recalculate'/>
+                     <str val='revalidate'/>
+                     <str val='refresh'/>
+                    </literal>
+                   </array>
+                  </ifCall>
+                 </choose>
                 </sequence>
                </choose>
-               <forEach line='583'>
-                <treat line='581' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|instanceKeys'>
+               <forEach line='588'>
+                <treat line='586' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|instanceKeys'>
                  <cvUntyped to='xs:string' diag='3|0|XTTE0570|instanceKeys'>
                   <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
                    <varRef name='Q{}xforms-instances' slot='9'/>
                   </ifCall>
                  </cvUntyped>
                 </treat>
-                <ifCall line='585' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                <ifCall line='590' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                  <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='5'/>
                  <str val='setInstance'/>
                  <arrayBlock>
                   <dot type='xs:string'/>
-                  <check line='584' card='1' diag='3|0|XTTE0570|instance'>
+                  <check line='589' card='1' diag='3|0|XTTE0570|instance'>
                    <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
                     <varRef name='Q{}xforms-instances' slot='9'/>
                     <dot type='xs:string'/>
@@ -11870,8 +11115,8 @@
                  </arrayBlock>
                 </ifCall>
                </forEach>
-               <let line='590' var='Q{}submissions' as='map(xs:string, map(*))' slot='19' eval='8'>
-                <ifCall line='592' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+               <let line='595' var='Q{}submissions' as='map(xs:string, map(*))' slot='19' eval='8'>
+                <ifCall line='597' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
                  <forEach>
                   <slash simple='2'>
                    <slash simple='2'>
@@ -11883,7 +11128,7 @@
                    </slash>
                    <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}submission)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;submission&#39;;'/>
                   </slash>
-                  <let line='597' var='Q{}map-key' as='xs:string' slot='20' eval='16'>
+                  <let line='602' var='Q{}map-key' as='xs:string' slot='20' eval='16'>
                    <choose>
                     <fn name='exists'>
                      <axis name='attribute' nodeTest='attribute(Q{}id)' jsTest='return item.name===&#39;id&#39;'/>
@@ -11904,20 +11149,20 @@
                     <true/>
                     <str val='saxon-forms-default-submission'/>
                    </choose>
-                   <let line='598' var='Q{}map-value' as='map(*)' slot='21' eval='16'>
-                    <treat line='599' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|map-value'>
+                   <let line='603' var='Q{}map-value' as='map(*)' slot='21' eval='16'>
+                    <treat line='604' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|map-value'>
                      <check card='1' diag='3|0|XTTE0570|map-value'>
                       <callT name='Q{}setSubmission' bSlot='6'>
                        <withParam name='Q{}this' flags='c' as='element()'>
-                        <dot line='600' type='element(Q{http://www.w3.org/2002/xforms}submission)'/>
+                        <dot line='605' type='element(Q{http://www.w3.org/2002/xforms}submission)'/>
                        </withParam>
                        <withParam name='Q{}submission-id' flags='c' as='xs:string'>
-                        <varRef line='601' name='Q{}map-key' slot='20'/>
+                        <varRef line='606' name='Q{}map-key' slot='20'/>
                        </withParam>
                       </callT>
                      </check>
                     </treat>
-                    <ifCall line='604' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+                    <ifCall line='609' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                      <varRef name='Q{}map-key' slot='20'/>
                      <varRef name='Q{}map-value' slot='21'/>
                     </ifCall>
@@ -11931,21 +11176,21 @@
                   <str val='XTDE3365'/>
                  </map>
                 </ifCall>
-                <sequence line='613'>
+                <sequence line='618'>
                  <forEach>
-                  <treat line='611' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|submissionKeys'>
+                  <treat line='616' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|submissionKeys'>
                    <cvUntyped to='xs:string' diag='3|0|XTTE0570|submissionKeys'>
                     <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}keys' type='xs:anyAtomicType*'>
                      <varRef name='Q{}submissions' slot='19'/>
                     </ifCall>
                    </cvUntyped>
                   </treat>
-                  <ifCall line='615' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+                  <ifCall line='620' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
                    <varRef name='Q{http://saxon.sf.net/generated-variable}v1' slot='4'/>
                    <str val='addSubmission'/>
                    <arrayBlock>
                     <dot type='xs:string'/>
-                    <check line='614' card='1' diag='3|0|XTTE0570|submission'>
+                    <check line='619' card='1' diag='3|0|XTTE0570|submission'>
                      <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
                       <varRef name='Q{}submissions' slot='19'/>
                       <dot type='xs:string'/>
@@ -11954,24 +11199,24 @@
                    </arrayBlock>
                   </ifCall>
                  </forEach>
-                 <resultDoc line='624' global='#&#xD;&#xA;#Sat Apr 04 13:28:45 BST 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Sat Apr 04 13:28:45 BST 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
+                 <resultDoc line='629' global='#&#xD;&#xA;#Sun Apr 05 16:19:18 BST 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Sun Apr 05 16:19:18 BST 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}replace-content&#xD;&#xA;'>
                   <fn role='href' name='concat'>
                    <str val='#'/>
                    <varRef name='Q{}xFormsId' slot='3'/>
                   </fn>
-                  <applyT role='content' line='625' bSlot='7'>
+                  <applyT role='content' line='630' bSlot='7'>
                    <slash role='select' simple='1'>
                     <varRef name='Q{}xforms-doci' slot='6'/>
                     <axis name='child' nodeTest='element(Q{http://www.w3.org/2002/xforms}xform)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;http://www.w3.org/2002/xforms&#39;&amp;&amp;q.local===&#39;xform&#39;;'/>
                    </slash>
                    <withParam name='Q{}instances' flags='t' as='map(xs:string, element())'>
-                    <varRef line='626' name='Q{}xforms-instances' slot='9'/>
+                    <varRef line='631' name='Q{}xforms-instances' slot='9'/>
                    </withParam>
                    <withParam name='Q{}bindings' flags='t' as='map(xs:string, node())'>
-                    <varRef line='627' name='Q{}bindings' slot='13'/>
+                    <varRef line='632' name='Q{}bindings' slot='13'/>
                    </withParam>
                    <withParam name='Q{}submissions' flags='t' as='map(xs:string, map(*))'>
-                    <varRef line='628' name='Q{}submissions' slot='19'/>
+                    <varRef line='633' name='Q{}submissions' slot='19'/>
                    </withParam>
                    <withParam name='Q{}nodeset' flags='t' as='xs:string'>
                     <str val=''/>
@@ -11994,17 +11239,17 @@
    </let>
   </template>
  </co>
- <co id='70' binds='70'>
+ <co id='75' binds='75'>
   <mode name='Q{}namespace-fix' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='31' rank='0' minImp='0' slots='1' flags='s' line='2408' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='28' rank='0' minImp='0' slots='1' flags='s' line='2127' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2409' var='Q{}current-namespace' as='xs:anyURI' slot='0' eval='8'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2128' var='Q{}current-namespace' as='xs:anyURI' slot='0' eval='8'>
      <fn name='namespace-uri'>
       <dot type='element()'/>
      </fn>
-     <compElem line='2411'>
+     <compElem line='2130'>
       <convert role='name' from='xs:QName' to='xs:string'>
-       <fn line='2410' name='QName'>
+       <fn line='2129' name='QName'>
         <convert from='xs:anyURI' to='xs:string'>
          <varRef name='Q{}current-namespace' slot='0'/>
         </convert>
@@ -12016,12 +11261,12 @@
       <convert role='namespace' from='xs:anyURI' to='xs:string'>
        <varRef name='Q{}current-namespace' slot='0'/>
       </convert>
-      <sequence role='content' line='2412'>
+      <sequence role='content' line='2131'>
        <namespace flags='l'>
         <str role='name' val='xforms'/>
         <str role='select' val='http://www.w3.org/2002/xforms'/>
        </namespace>
-       <applyT line='2414' mode='Q{}namespace-fix' bSlot='0'>
+       <applyT line='2133' mode='Q{}namespace-fix' bSlot='0'>
         <sequence role='select'>
          <axis name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
          <axis name='child' nodeTest='( element() | text() | comment() | processing-instruction() )' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===1 || item.nodeType===3 || item.nodeType===7 || item.nodeType===8);'/>
@@ -12033,9 +11278,9 @@
    </templateRule>
   </mode>
  </co>
- <co id='52' binds='67 5 7'>
-  <template name='Q{}HTTPsubmit' cxt='map(*)' jsTest='return SaxonJS.U.isMap(item)' flags='s' line='1009' module='saxon-xforms.xsl' slots='5'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1013'>
+ <co id='51' binds='71 5 61'>
+  <template name='Q{}HTTPsubmit' cxt='map(*)' jsTest='return SaxonJS.U.isMap(item)' flags='s' line='952' module='saxon-xforms.xsl' slots='5'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='956'>
     <param name='Q{}instance-id' slot='0' as='xs:string'>
      <str role='select' val='saxon-forms-default'/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|instance-id'>
@@ -12048,7 +11293,7 @@
       </check>
      </treat>
     </param>
-    <param line='1014' name='Q{}targetref' slot='1' as='xs:string?'>
+    <param line='957' name='Q{}targetref' slot='1' as='xs:string?'>
      <empty role='select'/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|targetref'>
       <check card='?' diag='8|0|XTTE0590|targetref'>
@@ -12060,7 +11305,7 @@
       </check>
      </treat>
     </param>
-    <param line='1015' name='Q{}replace' slot='2' as='xs:string?'>
+    <param line='958' name='Q{}replace' slot='2' as='xs:string?'>
      <empty role='select'/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|replace'>
       <check card='?' diag='8|0|XTTE0590|replace'>
@@ -12072,29 +11317,29 @@
       </check>
      </treat>
     </param>
-    <let line='1017' var='Q{}refi' as='xs:string' slot='3' eval='8'>
+    <let line='960' var='Q{}refi' as='xs:string' slot='3' eval='8'>
      <fn name='concat'>
       <str val='instance(&#39;'/>
       <varRef name='Q{}instance-id' slot='0'/>
       <str val='&#39;)/'/>
      </fn>
-     <let line='1025' var='Q{}response' as='item()?' slot='4' eval='7'>
+     <let line='968' var='Q{}response' as='item()?' slot='4' eval='7'>
       <check card='?' diag='3|0|XTTE0570|response'>
        <lookup>
         <dot type='map(*)'/>
         <str val='body'/>
        </lookup>
       </check>
-      <choose line='1028'>
+      <choose line='971'>
        <fn name='empty'>
         <varRef name='Q{}response' slot='4'/>
        </fn>
-       <callT line='1029' name='Q{}serverError' bSlot='0' flags='t'>
+       <callT line='972' name='Q{}serverError' bSlot='0' flags='t'>
         <withParam name='Q{}responseMap' flags='c' as='map(*)'>
-         <dot line='1030' type='map(*)'/>
+         <dot line='973' type='map(*)'/>
         </withParam>
        </callT>
-       <and line='1042' op='and'>
+       <and line='985' op='and'>
         <vc op='eq' onEmpty='0' comp='CCC'>
          <varRef name='Q{}replace' slot='2'/>
          <str val='instance'/>
@@ -12111,7 +11356,7 @@
          </fn>
         </filter>
        </and>
-       <sequence line='1043'>
+       <sequence line='986'>
         <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='1' eval='6 16'>
          <varRef name='Q{}refi' slot='3'/>
          <check card='1' diag='0|1||xforms:setInstance-JS'>
@@ -12123,7 +11368,16 @@
           </slash>
          </check>
         </ufCall>
-        <callT line='1045' name='Q{}xforms-recalculate' bSlot='2' flags='t'/>
+        <callT line='989' name='Q{}xforms-submit-done' bSlot='2' flags='t'>
+         <withParam name='Q{}instanceXML' flags='t' as='element()*'>
+          <slash line='990' simple='1'>
+           <treat as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='1|0|XPTY0019|/'>
+            <varRef name='Q{}response' slot='4'/>
+           </treat>
+           <axis name='child' nodeTest='element()' jsTest='return item.nodeType===1;'/>
+          </slash>
+         </withParam>
+        </callT>
        </sequence>
       </choose>
      </let>
@@ -12147,20 +11401,48 @@
    </treat>
   </function>
  </co>
- <co id='72' binds='47 66 11'>
+ <co id='77' binds='70 10 52'>
   <mode name='Q{http://saxonica.com/ns/interactiveXSLT}onclick' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='0.5' seq='3' rank='0' minImp='0' slots='1' flags='s' line='739' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.5' seq='23' rank='0' minImp='0' slots='0' flags='s' line='1938' module='saxon-xforms.xsl'>
+    <p.withPredicate role='match'>
+     <p.nodeTest test='*:button' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;button&#39;'/>
+     <fn ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1938' name='exists'>
+      <axis name='attribute' nodeTest='attribute(Q{}data-action)' jsTest='return item.name===&#39;data-action&#39;'/>
+     </fn>
+    </p.withPredicate>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1939' name='Q{}DOMActivate' bSlot='0' flags='t'>
+     <withParam name='Q{}form-control' flags='c' as='node()'>
+      <dot line='1940' type='*:button'/>
+     </withParam>
+    </callT>
+   </templateRule>
+   <templateRule prec='0' prio='0.5' seq='4' rank='0' minImp='0' slots='0' flags='s' line='934' module='saxon-xforms.xsl'>
+    <p.withPredicate role='match'>
+     <p.nodeTest test='*:button' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;button&#39;'/>
+     <fn ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='934' name='exists'>
+      <axis name='attribute' nodeTest='attribute(Q{}data-submit)' jsTest='return item.name===&#39;data-submit&#39;'/>
+     </fn>
+    </p.withPredicate>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='936' name='Q{}xforms-submit' bSlot='1' flags='t'>
+     <withParam name='Q{}submission' flags='c' as='xs:string'>
+      <fn line='937' name='string'>
+       <axis name='attribute' nodeTest='attribute(Q{}data-submit)' jsTest='return item.name===&#39;data-submit&#39;'/>
+      </fn>
+     </withParam>
+    </callT>
+   </templateRule>
+   <templateRule prec='0' prio='0.5' seq='3' rank='0' minImp='0' slots='1' flags='s' line='681' module='saxon-xforms.xsl'>
     <p.withUpper role='match' axis='ancestor' upFirst='false'>
      <p.withPredicate>
       <p.nodeTest test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-      <or ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='739' op='or'>
-       <axis name='self' nodeTest='element(Q{}span)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;span&#39;;'/>
-       <axis name='self' nodeTest='element(Q{}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
+      <or ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='681' op='or'>
+       <axis name='self' nodeTest='*:span' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;span&#39;'/>
+       <axis name='self' nodeTest='*:input' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;input&#39;'/>
       </or>
      </p.withPredicate>
      <p.withPredicate>
-      <p.nodeTest test='element(Q{}div)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;div&#39;;'/>
-      <vc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='739' op='eq' onEmpty='0' comp='CCC'>
+      <p.nodeTest test='*:div' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;div&#39;'/>
+      <vc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='681' op='eq' onEmpty='0' comp='CCC'>
        <cast as='xs:string' emptiable='1'>
         <data>
          <axis name='attribute' nodeTest='attribute(Q{}data-repeat-item)' jsTest='return item.name===&#39;data-repeat-item&#39;'/>
@@ -12170,11 +11452,11 @@
       </vc>
      </p.withPredicate>
     </p.withUpper>
-    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='748' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='0' eval='13'>
+    <let role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='690' var='Q{http://saxon.sf.net/generated-variable}v0' as='item()' slot='0' eval='13'>
      <check card='1' diag='0|0||ixsl:call'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
      </check>
-     <sequence line='740'>
+     <sequence line='682'>
       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
        <check card='1' diag='0|0||ixsl:call'>
         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
@@ -12186,10 +11468,10 @@
         </fn>
        </arrayBlock>
       </ifCall>
-      <forEach line='743'>
+      <forEach line='685'>
        <fn name='reverse'>
         <filter flags='b'>
-         <axis name='ancestor' nodeTest='element(Q{}div)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;div&#39;;'/>
+         <axis name='ancestor' nodeTest='*:div' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;div&#39;'/>
          <vc op='eq' onEmpty='0' comp='CCC'>
           <cast as='xs:string' emptiable='1'>
            <attVal name='Q{}data-repeat-item' chk='0'/>
@@ -12198,17 +11480,17 @@
          </vc>
         </filter>
        </fn>
-       <ifCall line='748' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+       <ifCall line='690' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
         <varRef name='Q{http://saxon.sf.net/generated-variable}v0' slot='0'/>
         <str val='setRepeatIndex'/>
         <arrayBlock>
-         <check line='744' card='1' diag='3|0|XTTE0570|repeat-id'>
+         <check line='686' card='1' diag='3|0|XTTE0570|repeat-id'>
           <cvUntyped to='xs:string' diag='3|0|XTTE0570|repeat-id'>
            <data>
             <slash simple='1'>
              <first>
               <filter flags='b'>
-               <axis name='ancestor' nodeTest='element(Q{}div)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;div&#39;;'/>
+               <axis name='ancestor' nodeTest='*:div' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;div&#39;'/>
                <fn name='exists'>
                 <axis name='attribute' nodeTest='attribute(Q{}data-repeatable-context)' jsTest='return item.name===&#39;data-repeatable-context&#39;'/>
                </fn>
@@ -12219,10 +11501,10 @@
            </data>
           </cvUntyped>
          </check>
-         <arith line='745' op='+' calc='i+i'>
+         <arith line='687' op='+' calc='i+i'>
           <fn name='count'>
            <filter flags='b'>
-            <axis name='preceding-sibling' nodeTest='element(Q{}div)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;div&#39;;'/>
+            <axis name='preceding-sibling' nodeTest='*:div' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;div&#39;'/>
             <vc op='eq' onEmpty='0' comp='CCC'>
              <cast as='xs:string' emptiable='1'>
               <attVal name='Q{}data-repeat-item' chk='0'/>
@@ -12236,48 +11518,20 @@
         </arrayBlock>
        </ifCall>
       </forEach>
-      <choose line='751'>
+      <choose line='693'>
        <fn name='exists'>
-        <axis name='self' nodeTest='element(Q{}span)' jsTest='var q=SaxonJS.U.nameOfNode(item); return item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;span&#39;;'/>
+        <axis name='self' nodeTest='*:span' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;span&#39;'/>
        </fn>
-       <callT line='752' name='Q{}refreshElementsUsingIndexFunction-JS' bSlot='0' flags='t'/>
+       <callT line='694' name='Q{}refreshElementsUsingIndexFunction-JS' bSlot='2' flags='t'/>
       </choose>
      </sequence>
     </let>
    </templateRule>
-   <templateRule prec='0' prio='0.5' seq='23' rank='0' minImp='0' slots='0' flags='s' line='1986' module='saxon-xforms.xsl'>
-    <p.withPredicate role='match'>
-     <p.nodeTest test='element(Q{}button)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;button&#39;;'/>
-     <fn ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1986' name='exists'>
-      <axis name='attribute' nodeTest='attribute(Q{}data-action)' jsTest='return item.name===&#39;data-action&#39;'/>
-     </fn>
-    </p.withPredicate>
-    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='1987' name='Q{}DOMActivate' bSlot='1' flags='t'>
-     <withParam name='Q{}form-control' flags='c' as='node()'>
-      <dot line='1988' type='element(Q{}button)'/>
-     </withParam>
-    </callT>
-   </templateRule>
-   <templateRule prec='0' prio='0.5' seq='4' rank='0' minImp='0' slots='0' flags='s' line='991' module='saxon-xforms.xsl'>
-    <p.withPredicate role='match'>
-     <p.nodeTest test='element(Q{}button)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;button&#39;;'/>
-     <fn ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='991' name='exists'>
-      <axis name='attribute' nodeTest='attribute(Q{}data-submit)' jsTest='return item.name===&#39;data-submit&#39;'/>
-     </fn>
-    </p.withPredicate>
-    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='993' name='Q{}xforms-submit' bSlot='2' flags='t'>
-     <withParam name='Q{}submission' flags='c' as='xs:string'>
-      <fn line='994' name='string'>
-       <axis name='attribute' nodeTest='attribute(Q{}data-submit)' jsTest='return item.name===&#39;data-submit&#39;'/>
-      </fn>
-     </withParam>
-    </callT>
-   </templateRule>
   </mode>
  </co>
- <co id='71' binds='61 62 63'>
-  <template name='Q{}setSubmission' flags='os' line='3494' module='saxon-xforms.xsl' slots='7'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3495'>
+ <co id='76' binds='64 65 66'>
+  <template name='Q{}setSubmission' flags='os' line='3256' module='saxon-xforms.xsl' slots='7'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3257'>
     <param name='Q{}this' slot='0' flags='i' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
       <check card='1' diag='8|0|XTTE0590|this'>
@@ -12285,7 +11539,7 @@
       </check>
      </treat>
     </param>
-    <param line='3496' name='Q{}submission-id' slot='1' flags='i' as='xs:string'>
+    <param line='3258' name='Q{}submission-id' slot='1' flags='i' as='xs:string'>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|submission-id'>
       <check card='1' diag='8|0|XTTE0590|submission-id'>
        <cvUntyped to='xs:string' diag='8|0|XTTE0590|submission-id'>
@@ -12296,64 +11550,52 @@
       </check>
      </treat>
     </param>
-    <message line='3498'>
-     <sequence role='select'>
-      <valueOf>
-       <str val='[setSubmission] setting submission for '/>
-      </valueOf>
-      <fn name='serialize'>
-       <varRef name='Q{}this' slot='0'/>
-      </fn>
-     </sequence>
-     <str role='terminate' val='no'/>
-     <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
-    </message>
-    <let line='3501' var='Q{}bindingi' as='node()?' slot='2' eval='7'>
-     <treat line='3502' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
+    <let line='3263' var='Q{}bindingi' as='node()?' slot='2' eval='7'>
+     <treat line='3264' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|bindingi'>
       <check card='?' diag='3|0|XTTE0570|bindingi'>
        <callT name='Q{}getBinding' bSlot='0'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <varRef line='3503' name='Q{}this' slot='0'/>
+         <varRef line='3265' name='Q{}this' slot='0'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <let line='3508' var='Q{}refi' as='xs:string' slot='3' eval='16'>
-      <treat line='3509' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
+     <let line='3270' var='Q{}refi' as='xs:string' slot='3' eval='16'>
+      <treat line='3271' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|refi'>
        <check card='1' diag='3|0|XTTE0570|refi'>
         <cvUntyped to='xs:string' diag='3|0|XTTE0570|refi'>
          <data>
           <callT name='Q{}getDataRef' bSlot='1'>
            <withParam name='Q{}this' flags='c' as='element()'>
-            <varRef line='3510' name='Q{}this' slot='0'/>
+            <varRef line='3272' name='Q{}this' slot='0'/>
            </withParam>
            <withParam name='Q{}bindingi' flags='c' as='node()?'>
-            <varRef line='3511' name='Q{}bindingi' slot='2'/>
+            <varRef line='3273' name='Q{}bindingi' slot='2'/>
            </withParam>
           </callT>
          </data>
         </cvUntyped>
        </check>
       </treat>
-      <let line='3516' var='Q{}actions' as='map(*)*' slot='4' eval='8'>
-       <treat line='3517' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
+      <let line='3278' var='Q{}actions' as='map(*)*' slot='4' eval='8'>
+       <treat line='3279' as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='3|0|XTTE0570|actions'>
         <callT name='Q{}setActions' bSlot='2'>
          <withParam name='Q{}this' flags='c' as='element()'>
-          <treat line='3518' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
+          <treat line='3280' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
            <dot flags='a'/>
           </treat>
          </withParam>
          <withParam name='Q{}nodeset' flags='t' as='xs:string'>
-          <varRef line='3519' name='Q{}refi' slot='3'/>
+          <varRef line='3281' name='Q{}refi' slot='3'/>
          </withParam>
         </callT>
        </treat>
-       <sequence line='3523'>
+       <sequence line='3285'>
         <choose>
          <fn name='exists'>
           <varRef name='Q{}actions' slot='4'/>
          </fn>
-         <ifCall line='3524' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+         <ifCall line='3286' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
           <check card='1' diag='0|0||ixsl:call'>
            <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
           </check>
@@ -12364,7 +11606,7 @@
           </arrayBlock>
          </ifCall>
         </choose>
-        <ifCall line='3529' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
+        <ifCall line='3291' name='Q{http://www.w3.org/2005/xpath-functions/map}merge' type='map(*)'>
          <sequence>
           <choose>
            <fn name='exists'>
@@ -12373,7 +11615,7 @@
              <axis name='attribute' nodeTest='attribute(Q{}resource)' jsTest='return item.name===&#39;resource&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3530' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='3292' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@resource'/>
             <cast as='xs:string' emptiable='1'>
              <data>
@@ -12385,18 +11627,18 @@
             </cast>
            </ifCall>
           </choose>
-          <ifCall line='3533' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <ifCall line='3295' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
            <str val='@ref'/>
            <varRef name='Q{}refi' slot='3'/>
           </ifCall>
-          <choose line='3535'>
+          <choose line='3297'>
            <fn name='exists'>
             <slash simple='1'>
              <varRef name='Q{}this' slot='0'/>
              <axis name='attribute' nodeTest='attribute(Q{}bind)' jsTest='return item.name===&#39;bind&#39;'/>
             </slash>
            </fn>
-           <ifCall line='3536' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+           <ifCall line='3298' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
             <str val='@bind'/>
             <cast as='xs:string' emptiable='1'>
              <data>
@@ -12408,7 +11650,7 @@
             </cast>
            </ifCall>
           </choose>
-          <ifCall line='3539' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+          <ifCall line='3301' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
            <str val='@mode'/>
            <choose>
             <fn name='exists'>
@@ -12429,8 +11671,8 @@
             <str val='asynchronous'/>
            </choose>
           </ifCall>
-          <let line='3541' var='Q{}submission-method' as='xs:string' slot='5' eval='16'>
-           <choose line='3543'>
+          <let line='3303' var='Q{}submission-method' as='xs:string' slot='5' eval='16'>
+           <choose line='3305'>
             <fn name='exists'>
              <slash simple='2'>
               <slash simple='1'>
@@ -12440,7 +11682,7 @@
               <axis name='attribute' nodeTest='attribute(Q{}value)' jsTest='return item.name===&#39;value&#39;'/>
              </slash>
             </fn>
-            <cvUntyped line='3544' to='xs:string' diag='3|0|XTTE0570|submission-method'>
+            <cvUntyped line='3306' to='xs:string' diag='3|0|XTTE0570|submission-method'>
              <cast as='xs:untypedAtomic' emptiable='0'>
               <fn name='string-join'>
                <convert from='xs:untypedAtomic' to='xs:string'>
@@ -12458,13 +11700,13 @@
               </fn>
              </cast>
             </cvUntyped>
-            <fn line='3546' name='exists'>
+            <fn line='3308' name='exists'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='attribute' nodeTest='attribute(Q{}method)' jsTest='return item.name===&#39;method&#39;'/>
              </slash>
             </fn>
-            <fn line='3547' name='string'>
+            <fn line='3309' name='string'>
              <slash simple='1'>
               <varRef name='Q{}this' slot='0'/>
               <axis name='attribute' nodeTest='attribute(Q{}method)' jsTest='return item.name===&#39;method&#39;'/>
@@ -12473,20 +11715,20 @@
             <true/>
             <str val='POST'/>
            </choose>
-           <sequence line='3555'>
+           <sequence line='3317'>
             <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
              <str val='@method'/>
              <varRef name='Q{}submission-method' slot='5'/>
             </ifCall>
-            <let line='3558' var='Q{}serialization' as='xs:string' slot='6' eval='16'>
-             <choose line='3560'>
+            <let line='3320' var='Q{}serialization' as='xs:string' slot='6' eval='16'>
+             <choose line='3322'>
               <fn name='exists'>
                <slash simple='1'>
                 <varRef name='Q{}this' slot='0'/>
                 <axis name='attribute' nodeTest='attribute(Q{}serialization)' jsTest='return item.name===&#39;serialization&#39;'/>
                </slash>
               </fn>
-              <cvUntyped line='3561' to='xs:string' diag='3|0|XTTE0570|serialization'>
+              <cvUntyped line='3323' to='xs:string' diag='3|0|XTTE0570|serialization'>
                <cast as='xs:untypedAtomic' emptiable='0'>
                 <fn name='string'>
                  <convert from='xs:untypedAtomic' to='xs:string'>
@@ -12500,7 +11742,7 @@
                 </fn>
                </cast>
               </cvUntyped>
-              <gc line='3563' op='=' card='N:1' comp='CCC'>
+              <gc line='3325' op='=' card='N:1' comp='CCC'>
                <literal count='4'>
                 <str val='post'/>
                 <str val='POST'/>
@@ -12510,7 +11752,7 @@
                <varRef name='Q{}submission-method' slot='5'/>
               </gc>
               <str val='application/xml'/>
-              <gc line='3566' op='=' card='N:1' comp='CCC'>
+              <gc line='3328' op='=' card='N:1' comp='CCC'>
                <literal count='6'>
                 <str val='get'/>
                 <str val='GET'/>
@@ -12522,7 +11764,7 @@
                <varRef name='Q{}submission-method' slot='5'/>
               </gc>
               <str val='application/x-www-form-urlencoded'/>
-              <gc line='3569' op='=' card='N:1' comp='CCC'>
+              <gc line='3331' op='=' card='N:1' comp='CCC'>
                <literal count='2'>
                 <str val='multipart-post'/>
                 <str val='MULTIPART-POST'/>
@@ -12530,7 +11772,7 @@
                <varRef name='Q{}submission-method' slot='5'/>
               </gc>
               <str val='multipart/related'/>
-              <gc line='3572' op='=' card='N:1' comp='CCC'>
+              <gc line='3334' op='=' card='N:1' comp='CCC'>
                <literal count='2'>
                 <str val='form-data-post'/>
                 <str val='FORM-DATA-POST'/>
@@ -12538,7 +11780,7 @@
                <varRef name='Q{}submission-method' slot='5'/>
               </gc>
               <str val='multipart/form-data'/>
-              <gc line='3575' op='=' card='N:1' comp='CCC'>
+              <gc line='3337' op='=' card='N:1' comp='CCC'>
                <literal count='2'>
                 <str val='post'/>
                 <str val='POST'/>
@@ -12549,7 +11791,7 @@
               <true/>
               <str val='application/xml'/>
              </choose>
-             <sequence line='3586'>
+             <sequence line='3348'>
               <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                <str val='@validate'/>
                <choose>
@@ -12574,7 +11816,7 @@
                 <str val='true'/>
                </choose>
               </ifCall>
-              <ifCall line='3591' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+              <ifCall line='3353' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                <str val='@relevant'/>
                <choose>
                 <fn name='exists'>
@@ -12598,11 +11840,11 @@
                 <str val='true'/>
                </choose>
               </ifCall>
-              <ifCall line='3593' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+              <ifCall line='3355' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                <str val='@serialization'/>
                <varRef name='Q{}serialization' slot='6'/>
               </ifCall>
-              <ifCall line='3595' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+              <ifCall line='3357' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                <str val='@version'/>
                <choose>
                 <fn name='exists'>
@@ -12621,7 +11863,7 @@
                 <str val='1.0'/>
                </choose>
               </ifCall>
-              <ifCall line='3597' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+              <ifCall line='3359' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                <str val='@indent'/>
                <choose>
                 <fn name='exists'>
@@ -12640,7 +11882,7 @@
                 <str val='false'/>
                </choose>
               </ifCall>
-              <ifCall line='3600' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+              <ifCall line='3362' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                <str val='@mediatype'/>
                <choose>
                 <fn name='exists'>
@@ -12659,7 +11901,7 @@
                 <str val='application/xml'/>
                </choose>
               </ifCall>
-              <ifCall line='3603' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+              <ifCall line='3365' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                <str val='@encoding'/>
                <choose>
                 <fn name='exists'>
@@ -12678,7 +11920,7 @@
                 <str val='UTF-8'/>
                </choose>
               </ifCall>
-              <ifCall line='3605' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+              <ifCall line='3367' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                <str val='@omit-xml-declaration'/>
                <choose>
                 <fn name='exists'>
@@ -12697,14 +11939,14 @@
                 <str val='false'/>
                </choose>
               </ifCall>
-              <choose line='3607'>
+              <choose line='3369'>
                <fn name='exists'>
                 <slash simple='1'>
                  <varRef name='Q{}this' slot='0'/>
                  <axis name='attribute' nodeTest='attribute(Q{}standalone)' jsTest='return item.name===&#39;standalone&#39;'/>
                 </slash>
                </fn>
-               <ifCall line='3608' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+               <ifCall line='3370' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                 <str val='@standalone'/>
                 <fn name='string'>
                  <slash simple='1'>
@@ -12714,7 +11956,7 @@
                 </fn>
                </ifCall>
               </choose>
-              <ifCall line='3611' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+              <ifCall line='3373' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                <str val='@cdata-section-elements'/>
                <choose>
                 <fn name='exists'>
@@ -12733,7 +11975,7 @@
                 <str val=''/>
                </choose>
               </ifCall>
-              <ifCall line='3613' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+              <ifCall line='3375' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                <str val='@replace'/>
                <choose>
                 <fn name='exists'>
@@ -12752,7 +11994,7 @@
                 <str val='all'/>
                </choose>
               </ifCall>
-              <ifCall line='3615' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+              <ifCall line='3377' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                <str val='@instance'/>
                <choose>
                 <fn name='exists'>
@@ -12771,14 +12013,14 @@
                 <str val='saxon-forms-default'/>
                </choose>
               </ifCall>
-              <choose line='3618'>
+              <choose line='3380'>
                <fn name='exists'>
                 <slash simple='1'>
                  <varRef name='Q{}this' slot='0'/>
                  <axis name='attribute' nodeTest='attribute(Q{}targetref)' jsTest='return item.name===&#39;targetref&#39;'/>
                 </slash>
                </fn>
-               <ifCall line='3619' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+               <ifCall line='3381' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                 <str val='@targetref'/>
                 <fn name='string'>
                  <slash simple='1'>
@@ -12788,7 +12030,7 @@
                 </fn>
                </ifCall>
               </choose>
-              <ifCall line='3622' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+              <ifCall line='3384' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                <str val='@separator'/>
                <choose>
                 <fn name='exists'>
@@ -12807,14 +12049,14 @@
                 <str val='&amp;'/>
                </choose>
               </ifCall>
-              <choose line='3624'>
+              <choose line='3386'>
                <fn name='exists'>
                 <slash simple='1'>
                  <varRef name='Q{}this' slot='0'/>
                  <axis name='attribute' nodeTest='attribute(Q{}includenamespaceprefixes)' jsTest='return item.name===&#39;includenamespaceprefixes&#39;'/>
                 </slash>
                </fn>
-               <ifCall line='3625' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
+               <ifCall line='3387' name='Q{http://www.w3.org/2005/xpath-functions/map}entry' type='map(*)'>
                 <str val='@includenamespaceprefixes'/>
                 <fn name='string'>
                  <slash simple='1'>
@@ -12843,18 +12085,18 @@
    </sequence>
   </template>
  </co>
- <co id='73' binds='18'>
+ <co id='78' binds='73'>
   <mode name='Q{http://saxonica.com/ns/interactiveXSLT}onkeyup' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='0.5' seq='0' rank='0' minImp='0' slots='0' flags='s' line='706' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='0.5' seq='0' rank='0' minImp='0' slots='0' flags='s' line='648' module='saxon-xforms.xsl'>
     <p.withPredicate role='match'>
-     <p.nodeTest test='element(Q{}input)' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1 &amp;&amp; q.uri===&#39;&#39;&amp;&amp;q.local===&#39;input&#39;;'/>
-     <gc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='706' op='=' card='N:1' comp='CCC'>
+     <p.nodeTest test='*:input' jsTest='var q=SaxonJS.U.nameOfNode(item); return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1&amp;&amp;q.local===&#39;input&#39;'/>
+     <gc ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='648' op='=' card='N:1' comp='CCC'>
       <fn name='tokenize'>
        <cvUntyped to='xs:string' diag='3|0|XTTE0570|class'>
         <data>
          <slash simple='1'>
-          <dot type='element(Q{}input)'/>
-          <axis line='2615' name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
+          <dot type='*:input'/>
+          <axis line='2334' name='attribute' nodeTest='attribute(Q{}class)' jsTest='return item.name===&#39;class&#39;'/>
          </slash>
         </data>
        </cvUntyped>
@@ -12862,17 +12104,17 @@
       <str val='incremental'/>
      </gc>
     </p.withPredicate>
-    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='708' name='Q{}xforms-value-changed' bSlot='0' flags='t'>
+    <callT role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='650' name='Q{}action-setvalue-form-control' bSlot='0' flags='t'>
      <withParam name='Q{}form-control' flags='c' as='node()'>
-      <dot line='709' type='element(Q{}input)'/>
+      <dot line='651' type='*:input'/>
      </withParam>
     </callT>
    </templateRule>
   </mode>
  </co>
- <co id='61' binds=''>
-  <template name='Q{}getBinding' flags='os' line='2826' module='saxon-xforms.xsl' slots='4'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2827'>
+ <co id='64' binds=''>
+  <template name='Q{}getBinding' flags='os' line='2545' module='saxon-xforms.xsl' slots='4'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2546'>
     <param name='Q{}this' slot='0' flags='r' as='element()'>
      <treat role='conversion' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='8|0|XTTE0590|this'>
       <check card='1' diag='8|0|XTTE0590|this'>
@@ -12880,7 +12122,7 @@
       </check>
      </treat>
     </param>
-    <param line='2828' name='Q{}bindings' slot='1' flags='t' as='map(xs:string, node())'>
+    <param line='2547' name='Q{}bindings' slot='1' flags='t' as='map(xs:string, node())'>
      <map role='select' size='0'/>
      <treat role='conversion' as='map(xs:string, node())' jsTest='function k(item) {return SaxonJS.U.Atomic.string.matches(item);};function v(item) {return SaxonJS.U.isNode(item);};function c(n) {return n==1;};return SaxonJS.U.isMap(item) &amp;&amp; item.conforms(k, v, c);' diag='8|0|XTTE0590|bindings'>
       <check card='1' diag='8|0|XTTE0590|bindings'>
@@ -12888,7 +12130,7 @@
       </check>
      </treat>
     </param>
-    <let line='2837' var='Q{}ref-binding' as='xs:string' slot='2' eval='16'>
+    <let line='2556' var='Q{}ref-binding' as='xs:string' slot='2' eval='16'>
      <choose>
       <fn name='exists'>
        <slash simple='1'>
@@ -12925,8 +12167,8 @@
       <true/>
       <str val=''/>
      </choose>
-     <let line='2839' var='Q{}binding' as='element()?' slot='3' eval='7'>
-      <choose line='2844'>
+     <let line='2558' var='Q{}binding' as='element()?' slot='3' eval='7'>
+      <choose line='2563'>
        <fn name='empty'>
         <varRef name='Q{}ref-binding' slot='2'/>
        </fn>
@@ -12939,12 +12181,12 @@
         </ifCall>
        </treat>
       </choose>
-      <sequence line='2847'>
+      <sequence line='2566'>
        <choose>
         <fn name='exists'>
          <varRef name='Q{}binding' slot='3'/>
         </fn>
-        <message line='2853'>
+        <message line='2572'>
          <sequence role='select'>
           <valueOf>
            <str val='[getBinding for '/>
@@ -12967,16 +12209,16 @@
          <str role='error' val='Q{http://www.w3.org/2005/xqt-errors}XTMM9000'/>
         </message>
        </choose>
-       <varRef line='2857' name='Q{}binding' slot='3'/>
+       <varRef line='2576' name='Q{}binding' slot='3'/>
       </sequence>
      </let>
     </let>
    </sequence>
   </template>
  </co>
- <co id='24' binds='45'>
-  <template name='Q{}logToPage' flags='os' line='2589' module='saxon-xforms.xsl' slots='2'>
-   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2590'>
+ <co id='19' binds='44'>
+  <template name='Q{}logToPage' flags='os' line='2308' module='saxon-xforms.xsl' slots='2'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2309'>
     <param name='Q{}message' slot='0' flags='i' as='xs:string'>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|message'>
       <check card='1' diag='8|0|XTTE0590|message'>
@@ -12988,7 +12230,7 @@
       </check>
      </treat>
     </param>
-    <param line='2591' name='Q{}level' slot='1' as='xs:string'>
+    <param line='2310' name='Q{}level' slot='1' as='xs:string'>
      <str role='select' val='info'/>
      <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|level'>
       <check card='1' diag='8|0|XTTE0590|level'>
@@ -13000,12 +12242,12 @@
       </check>
      </treat>
     </param>
-    <resultDoc line='2593' global='#&#xD;&#xA;#Sat Apr 04 13:28:45 BST 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Sat Apr 04 13:28:45 BST 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}append-content&#xD;&#xA;'>
+    <resultDoc line='2312' global='#&#xD;&#xA;#Sun Apr 05 16:19:18 BST 2020&#xD;&#xA;indent=no&#xD;&#xA;doctype-system=http\://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&#xD;&#xA;encoding=utf-8&#xD;&#xA;doctype-public=-//W3C//DTD XHTML 1.0 Transitional//EN&#xD;&#xA;omit-xml-declaration=no&#xD;&#xA;method=html&#xD;&#xA;' local='#&#xD;&#xA;#Sun Apr 05 16:19:18 BST 2020&#xD;&#xA;method={http\://saxonica.com/ns/interactiveXSLT}append-content&#xD;&#xA;'>
      <fn role='href' name='concat'>
       <str val='#'/>
       <gVarRef name='Q{}xform-html-id' bSlot='0'/>
      </fn>
-     <elem role='content' line='2594' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
+     <elem role='content' line='2313' name='div' nsuri='' namespaces='xd rdf xhtml js in fn map array ev'>
       <sequence>
        <att name='class' flags='l'>
         <fn name='concat'>
@@ -13013,17 +12255,17 @@
          <varRef name='Q{}level' slot='1'/>
         </fn>
        </att>
-       <elem line='2595' name='p' nsuri='' flags='l'>
-        <sequence line='2596'>
+       <elem line='2314' name='p' nsuri='' flags='l'>
+        <sequence line='2315'>
          <elem name='b' nsuri='' flags='l'>
-          <fn line='2597' name='concat'>
+          <fn line='2316' name='concat'>
            <fn name='upper-case'>
             <varRef name='Q{}level' slot='1'/>
            </fn>
            <str val=': '/>
           </fn>
          </elem>
-         <varRef line='2599' name='Q{}message' slot='0'/>
+         <varRef line='2318' name='Q{}message' slot='0'/>
         </sequence>
        </elem>
       </sequence>
@@ -13032,14 +12274,19 @@
    </sequence>
   </template>
  </co>
- <co id='74' binds=''>
-  <globalVariable name='Q{}default-instance-id' type='xs:string' line='82' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
+ <co id='79' binds=''>
+  <globalVariable name='Q{}default-instance-id' type='xs:string' line='84' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.string.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
    <str val='saxon-forms-default'/>
   </globalVariable>
  </co>
- <co id='69' binds='48 48 48'>
-  <globalParam name='Q{}xforms-doc-global' type='document-node()?' line='78' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='function test(item) {return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);};if (test(val)) {return val;} else {throw SaxonJS.XError(&#39;Conversion failed&#39;, &#39;XTTE0590&#39;);}' jsCardCheck='function c(n) {return n&lt;=1;};'>
-   <choose ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='78'>
+ <co id='67' binds=''>
+  <template name='Q{}xforms-revalidate' flags='os' line='3495' module='saxon-xforms.xsl' slots='0'>
+   <empty role='body'/>
+  </template>
+ </co>
+ <co id='74' binds='46 46 46'>
+  <globalParam name='Q{}xforms-doc-global' type='document-node()?' line='80' module='saxon-xforms.xsl' visibility='PUBLIC' jsAcceptor='function test(item) {return SaxonJS.U.isNode(item) &amp;&amp; (item.nodeType===9||item.nodeType===11);};if (test(val)) {return val;} else {throw SaxonJS.XError(&#39;Conversion failed&#39;, &#39;XTTE0590&#39;);}' jsCardCheck='function c(n) {return n&lt;=1;};'>
+   <choose ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='80'>
     <and op='and'>
      <fn name='exists'>
       <gVarRef name='Q{}xforms-file-global' bSlot='0'/>
@@ -13066,16 +12313,16 @@
    </choose>
   </globalParam>
  </co>
- <co id='75' binds=''>
-  <globalVariable name='Q{}debugTiming' type='xs:boolean' line='81' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.boolean.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
+ <co id='80' binds=''>
+  <globalVariable name='Q{}debugTiming' type='xs:boolean' line='83' module='saxon-xforms.xsl' visibility='PRIVATE' jsAcceptor='return SaxonJS.U.Atomic.boolean.cast(val);' jsCardCheck='function c(n) {return n==1;};'>
    <false/>
   </globalVariable>
  </co>
- <co id='44' binds='61'>
-  <function name='Q{http://www.w3.org/2002/xforms}getDataRef' line='2712' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:string' slots='11'>
+ <co id='42' binds='64'>
+  <function name='Q{http://www.w3.org/2002/xforms}getDataRef' line='2431' module='saxon-xforms.xsl' eval='16' flags='pU' as='xs:string' slots='11'>
    <arg name='Q{}this' as='element()'/>
    <arg name='Q{}nodeset' as='xs:string?'/>
-   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2721' var='Q{}this-ref' as='xs:string?' slot='2' eval='7'>
+   <let role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2440' var='Q{}this-ref' as='xs:string?' slot='2' eval='7'>
     <choose>
      <fn name='exists'>
       <slash simple='1'>
@@ -13110,27 +12357,27 @@
       </cast>
      </fn>
     </choose>
-    <let line='2724' var='Q{}this-binding' as='node()?' slot='3' eval='7'>
-     <treat line='2725' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|this-binding'>
+    <let line='2443' var='Q{}this-binding' as='node()?' slot='3' eval='7'>
+     <treat line='2444' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|this-binding'>
       <check card='?' diag='3|0|XTTE0570|this-binding'>
        <callT name='Q{}getBinding' bSlot='0'>
         <withParam name='Q{}this' flags='c' as='element()'>
-         <varRef line='2726' name='Q{}this' slot='0'/>
+         <varRef line='2445' name='Q{}this' slot='0'/>
         </withParam>
        </callT>
       </check>
      </treat>
-     <choose line='2751'>
+     <choose line='2470'>
       <fn name='exists'>
        <varRef name='Q{}this-binding' slot='3'/>
       </fn>
-      <let line='2732' var='Q{}relative' as='xs:string' slot='4' eval='16'>
+      <let line='2451' var='Q{}relative' as='xs:string' slot='4' eval='16'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
         <choose>
          <fn name='exists'>
           <varRef name='Q{}this-binding' slot='3'/>
          </fn>
-         <cvUntyped line='2743' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
+         <cvUntyped line='2462' to='xs:string' diag='3|0|XTTE0570|this-binding-ref'>
           <cast as='xs:untypedAtomic' emptiable='0'>
            <choose>
             <fn name='exists'>
@@ -13165,25 +12412,25 @@
          </cvUntyped>
         </choose>
        </check>
-       <choose line='843'>
+       <choose line='785'>
         <fn name='starts-with'>
          <varRef name='Q{}relative' slot='4'/>
          <str val='/'/>
         </fn>
-        <varRef line='844' name='Q{}relative' slot='4'/>
-        <fn line='846' name='starts-with'>
+        <varRef line='786' name='Q{}relative' slot='4'/>
+        <fn line='788' name='starts-with'>
          <varRef name='Q{}relative' slot='4'/>
          <str val='instance('/>
         </fn>
-        <varRef line='847' name='Q{}relative' slot='4'/>
+        <varRef line='789' name='Q{}relative' slot='4'/>
         <true/>
-        <varRef line='850' name='Q{}relative' slot='4'/>
+        <varRef line='792' name='Q{}relative' slot='4'/>
        </choose>
       </let>
-      <fn line='2754' name='exists'>
+      <fn line='2473' name='exists'>
        <varRef name='Q{}this-ref' slot='2'/>
       </fn>
-      <let line='2755' var='Q{}base' as='xs:string' slot='5' eval='16'>
+      <let line='2474' var='Q{}base' as='xs:string' slot='5' eval='16'>
        <check card='1' diag='0|0||xforms:resolveXPathStrings'>
         <varRef name='Q{}nodeset' slot='1'/>
        </check>
@@ -13191,22 +12438,22 @@
         <check card='1' diag='0|1||xforms:resolveXPathStrings'>
          <varRef name='Q{}this-ref' slot='2'/>
         </check>
-        <choose line='843'>
+        <choose line='785'>
          <fn name='starts-with'>
           <varRef name='Q{}relative' slot='6'/>
           <str val='/'/>
          </fn>
-         <varRef line='844' name='Q{}relative' slot='6'/>
-         <fn line='846' name='starts-with'>
+         <varRef line='786' name='Q{}relative' slot='6'/>
+         <fn line='788' name='starts-with'>
           <varRef name='Q{}relative' slot='6'/>
           <str val='instance('/>
          </fn>
-         <varRef line='847' name='Q{}relative' slot='6'/>
-         <fn line='849' name='not'>
+         <varRef line='789' name='Q{}relative' slot='6'/>
+         <fn line='791' name='not'>
           <varRef name='Q{}base' slot='5'/>
          </fn>
-         <varRef line='850' name='Q{}relative' slot='6'/>
-         <or line='852' op='or'>
+         <varRef line='792' name='Q{}relative' slot='6'/>
+         <or line='794' op='or'>
           <fn name='not'>
            <varRef name='Q{}relative' slot='6'/>
           </fn>
@@ -13215,9 +12462,9 @@
            <str val='.'/>
           </vc>
          </or>
-         <varRef line='853' name='Q{}base' slot='5'/>
+         <varRef line='795' name='Q{}base' slot='5'/>
          <true/>
-         <let line='857' var='Q{}parentCallCount' as='xs:integer' slot='7' eval='16'>
+         <let line='799' var='Q{}parentCallCount' as='xs:integer' slot='7' eval='16'>
           <choose>
            <fn name='contains'>
             <varRef name='Q{}relative' slot='6'/>
@@ -13244,7 +12491,7 @@
            <true/>
            <int val='0'/>
           </choose>
-          <let line='860' var='Q{}slashes' as='xs:integer*' slot='8' eval='4'>
+          <let line='802' var='Q{}slashes' as='xs:integer*' slot='8' eval='4'>
            <choose>
             <fn name='contains'>
              <varRef name='Q{}base' slot='5'/>
@@ -13259,15 +12506,15 @@
             <true/>
             <int val='0'/>
            </choose>
-           <choose line='892'>
+           <choose line='834'>
             <compareToInt op='gt' val='0'>
              <varRef name='Q{}parentCallCount' slot='7'/>
             </compareToInt>
-            <fn line='896' name='concat'>
+            <fn line='838' name='concat'>
              <fn name='substring'>
               <varRef name='Q{}base' slot='5'/>
               <int val='1'/>
-              <choose line='871'>
+              <choose line='813'>
                <and op='and'>
                 <vc op='ge' onEmpty='0' comp='CAVC'>
                  <fn name='count'>
@@ -13279,7 +12526,7 @@
                  <varRef name='Q{}parentCallCount' slot='7'/>
                 </compareToInt>
                </and>
-               <let line='872' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='9' eval='16'>
+               <let line='814' var='Q{http://saxon.sf.net/generated-variable}v0' as='xs:integer' slot='9' eval='16'>
                 <arith op='-' calc='i-i'>
                  <varRef name='Q{}parentCallCount' slot='7'/>
                  <int val='1'/>
@@ -13295,7 +12542,7 @@
                 </check>
                </let>
                <true/>
-               <check line='875' card='1' diag='3|0|XTTE0570|parentSlash'>
+               <check line='817' card='1' diag='3|0|XTTE0570|parentSlash'>
                 <lastOf>
                  <varRef name='Q{}slashes' slot='8'/>
                 </lastOf>
@@ -13310,7 +12557,7 @@
              </fn>
             </fn>
             <true/>
-            <fn line='899' name='concat'>
+            <fn line='841' name='concat'>
              <varRef name='Q{}base' slot='5'/>
              <str val='/'/>
              <varRef name='Q{}relative' slot='6'/>
@@ -13321,24 +12568,24 @@
         </choose>
        </let>
       </let>
-      <varRef line='2757' name='Q{}nodeset' slot='1'/>
-      <let line='2758' var='Q{}relative' as='xs:string' slot='10' eval='16'>
+      <varRef line='2476' name='Q{}nodeset' slot='1'/>
+      <let line='2477' var='Q{}relative' as='xs:string' slot='10' eval='16'>
        <check card='1' diag='0|1||xforms:resolveXPathStrings'>
         <varRef name='Q{}nodeset' slot='1'/>
        </check>
-       <choose line='843'>
+       <choose line='785'>
         <fn name='starts-with'>
          <varRef name='Q{}relative' slot='10'/>
          <str val='/'/>
         </fn>
-        <varRef line='844' name='Q{}relative' slot='10'/>
-        <fn line='846' name='starts-with'>
+        <varRef line='786' name='Q{}relative' slot='10'/>
+        <fn line='788' name='starts-with'>
          <varRef name='Q{}relative' slot='10'/>
          <str val='instance('/>
         </fn>
-        <varRef line='847' name='Q{}relative' slot='10'/>
+        <varRef line='789' name='Q{}relative' slot='10'/>
         <true/>
-        <varRef line='850' name='Q{}relative' slot='10'/>
+        <varRef line='792' name='Q{}relative' slot='10'/>
        </choose>
       </let>
       <true/>
@@ -13348,18 +12595,18 @@
    </let>
   </function>
  </co>
- <co id='19' binds='19 19'>
+ <co id='33' binds='33 33'>
   <mode name='Q{}recalculate' onNo='TC' flags='W' patternSlots='0'>
-   <templateRule prec='0' prio='-0.5' seq='28' rank='0' minImp='0' slots='5' flags='s' line='2316' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='26' rank='0' minImp='0' slots='5' flags='s' line='2075' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2317'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2076'>
      <param name='Q{}updated-nodes' slot='0' flags='t' as='node()*'>
       <empty role='select'/>
       <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|updated-nodes'>
        <supplied slot='0'/>
       </treat>
      </param>
-     <param line='2318' name='Q{}updated-values' slot='1' flags='t' as='xs:string*'>
+     <param line='2077' name='Q{}updated-values' slot='1' flags='t' as='xs:string*'>
       <empty role='select'/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|updated-values'>
        <cvUntyped to='xs:string' diag='8|0|XTTE0590|updated-values'>
@@ -13369,14 +12616,14 @@
        </cvUntyped>
       </treat>
      </param>
-     <copy line='2324' flags='cin'>
+     <copy line='2083' flags='cin'>
       <sequence role='content'>
        <applyT mode='Q{}recalculate' bSlot='0'>
         <axis role='select' name='attribute' nodeTest='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
        </applyT>
-       <choose line='2327'>
+       <choose line='2086'>
         <fn name='exists'>
-         <let line='2320' var='Q{http://saxon.sf.net/generated-variable}current-1560395415' as='element()' slot='2' eval='16'>
+         <let line='2079' var='Q{http://saxon.sf.net/generated-variable}current1827995683' as='element()' slot='2' eval='16'>
           <dot type='element()'/>
           <treat as='element()' jsTest='return item.nodeType===1;' diag='3|0|XTTE0570|updated-node'>
            <check card='?' diag='3|0|XTTE0570|updated-node'>
@@ -13384,15 +12631,15 @@
              <varRef name='Q{}updated-nodes' slot='0'/>
              <is op='is'>
               <dot type='node()'/>
-              <varRef name='Q{http://saxon.sf.net/generated-variable}current-1560395415' slot='2'/>
+              <varRef name='Q{http://saxon.sf.net/generated-variable}current1827995683' slot='2'/>
              </is>
             </filter>
            </check>
           </treat>
          </let>
         </fn>
-        <let line='2328' var='Q{}updated-node-position' as='xs:integer' slot='3' eval='16'>
-         <let var='Q{http://saxon.sf.net/generated-variable}current-1764648265' as='element()' slot='4' eval='16'>
+        <let line='2087' var='Q{}updated-node-position' as='xs:integer' slot='3' eval='16'>
+         <let var='Q{http://saxon.sf.net/generated-variable}current-319858099' as='element()' slot='4' eval='16'>
           <dot type='element()'/>
           <check card='1' diag='3|0|XTTE0570|updated-node-position'>
            <slash>
@@ -13400,20 +12647,20 @@
              <varRef name='Q{}updated-nodes' slot='0'/>
              <is op='is'>
               <dot type='node()'/>
-              <varRef name='Q{http://saxon.sf.net/generated-variable}current-1764648265' slot='4'/>
+              <varRef name='Q{http://saxon.sf.net/generated-variable}current-319858099' slot='4'/>
              </is>
             </filter>
             <fn name='position'/>
            </slash>
           </check>
          </let>
-         <subscript line='2329'>
+         <subscript line='2089'>
           <varRef name='Q{}updated-values' slot='1'/>
           <varRef name='Q{}updated-node-position' slot='3'/>
          </subscript>
         </let>
         <true/>
-        <applyT line='2332' mode='Q{}recalculate' bSlot='1'>
+        <applyT line='2092' mode='Q{}recalculate' bSlot='1'>
          <axis role='select' name='child' nodeTest='node()' jsTest='return SaxonJS.U.isNode(item);'/>
         </applyT>
        </choose>
@@ -13421,16 +12668,16 @@
      </copy>
     </sequence>
    </templateRule>
-   <templateRule prec='0' prio='-0.5' seq='29' rank='0' minImp='0' slots='5' flags='s' line='2345' module='saxon-xforms.xsl'>
+   <templateRule prec='0' prio='-0.5' seq='27' rank='0' minImp='0' slots='5' flags='s' line='2105' module='saxon-xforms.xsl'>
     <p.nodeTest role='match' test='attribute()' jsTest='return SaxonJS.U.isAttr(item)'/>
-    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2346'>
+    <sequence role='action' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='2106'>
      <param name='Q{}updated-nodes' slot='0' flags='t' as='node()*'>
       <empty role='select'/>
       <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|updated-nodes'>
        <supplied slot='0'/>
       </treat>
      </param>
-     <param line='2347' name='Q{}updated-values' slot='1' flags='t' as='xs:string*'>
+     <param line='2107' name='Q{}updated-values' slot='1' flags='t' as='xs:string*'>
       <empty role='select'/>
       <treat role='conversion' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='8|0|XTTE0590|updated-values'>
        <cvUntyped to='xs:string' diag='8|0|XTTE0590|updated-values'>
@@ -13440,9 +12687,9 @@
        </cvUntyped>
       </treat>
      </param>
-     <choose line='2352'>
+     <choose line='2112'>
       <fn name='exists'>
-       <let line='2349' var='Q{http://saxon.sf.net/generated-variable}current-1560395414' as='attribute()' slot='2' eval='16'>
+       <let line='2109' var='Q{http://saxon.sf.net/generated-variable}current1827995680' as='attribute()' slot='2' eval='16'>
         <dot type='attribute()'/>
         <treat as='attribute()' jsTest='return SaxonJS.U.isAttr(item)' diag='3|0|XTTE0570|updated-node'>
          <check card='?' diag='3|0|XTTE0570|updated-node'>
@@ -13450,15 +12697,15 @@
            <varRef name='Q{}updated-nodes' slot='0'/>
            <is op='is'>
             <dot type='node()'/>
-            <varRef name='Q{http://saxon.sf.net/generated-variable}current-1560395414' slot='2'/>
+            <varRef name='Q{http://saxon.sf.net/generated-variable}current1827995680' slot='2'/>
            </is>
           </filter>
          </check>
         </treat>
        </let>
       </fn>
-      <let line='2353' var='Q{}updated-node-position' as='xs:integer' slot='3' eval='16'>
-       <let var='Q{http://saxon.sf.net/generated-variable}current-1764648265' as='attribute()' slot='4' eval='16'>
+      <let line='2113' var='Q{}updated-node-position' as='xs:integer' slot='3' eval='16'>
+       <let var='Q{http://saxon.sf.net/generated-variable}current-319858099' as='attribute()' slot='4' eval='16'>
         <dot type='attribute()'/>
         <check card='1' diag='3|0|XTTE0570|updated-node-position'>
          <slash>
@@ -13466,14 +12713,14 @@
            <varRef name='Q{}updated-nodes' slot='0'/>
            <is op='is'>
             <dot type='node()'/>
-            <varRef name='Q{http://saxon.sf.net/generated-variable}current-1764648265' slot='4'/>
+            <varRef name='Q{http://saxon.sf.net/generated-variable}current-319858099' slot='4'/>
            </is>
           </filter>
           <fn name='position'/>
          </slash>
         </check>
        </let>
-       <compAtt line='2354'>
+       <compAtt line='2114'>
         <fn role='name' name='name'>
          <dot type='attribute()'/>
         </fn>
@@ -13484,13 +12731,164 @@
        </compAtt>
       </let>
       <true/>
-      <copyOf line='2357' flags='vc'>
+      <copyOf line='2117' flags='vc'>
        <dot type='attribute()'/>
       </copyOf>
      </choose>
     </sequence>
    </templateRule>
   </mode>
+ </co>
+ <co id='73' binds='1 2 3 48 33 5 15 13 21'>
+  <template name='Q{}action-setvalue-form-control' flags='os' line='3983' module='saxon-xforms.xsl' slots='8'>
+   <sequence role='body' ns='xforms=http://www.w3.org/2002/xforms in=http://www.w3.org/2002/xforms-instance fn=~ js=~ saxon=~ xd=http://www.oxygenxml.com/ns/doc/xsl xf=http://www.w3.org/2002/xforms xhtml=http://www.w3.org/1999/xhtml xsl=~ ev=http://www.w3.org/2001/xml-events rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns# array=~ sfl=http://saxonica.com/ns/forms-local ixsl=~ xs=~ math=~ sfp=http://saxon.sf.net/ns/packages map=~' line='3984'>
+    <param name='Q{}form-control' slot='0' flags='i' as='node()'>
+     <treat role='conversion' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='8|0|XTTE0590|form-control'>
+      <check card='1' diag='8|0|XTTE0590|form-control'>
+       <supplied slot='0'/>
+      </check>
+     </treat>
+    </param>
+    <let line='3986' var='Q{}refi' as='attribute(Q{}data-ref)?' slot='1' eval='8'>
+     <slash simple='1'>
+      <varRef name='Q{}form-control' slot='0'/>
+      <axis name='attribute' nodeTest='attribute(Q{}data-ref)' jsTest='return item.name===&#39;data-ref&#39;'/>
+     </slash>
+     <let line='3989' var='Q{}instance-id' as='xs:string' slot='2' eval='16'>
+      <ufCall name='Q{http://www.w3.org/2002/xforms}getInstanceId' tailCall='false' bSlot='0' eval='16'>
+       <check card='1' diag='0|0||xforms:getInstanceId'>
+        <cvUntyped to='xs:string'>
+         <data>
+          <varRef name='Q{}refi' slot='1'/>
+         </data>
+        </cvUntyped>
+       </check>
+      </ufCall>
+      <let line='3990' var='Q{}actions' as='item()?' slot='3' eval='8'>
+       <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+        <check card='1' diag='0|0||ixsl:call'>
+         <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+        </check>
+        <str val='getAction'/>
+        <arrayBlock>
+         <fn name='string'>
+          <slash simple='1'>
+           <varRef name='Q{}form-control' slot='0'/>
+           <axis name='attribute' nodeTest='attribute(Q{}data-action)' jsTest='return item.name===&#39;data-action&#39;'/>
+          </slash>
+         </fn>
+        </arrayBlock>
+       </ifCall>
+       <let line='3995' var='Q{}instanceXML' as='element()' slot='4' eval='16'>
+        <check card='1' diag='3|0|XTTE0570|instanceXML'>
+         <ufCall name='Q{http://www.w3.org/2002/xforms}instance' tailCall='false' bSlot='1' eval='6'>
+          <varRef name='Q{}instance-id' slot='2'/>
+         </ufCall>
+        </check>
+        <let line='3996' var='Q{}updatedNode' as='node()' slot='5' eval='16'>
+         <treat line='3997' as='node()' jsTest='return SaxonJS.U.isNode(item);' diag='3|0|XTTE0570|updatedNode'>
+          <check card='1' diag='3|0|XTTE0570|updatedNode'>
+           <evaluate dxns=''>
+            <ufCall role='xpath' name='Q{http://www.w3.org/2002/xforms}impose' tailCall='false' bSlot='2' eval='16'>
+             <check card='1' diag='0|0||xforms:impose'>
+              <cvUntyped to='xs:string'>
+               <data>
+                <varRef name='Q{}refi' slot='1'/>
+               </data>
+              </cvUntyped>
+             </check>
+            </ufCall>
+            <varRef role='cxt' name='Q{}instanceXML' slot='4'/>
+            <varRef role='nsCxt' name='Q{}instanceXML' slot='4'/>
+            <str role='sa' val='no'/>
+            <map role='options' size='0'/>
+            <map role='wp' size='0'/>
+           </evaluate>
+          </check>
+         </treat>
+         <let line='3999' var='Q{}new-value' as='xs:string' slot='6' eval='16'>
+          <treat line='4000' as='xs:string' jsTest='return SaxonJS.U.Atomic.string.matches(item);' diag='3|0|XTTE0570|new-value'>
+           <check card='1' diag='3|0|XTTE0570|new-value'>
+            <cvUntyped to='xs:string' diag='3|0|XTTE0570|new-value'>
+             <data>
+              <applyT mode='Q{}get-field' bSlot='3'>
+               <varRef role='select' name='Q{}form-control' slot='0'/>
+              </applyT>
+             </data>
+            </cvUntyped>
+           </check>
+          </treat>
+          <let line='4002' var='Q{}updatedInstanceXML' as='element()' slot='7' eval='16'>
+           <treat line='4003' as='element()' jsTest='return SaxonJS.U.isNode(item) &amp;&amp; item.nodeType===1;' diag='3|0|XTTE0570|updatedInstanceXML'>
+            <check card='1' diag='3|0|XTTE0570|updatedInstanceXML'>
+             <applyT mode='Q{}recalculate' bSlot='4'>
+              <varRef role='select' name='Q{}instanceXML' slot='4'/>
+              <withParam name='Q{}instance-id' as='xs:string'>
+               <varRef line='4004' name='Q{}instance-id' slot='2'/>
+              </withParam>
+              <withParam name='Q{}updated-nodes' flags='t' as='node()'>
+               <varRef line='4005' name='Q{}updatedNode' slot='5'/>
+              </withParam>
+              <withParam name='Q{}updated-values' flags='t' as='xs:string'>
+               <varRef line='4006' name='Q{}new-value' slot='6'/>
+              </withParam>
+             </applyT>
+            </check>
+           </treat>
+           <sequence line='4013'>
+            <ufCall name='Q{http://www.w3.org/2002/xforms}setInstance-JS' tailCall='false' bSlot='5' eval='16 6'>
+             <check card='1' diag='0|0||xforms:setInstance-JS'>
+              <cvUntyped to='xs:string'>
+               <data>
+                <varRef name='Q{}refi' slot='1'/>
+               </data>
+              </cvUntyped>
+             </check>
+             <varRef name='Q{}updatedInstanceXML' slot='7'/>
+            </ufCall>
+            <ifCall line='4015' name='Q{http://saxonica.com/ns/interactiveXSLT}call' type='item()?'>
+             <check card='1' diag='0|0||ixsl:call'>
+              <ifCall name='Q{http://saxonica.com/ns/interactiveXSLT}window' type='item()?'/>
+             </check>
+             <str val='setDeferredUpdateFlags'/>
+             <array size='1'>
+              <literal count='3'>
+               <str val='recalculate'/>
+               <str val='revalidate'/>
+               <str val='refresh'/>
+              </literal>
+             </array>
+            </ifCall>
+            <callT line='4017' name='Q{}xforms-value-changed' bSlot='6'>
+             <withParam name='Q{}when-value-changed' flags='t' as='item()?'>
+              <filter line='4018' flags='b'>
+               <varRef name='Q{}actions' slot='3'/>
+               <gc op='=' card='N:1' comp='GAC|http://www.w3.org/2005/xpath-functions/collation/codepoint'>
+                <data>
+                 <ifCall name='Q{http://www.w3.org/2005/xpath-functions/map}get' type='item()*'>
+                  <treat as='map(*)' jsTest='return SaxonJS.U.isMap(item)' diag='0|0||map:get'>
+                   <dot/>
+                  </treat>
+                  <str val='@event'/>
+                 </ifCall>
+                </data>
+                <str val='xforms-value-changed'/>
+               </gc>
+              </filter>
+             </withParam>
+            </callT>
+            <callT line='4021' name='Q{}xforms-recalculate' bSlot='7'/>
+            <callT line='4022' name='Q{}xforms-refresh' bSlot='8' flags='t'/>
+           </sequence>
+          </let>
+         </let>
+        </let>
+       </let>
+      </let>
+     </let>
+    </let>
+   </sequence>
+  </template>
  </co>
  <overridden/>
  <output>
@@ -13504,4 +12902,4 @@
  </output>
  <decimalFormat/>
 </package>
-<?Σ f3f7ba0a?>
+<?Σ da2c0860?>


### PR DESCRIPTION
The "pending updates" behaviour has been replaced with an implementation of the XForms 1.1 "deferred update behaviour"

https://www.w3.org/TR/xforms11/#action-deferred-update-behavior

Reworked the relevant fields check, which now takes place as part of the refresh event.

The setvalue action now uses the recalculate mode. The "form-check" mode is now redundant and has been dropped.

Added "*:" prefix to templates for HTML elements (to allow XHTML handling).

Moved handling of "xforms-submit-done" actions to after the submission is competed.